### PR TITLE
Add device udid to appRemotePath call for vcremote

### DIFF
--- a/src/IOSDebugLauncher/VcRemoteClient.cs
+++ b/src/IOSDebugLauncher/VcRemoteClient.cs
@@ -58,7 +58,7 @@ namespace IOSDebugLauncher
         public Launcher.RemotePorts StartDebugListener()
         {
             string remotePortsJsonString;
-            CallVcRemote(new Uri("debug/setupForDebugging?target=" + _launchOptions.IOSDebugTarget.ToString() + "?deviceUdid=" + _launchOptions.DeviceUdid, UriKind.Relative), LauncherResources.Info_StartingDebugListener, out remotePortsJsonString);
+            CallVcRemote(new Uri("debug/setupForDebugging?target=" + _launchOptions.IOSDebugTarget.ToString() + "&deviceUdid=" + _launchOptions.DeviceUdid, UriKind.Relative), LauncherResources.Info_StartingDebugListener, out remotePortsJsonString);
 
             try
             {
@@ -74,7 +74,7 @@ namespace IOSDebugLauncher
         public string GetRemoteAppPath()
         {
             string appPath = string.Empty;
-            var response = CallVcRemote(new Uri("debug/appRemotePath/" + _launchOptions.PackageId, UriKind.Relative), LauncherResources.Info_GettingInfo, out appPath);
+            var response = CallVcRemote(new Uri("debug/appRemotePath?package" + _launchOptions.PackageId + "&deviceUdid=" + _launchOptions.DeviceUdid, UriKind.Relative), LauncherResources.Info_GettingInfo, out appPath);
 
             if (string.IsNullOrWhiteSpace(appPath))
             {


### PR DESCRIPTION
We need to send the device udid to both the seutp for debugging call and
the appremotepath call. In a perfect world, we would make this a global
setting in the header of all vcremote packets, but that fix will have to
wait for another day.

Additionally, fix a URI issue in setupForDebugging where the second '?'
needed to be an &.