### PR TITLE
Include commit id in version info for official builds

### DIFF
--- a/build/miengine.settings.targets
+++ b/build/miengine.settings.targets
@@ -49,5 +49,7 @@
 
     <AssemblyVersion>$(MajorVersion).$(MinorVersion).0</AssemblyVersion>
     <BuildVersion>$(MajorVersion).$(MinorVersion).$(BuildNumberMajor).$(BuildNumberMinor)</BuildVersion>
+    <BuildVersionExtended>$(BuildVersion)</BuildVersionExtended>
+    <BuildVersionExtended Condition="'$(TF_BUILD_SOURCEGETVERSION)'!=''">$(BuildVersionExtended) commit:$(TF_BUILD_SOURCEGETVERSION)</BuildVersionExtended>
   </PropertyGroup>
 </Project>

--- a/build/miengine.targets
+++ b/build/miengine.targets
@@ -67,7 +67,7 @@
         <_Parameter1>$(BuildVersion)</_Parameter1>
       </AssemblyAttribute>
       <AssemblyAttribute Include="System.Reflection.AssemblyInformationalVersionAttribute">
-        <_Parameter1>$(BuildVersion)</_Parameter1>
+        <_Parameter1>$(BuildVersionExtended)</_Parameter1>
       </AssemblyAttribute>
     </ItemGroup>
 


### PR DESCRIPTION
The 'ProductVersion' section should now include the commit id in offical builds.

Something like this --
PS C:\MIEngine> filever -v .\bin\Debug\drop\Microsoft.MICore.dll
--a-- W32i   DLL   -    14.0.20817.0 shp    169,984 08-17-2015 microsoft.micore.dll
...
        ProductVersion  14.0.20817.0 commit:8650cf1287e9cfc1dfb0054b4317645eb1e6f4cf