### PR TITLE
Fix LLDB/GDB Frame formatting

### DIFF
--- a/src/MICore/MICommandFactory.cs
+++ b/src/MICore/MICommandFactory.cs
@@ -415,7 +415,7 @@ namespace MICore
         /// </summary>
         public virtual bool SupportsFrameFormatting
         {
-            get { return true; }
+            get { return false; }
         }
 
         public virtual bool IsAsyncBreakSignal(Results results)


### PR DESCRIPTION
Commit e2c73817b9db22e7cc04600e311d9732089c3752 regressed LLDB/GDB Frame formatting because I accentially returned the wrong value in the base virtual method. This fixes it.