### PR TITLE
Refactor registry access

### DIFF
--- a/src/AndroidDebugLauncher/Launcher.cs
+++ b/src/AndroidDebugLauncher/Launcher.cs
@@ -40,15 +40,15 @@ namespace AndroidDebugLauncher
         private const string LogcatServiceMessage_SourceId = "1CED0608-638C-4B00-A1D2-CE56B1B672FA";
         private const int LogcatServiceMessage_NewProcess = 0;
 
-        void IPlatformAppLauncher.Initialize(string registryRoot, IDeviceAppLauncherEventCallback eventCallback)
+        void IPlatformAppLauncher.Initialize(HostConfigurationStore configStore, IDeviceAppLauncherEventCallback eventCallback)
         {
-            if (string.IsNullOrEmpty(registryRoot))
-                throw new ArgumentNullException("registryRoot");
+            if (configStore == null)
+                throw new ArgumentNullException("configStore");
             if (eventCallback == null)
                 throw new ArgumentNullException("eventCallback");
 
             _eventCallback = eventCallback;
-            RegistryRoot.Set(registryRoot);
+            RegistryRoot.Set(configStore.RegistryRoot);
         }
 
         void IPlatformAppLauncher.SetLaunchOptions(string exePath, string args, string dir, object launcherXmlOptions)

--- a/src/DebugEngineHost/DebugEngineHost.csproj
+++ b/src/DebugEngineHost/DebugEngineHost.csproj
@@ -77,6 +77,9 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Host.cs" />
+    <Compile Include="HostConfigurationSection.cs" />
+    <Compile Include="HostConfigurationStore.cs" />
+    <Compile Include="HostConfirigurationException.cs" />
     <Compile Include="VSImpl\VSEventCallbackWrapper.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="HostMarshal.cs" />

--- a/src/DebugEngineHost/HostConfigurationSection.cs
+++ b/src/DebugEngineHost/HostConfigurationSection.cs
@@ -1,0 +1,47 @@
+﻿using Microsoft.Win32;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Microsoft.DebugEngineHost
+{
+    /// <summary>
+    /// Abstraction over a named section within the HostConfigurationStore. This provides the ability
+    /// to enumerate values within the section.
+    /// </summary>
+    public sealed class HostConfigurationSection : IDisposable
+    {
+        readonly RegistryKey _key;
+
+        internal HostConfigurationSection(RegistryKey key)
+        {
+            _key = key;
+        }
+
+        public void Dispose()
+        {
+            _key.Close();
+        }
+
+        /// <summary>
+        /// Obtains the value of the specified valueName
+        /// </summary>
+        /// <param name="valueName">Name of the value to obtain</param>
+        /// <returns>[Optional] null if the value doesn't exist, otherwise the value</returns>
+        public object GetValue(string valueName)
+        {
+            return _key.GetValue(valueName);
+        }
+
+        /// <summary>
+        /// Enumerates the names of all the values defined in this section
+        /// </summary>
+        /// <returns>Enumerator of strings</returns>
+        public IEnumerable<string> GetValueNames()
+        {
+            return _key.GetValueNames();
+        }
+    }
+}

--- a/src/DebugEngineHost/HostConfigurationStore.cs
+++ b/src/DebugEngineHost/HostConfigurationStore.cs
@@ -1,0 +1,73 @@
+﻿using Microsoft.Win32;
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Microsoft.DebugEngineHost
+{
+    public sealed class HostConfigurationStore
+    {
+        private string _engineId;
+        private string _registryRoot;
+        private RegistryKey _configKey;
+
+        public HostConfigurationStore(string registryRoot, string engineId)
+        {
+            if (string.IsNullOrEmpty(registryRoot))
+                throw new ArgumentNullException("registryRoot");
+            if (string.IsNullOrEmpty("engineId"))
+                throw new ArgumentNullException("engineId");
+
+            _registryRoot = registryRoot;
+            _engineId = engineId;
+            _configKey = Registry.LocalMachine.OpenSubKey(registryRoot);
+            if (_configKey == null)
+            {
+                throw new HostConfirigurationException(registryRoot);
+            }
+        }
+
+        // TODO: This should be removed. It is here only to make the Android launcher work for now
+        public string RegistryRoot
+        {
+            get
+            {
+                return _registryRoot;
+            }
+        }
+
+        public object GetEngineMetric(string metric)
+        {
+            return GetOptionalValue(@"AD7Metrics\Engine\" + _engineId.ToUpper(CultureInfo.InvariantCulture), metric);
+        }
+
+        public void GetExceptionCategorySettings(Guid categoryId, out HostConfigurationSection categoryConfigSection, out string categoryName)
+        {
+            string subKeyName = @"AD7Metrics\Exception\" + categoryId.ToString("B", CultureInfo.InvariantCulture);
+            RegistryKey categoryKey = _configKey.OpenSubKey(subKeyName);
+            if (categoryKey == null)
+            {
+                throw new HostConfirigurationException("$RegRoot$\\" + subKeyName);
+            }
+
+            categoryConfigSection = new HostConfigurationSection(categoryKey);
+            categoryName = categoryKey.GetSubKeyNames().Single();
+        }
+
+        public object GetOptionalValue(string section, string valueName)
+        {
+            using (RegistryKey key = _configKey.OpenSubKey(section))
+            {
+                if (key == null)
+                {
+                    return null;
+                }
+
+                return key.GetValue(valueName);
+            }
+        }
+    }
+}

--- a/src/DebugEngineHost/HostConfirigurationException.cs
+++ b/src/DebugEngineHost/HostConfirigurationException.cs
@@ -1,0 +1,14 @@
+﻿using System;
+
+namespace Microsoft.DebugEngineHost
+{
+    internal sealed class HostConfirigurationException : Exception
+    {
+        const int E_DEBUG_ENGINE_NOT_REGISTERED = unchecked((int)0x80040019);
+
+        public HostConfirigurationException(string missingLocation) : base(string.Format("Missing configuration section '{0}'", missingLocation))
+        {
+            this.HResult = E_DEBUG_ENGINE_NOT_REGISTERED;
+        }
+    }
+}

--- a/src/DebugEngineHost/HostLoader.cs
+++ b/src/DebugEngineHost/HostLoader.cs
@@ -20,13 +20,13 @@ namespace Microsoft.DebugEngineHost
         /// <summary>
         /// Looks up the specified CLSID in the VS registry and loads it
         /// </summary>
-        /// <param name="registryRoot">Registry root to lookup the type</param>
+        /// <param name="configStore">Registry root to lookup the type</param>
         /// <param name="clsid">CLSID to CoCreate</param>
         /// <returns>[Optional] loaded object. Null if the type is not registered, or points to a type that doesn't exist</returns>
-        public static object VsCoCreateManagedObject(string registryRoot, Guid clsid)
+        public static object VsCoCreateManagedObject(HostConfigurationStore configStore, Guid clsid)
         {
             string assemblyNameString, className, codeBase;
-            if (!GetManagedTypeInfoForCLSID(registryRoot, clsid, out assemblyNameString, out className, out codeBase))
+            if (!GetManagedTypeInfoForCLSID(configStore, clsid, out assemblyNameString, out className, out codeBase))
             {
                 return null;
             }
@@ -46,13 +46,13 @@ namespace Microsoft.DebugEngineHost
             return assemblyObject.CreateInstance(className);
         }
 
-        private static bool GetManagedTypeInfoForCLSID(string registryRoot, Guid clsid, out string assembly, out string className, out string codeBase)
+        private static bool GetManagedTypeInfoForCLSID(HostConfigurationStore configStore, Guid clsid, out string assembly, out string className, out string codeBase)
         {
             assembly = null;
             className = null;
             codeBase = null;
 
-            string keyPath = registryRoot + @"\CLSID\" + clsid.ToString("B");
+            string keyPath = configStore.RegistryRoot + @"\CLSID\" + clsid.ToString("B");
             using (RegistryKey key = Registry.LocalMachine.OpenSubKey(keyPath))
             {
                 if (key == null)

--- a/src/DebugEngineHost/HostNatvisProject.cs
+++ b/src/DebugEngineHost/HostNatvisProject.cs
@@ -16,7 +16,7 @@ namespace Microsoft.DebugEngineHost
     /// Provides interactions with the host's source workspace to locate and load any natvis files
     /// in the project.
     /// </summary>
-    public class HostNatvisProject
+    public static class HostNatvisProject
     {
         public delegate void NatvisLoader(string path);
 

--- a/src/DebugEngineHost/HostWaitDialog.cs
+++ b/src/DebugEngineHost/HostWaitDialog.cs
@@ -15,7 +15,7 @@ namespace Microsoft.DebugEngineHost
     /// Provides an optional wait dialog to allow long running operations to be canceled. Some hosts
     /// may not implement the dialog, in which case these methods will be a nop.
     /// </summary>
-    public class HostWaitDialog : IDisposable
+    public sealed class HostWaitDialog : IDisposable
     {
         private VSImpl.VSWaitDialog _theDialog;
         public HostWaitDialog(string format, string caption)

--- a/src/DebugEngineHost/HostWaitLoop.cs
+++ b/src/DebugEngineHost/HostWaitLoop.cs
@@ -11,7 +11,7 @@ using System.Threading.Tasks;
 
 namespace Microsoft.DebugEngineHost
 {
-    public class HostWaitLoop
+    public sealed class HostWaitLoop
     {
         private readonly object _progressLock = new object();
         private VSImpl.VsWaitLoop _vsWaitLoop;

--- a/src/IOSDebugLauncher/Launcher.cs
+++ b/src/IOSDebugLauncher/Launcher.cs
@@ -19,6 +19,7 @@ using System.Threading;
 using System.Runtime.ExceptionServices;
 using Newtonsoft.Json;
 using System.Collections.ObjectModel;
+using Microsoft.DebugEngineHost;
 
 namespace IOSDebugLauncher
 {
@@ -42,7 +43,7 @@ namespace IOSDebugLauncher
         }
         private RemotePorts _remotePorts;
 
-        void IPlatformAppLauncher.Initialize(string registryRoot, IDeviceAppLauncherEventCallback eventCallback)
+        void IPlatformAppLauncher.Initialize(HostConfigurationStore configStore, IDeviceAppLauncherEventCallback eventCallback)
         {
             _callback = eventCallback;
         }

--- a/src/MICore/LaunchOptions.cs
+++ b/src/MICore/LaunchOptions.cs
@@ -355,16 +355,13 @@ namespace MICore
             }
         }
 
-        public static LaunchOptions GetInstance(string registryRoot, string exePath, string args, string dir, string options, IDeviceAppLauncherEventCallback eventCallback)
+        public static LaunchOptions GetInstance(HostConfigurationStore configStore, string exePath, string args, string dir, string options, IDeviceAppLauncherEventCallback eventCallback)
         {
             if (string.IsNullOrWhiteSpace(exePath))
                 throw new ArgumentNullException("exePath");
 
             if (string.IsNullOrWhiteSpace(options))
                 throw new InvalidLaunchOptionsException(MICoreResources.Error_StringIsNullOrEmpty);
-
-            if (string.IsNullOrEmpty(registryRoot))
-                throw new ArgumentNullException("registryRoot");
 
             Logger.WriteTextBlock("LaunchOptions", options);
 
@@ -444,7 +441,7 @@ namespace MICore
 
             if (clsidLauncher != Guid.Empty)
             {
-                launchOptions = ExecuteLauncher(registryRoot, clsidLauncher, exePath, args, dir, launcherXmlOptions, eventCallback);
+                launchOptions = ExecuteLauncher(configStore, clsidLauncher, exePath, args, dir, launcherXmlOptions, eventCallback);
             }
 
             if (launchOptions.ExePath == null)
@@ -651,9 +648,9 @@ namespace MICore
             return attributeValue;
         }
 
-        private static LaunchOptions ExecuteLauncher(string registryRoot, Guid clsidLauncher, string exePath, string args, string dir, object launcherXmlOptions, IDeviceAppLauncherEventCallback eventCallback)
+        private static LaunchOptions ExecuteLauncher(HostConfigurationStore configStore, Guid clsidLauncher, string exePath, string args, string dir, object launcherXmlOptions, IDeviceAppLauncherEventCallback eventCallback)
         {
-            var deviceAppLauncher = (IPlatformAppLauncher)HostLoader.VsCoCreateManagedObject(registryRoot, clsidLauncher);
+            var deviceAppLauncher = (IPlatformAppLauncher)HostLoader.VsCoCreateManagedObject(configStore, clsidLauncher);
             if (deviceAppLauncher == null)
             {
                 throw new ApplicationException(string.Format(CultureInfo.CurrentCulture, MICoreResources.Error_LauncherNotFound, clsidLauncher.ToString("B")));
@@ -665,7 +662,7 @@ namespace MICore
             {
                 try
                 {
-                    deviceAppLauncher.Initialize(registryRoot, eventCallback);
+                    deviceAppLauncher.Initialize(configStore, eventCallback);
                     deviceAppLauncher.SetLaunchOptions(exePath, args, dir, launcherXmlOptions);
                 }
                 catch (Exception e) when (!(e is InvalidLaunchOptionsException))
@@ -742,9 +739,9 @@ namespace MICore
         /// <summary>
         /// Initialized the device app launcher
         /// </summary>
-        /// <param name="registryRoot">Current VS registry root</param>
+        /// <param name="configStore">Current VS registry root</param>
         /// <param name="eventCallback">[Required] Callback object used to send events to the rest of Visual Studio</param>
-        void Initialize(string registryRoot, IDeviceAppLauncherEventCallback eventCallback);
+        void Initialize(HostConfigurationStore configStore, IDeviceAppLauncherEventCallback eventCallback);
 
         /// <summary>
         /// Initializes the launcher from the launch settings

--- a/src/MICore/Logger.cs
+++ b/src/MICore/Logger.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using Microsoft.Win32;
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
@@ -12,6 +11,7 @@ using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using System.Globalization;
+using Microsoft.DebugEngineHost;
 
 namespace MICore
 {
@@ -27,21 +27,14 @@ namespace MICore
         // NOTE: We never clean this up
         private static StreamWriter s_streamWriter;
 
-        public static void EnsureInitialized(string registryRoot)
+        public static void EnsureInitialized(HostConfigurationStore configStore)
         {
             if (!s_isInitialized)
             {
                 s_isInitialized = true;
                 s_initTime = DateTime.Now;
 
-                RegistryKey key = Registry.LocalMachine.OpenSubKey(registryRoot + @"\Debugger");
-                if (key == null)
-                {
-                    Debug.Fail("Why is Debugger key missing?");
-                    return;
-                }
-
-                object enableMILoggerValue = key.GetValue("EnableMIDebugLogger");
+                object enableMILoggerValue = configStore.GetOptionalValue("Debugger", "EnableMIDebugLogger");
                 if (IsRegValueTrue(enableMILoggerValue))
                 {
                     string tempDirectory = Environment.GetEnvironmentVariable("TMP");

--- a/src/MICoreUnitTests/BasicLaunchOptionsTests.cs
+++ b/src/MICoreUnitTests/BasicLaunchOptionsTests.cs
@@ -287,7 +287,7 @@ namespace MICoreUnitTests
 
         private LaunchOptions GetLaunchOptions(string content)
         {
-            return LaunchOptions.GetInstance("bogus-registry-root", "bogus-exe-path", null, null, content, null);
+            return LaunchOptions.GetInstance(null, "bogus-exe-path", null, null, content, null);
         }
     }
 }

--- a/src/MICoreUnitTests/MICoreUnitTests.csproj
+++ b/src/MICoreUnitTests/MICoreUnitTests.csproj
@@ -103,9 +103,17 @@
       <Project>{e0844bff-2d67-4cb0-8e2a-e9cd888f2eb0}</Project>
       <Name>AndroidDebugLauncher</Name>
     </ProjectReference>
+    <ProjectReference Include="..\DebugEngineHost\DebugEngineHost.csproj">
+      <Project>{e659fee3-7773-4a73-880a-83ce5c9634cc}</Project>
+      <Name>DebugEngineHost</Name>
+    </ProjectReference>
     <ProjectReference Include="..\MICore\MICore.csproj">
       <Project>{12cc862d-95b7-4224-8e16-b928c6333677}</Project>
       <Name>MICore</Name>
+    </ProjectReference>
+    <ProjectReference Include="..\MIDebugEngine\MIDebugEngine.csproj">
+      <Project>{6d2688fe-6fd8-44a8-b96a-6037457f72a7}</Project>
+      <Name>MIDebugEngine</Name>
     </ProjectReference>
   </ItemGroup>
   <ItemGroup>

--- a/src/MIDebugEngine/AD7.Impl/AD7Engine.cs
+++ b/src/MIDebugEngine/AD7.Impl/AD7Engine.cs
@@ -11,7 +11,6 @@ using System.Threading;
 using System.Threading.Tasks;
 using MICore;
 using System.Globalization;
-using Microsoft.Win32;
 using Microsoft.DebugEngineHost;
 
 namespace Microsoft.MIDebugEngine
@@ -51,7 +50,7 @@ namespace Microsoft.MIDebugEngine
         // A unique identifier for the program being debugged.
         private Guid _ad7ProgramId;
 
-        private string _registryRoot;
+        private HostConfigurationStore _configStore;
 
         private IDebugSettingsCallback110 _settingsCallback;
 
@@ -109,15 +108,8 @@ namespace Microsoft.MIDebugEngine
 
         public object GetMetric(string metric)
         {
-            using (RegistryKey key = Registry.LocalMachine.OpenSubKey(_registryRoot + @"\AD7Metrics\Engine\" + EngineConstants.EngineId.ToUpper(CultureInfo.InvariantCulture)))
-            {
-                if (key == null)
-                {
-                    return null;
-                }
-
-                return key.GetValue(metric);
-            }
+            return _configStore.GetEngineMetric(metric);
+            
         }
 
         #region IDebugEngine2 Members
@@ -335,8 +327,8 @@ namespace Microsoft.MIDebugEngine
         // This allows the debugger to tell the engine where that location is.
         int IDebugEngine2.SetRegistryRoot(string registryRoot)
         {
-            _registryRoot = registryRoot;
-            Logger.EnsureInitialized(registryRoot);
+            _configStore = new HostConfigurationStore(registryRoot, EngineConstants.EngineId);
+            Logger.EnsureInitialized(_configStore);
             return Constants.S_OK;
         }
 
@@ -396,7 +388,7 @@ namespace Microsoft.MIDebugEngine
             try
             {
                 // Note: LaunchOptions.GetInstance can be an expensive operation and may push a wait message loop
-                LaunchOptions launchOptions = LaunchOptions.GetInstance(_registryRoot, exe, args, dir, options, _engineCallback);
+                LaunchOptions launchOptions = LaunchOptions.GetInstance(_configStore, exe, args, dir, options, _engineCallback);
 
                 // We are being asked to debug a process when we currently aren't debugging anything
                 _pollThread = new WorkerThread();
@@ -408,7 +400,7 @@ namespace Microsoft.MIDebugEngine
                     {
                         try
                         {
-                            _debuggedProcess = new DebuggedProcess(true, launchOptions, _engineCallback, _pollThread, _breakpointManager, this, _registryRoot);
+                            _debuggedProcess = new DebuggedProcess(true, launchOptions, _engineCallback, _pollThread, _breakpointManager, this, _configStore);
                         }
                         finally
                         {

--- a/src/MIDebugEngine/Engine.Impl/DebuggedProcess.cs
+++ b/src/MIDebugEngine/Engine.Impl/DebuggedProcess.cs
@@ -45,7 +45,7 @@ namespace Microsoft.MIDebugEngine
         private ReadOnlyCollection<RegisterDescription> _registers;
         private ReadOnlyCollection<RegisterGroup> _registerGroups;
 
-        public DebuggedProcess(bool bLaunched, LaunchOptions launchOptions, ISampleEngineCallback callback, WorkerThread worker, BreakpointManager bpman, AD7Engine engine, string registryRoot)
+        public DebuggedProcess(bool bLaunched, LaunchOptions launchOptions, ISampleEngineCallback callback, WorkerThread worker, BreakpointManager bpman, AD7Engine engine, HostConfigurationStore configStore)
         {
             uint processExitCode = 0;
             g_Process = this;
@@ -72,7 +72,7 @@ namespace Microsoft.MIDebugEngine
             _moduleList = new List<DebuggedModule>();
             ThreadCache = new ThreadCache(callback, this);
             Disassembly = new Disassembly(this);
-            ExceptionManager = new ExceptionManager(MICommandFactory, _worker, _callback, registryRoot);
+            ExceptionManager = new ExceptionManager(MICommandFactory, _worker, _callback, configStore);
 
             VariablesToDelete = new List<string>();
 

--- a/src/MIDebugEngine/Natvis.Impl/Natvis.cs
+++ b/src/MIDebugEngine/Natvis.Impl/Natvis.cs
@@ -15,7 +15,6 @@ using System.Text.RegularExpressions;
 using System.Xml.Serialization;
 using System.Xml;
 using System.IO;
-using Microsoft.Win32;
 using Microsoft.DebugEngineHost;
 
 namespace Microsoft.MIDebugEngine.Natvis


### PR DESCRIPTION
This moves registry access out of MIDebugEngine/MICore and into DebugEngineHost. This allows us to swap out a different configuration store in VS Code.