### PR TITLE
Address code analysis error in LaunchOptions.cs

### DIFF
--- a/src/MICore/LaunchOptions.cs
+++ b/src/MICore/LaunchOptions.cs
@@ -469,6 +469,7 @@ namespace MICore
             settings.IgnoreProcessingInstructions = true;
             settings.IgnoreWhitespace = true;
             settings.NameTable = new NameTable();
+            settings.XmlResolver = null;
 
             // Create our own namespace manager so that we can set the default namespace
             // We need this because the XML serializer requires correct namespaces,


### PR DESCRIPTION
Previously we did not explicitly set the XmlResolver to null, which could theoratically cause an information disclosure if the XmlReader decided to go off and download external references. We now explicitly set it to null to prevent access to external resources.