### PR TITLE
Run CodeFormatter

### DIFF
--- a/src/AndroidDebugLauncher/PwdOutputParser.cs
+++ b/src/AndroidDebugLauncher/PwdOutputParser.cs
@@ -1,4 +1,7 @@
-﻿using System;
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
 using System.Collections.Generic;
 using System.Globalization;
 using System.IO;
@@ -8,7 +11,7 @@ using System.Threading.Tasks;
 
 namespace AndroidDebugLauncher
 {
-    static class PwdOutputParser
+    internal static class PwdOutputParser
     {
         public static string ExtractWorkingDirectory(string commandOutput, string packageName)
         {

--- a/src/IOSDebugLauncher/Launcher.cs
+++ b/src/IOSDebugLauncher/Launcher.cs
@@ -95,7 +95,7 @@ namespace IOSDebugLauncher
             debuggerLaunchOptions.LaunchCompleteCommand = GetLaunchCompleteCommand();
         }
 
-        ReadOnlyCollection<LaunchCommand> GetCustomLaunchSetupCommands()
+        private ReadOnlyCollection<LaunchCommand> GetCustomLaunchSetupCommands()
         {
             var commands = new List<LaunchCommand>();
 

--- a/src/MICore/Debugger.cs
+++ b/src/MICore/Debugger.cs
@@ -429,7 +429,7 @@ namespace MICore
             {
                 if (t.Result.Contains("reason"))    // interrupt finished synchronously
                 {
-                    ScheduleResultProcessing(()=>OnStopped(t.Result));
+                    ScheduleResultProcessing(() => OnStopped(t.Result));
                 }
             });
         }

--- a/src/MICore/InvalidLaunchOptionsException.cs
+++ b/src/MICore/InvalidLaunchOptionsException.cs
@@ -1,11 +1,14 @@
-﻿using System;
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
 using System.Globalization;
 
 namespace MICore
 {
     public class InvalidLaunchOptionsException : Exception
     {
-        internal InvalidLaunchOptionsException(string problemDescription) : 
+        internal InvalidLaunchOptionsException(string problemDescription) :
             base(string.Format(CultureInfo.CurrentCulture, MICoreResources.Error_InvalidLaunchOptions, problemDescription))
         {
         }

--- a/src/MICore/LaunchOptions.cs
+++ b/src/MICore/LaunchOptions.cs
@@ -94,7 +94,7 @@ namespace MICore
 
             return options;
         }
-        
+
         /// <summary>
         /// [Required] Path to the pipe executable.
         /// </summary>
@@ -196,7 +196,7 @@ namespace MICore
     /// </summary>
     public abstract class LaunchOptions
     {
-        const string XmlNamespace = "http://schemas.microsoft.com/vstudio/MDDDebuggerOptions/2014";
+        private const string XmlNamespace = "http://schemas.microsoft.com/vstudio/MDDDebuggerOptions/2014";
 
         private bool _initializationComplete;
 
@@ -455,7 +455,7 @@ namespace MICore
                 launchOptions.WorkingDirectory = dir;
 
             if (launchOptions._setupCommands == null)
-                launchOptions._setupCommands = new List<LaunchCommand>(capacity:0).AsReadOnly();
+                launchOptions._setupCommands = new List<LaunchCommand>(capacity: 0).AsReadOnly();
 
             launchOptions._initializationComplete = true;
             return launchOptions;

--- a/src/MICore/Transports/SerialTransport.cs
+++ b/src/MICore/Transports/SerialTransport.cs
@@ -44,7 +44,7 @@ namespace MICore
 
             Echo("");
 
-            for (; ;)
+            for (;;)
             {
                 line = GetLine();
                 if (line != null)
@@ -71,7 +71,7 @@ namespace MICore
         {
             Echo(cmd);
             Thread.Sleep(333);             // give it 1/3 of a second to do something
-            for (; ;)
+            for (;;)
             {
                 string line = GetLine();
                 if (line != null && line.EndsWith(cmd, StringComparison.Ordinal))
@@ -127,7 +127,7 @@ namespace MICore
         {
             // read chars until we get a Newline, or until we get a long delay
             StringBuilder sb = new StringBuilder(300);
-            for (; ;)
+            for (;;)
             {
                 try
                 {

--- a/src/MICoreUnitTests/AndroidLauncherTests.cs
+++ b/src/MICoreUnitTests/AndroidLauncherTests.cs
@@ -111,7 +111,7 @@ namespace MICoreUnitTests
             }
         }
 
-        AndroidDebugLauncher.AndroidLaunchOptions CreateFromXml(string content)
+        private AndroidDebugLauncher.AndroidLaunchOptions CreateFromXml(string content)
         {
             using (XmlReader reader = MICore.LaunchOptions.OpenXml(content))
             {
@@ -300,6 +300,5 @@ namespace MICoreUnitTests
                 Assert.True(e.TelemetryCode == Telemetry.LaunchFailureCode.RunAsPackageUnknown);
             }
         }
-
     }
 }

--- a/src/MIDebugEngine/AD7.Impl/AD7PendingBreakpoint.cs
+++ b/src/MIDebugEngine/AD7.Impl/AD7PendingBreakpoint.cs
@@ -412,8 +412,8 @@ namespace Microsoft.MIDebugEngine
                     _engine.Callback.OnBreakpointError(_BPError);
                     return Constants.E_FAIL;
                 }
-                if ((_bpRequestInfo.dwFields & enum_BPREQI_FIELDS.BPREQI_CONDITION) != 0 
-                    && _bpRequestInfo.bpCondition.styleCondition == bpCondition.styleCondition 
+                if ((_bpRequestInfo.dwFields & enum_BPREQI_FIELDS.BPREQI_CONDITION) != 0
+                    && _bpRequestInfo.bpCondition.styleCondition == bpCondition.styleCondition
                     && _bpRequestInfo.bpCondition.bstrCondition == bpCondition.bstrCondition)
                 {
                     return Constants.S_OK;  // this condition was already set
@@ -429,9 +429,9 @@ namespace Microsoft.MIDebugEngine
             {
                 _engine.DebuggedProcess.WorkerThread.RunOperation(() =>
                 {
-                _engine.DebuggedProcess.AddInternalBreakAction(
-                    ()=>bp.SetConditionAsync(bpCondition.bstrCondition, _engine.DebuggedProcess)
-                        );
+                    _engine.DebuggedProcess.AddInternalBreakAction(
+                        () => bp.SetConditionAsync(bpCondition.bstrCondition, _engine.DebuggedProcess)
+                            );
                 });
             }
             return Constants.S_OK;

--- a/src/MIDebugEngine/Engine.Impl/DebuggedProcess.cs
+++ b/src/MIDebugEngine/Engine.Impl/DebuggedProcess.cs
@@ -453,7 +453,7 @@ namespace Microsoft.MIDebugEngine
                 string exe = EscapePath(_launchOptions.ExePath);
                 commands.Add(new LaunchCommand("-file-exec-and-symbols " + exe, string.Format(CultureInfo.CurrentUICulture, ResourceStrings.LoadingSymbolMessage, _launchOptions.ExePath)));
 
-                commands.Add(new LaunchCommand("-break-insert main", ignoreFailures:true));
+                commands.Add(new LaunchCommand("-break-insert main", ignoreFailures: true));
 
                 if (_launchOptions is LocalLaunchOptions)
                 {

--- a/src/MIDebugEngine/Engine.Impl/MITextPosition.cs
+++ b/src/MIDebugEngine/Engine.Impl/MITextPosition.cs
@@ -33,10 +33,10 @@ namespace Microsoft.MIDebugEngine
                 filename = miTuple.TryFindString("file");
             }
             if (!string.IsNullOrEmpty(filename))
-            { 
+            {
                 filename = DebuggedProcess.UnixPathToWindowsPath(filename);
             }
-       
+
             if (string.IsNullOrWhiteSpace(filename))
                 return null;
 

--- a/src/MIDebugEngine/Engine.Impl/Variables.cs
+++ b/src/MIDebugEngine/Engine.Impl/Variables.cs
@@ -113,7 +113,7 @@ namespace Microsoft.MIDebugEngine
                             // Underlying debugger sometimes has trouble with long expressions (parent-expression can be arbitrarily long),
                             // so attempt to simplify the expression by using ((parent-type)0xabc)->field instead of (parent-expression)->field 
                             ulong addr;
-                            if (_parent.Value.StartsWith("0x", StringComparison.OrdinalIgnoreCase) 
+                            if (_parent.Value.StartsWith("0x", StringComparison.OrdinalIgnoreCase)
                                     && ulong.TryParse(_parent.Value.Substring(2), NumberStyles.AllowHexSpecifier, CultureInfo.InvariantCulture, out addr))
                             {
                                 parentName = '(' + _parent.TypeName + ')' + _parent.Value;

--- a/src/MIDebugEngine/Natvis.Impl/Natvis.cs
+++ b/src/MIDebugEngine/Natvis.Impl/Natvis.cs
@@ -805,7 +805,7 @@ namespace Microsoft.MIDebugEngine.Natvis
         private VisualizerInfo Scan(TypeName name, IVariableInformation variable)
         {
             int aliasChain = 0;
-            tryAgain:
+        tryAgain:
             foreach (var autoVis in _typeVisualizers)
             {
                 var visualizer = autoVis.Visualizers.Find((v) => v.ParsedName.Match(name));   // TODO: match on View, version, etc

--- a/src/MIDebugEngine/Natvis.Impl/NatvisXsdTypes.cs
+++ b/src/MIDebugEngine/Natvis.Impl/NatvisXsdTypes.cs
@@ -2165,7 +2165,6 @@ namespace Microsoft.MIDebugEngine.Natvis
     [System.Xml.Serialization.XmlTypeAttribute(Namespace = "http://schemas.microsoft.com/vstudio/debugger/natvis/2010")]
     public partial class AliasType
     {
-
         private string _valueField;
 
         private string _nameField;
@@ -2197,5 +2196,4 @@ namespace Microsoft.MIDebugEngine.Natvis
             }
         }
     }
-
 }

--- a/src/MIDebugEngine/Natvis.Impl/VsNatvisProject.cs
+++ b/src/MIDebugEngine/Natvis.Impl/VsNatvisProject.cs
@@ -46,7 +46,6 @@ namespace Microsoft.MIDebugEngine.Natvis
             }
             catch (Exception)
             {
-
             }
             paths.ForEach((s) => loader(s));
         }
@@ -133,7 +132,6 @@ namespace Microsoft.MIDebugEngine.Natvis
                     return Constants.S_OK == proj.GetFilesWithItemType("natvis", celt, rgitemids, out cActual);
                 }
             }
-
         }
     }
 }


### PR DESCRIPTION
I ran codeformatter over this just for housekeepings sake. one wrinkle is that codeformatter likes to fix up a bunch of things in the autogenerated LaunchOptions.xsd.types.desginer.cs. I ran codeformatter, then built again to regenerated, and left the generated version as is. 