### PR TITLE
64 bit support for android debugging

### DIFF
--- a/IL/libadb.il
+++ b/IL/libadb.il
@@ -852,12 +852,14 @@
        extends [mscorlib]System.Enum
 {
   .field public specialname rtspecialname int32 value__
+  .field public static literal valuetype libadb.DeviceAbi unknown = int32(0x00000000)
+  .field public static literal valuetype libadb.DeviceAbi 'x86' = int32(0x00000001)
   .field public static literal valuetype libadb.DeviceAbi armeabi = int32(0x00000002)
   .field public static literal valuetype libadb.DeviceAbi armeabiv7a = int32(0x00000003)
   .field public static literal valuetype libadb.DeviceAbi mips = int32(0x00000004)
   .field public static literal valuetype libadb.DeviceAbi mipsr2 = int32(0x00000005)
-  .field public static literal valuetype libadb.DeviceAbi unknown = int32(0x00000000)
-  .field public static literal valuetype libadb.DeviceAbi 'x86' = int32(0x00000001)
+  .field public static literal valuetype libadb.DeviceAbi x64 = int32(0x00000006)
+  .field public static literal valuetype libadb.DeviceAbi arm64v8a = int32(0x00000007)
 } // end of class libadb.DeviceAbi
 
 .class public auto ansi sealed libadb.DeviceState

--- a/src/AndroidDebugLauncher/AndroidLaunchOptions.cs
+++ b/src/AndroidDebugLauncher/AndroidLaunchOptions.cs
@@ -121,10 +121,13 @@ namespace AndroidDebugLauncher
             switch (this.TargetArchitecture)
             {
                 case MICore.TargetArchitecture.X86:
+                case MICore.TargetArchitecture.X64:
                 case MICore.TargetArchitecture.ARM:
+                case MICore.TargetArchitecture.ARM64:
                     return;
 
                 default:
+
                     throw new LauncherException(Telemetry.LaunchFailureCode.NoReport, string.Format(CultureInfo.CurrentCulture, LauncherResources.UnsupportedTargetArchitecture, this.TargetArchitecture));
             }
         }

--- a/src/AndroidDebugLauncher/InstallPaths.cs
+++ b/src/AndroidDebugLauncher/InstallPaths.cs
@@ -64,9 +64,19 @@ namespace AndroidDebugLauncher
                     possibleGDBPaths = NDKToolChainFilePath.x86_GDBPaths();
                     break;
 
+                case MICore.TargetArchitecture.X64:
+                    targetArchitectureName = "x64";
+                    possibleGDBPaths = NDKToolChainFilePath.x64_GDBPaths();
+                    break;
+
                 case MICore.TargetArchitecture.ARM:
                     targetArchitectureName = "arm";
                     possibleGDBPaths = NDKToolChainFilePath.ARM_GDBPaths();
+                    break;
+
+                case MICore.TargetArchitecture.ARM64:
+                    targetArchitectureName = "arm64";
+                    possibleGDBPaths = NDKToolChainFilePath.ARM64_GDBPaths();
                     break;
 
                 default:

--- a/src/AndroidDebugLauncher/NDKToolChainFilePath.cs
+++ b/src/AndroidDebugLauncher/NDKToolChainFilePath.cs
@@ -39,12 +39,29 @@ namespace AndroidDebugLauncher
             };
         }
 
+        public static NDKToolChainFilePath[] x64_GDBPaths()
+        {
+            return new NDKToolChainFilePath[]
+            {
+                new NDKToolChainFilePath(@"x86_64", "4.9", @"prebuilt\windows\bin\x86_64-linux-android-gdb.exe"),
+                new NDKToolChainFilePath(@"x86_64", "4.9", @"prebuilt\windows-x86_64\bin\x86_64-linux-android-gdb.exe")
+            };
+        }
+
         public static NDKToolChainFilePath[] ARM_GDBPaths()
         {
             return new NDKToolChainFilePath[] {
                 new NDKToolChainFilePath("arm-linux-androideabi", "4.8", @"prebuilt\windows\bin\arm-linux-androideabi-gdb.exe"),
                 // NOTE: The 4.8 GDB from the windows-x86_64 NDK doesn't work (Symbol format `elf32-littlearm' unknown)
                 new NDKToolChainFilePath("arm-linux-androideabi", "4.6", @"prebuilt\windows-x86_64\bin\arm-linux-androideabi-gdb.exe")
+            };
+        }
+
+        public static NDKToolChainFilePath[] ARM64_GDBPaths()
+        {
+            return new NDKToolChainFilePath[] {
+                new NDKToolChainFilePath("aarch64-linux-android", "4.9", @"prebuilt\windows\bin\aarch64-linux-android-gdb.exe"),
+                new NDKToolChainFilePath("aarch64-linux-android", "4.9", @"prebuilt\windows-x86_64\bin\aarch64-linux-android-gdb.exe")
             };
         }
 

--- a/src/MICore/Debugger.cs
+++ b/src/MICore/Debugger.cs
@@ -327,6 +327,11 @@ namespace MICore
                     Is64BitArch = false;
                     break;
 
+                case TargetArchitecture.ARM64:
+                    MaxInstructionSize = 8;
+                    Is64BitArch = true;
+                    break;
+
                 case TargetArchitecture.X86:
                     MaxInstructionSize = 20;
                     Is64BitArch = false;

--- a/src/MICore/LaunchOptions.cs
+++ b/src/MICore/LaunchOptions.cs
@@ -21,6 +21,7 @@ namespace MICore
     {
         Unknown,
         ARM,
+        ARM64,
         X86,
         X64,
         Mips
@@ -716,6 +717,10 @@ namespace MICore
                 case Xml.LaunchOptions.TargetArchitecture.AMD64:
                 case Xml.LaunchOptions.TargetArchitecture.X86_64:
                     return TargetArchitecture.X64;
+
+                case Xml.LaunchOptions.TargetArchitecture.arm64:
+                case Xml.LaunchOptions.TargetArchitecture.ARM64:
+                    return TargetArchitecture.ARM64;
 
                 default:
                     throw new ArgumentException(string.Format(CultureInfo.CurrentCulture, MICoreResources.Error_UnknownTargetArchitecture, source.ToString()));

--- a/src/MICore/LaunchOptions.xsd
+++ b/src/MICore/LaunchOptions.xsd
@@ -125,6 +125,7 @@
     <xs:restriction base="xs:string">
       <xs:enumeration value="x86"/>
       <xs:enumeration value="arm"/>
+      <xs:enumeration value="arm64"/>
       <xs:enumeration value="mips"/>
       <xs:enumeration value="x64"/>
       <xs:enumeration value="amd64"/>
@@ -133,6 +134,7 @@
       <!--Allow them in upper case also-->
       <xs:enumeration value="X86"/>
       <xs:enumeration value="ARM"/>
+      <xs:enumeration value="ARM64"/>
       <xs:enumeration value="MIPS"/>
       <xs:enumeration value="X64"/>
       <xs:enumeration value="AMD64"/>

--- a/src/MICore/LaunchOptions.xsd.serializer.designer.cs
+++ b/src/MICore/LaunchOptions.xsd.serializer.designer.cs
@@ -255,12 +255,14 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             switch (v) {
                 case global::MICore.Xml.LaunchOptions.TargetArchitecture.@x86: s = @"x86"; break;
                 case global::MICore.Xml.LaunchOptions.TargetArchitecture.@arm: s = @"arm"; break;
+                case global::MICore.Xml.LaunchOptions.TargetArchitecture.@arm64: s = @"arm64"; break;
                 case global::MICore.Xml.LaunchOptions.TargetArchitecture.@mips: s = @"mips"; break;
                 case global::MICore.Xml.LaunchOptions.TargetArchitecture.@x64: s = @"x64"; break;
                 case global::MICore.Xml.LaunchOptions.TargetArchitecture.@amd64: s = @"amd64"; break;
                 case global::MICore.Xml.LaunchOptions.TargetArchitecture.@x86_64: s = @"x86_64"; break;
                 case global::MICore.Xml.LaunchOptions.TargetArchitecture.@X86: s = @"X86"; break;
                 case global::MICore.Xml.LaunchOptions.TargetArchitecture.@ARM: s = @"ARM"; break;
+                case global::MICore.Xml.LaunchOptions.TargetArchitecture.@ARM64: s = @"ARM64"; break;
                 case global::MICore.Xml.LaunchOptions.TargetArchitecture.@MIPS: s = @"MIPS"; break;
                 case global::MICore.Xml.LaunchOptions.TargetArchitecture.@X64: s = @"X64"; break;
                 case global::MICore.Xml.LaunchOptions.TargetArchitecture.@AMD64: s = @"AMD64"; break;
@@ -1078,12 +1080,14 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             switch (s) {
                 case @"x86": return global::MICore.Xml.LaunchOptions.TargetArchitecture.@x86;
                 case @"arm": return global::MICore.Xml.LaunchOptions.TargetArchitecture.@arm;
+                case @"arm64": return global::MICore.Xml.LaunchOptions.TargetArchitecture.@arm64;
                 case @"mips": return global::MICore.Xml.LaunchOptions.TargetArchitecture.@mips;
                 case @"x64": return global::MICore.Xml.LaunchOptions.TargetArchitecture.@x64;
                 case @"amd64": return global::MICore.Xml.LaunchOptions.TargetArchitecture.@amd64;
                 case @"x86_64": return global::MICore.Xml.LaunchOptions.TargetArchitecture.@x86_64;
                 case @"X86": return global::MICore.Xml.LaunchOptions.TargetArchitecture.@X86;
                 case @"ARM": return global::MICore.Xml.LaunchOptions.TargetArchitecture.@ARM;
+                case @"ARM64": return global::MICore.Xml.LaunchOptions.TargetArchitecture.@ARM64;
                 case @"MIPS": return global::MICore.Xml.LaunchOptions.TargetArchitecture.@MIPS;
                 case @"X64": return global::MICore.Xml.LaunchOptions.TargetArchitecture.@X64;
                 case @"AMD64": return global::MICore.Xml.LaunchOptions.TargetArchitecture.@AMD64;

--- a/src/MICore/LaunchOptions.xsd.types.desginer.cs
+++ b/src/MICore/LaunchOptions.xsd.types.desginer.cs
@@ -91,6 +91,9 @@ namespace MICore.Xml.LaunchOptions {
         arm,
         
         /// <remarks/>
+        arm64,
+        
+        /// <remarks/>
         mips,
         
         /// <remarks/>
@@ -107,6 +110,9 @@ namespace MICore.Xml.LaunchOptions {
         
         /// <remarks/>
         ARM,
+        
+        /// <remarks/>
+        ARM64,
         
         /// <remarks/>
         MIPS,


### PR DESCRIPTION
Implement 64 bit debugging support for native android apps. This work
required:

1. Adding the paths for the 64 bit targeted files on windows (gdb.exe,
linker, libc.so, etc.)
2. Adding ARM64 and x64 launch options support.
3. Working around 64 bit android issues with deployment.
4. Updating libadb.il for new abi's