### PR TITLE
Conditional breakpoints port from release branch. 

### DIFF
--- a/src/MICore/Debugger.cs
+++ b/src/MICore/Debugger.cs
@@ -93,6 +93,32 @@ namespace MICore
         private StringBuilder _consoleCommandOutput;
 
         private bool _pendingInternalBreak;
+        private bool _waitingToStop;
+        private Timer _breakTimer = null;
+        private int _retryCount;
+        private const int BREAK_DELTA = 3000;   // millisec before trying to break again
+        private const int BREAK_RETRY_MAX = 3;  // maximum times to retry
+
+        private void RetryBreak(object o)
+        {
+            lock (_internalBreakActions)
+            {
+                if (_waitingToStop && _retryCount < BREAK_RETRY_MAX)
+                {
+                    Logger.WriteLine("Debugger failed to break. Trying again.");
+                    CmdBreakInternal();
+                    _retryCount++;
+                }
+                else
+                {
+                    if (_breakTimer != null)
+                    {
+                        _breakTimer.Dispose();
+                        _breakTimer = null;
+                    }
+                }
+            }
+        }
 
         public Task AddInternalBreakAction(Func<Task> func)
         {
@@ -114,9 +140,63 @@ namespace MICore
                     {
                         _pendingInternalBreak = true;
                         CmdBreakInternal();
+                        _retryCount = 0;
+                        _waitingToStop = true;
+                        _breakTimer = new Timer(RetryBreak, null, BREAK_DELTA, BREAK_DELTA);
                     }
                     return _internalBreakActionCompletionSource.Task;
                 }
+            }
+        }
+
+        private async void OnStopped(Results results)
+        {
+            string reason = results.TryFindString("reason");
+
+            if (reason.StartsWith("exited"))
+            {
+                this.ProcessState = ProcessState.Exited;
+                if (ProcessExitEvent != null)
+                {
+                    ProcessExitEvent(this, new ResultEventArgs(results));
+                }
+                return;
+            }
+
+            //if this is an exception reported from LLDB, it will not currently contain a frame object in the MI
+            //if we don't have a frame, check if this is an excpetion and retrieve the frame
+            if (!results.Contains("frame") &&
+                string.Compare(reason, "exception-received", StringComparison.OrdinalIgnoreCase) == 0
+                )
+            {
+                //get the info for the current frame
+                Results frameResult = await MICommandFactory.StackInfoFrame();
+
+                //add the frame to the stopping results
+                results.Add("frame", frameResult.Find("frame"));
+            }
+
+            bool fIsAsyncBreak = MICommandFactory.IsAsyncBreakSignal(results);
+
+            if (await DoInternalBreakActions(fIsAsyncBreak))
+            {
+                return;
+            }
+
+            this.ProcessState = ProcessState.Stopped;
+            FlushBreakStateData();
+
+            if (!results.Contains("frame"))
+            {
+                if (ModuleLoadEvent != null)
+                {
+                    ModuleLoadEvent(this, new ResultEventArgs(results));
+                }
+            }
+            else if (BreakModeEvent != null)
+            {
+                if (fIsAsyncBreak) { _requestingRealAsyncBreak = false; }
+                BreakModeEvent(this, new ResultEventArgs(results));
             }
         }
 
@@ -128,53 +208,7 @@ namespace MICore
 
             if (mode == "stopped")
             {
-                string reason = results.TryFindString("reason");
-
-                if (reason.StartsWith("exited"))
-                {
-                    this.ProcessState = ProcessState.Exited;
-                    if (ProcessExitEvent != null)
-                    {
-                        ProcessExitEvent(this, new ResultEventArgs(results));
-                    }
-                    return;
-                }
-
-                //if this is an exception reported from LLDB, it will not currently contain a frame object in the MI
-                //if we don't have a frame, check if this is an excpetion and retrieve the frame
-                if (!results.Contains("frame") &&
-                    string.Compare(reason, "exception-received", StringComparison.OrdinalIgnoreCase) == 0
-                    )
-                {
-                    //get the info for the current frame
-                    Results frameResult = await MICommandFactory.StackInfoFrame();
-
-                    //add the frame to the stopping results
-                    results.Add("frame", frameResult.Find("frame"));
-                }
-
-                bool fIsAsyncBreak = MICommandFactory.IsAsyncBreakSignal(results);
-
-                if (await DoInternalBreakActions(fIsAsyncBreak))
-                {
-                    return;
-                }
-
-                this.ProcessState = ProcessState.Stopped;
-                FlushBreakStateData();
-
-                if (!results.Contains("frame"))
-                {
-                    if (ModuleLoadEvent != null)
-                    {
-                        ModuleLoadEvent(this, new ResultEventArgs(results));
-                    }
-                }
-                else if (BreakModeEvent != null)
-                {
-                    if (fIsAsyncBreak) { _requestingRealAsyncBreak = false; }
-                    BreakModeEvent(this, new ResultEventArgs(results));
-                }
+                OnStopped(results);
             }
             else if (mode == "running")
             {
@@ -227,6 +261,7 @@ namespace MICore
             {
                 lock (_internalBreakActions)
                 {
+                    _waitingToStop = false;
                     if (_internalBreakActions.Count == 0)
                     {
                         _pendingInternalBreak = false;
@@ -377,7 +412,6 @@ namespace MICore
             return CmdAsync("-exec-run", ResultClass.running);
         }
 
-
         protected bool _requestingRealAsyncBreak = false;
         public Task CmdBreak()
         {
@@ -392,7 +426,14 @@ namespace MICore
 
         public Task CmdBreakInternal()
         {
-            return CmdAsync("-exec-interrupt", ResultClass.done);
+            var res = CmdAsync("-exec-interrupt", ResultClass.done);
+            return res.ContinueWith((t) =>
+            {
+                if (t.Result.Contains("reason"))    // interrupt finished synchronously
+                {
+                    ScheduleResultProcessing(()=>OnStopped(t.Result));
+                }
+            });
         }
 
         public void CmdContinueAsync()
@@ -618,6 +659,11 @@ namespace MICore
         protected virtual void ScheduleStdOutProcessing(string line)
         {
             ProcessStdOutLine(line);
+        }
+
+        protected virtual void ScheduleResultProcessing(Action func)
+        {
+            func();
         }
 
         // a Token is a sequence of decimal digits followed by something else

--- a/src/MICore/MICommandFactory.cs
+++ b/src/MICore/MICommandFactory.cs
@@ -6,7 +6,7 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.Threading.Tasks;
 using System.IO;
-
+using System.Text;
 
 namespace MICore
 {
@@ -344,10 +344,19 @@ namespace MICore
 
         #region Breakpoints
 
-        public virtual async Task<Results> BreakInsert(string filename, uint line, ResultClass resultClass = ResultClass.done)
+        public virtual async Task<Results> BreakInsert(string filename, uint line, string condition, ResultClass resultClass = ResultClass.done)
         {
-            string cmd = "-break-insert -f " + filename + ":" + line.ToString();
-            return await _debugger.CmdAsync(cmd, resultClass);
+            StringBuilder cmd = new StringBuilder("-break-insert -f ");
+            if (condition != null)
+            {
+                cmd.Append("-c \"");
+                cmd.Append(condition);
+                cmd.Append("\" ");
+            }
+            cmd.Append(filename);
+            cmd.Append(":");
+            cmd.Append(line.ToString());
+            return await _debugger.CmdAsync(cmd.ToString(), resultClass);
         }
 
         public virtual async Task<TupleValue> BreakInfo(string bkptno)
@@ -376,6 +385,16 @@ namespace MICore
         public virtual async Task BreakDelete(string bkptno)
         {
             await _debugger.CmdAsync("-break-delete " + bkptno, ResultClass.done);
+        }
+
+        public virtual async Task BreakCondition(string bkptno, string expr)
+        {
+            if (string.IsNullOrWhiteSpace(expr))
+            {
+                expr = string.Empty;
+            }
+            string command = string.Format("-break-condition {0} {1}", bkptno, expr);
+            await _debugger.CmdAsync(command, ResultClass.done);
         }
 
         #endregion
@@ -628,7 +647,7 @@ namespace MICore
         }
         public override Task<List<ulong>> StartAddressesForLine(string file, uint line)
         {
-            return null;
+            return Task.FromResult<List<ulong>>(null);
         }
 
         public override Task EnableTargetAsyncOption()
@@ -677,7 +696,7 @@ namespace MICore
         }
         public override Task<List<ulong>> StartAddressesForLine(string file, uint line)
         {
-            return null;
+            return Task.FromResult<List<ulong>>(null);
         }
 
         public override Task EnableTargetAsyncOption()

--- a/src/MIDebugEngine/AD7.Impl/AD7BoundBreakpoint.cs
+++ b/src/MIDebugEngine/AD7.Impl/AD7BoundBreakpoint.cs
@@ -107,18 +107,9 @@ namespace Microsoft.MIDebugEngine
             return Constants.S_OK;
         }
 
-        // The sample engine does not support conditions on breakpoints.
-        // A real-world debugger will use this to specify when a breakpoint will be hit
-        // and when it should be ignored.
         int IDebugBoundBreakpoint2.SetCondition(BP_CONDITION bpCondition)
         {
-            if (bpCondition.styleCondition != enum_BP_COND_STYLE.BP_COND_NONE)
-            {
-                Delete();
-                _engine.Callback.OnBreakpointUnbound(this, enum_BP_UNBOUND_REASON.BPUR_BREAKPOINT_ERROR);
-                return Constants.E_FAIL;
-            }
-            return Constants.S_OK;
+            return ((IDebugPendingBreakpoint2)_pendingBreakpoint).SetCondition(bpCondition);  // setting on the pending break will set the condition
         }
 
         // The sample engine does not support hit counts on breakpoints. A real-world debugger will want to keep track 

--- a/src/MIDebugEngine/Engine.Impl/Breakpoints.cs
+++ b/src/MIDebugEngine/Engine.Impl/Breakpoints.cs
@@ -84,10 +84,10 @@ namespace Microsoft.MIDebugEngine
             }
         }
 
-        internal static async Task<BindResult> Bind(string documentName, uint line, uint column, DebuggedProcess process, AD7PendingBreakpoint pbreak)
+        internal static async Task<BindResult> Bind(string documentName, uint line, uint column, DebuggedProcess process, string condition, AD7PendingBreakpoint pbreak)
         {
             string basename = System.IO.Path.GetFileName(documentName);     // get basename from Windows path
-            Results bindResult = await process.MICommandFactory.BreakInsert(process.EscapePath(basename), line, ResultClass.None);
+            Results bindResult = await process.MICommandFactory.BreakInsert(process.EscapePath(basename), line, condition, ResultClass.None);
             string errormsg = "Unknown error";
             if (bindResult.ResultClass == ResultClass.error)
             {
@@ -258,6 +258,14 @@ namespace Microsoft.MIDebugEngine
             if (process.ProcessState != MICore.ProcessState.Exited)
             {
                 await process.MICommandFactory.BreakDelete(Number);
+            }
+        }
+
+        internal async Task SetConditionAsync(string expr, DebuggedProcess process)
+        {
+            if (process.ProcessState != MICore.ProcessState.Exited)
+            {
+                await process.MICommandFactory.BreakCondition(Number, expr);
             }
         }
     }


### PR DESCRIPTION
Description:
1. Allow breaks to have conditions, implement SetCondition
2. When conditions are set while running, use AddInternalBreakAction to postpose until process can be paused.
3. Retry pausing when it doesn't happen after a few seconds.
4. Handle case where result of -exec-break contains stopping info (and thus no *stopped event is delivered). I have only seen this after using -break-condition asynchronously. Perhaps these fixes are unnecessary now that I don't do that anymore?

 Changes to be committed:
    modified:   MICore/Debugger.cs
    modified:   MICore/MICommandFactory.cs
    modified:   MIDebugEngine/AD7.Impl/AD7BoundBreakpoint.cs
    modified:   MIDebugEngine/AD7.Impl/AD7PendingBreakpoint.cs
    modified:   MIDebugEngine/Engine.Impl/Breakpoints.cs
    modified:   MIDebugEngine/Engine.Impl/DebuggedProcess.cs

Conflicts:
    src/MIDebugEngine/Engine.Impl/DebuggedProcess.cs
