### PR TITLE
CLRDBG message event + output window improvements

### DIFF
--- a/src/MIDebugEngine/Engine.Impl/EngineCallback.cs
+++ b/src/MIDebugEngine/Engine.Impl/EngineCallback.cs
@@ -139,7 +139,7 @@ namespace Microsoft.MIDebugEngine
 
         public void OnError(string message)
         {
-            SendMessage(message, AD7MessageEvent.Severity.Error, isAsync: true);
+            SendMessage(message, OutputMessage.Severity.Error, isAsync: true);
         }
 
         /// <summary>
@@ -148,12 +148,12 @@ namespace Microsoft.MIDebugEngine
         /// <param name="message">string to display to the user</param>
         public void OnErrorImmediate(string message)
         {
-            SendMessage(message, AD7MessageEvent.Severity.Error, isAsync: false);
+            SendMessage(message, OutputMessage.Severity.Error, isAsync: false);
         }
 
         public void OnWarning(string message)
         {
-            SendMessage(message, AD7MessageEvent.Severity.Warning, isAsync: true);
+            SendMessage(message, OutputMessage.Severity.Warning, isAsync: true);
         }
 
         public void OnModuleLoad(DebuggedModule debuggedModule)
@@ -197,12 +197,20 @@ namespace Microsoft.MIDebugEngine
             Send(eventObject, AD7OutputDebugStringEvent.IID, null);
         }
 
-        public void OnOutputMessage(string outputMessage, enum_MESSAGETYPE messageType)
+        public void OnOutputMessage(OutputMessage outputMessage)
         {
             try
             {
-                var eventObject = new AD7MessageEvent(outputMessage, messageType, isAsync: false, severity: AD7MessageEvent.Severity.Warning);
-                Send(eventObject, AD7MessageEvent.IID, null);
+                if (outputMessage.ErrorCode == 0)
+                {
+                    var eventObject = new AD7MessageEvent(outputMessage, isAsync:true);
+                    Send(eventObject, AD7MessageEvent.IID, null);
+                }
+                else
+                {
+                    var eventObject = new AD7ErrorEvent(outputMessage, isAsync:true);
+                    Send(eventObject, AD7ErrorEvent.IID, null);
+                }
             }
             catch
             {
@@ -374,14 +382,14 @@ namespace Microsoft.MIDebugEngine
             Send(eventObject, AD7CustomDebugEvent.IID, null);
         }
 
-        private void SendMessage(string message, AD7MessageEvent.Severity severity, bool isAsync)
+        private void SendMessage(string message, OutputMessage.Severity severity, bool isAsync)
         {
             try
             {
                 // IDebugErrorEvent2 is used to report error messages to the user when something goes wrong in the debug engine.
                 // The sample engine doesn't take advantage of this.
 
-                AD7MessageEvent eventObject = new AD7MessageEvent(message, enum_MESSAGETYPE.MT_MESSAGEBOX, isAsync, severity);
+                AD7MessageEvent eventObject = new AD7MessageEvent(new OutputMessage(message, enum_MESSAGETYPE.MT_MESSAGEBOX, severity), isAsync);
                 Send(eventObject, AD7MessageEvent.IID, null);
             }
             catch

--- a/src/MIDebugEngine/Engine.Impl/EngineCallback.cs
+++ b/src/MIDebugEngine/Engine.Impl/EngineCallback.cs
@@ -221,8 +221,6 @@ namespace Microsoft.MIDebugEngine
 
         public void OnProcessExit(uint exitCode)
         {
-            Debug.Assert(_engine.DebuggedProcess.WorkerThread.IsPollThread());
-
             AD7ProgramDestroyEvent eventObject = new AD7ProgramDestroyEvent(exitCode);
 
             try

--- a/src/MIDebugEngine/Engine.Impl/Structures.cs
+++ b/src/MIDebugEngine/Engine.Impl/Structures.cs
@@ -52,6 +52,32 @@ namespace Microsoft.MIDebugEngine
         }
     }
 
+    public class OutputMessage
+    {
+        public enum Severity
+        {
+            Error,
+            Warning
+        };
+
+        public readonly string Message;
+        public readonly enum_MESSAGETYPE MessageType;
+        public readonly Severity SeverityValue;
+
+        /// <summary>
+        /// Error HRESULT to send to the debug package. 0 (S_OK) if there is no associated error code.
+        /// </summary>
+        public readonly uint ErrorCode;
+
+        public OutputMessage(string message, enum_MESSAGETYPE messageType, Severity severity, uint errorCode = 0)
+        {
+            this.Message = message;
+            this.MessageType = messageType;
+            this.SeverityValue = severity;
+            this.ErrorCode = errorCode;
+        }
+    }
+
     public interface ISampleEngineCallback
     {
         void OnModuleLoad(DebuggedModule module);
@@ -60,7 +86,7 @@ namespace Microsoft.MIDebugEngine
         void OnThreadExit(DebuggedThread thread, uint exitCode);
         void OnProcessExit(uint exitCode);
         void OnOutputString(string outputString);
-        void OnOutputMessage(string message, enum_MESSAGETYPE messageType);
+        void OnOutputMessage(OutputMessage outputMessage);
 
         /// <summary>
         /// Raises an error event to Visual Studio, which will show a message box. Note that this function should never throw.

--- a/src/MIDebugEngine/MIDebugEngine.csproj
+++ b/src/MIDebugEngine/MIDebugEngine.csproj
@@ -76,6 +76,7 @@
     <Reference Include="Microsoft.VisualStudio.Debugger.Interop.11.0, Version=11.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
       <Private>False</Private>
     </Reference>
+    <Reference Include="Microsoft.VisualStudio.Debugger.Interop.12.0, Version=12.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL" />
     <Reference Include="Microsoft.VisualStudio.Debugger.InteropA, Version=9.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
       <Private>False</Private>
     </Reference>


### PR DESCRIPTION
commit 5b082abc997235668acbe7a892425b08d6efcd70
Author: Gregg Miskelly <greggm@microsoft.com>
Date:   Mon Sep 14 08:21:49 2015 -0700

    Support for CLRDBG 'message' events
    
    CLRDBG uses an MI Extension to send message events. This adds support for it to the MI Engine.

commit be9b8ca39044e5af13287ec4d54bb2aa4afecbcb
Author: Gregg Miskelly <greggm@microsoft.com>
Date:   Mon Sep 14 09:29:23 2015 -0700

    Output message improvements
    
    1. Using plink to send messages to the target debugger and back results in an echo of the command that we sent. We were treating this echo as debuggee output instead of ignoring it. Now we ignore it.
    
    2. We were echoing the output of message events, thread create events, and thread exit events. Not sure why. Now we aren't.
    
    3. The debugger was waiting for the first run mode transition in the underlying debugger to decide that AD7 was ready to receive output string events. This doesn't really make much sense since it is really the AD7 side which needs to be ready, and that has nothing to do with run mode events from the underlying debugger. Now we wait for the resume process call instead.
