### PR TITLE
DebugEngineHost Fixes

### DIFF
--- a/build/miengine.settings.targets
+++ b/build/miengine.settings.targets
@@ -47,7 +47,7 @@
     <BuildNumberMinor>0</BuildNumberMinor>
     <BuildNumberMinor Condition="$(BuildDateRevision.Length) &gt; 9">$(BuildDateRevision.Substring(9))</BuildNumberMinor>
 
-    <AssemblyVersion>$(MajorVersion).$(MinorVersion).0</AssemblyVersion>
+    <AssemblyVersion Condition="'$(AssemblyVersion)'==''">$(MajorVersion).$(MinorVersion).0</AssemblyVersion>
     <BuildVersion>$(MajorVersion).$(MinorVersion).$(BuildNumberMajor).$(BuildNumberMinor)</BuildVersion>
     <BuildVersionExtended>$(BuildVersion)</BuildVersionExtended>
     <BuildVersionExtended Condition="'$(TF_BUILD_SOURCEGETVERSION)'!=''">$(BuildVersionExtended) commit:$(TF_BUILD_SOURCEGETVERSION)</BuildVersionExtended>

--- a/src/AndroidDebugLauncher/AndroidDebugLauncher.csproj
+++ b/src/AndroidDebugLauncher/AndroidDebugLauncher.csproj
@@ -140,6 +140,7 @@
     <ProjectReference Include="..\DebugEngineHost.Stub\DebugEngineHost.Stub.csproj">
       <Project>{ea876a2d-ab0f-4204-97dd-dfb3b5568978}</Project>
       <Name>DebugEngineHost.Stub</Name>
+      <Private>False</Private>
     </ProjectReference>
     <ProjectReference Include="..\JDbg\JDbg.csproj">
       <Project>{78728205-db3e-4b7b-a7d2-5cbe38e9c607}</Project>

--- a/src/DebugEngineHost.Stub/DebugEngineHost.Stub.csproj
+++ b/src/DebugEngineHost.Stub/DebugEngineHost.Stub.csproj
@@ -1,5 +1,12 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+
+  <PropertyGroup>
+    <!--Fix the assembly version for DebugEngineHost as all the versions of this dll must have the same assembly identity
+    NOTE: Ths must be set BEFORE improting miengine.settings.targets-->
+    <AssemblyVersion>1.0.0</AssemblyVersion>
+  </PropertyGroup>  
+  
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <Import Project="..\..\build\miengine.settings.targets" />
   <PropertyGroup>
@@ -52,6 +59,7 @@
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <Import Project="$(MSBuildExtensionsPath32)\Microsoft\Portable\$(TargetFrameworkVersion)\Microsoft.Portable.CSharp.targets" />
+  <Import Project="..\..\build\miengine.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it.
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">

--- a/src/DebugEngineHost.Stub/Properties/AssemblyInfo.cs
+++ b/src/DebugEngineHost.Stub/Properties/AssemblyInfo.cs
@@ -6,25 +6,9 @@ using System.Runtime.InteropServices;
 // General Information about an assembly is controlled through the following 
 // set of attributes. Change these attribute values to modify the information
 // associated with an assembly.
-[assembly: AssemblyTitle("DebugEngineHost.Stub")]
-[assembly: AssemblyDescription("")]
+[assembly: AssemblyTitle("Microsoft.DebugEngineHost")]
+[assembly: AssemblyDescription("Contract version of Microsoft.DebugEngineHost. This assembly is not runnable.")]
 [assembly: AssemblyConfiguration("")]
-[assembly: AssemblyCompany("")]
-[assembly: AssemblyProduct("DebugEngineHost.Stub")]
-[assembly: AssemblyCopyright("Copyright ©  2015")]
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]
 [assembly: NeutralResourcesLanguage("en")]
-
-// Version information for an assembly consists of the following four values:
-//
-//      Major Version
-//      Minor Version 
-//      Build Number
-//      Revision
-//
-// You can specify all the values or you can default the Build and Revision Numbers 
-// by using the '*' as shown below:
-// [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.0.0.0")]
-[assembly: AssemblyFileVersion("1.0.0.0")]

--- a/src/DebugEngineHost/DebugEngineHost.csproj
+++ b/src/DebugEngineHost/DebugEngineHost.csproj
@@ -1,5 +1,12 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  
+  <PropertyGroup>
+    <!--Fix the assembly version for DebugEngineHost as all the versions of this dll must have the same assembly identity
+    NOTE: Ths must be set BEFORE improting miengine.settings.targets-->
+    <AssemblyVersion>1.0.0</AssemblyVersion>
+  </PropertyGroup>
+  
   <Import Project="..\..\build\miengine.settings.targets" />
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
@@ -40,7 +47,9 @@
     <Reference Include="Microsoft.VisualStudio.Debugger.Interop.11.0, Version=11.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
       <Private>False</Private>
     </Reference>
-    <Reference Include="Microsoft.VisualStudio.Debugger.Interop.12.0, Version=12.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL" />
+    <Reference Include="Microsoft.VisualStudio.Debugger.Interop.12.0, Version=12.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <Private>False</Private>
+    </Reference>
     <Reference Include="Microsoft.VisualStudio.Debugger.InteropA, Version=9.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
       <Private>False</Private>
     </Reference>

--- a/src/IOSDebugLauncher/IOSDebugLauncher.csproj
+++ b/src/IOSDebugLauncher/IOSDebugLauncher.csproj
@@ -66,19 +66,19 @@
     </Reference>
     <Reference Include="System.Security.Cryptography.Algorithms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <HintPath>..\packages\System.Security.Cryptography.Algorithms.4.0.0-beta-23225\lib\net46\System.Security.Cryptography.Algorithms.dll</HintPath>
-      <Private>True</Private>
+      <Private>False</Private>
     </Reference>
     <Reference Include="System.Security.Cryptography.Encoding, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <HintPath>..\packages\System.Security.Cryptography.Encoding.4.0.0-beta-23225\lib\net46\System.Security.Cryptography.Encoding.dll</HintPath>
-      <Private>True</Private>
+      <Private>False</Private>
     </Reference>
     <Reference Include="System.Security.Cryptography.Primitives, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <HintPath>..\packages\System.Security.Cryptography.Primitives.4.0.0-beta-23225\lib\net46\System.Security.Cryptography.Primitives.dll</HintPath>
-      <Private>True</Private>
+      <Private>False</Private>
     </Reference>
     <Reference Include="System.Security.Cryptography.X509Certificates, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <HintPath>..\packages\System.Security.Cryptography.X509Certificates.4.0.0-beta-23225\lib\net46\System.Security.Cryptography.X509Certificates.dll</HintPath>
-      <Private>True</Private>
+      <Private>False</Private>
     </Reference>
     <Reference Include="System.Xml.Linq" />
     <Reference Include="System.Data.DataSetExtensions" />
@@ -125,6 +125,7 @@
     <ProjectReference Include="..\DebugEngineHost.Stub\DebugEngineHost.Stub.csproj">
       <Project>{ea876a2d-ab0f-4204-97dd-dfb3b5568978}</Project>
       <Name>DebugEngineHost.Stub</Name>
+      <Private>False</Private>
     </ProjectReference>
     <ProjectReference Include="..\MICore\MICore.csproj">
       <Project>{54c33afa-438d-4932-a2f0-d0f2bb2fadc9}</Project>

--- a/src/MICore/MICore.csproj
+++ b/src/MICore/MICore.csproj
@@ -114,6 +114,7 @@
     <ProjectReference Include="..\DebugEngineHost.Stub\DebugEngineHost.Stub.csproj">
       <Project>{ea876a2d-ab0f-4204-97dd-dfb3b5568978}</Project>
       <Name>DebugEngineHost.Stub</Name>
+      <Private>False</Private>
     </ProjectReference>
   </ItemGroup>
   <Import Project="$(MSBuildExtensionsPath32)\Microsoft\Portable\$(TargetFrameworkVersion)\Microsoft.Portable.CSharp.targets" />

--- a/src/MIDebugEngine/MIDebugEngine.csproj
+++ b/src/MIDebugEngine/MIDebugEngine.csproj
@@ -126,6 +126,7 @@
     <ProjectReference Include="..\DebugEngineHost.Stub\DebugEngineHost.Stub.csproj">
       <Project>{ea876a2d-ab0f-4204-97dd-dfb3b5568978}</Project>
       <Name>DebugEngineHost.Stub</Name>
+      <Private>False</Private>
     </ProjectReference>
     <ProjectReference Include="..\MICore\MICore.csproj">
       <Project>{54c33afa-438d-4932-a2f0-d0f2bb2fadc9}</Project>

--- a/src/MIDebugPackage/MIDebugPackage.csproj
+++ b/src/MIDebugPackage/MIDebugPackage.csproj
@@ -156,26 +156,26 @@
     <Content Include="Resources\Package.ico" />
   </ItemGroup>
   <ItemGroup>
-    <DropUnsignedFile Include="$(OutDir)\Microsoft.Android.natvis"/>
-    <DropSignedFile Include="$(OutDir)\Microsoft.AndroidDebugLauncher.dll"/>
-    <DropUnsignedFile Include="$(OutDir)\Microsoft.AndroidDebugLauncher.pdb"/>
-    <DropUnsignedFile Include="$(OutDir)\Microsoft.AndroidDebugLauncher.pkgdef"/>
-    <DropSignedFile Include="$(OutDir)\Microsoft.IOSDebugLauncher.dll"/>
-    <DropUnsignedFile Include="$(OutDir)\Microsoft.IOSDebugLauncher.pdb"/>
-    <DropUnsignedFile Include="$(OutDir)\Microsoft.IOSDebugLauncher.pkgdef"/>
-    <DropSignedFile Include="$(OutDir)\Microsoft.JDbg.dll"/>
-    <DropUnsignedFile Include="$(OutDir)\Microsoft.JDbg.pdb"/>
-    <DropSignedFile Include="$(OutDir)\Microsoft.MICore.dll"/>
-    <DropUnsignedFile Include="$(OutDir)\Microsoft.MICore.pdb"/>
-    <DropSignedFile Include="$(OutDir)\Microsoft.MIDebugEngine.dll"/>
-    <DropUnsignedFile Include="$(OutDir)\Microsoft.MIDebugEngine.pdb"/>
-    <DropUnsignedFile Include="$(OutDir)\Microsoft.MIDebugEngine.pkgdef"/>
-    <DropSignedFile Include="$(OutDir)\Microsoft.MIDebugPackage.dll"/>
-    <DropUnsignedFile Include="$(OutDir)\Microsoft.MIDebugPackage.pdb"/>
-    <DropUnsignedFile Include="$(OutDir)\Microsoft.MIDebugPackage.pkgdef"/>
-    <DropSignedFile Include="$(OutDir)\Microsoft.DebugEngineHost.dll"/>
-    <DropUnsignedFile Include="$(OutDir)\Microsoft.DebugEngineHost.pdb"/>
-    <DropUnsignedFile Include="Install.cmd"/>
+    <DropUnsignedFile Include="$(OutDir)\Microsoft.Android.natvis" />
+    <DropSignedFile Include="$(OutDir)\Microsoft.AndroidDebugLauncher.dll" />
+    <DropUnsignedFile Include="$(OutDir)\Microsoft.AndroidDebugLauncher.pdb" />
+    <DropUnsignedFile Include="$(OutDir)\Microsoft.AndroidDebugLauncher.pkgdef" />
+    <DropSignedFile Include="$(OutDir)\Microsoft.IOSDebugLauncher.dll" />
+    <DropUnsignedFile Include="$(OutDir)\Microsoft.IOSDebugLauncher.pdb" />
+    <DropUnsignedFile Include="$(OutDir)\Microsoft.IOSDebugLauncher.pkgdef" />
+    <DropSignedFile Include="$(OutDir)\Microsoft.JDbg.dll" />
+    <DropUnsignedFile Include="$(OutDir)\Microsoft.JDbg.pdb" />
+    <DropSignedFile Include="$(OutDir)\Microsoft.MICore.dll" />
+    <DropUnsignedFile Include="$(OutDir)\Microsoft.MICore.pdb" />
+    <DropSignedFile Include="$(OutDir)\Microsoft.MIDebugEngine.dll" />
+    <DropUnsignedFile Include="$(OutDir)\Microsoft.MIDebugEngine.pdb" />
+    <DropUnsignedFile Include="$(OutDir)\Microsoft.MIDebugEngine.pkgdef" />
+    <DropSignedFile Include="$(OutDir)\Microsoft.MIDebugPackage.dll" />
+    <DropUnsignedFile Include="$(OutDir)\Microsoft.MIDebugPackage.pdb" />
+    <DropUnsignedFile Include="$(OutDir)\Microsoft.MIDebugPackage.pkgdef" />
+    <DropSignedFile Include="$(OutDir)\Microsoft.DebugEngineHost.dll" />
+    <DropUnsignedFile Include="$(OutDir)\Microsoft.DebugEngineHost.pdb" />
+    <DropUnsignedFile Include="Install.cmd" />
     <DropUnsignedFile Include="$(OutDir)\Microsoft.Android.natvis" />
     <DropSignedFile Include="$(OutDir)\Microsoft.AndroidDebugLauncher.dll" />
     <DropUnsignedFile Include="$(OutDir)\Microsoft.AndroidDebugLauncher.pdb" />
@@ -209,9 +209,15 @@
       <Name>AndroidDebugLauncher</Name>
       <IncludeOutputGroupsInVSIX>BuiltProjectOutputGroup;BuiltProjectOutputGroupDependencies;GetCopyToOutputDirectoryItems;SatelliteDllsProjectOutputGroup;</IncludeOutputGroupsInVSIX>
     </ProjectReference>
+    <ProjectReference Include="..\DebugEngineHost\DebugEngineHost.csproj">
+      <Project>{e659fee3-7773-4a73-880a-83ce5c9634cc}</Project>
+      <Name>DebugEngineHost</Name>
+      <IncludeOutputGroupsInVSIX>BuiltProjectOutputGroup;BuiltProjectOutputGroupDependencies;GetCopyToOutputDirectoryItems;SatelliteDllsProjectOutputGroup;</IncludeOutputGroupsInVSIX>
+    </ProjectReference>
     <ProjectReference Include="..\IOSDebugLauncher\IOSDebugLauncher.csproj">
       <Project>{d2a11674-f677-4b11-9989-2f6099a6f0a2}</Project>
       <Name>IOSDebugLauncher</Name>
+      <IncludeOutputGroupsInVSIX>BuiltProjectOutputGroup;BuiltProjectOutputGroupDependencies;GetCopyToOutputDirectoryItems;SatelliteDllsProjectOutputGroup;</IncludeOutputGroupsInVSIX>
     </ProjectReference>
     <ProjectReference Include="..\MICore\MICore.csproj">
       <Project>{54c33afa-438d-4932-a2f0-d0f2bb2fadc9}</Project>


### PR DESCRIPTION
This fixes the assembly version of Microsoft.DebugEngineHost to be set to '1.0.0.0' so that it is consistent accross the various implementations.

This also fixes the VSIX to exclude the contract version of this assembly and instead use the VS version. Still need to figure out how to exclude a few other assemblies, but this is a good start.