### PR TITLE
Add CLRDBG/LLDB/GDB links in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 |**master**|[![Build Status](http://dotnet-ci.cloudapp.net/job/microsoft_miengine_debug/badge/icon)](http://dotnet-ci.cloudapp.net/job/microsoft_miengine_debug)|[![Build Status](http://dotnet-ci.cloudapp.net/job/microsoft_miengine_release/badge/icon)](http://dotnet-ci.cloudapp.net/job/microsoft_miengine_release)|
 
 The Visual Studio MI Debug Engine ("MIEngine") provides an open-source Visual Studio extension that enables debugging with debuggers that support the gdb Machine Interface ("MI")
-specification such as GDB, LLDB, and CLRDBG.
+specification such as [GDB](http://www.gnu.org/software/gdb/), [LLDB](http://lldb.llvm.org/), and [CLRDBG](https://github.com/Microsoft/MIEngine/wiki/What-is-CLRDBG).
 
 ### What is MIEngine?
 


### PR DESCRIPTION
I created a new Wiki page to describe CLRDBG:
https://github.com/Microsoft/MIEngine/wiki/What-is-CLRDBG

I am now updating the readme to link to it. While I was at it, I added
links for GDB/LLDB also.