### PR TITLE
Support 32-bit apps on 64-bit Android devices

### DIFF
--- a/src/AndroidDebugLauncher/AndroidDebugLauncher.csproj
+++ b/src/AndroidDebugLauncher/AndroidDebugLauncher.csproj
@@ -101,6 +101,7 @@
     <Compile Include="NdkReleaseId.cs" />
     <Compile Include="ProcessListParser.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="PwdOutputParser.cs" />
     <Compile Include="RegistryRoot.cs" />
     <Compile Include="Telemetry.cs" />
     <Compile Include="TextColumn.cs" />
@@ -131,7 +132,7 @@
     </EmbeddedResource>
   </ItemGroup>
   <ItemGroup>
-	<GlassDirCopy Include="$(OutDir)$(AssemblyName)$(TargetExt)" />
+    <GlassDirCopy Include="$(OutDir)$(AssemblyName)$(TargetExt)" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Import Project="..\..\build\miengine.targets" />

--- a/src/AndroidDebugLauncher/PwdOutputParser.cs
+++ b/src/AndroidDebugLauncher/PwdOutputParser.cs
@@ -1,0 +1,79 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace AndroidDebugLauncher
+{
+    static class PwdOutputParser
+    {
+        public static string ExtractWorkingDirectory(string commandOutput, string packageName)
+        {
+            IEnumerable<string> allLines = GetLines(commandOutput);
+
+            // Linux will allow just about anything in a directory name as long as it is excaped. Android is much
+            // more picky about package names. Let's reject characters which are invalid in a package name, highly
+            // unlikely that any Android distribution would decide to use in the base directory, and likely to show
+            // up in any debug spew we should ignore.
+            char[] invalidPackageNameChars = { ' ', '\t', '*', '[', ']', '(', ')', '{', '}', ':' };
+
+            // run-as is giving debug spew on a Galaxy S6, so we need to look at all the lines, and find the one that could be the working directory
+            IEnumerable<string> workingDirectoryLines = allLines.Where(
+                line => line.Length > 0 &&
+                line[0] == '/' &&
+                line.IndexOfAny(invalidPackageNameChars) < 0
+                );
+            if (workingDirectoryLines.Count() == 1)
+            {
+                return workingDirectoryLines.Single();
+            }
+
+            // Handle run-as errors. We will get into this code path if the supplied package name is wrong.
+            // Example commandOutput: "run-as: Package 'com.bogus.hellojni' is unknown"
+            string runAsLine = allLines.Where(line => line.StartsWith("run-as:", StringComparison.Ordinal))
+                .FirstOrDefault();
+
+            if (runAsLine != null)
+            {
+                string errorMessage = runAsLine.Substring("run-as:".Length).Trim();
+                if (errorMessage.Length > 0)
+                {
+                    if (!char.IsPunctuation(errorMessage[errorMessage.Length - 1]))
+                    {
+                        errorMessage = string.Concat(errorMessage, ".");
+                    }
+
+                    Telemetry.LaunchFailureCode telemetryCode = Telemetry.LaunchFailureCode.RunAsFailure;
+
+                    if (errorMessage == string.Format(CultureInfo.InvariantCulture, "Package '{0}' is unknown.", packageName))
+                    {
+                        telemetryCode = Telemetry.LaunchFailureCode.RunAsPackageUnknown;
+                        errorMessage = string.Concat(errorMessage, "\r\n\r\n", LauncherResources.Error_RunAsUnknownPackage);
+                    }
+
+                    throw new LauncherException(telemetryCode, string.Format(CultureInfo.CurrentCulture, LauncherResources.Error_ShellCommandFailed, "run-as", errorMessage));
+                }
+            }
+
+            throw new LauncherException(Telemetry.LaunchFailureCode.BadPwdOutput, string.Format(CultureInfo.CurrentCulture, LauncherResources.Error_ShellCommandBadResults, "pwd"));
+        }
+
+        private static IEnumerable<string> GetLines(string content)
+        {
+            using (var reader = new StringReader(content))
+            {
+                while (true)
+                {
+                    var line = reader.ReadLine();
+                    if (line == null)
+                        break;
+
+                    yield return line;
+                }
+            }
+        }
+    }
+}

--- a/src/MICoreUnitTests/AndroidLauncherTests.cs
+++ b/src/MICoreUnitTests/AndroidLauncherTests.cs
@@ -256,5 +256,50 @@ namespace MICoreUnitTests
 
             return lines;
         }
+
+        [Fact]
+        public void TestPwdOutputParser()
+        {
+            string result = PwdOutputParser.ExtractWorkingDirectory("/example/directory", "does-not-matter");
+            Assert.Equal(result, "/example/directory");
+
+            string outputWithDebugSpew = string.Concat(
+                "Function: selinux_compare_spd_ram , priority [2] , priority version is VE=SEPF_SM-G920I_5.0.2_0011\n",
+                "[DEBUG] get_category: variable seinfo: default sensitivity: NULL, cateogry: NULL\n",
+                "/data/data/com.Android53");
+            result = PwdOutputParser.ExtractWorkingDirectory(outputWithDebugSpew, "com.Android53");
+            Assert.Equal(result, "/data/data/com.Android53");
+
+            try
+            {
+                PwdOutputParser.ExtractWorkingDirectory("/bogus-directory-with-a-*", "com.Android53");
+                Assert.True(false, "Code should not be reached");
+            }
+            catch (LauncherException e)
+            {
+                Assert.True(e.TelemetryCode == Telemetry.LaunchFailureCode.BadPwdOutput);
+            }
+
+            try
+            {
+                PwdOutputParser.ExtractWorkingDirectory("/directory1\n/directory2", "com.Android53");
+                Assert.True(false, "Code should not be reached");
+            }
+            catch (LauncherException e)
+            {
+                Assert.True(e.TelemetryCode == Telemetry.LaunchFailureCode.BadPwdOutput);
+            }
+
+            try
+            {
+                PwdOutputParser.ExtractWorkingDirectory("run-as: Package 'com.bogus.hellojni' is unknown", "com.bogus.hellojni");
+                Assert.True(false, "Code should not be reached");
+            }
+            catch (LauncherException e)
+            {
+                Assert.True(e.TelemetryCode == Telemetry.LaunchFailureCode.RunAsPackageUnknown);
+            }
+        }
+
     }
 }


### PR DESCRIPTION
Address the following problems we had when targetting a 64-bit Android
device:

- Our ABI detection logic fell down because the device's ABI is arm64
instead of one of the arm values. Changed the code to check the
'abilist' property as weell.

- At least on Galaxy S6 thet we tested, run-as was adding extra debug
spew which broke our processing of the output from pwd. Modified this
code to ignore the extra spew.

- The 32-bit app_process is now called 'app_process32' and at least on
this device, ADB wasn't handling the redirect