### PR TITLE
Address FxCop error in Natvis.cs

### DIFF
--- a/src/MIDebugEngine/Natvis.Impl/Natvis.cs
+++ b/src/MIDebugEngine/Natvis.Impl/Natvis.cs
@@ -210,8 +210,14 @@ namespace Microsoft.MIDebugEngine.Natvis
                     _process.WriteOutput(String.Format(CultureInfo.CurrentCulture, ResourceStrings.FileNotFound, path));
                     return false;
                 }
+                XmlReaderSettings settings = new XmlReaderSettings();
+                settings.IgnoreComments = true;
+                settings.IgnoreProcessingInstructions = true;
+                settings.IgnoreWhitespace = true;
+                settings.XmlResolver = null;
+
                 using (var stream = new System.IO.FileStream(path, FileMode.Open, FileAccess.Read))
-                using (var reader = XmlReader.Create(stream))
+                using (var reader = XmlReader.Create(stream, settings))
                 {
                     AutoVisualizer autoVis = null;
                     autoVis = serializer.Deserialize(reader) as AutoVisualizer;


### PR DESCRIPTION
The new version of FxCop we are now using in official builds is issuing an error in the use of XmlReader by the natvis code. The error is because we were not providing a settings object which set the XmlResolver property set to null. With this checkin we are now doing that.

I also made the code a bit closer to our launch option reader code by having the XmlReader ignore a bunch of things that we will not care about (comments, processing instructions, whitespace).