### PR TITLE
Remove quotes in -var-list-children

### DIFF
--- a/src/MIDebugEngine/Engine.Impl/Variables.cs
+++ b/src/MIDebugEngine/Engine.Impl/Variables.cs
@@ -483,7 +483,7 @@ namespace Microsoft.MIDebugEngine
         }
         private async Task InternalFetchChildren()
         {
-            Results results = await _engine.DebuggedProcess.CmdAsync(string.Format("-var-list-children --simple-values \"{0}\"", _internalName), ResultClass.None);
+            Results results = await _engine.DebuggedProcess.CmdAsync(string.Format("-var-list-children --simple-values {0}", _internalName), ResultClass.None);
 
             if (results.ResultClass == ResultClass.done)
             {


### PR DESCRIPTION
lldb does not accept quotes by default and gdb does not required them.