### PR TITLE
Remove extra '()' from CLRDBG frames

### DIFF
--- a/src/MICore/MICommandFactory.cs
+++ b/src/MICore/MICommandFactory.cs
@@ -410,6 +410,14 @@ namespace MICore
 
         abstract public bool SupportsStopOnDynamicLibLoad();
 
+        /// <summary>
+        /// True if the underlying debugger can format frames itself
+        /// </summary>
+        public virtual bool SupportsFrameFormatting
+        {
+            get { return true; }
+        }
+
         public virtual bool IsAsyncBreakSignal(Results results)
         {
             return (results.TryFindString("reason") == "signal-received" && results.TryFindString("signal-name") == "SIGINT");
@@ -668,6 +676,12 @@ namespace MICore
             return false;
         }
 
+        // CLRDBG supports frame formatting itself
+        override public bool SupportsFrameFormatting
+        {
+            get { return true; }
+        }
+
         public override bool AllowCommandsWhileRunning()
         {
             return true;
@@ -675,8 +689,8 @@ namespace MICore
 
         public override Task<TupleValue[]> StackListArguments(PrintValues printValues, int threadId, uint lowFrameLevel, uint hiFrameLevel)
         {
-            // TODO: for clrdbg, we should get this from the original stack walk instead
-            return Task<TupleValue[]>.FromResult(new TupleValue[0]);
+            // CLRDBG supports stack frame formatting, so this should not be used
+            throw new NotImplementedException();
         }
 
         protected override async Task<Results> ThreadFrameCmdAsync(string command, ResultClass exepctedResultClass, int threadId, uint frameLevel)

--- a/src/MIDebugEngine/AD7.Impl/AD7StackFrame.cs
+++ b/src/MIDebugEngine/AD7.Impl/AD7StackFrame.cs
@@ -60,7 +60,7 @@ namespace Microsoft.MIDebugEngine
         public void SetFrameInfo(enum_FRAMEINFO_FLAGS dwFieldSpec, out FRAMEINFO frameInfo)
         {
             List<SimpleVariableInformation> parameters = null;
-            if ((dwFieldSpec & enum_FRAMEINFO_FLAGS.FIF_FUNCNAME_ARGS) != 0)
+            if ((dwFieldSpec & enum_FRAMEINFO_FLAGS.FIF_FUNCNAME_ARGS) != 0 && !this.Engine.DebuggedProcess.MICommandFactory.SupportsFrameFormatting)
             {
                 Engine.DebuggedProcess.WorkerThread.RunOperation(async () =>
                 {
@@ -94,7 +94,7 @@ namespace Microsoft.MIDebugEngine
 
                     frameInfo.m_bstrFuncName += _functionName;
 
-                    if ((dwFieldSpec & enum_FRAMEINFO_FLAGS.FIF_FUNCNAME_ARGS) != 0)
+                    if ((dwFieldSpec & enum_FRAMEINFO_FLAGS.FIF_FUNCNAME_ARGS) != 0 && !Engine.DebuggedProcess.MICommandFactory.SupportsFrameFormatting)
                     {
                         frameInfo.m_bstrFuncName += "(";
                         if (parameters != null && parameters.Count > 0)

--- a/src/MIDebugEngine/AD7.Impl/AD7Thread.cs
+++ b/src/MIDebugEngine/AD7.Impl/AD7Thread.cs
@@ -133,7 +133,7 @@ namespace Microsoft.MIDebugEngine
                     frameInfoArray = new FRAMEINFO[numStackFrames];
                     List<ArgumentList> parameters = null;
 
-                    if ((dwFieldSpec & enum_FRAMEINFO_FLAGS.FIF_FUNCNAME_ARGS) != 0)
+                    if ((dwFieldSpec & enum_FRAMEINFO_FLAGS.FIF_FUNCNAME_ARGS) != 0 && !_engine.DebuggedProcess.MICommandFactory.SupportsFrameFormatting)
                     {
                         _engine.DebuggedProcess.WorkerThread.RunOperation(async () => parameters = await _engine.DebuggedProcess.GetParameterInfoOnly(this, (dwFieldSpec & enum_FRAMEINFO_FLAGS.FIF_FUNCNAME_ARGS_VALUES) != 0,
                             (dwFieldSpec & enum_FRAMEINFO_FLAGS.FIF_FUNCNAME_ARGS_TYPES) != 0, low, high));


### PR DESCRIPTION
CLRDBG will format frames itself, so the MIEngine doesn't need to append arguments. In the initial bring up, I disabled fetching the arguments, but MIEngine was still adding an extra '()' at the end of frames. This removes that.