### PR TITLE
Fix address column in modules window for 64-bit processes

### DIFF
--- a/src/MIDebugEngine/AD7.Impl/AD7Engine.cs
+++ b/src/MIDebugEngine/AD7.Impl/AD7Engine.cs
@@ -654,7 +654,7 @@ namespace Microsoft.MIDebugEngine
             AD7Module[] moduleObjects = new AD7Module[modules.Length];
             for (int i = 0; i < modules.Length; i++)
             {
-                moduleObjects[i] = new AD7Module(modules[i]);
+                moduleObjects[i] = new AD7Module(modules[i], _debuggedProcess);
             }
 
             ppEnum = new Microsoft.MIDebugEngine.AD7ModuleEnum(moduleObjects);

--- a/src/MIDebugEngine/AD7.Impl/AD7Module.cs
+++ b/src/MIDebugEngine/AD7.Impl/AD7Module.cs
@@ -15,11 +15,16 @@ namespace Microsoft.MIDebugEngine
     // this class represents a module loaded in the debuggee process to the debugger. 
     internal class AD7Module : IDebugModule2, IDebugModule3
     {
+        public readonly DebuggedProcess Process;
         public readonly DebuggedModule DebuggedModule;
 
-        public AD7Module(DebuggedModule debuggedModule)
+        public AD7Module(DebuggedModule debuggedModule, DebuggedProcess process)
         {
+            Debug.Assert(debuggedModule != null, "No module provided?");
+            Debug.Assert(process != null, "No process provided?");
+
             this.DebuggedModule = debuggedModule;
+            this.Process = process;
         }
 
         #region IDebugModule2 Members
@@ -79,6 +84,12 @@ namespace Microsoft.MIDebugEngine
                     {
                         info.m_dwModuleFlags |= (enum_MODULE_FLAGS.MODULE_FLAG_SYMBOLS);
                     }
+
+                    if (this.Process.Is64BitArch)
+                    {
+                        info.m_dwModuleFlags |= enum_MODULE_FLAGS.MODULE_FLAG_64BIT;
+                    }
+
                     info.dwValidFields |= enum_MODULE_INFO_FIELDS.MIF_FLAGS;
                 }
 

--- a/src/MIDebugEngine/Engine.Impl/EngineCallback.cs
+++ b/src/MIDebugEngine/Engine.Impl/EngineCallback.cs
@@ -164,7 +164,7 @@ namespace Microsoft.MIDebugEngine
                 Debug.Assert(_engine.DebuggedProcess.WorkerThread.IsPollThread());
             }
 
-            AD7Module ad7Module = new AD7Module(debuggedModule);
+            AD7Module ad7Module = new AD7Module(debuggedModule, _engine.DebuggedProcess);
             AD7ModuleLoadEvent eventObject = new AD7ModuleLoadEvent(ad7Module, true /* this is a module load */);
 
             debuggedModule.Client = ad7Module;
@@ -337,7 +337,7 @@ namespace Microsoft.MIDebugEngine
 
             string statusString = ((statusFlags & enum_MODULE_INFO_FLAGS.MIF_SYMBOLS_LOADED) != 0 ? "Symbols Loaded - " : "No symbols loaded") + status;
 
-            AD7Module ad7Module = new AD7Module(module);
+            AD7Module ad7Module = new AD7Module(module, _engine.DebuggedProcess);
             AD7SymbolSearchEvent eventObject = new AD7SymbolSearchEvent(ad7Module, statusString, statusFlags);
             Send(eventObject, AD7SymbolSearchEvent.IID, null);
         }


### PR DESCRIPTION
The MI engine wasn't setting MODULE_FLAG_64BIT, so 64-bit addresses were being displayed wrong in the modules window.
