### PR TITLE
Get MIEngine working after the refactor

### DIFF
--- a/src/MICoreUnitTests/MICoreUnitTests.csproj
+++ b/src/MICoreUnitTests/MICoreUnitTests.csproj
@@ -2,6 +2,7 @@
 <Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="..\packages\xunit.runner.visualstudio.2.0.0\build\net20\xunit.runner.visualstudio.props" Condition="Exists('..\packages\xunit.runner.visualstudio.2.0.0\build\net20\xunit.runner.visualstudio.props')" />
   <Import Project="..\packages\xunit.core.2.0.0\build\portable-net45+win+wpa81+wp80+monotouch+monoandroid+Xamarin.iOS\xunit.core.props" Condition="Exists('..\packages\xunit.core.2.0.0\build\portable-net45+win+wpa81+wp80+monotouch+monoandroid+Xamarin.iOS\xunit.core.props')" />
+  <Import Project="..\RequiredNetFX46FacadeAssemblies.targets" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
@@ -97,6 +98,9 @@
     <Compile Include="MIResultsTests.cs" />
     <Compile Include="NdkVersionTests.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
+    <None Include="@(RequiredNetFX46FacadeAssemblies)">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\AndroidDebugLauncher\AndroidDebugLauncher.csproj">

--- a/src/MIDebugEngine/ResourceStrings.Designer.cs
+++ b/src/MIDebugEngine/ResourceStrings.Designer.cs
@@ -11,7 +11,7 @@
 namespace Microsoft.MIDebugEngine {
     using System;
     using System.Reflection;
-    
+
     /// <summary>
     ///   A strongly-typed resource class, for looking up localized strings, etc.
     /// </summary>
@@ -39,7 +39,7 @@ namespace Microsoft.MIDebugEngine {
         internal static global::System.Resources.ResourceManager ResourceManager {
             get {
                 if (object.ReferenceEquals(resourceMan, null)) {
-                    global::System.Resources.ResourceManager temp = new global::System.Resources.ResourceManager("MIDebugEngine.ResourceStrings", typeof(ResourceStrings).GetTypeInfo().Assembly);
+                    global::System.Resources.ResourceManager temp = new global::System.Resources.ResourceManager("Microsoft.MIDebugEngine.ResourceStrings", typeof(ResourceStrings).GetTypeInfo().Assembly);
                     resourceMan = temp;
                 }
                 return resourceMan;

--- a/src/MIDebugPackage/MIDebugPackage.csproj
+++ b/src/MIDebugPackage/MIDebugPackage.csproj
@@ -28,6 +28,8 @@
     <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <Import Project="..\RequiredNetFX46FacadeAssemblies.targets" />
+  <Import Project="SuppressFromVsix.targets" />
   <PropertyGroup>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
     <SchemaVersion>2.0</SchemaVersion>
@@ -143,6 +145,8 @@
     <None Include="source.extension.vsixmanifest">
       <SubType>Designer</SubType>
     </None>
+    <None Include="..\RequiredNetFX46FacadeAssemblies.targets" />
+    <None Include="SuppressFromVsix.targets" />
   </ItemGroup>
   <ItemGroup>
     <VSCTCompile Include="MIDebugPackage.vsct">
@@ -156,6 +160,9 @@
     <Content Include="Resources\Package.ico" />
   </ItemGroup>
   <ItemGroup>
+    <VSIXSourceItem Include="@(RequiredNetFX46FacadeAssemblies)" />
+  </ItemGroup>
+  <ItemGroup>
     <DropUnsignedFile Include="$(OutDir)\Microsoft.Android.natvis" />
     <DropSignedFile Include="$(OutDir)\Microsoft.AndroidDebugLauncher.dll" />
     <DropUnsignedFile Include="$(OutDir)\Microsoft.AndroidDebugLauncher.pdb" />
@@ -196,6 +203,7 @@
     <DropSignedFile Include="$(OutDir)\Microsoft.DebugEngineHost.dll" />
     <DropUnsignedFile Include="$(OutDir)\Microsoft.DebugEngineHost.pdb" />
     <DropUnsignedFile Include="Install.cmd" />
+    <DropUnsignedFile Include="@(RequiredNetFX46FacadeAssemblies)" />
   </ItemGroup>
   <ItemGroup>
     <FilesToSign Include="@(DropSignedFile)">
@@ -252,7 +260,7 @@
       <DropLocation Condition="'$(DropLocation)'==''">$(MSBuildThisFileDirectory)..\..\bin\$(DropConfigurationName)\drop</DropLocation>
     </PropertyGroup>
     <MakeDir Condition="!Exists($(DropLocation))" Directories="$(DropLocation)" />
-    <Copy DestinationFolder="$(DropLocation)" SourceFiles="@(DropUnsignedFile);@(DropSignedFile)"/>
+    <Copy DestinationFolder="$(DropLocation)" SourceFiles="@(DropUnsignedFile);@(DropSignedFile)" />
   </Target>
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.

--- a/src/MIDebugPackage/SuppressFromVsix.targets
+++ b/src/MIDebugPackage/SuppressFromVsix.targets
@@ -1,0 +1,17 @@
+<Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <!--This targets file is used to add additional dlls to the built in list of dlls which should be excluded
+  from a VSIX.
+  
+  These files are included by default due to MSBuild's dependency include logic, but we don't ship them with 
+  the MIEngine so therefore we want to make sure they don't wind up in the output directory either so we are
+  testing the same way we will ship.
+  
+  You can test for any other dlls on the list by looking at the files in this directory:
+  C:\Users\greggm\AppData\Local\Microsoft\VisualStudio\14.0Exp\Extensions\Microsoft\Microsoft MI-based Debugger\1.0.6
+  -->
+  <ItemGroup>
+    <SuppressFromVsix Include="System.Numerics.dll"/>
+    <SuppressFromVsix Include="System.Runtime.Serialization.dll"/>
+    <SuppressFromVsix Include="Newtonsoft.Json.dll"/>
+  </ItemGroup>
+</Project>

--- a/src/RequiredNetFX46FacadeAssemblies.targets
+++ b/src/RequiredNetFX46FacadeAssemblies.targets
@@ -1,0 +1,16 @@
+<Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  
+  <!--This is a list of additional facade assemblies which didn't ship with .NET 4.6, and we use, and therefore need
+  to be included in our setup in some way.
+  -->
+  <ItemGroup>
+    <RequiredNetFX46FacadeAssemblies Include="$(UserProfile)\.nuget\packages\System.IO.FileSystem\4.0.0\lib\net46\System.IO.FileSystem.dll"/>
+    <RequiredNetFX46FacadeAssemblies Include="$(UserProfile)\.nuget\packages\System.IO.FileSystem.Primitives\4.0.0\lib\net46\System.IO.FileSystem.Primitives.dll"/>
+    <RequiredNetFX46FacadeAssemblies Include="$(UserProfile)\.nuget\packages\System.Reflection.TypeExtensions\4.0.0\lib\net46\System.Reflection.TypeExtensions.dll"/>
+    <RequiredNetFX46FacadeAssemblies Include="$(UserProfile)\.nuget\packages\System.Threading.Thread\4.0.0-beta-23225\lib\net46\System.Threading.Thread.dll"/>
+    <RequiredNetFX46FacadeAssemblies Include="$(UserProfile)\.nuget\packages\System.Diagnostics.Process\4.0.0-beta-23225\ref\net46\System.Diagnostics.Process.dll"/>
+    <RequiredNetFX46FacadeAssemblies Include="$(UserProfile)\.nuget\packages\System.Net.Security\4.0.0-beta-23225\lib\net46\System.Net.Security.dll"/>
+    <RequiredNetFX46FacadeAssemblies Include="$(UserProfile)\.nuget\packages\System.Net.Sockets\4.0.0\lib\net46\System.Net.Sockets.dll"/>
+    <RequiredNetFX46FacadeAssemblies Include="$(UserProfile)\.nuget\packages\System.Security.Cryptography.X509Certificates\4.0.0-beta-23225\lib\net46\System.Security.Cryptography.X509Certificates.dll"/>
+  </ItemGroup>
+</Project>


### PR DESCRIPTION
- Update the name of the managed resource to match what is embedded in the module
- Update the MIDebugPackage and MICoreUnitTests projects to copy required facade assemblies
- Update the MIDebugPackage to exclude extra assemblies it was copying which we don't plan to ship with the MIEngine