### PR TITLE
Add support for executing console interface commands

### DIFF
--- a/src/MIDebugEngine/Engine.Impl/DebuggedProcess.cs
+++ b/src/MIDebugEngine/Engine.Impl/DebuggedProcess.cs
@@ -394,6 +394,10 @@ namespace Microsoft.MIDebugEngine
                             throw new UnexpectedMIResultException(command.CommandText, miError);
                         }
                     }
+                    else
+                    {
+                        await ConsoleCmdAsync(command.CommandText);
+                    }
                 }
 
 


### PR DESCRIPTION
Non-MI commands specified via SetupCommands/CustomLaunchSetupCommands are currently ignored silently. This patch adds the capability to execute console interface commands. It is especially useful for remote debugging situations in which you want to pass commands to the gdbserver via the "monitor ..." command in order to set it up properly for debugging.