### PR TITLE
Add build.cmd script

### DIFF
--- a/build.cmd
+++ b/build.cmd
@@ -1,0 +1,47 @@
+@echo off
+setlocal
+
+:: Note: We've disabled node reuse because it causes file locking issues.
+::       The issue is that we extend the build with our own targets which
+::       means that that rebuilding cannot successfully delete the task
+::       assembly. 
+
+if not defined VisualStudioVersion (
+    if defined VS140COMNTOOLS (
+        call "%VS140COMNTOOLS%\VsDevCmd.bat"
+        goto :EnvSet
+    )
+
+    echo Error: build.cmd requires Visual Studio 2015.
+    exit /b 1
+)
+
+:EnvSet
+
+:: Log build command line
+set _buildproj=%~dp0MIDebugEngine.sln
+set _buildlog=%~dp0msbuild.log
+set _buildprefix=echo
+set _buildpostfix=^> "%_buildlog%"
+call :build %*
+
+:: Build
+set _buildprefix=
+set _buildpostfix=
+call :build %*
+
+goto :AfterBuild
+
+:build
+%_buildprefix% msbuild "%_buildproj%" /nologo /maxcpucount /verbosity:minimal /nodeReuse:false /fileloggerparameters:Verbosity=normal;LogFile="%_buildlog%" %* %_buildpostfix%
+set BUILDERRORLEVEL=%ERRORLEVEL%
+goto :eof
+
+:AfterBuild
+
+echo.
+:: Pull the build summary from the log file
+findstr /ir /c:".*Warning(s)" /c:".*Error(s)" /c:"Time Elapsed.*" "%_buildlog%"
+echo Build Exit Code = %BUILDERRORLEVEL%
+
+exit /b %BUILDERRORLEVEL%


### PR DESCRIPTION
Port the build.cmd script to the release branch so we can have CI builds for PR's against release. The build.cmd script has already changed in master but this pulls it in from a time when master still resembled the current release branch. 
