### PR TITLE
I fought the build, and I won (package management fix)

### DIFF
--- a/BuildAndTest.proj
+++ b/BuildAndTest.proj
@@ -24,21 +24,17 @@
     </Solution>
   </ItemGroup>
 
-  <Target Name="RestorePackages">
-    <Exec Command="&quot;$(ToolsHome)NuGet\NuGet.exe&quot; restore &quot;%(Solution.Identity)&quot;" />
-  </Target>
-
   <Target Name="Clean">
     <MSBuild Targets="Clean"
              Projects="@(Solution)" />
   </Target>
 
-  <Target Name="Build" DependsOnTargets="RestorePackages">
+  <Target Name="Build">
     <MSBuild Targets="Build"
              Projects="@(Solution)" />
   </Target>
 
-  <Target Name="Rebuild" DependsOnTargets="RestorePackages">
+  <Target Name="Rebuild">
     <MSBuild Targets="Rebuild"
              Projects="@(Solution)" />
   </Target>

--- a/build/all_projects.settings.targets
+++ b/build/all_projects.settings.targets
@@ -1,0 +1,14 @@
+<Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  
+  <!--
+  Settings file which is included by all projects in the repo. Most projects include it through miengine.settings.targets,
+  the few special projects (prebuild.csproj, some unit tests) include it directly.
+  -->
+  
+  <PropertyGroup>
+    <MIEngineRoot>$([System.IO.Path]::GetFullPath('$(MSBuildThisFileDirectory)..'))\</MIEngineRoot>
+    <ILDir>$(MIEngineRoot)IL\</ILDir>
+    <NuGetPackagesDirectory>$(MIEngineRoot)src\packages</NuGetPackagesDirectory>
+    <GeneratedAssembliesDir>$(ILDir)GeneratedAssemblies\</GeneratedAssembliesDir>
+  </PropertyGroup>
+</Project>

--- a/build/miengine.settings.targets
+++ b/build/miengine.settings.targets
@@ -1,4 +1,11 @@
 <Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003"> 
+  
+  <!--
+  Settings file which is included by all the shipping code projects in the repo.
+  -->
+  
+  <Import Project="all_projects.settings.targets"/>
+
   <Choose>
     <When Condition="'$(Configuration)' == 'Debug.Lab' Or '$(Configuration)' == 'Release.Lab'">
         <PropertyGroup>
@@ -16,14 +23,9 @@
   </Choose>
   
   <PropertyGroup>
-	<GlassDir>$(MSBuildThisFileDirectory)..\Microsoft.VisualStudio.Glass\</GlassDir>
+    <GlassDir>$(MSBuildThisFileDirectory)..\Microsoft.VisualStudio.Glass\</GlassDir>
   </PropertyGroup>
-  
-  <PropertyGroup>
-    <ILDir>$(MSBuildThisFileDirectory)..\IL\</ILDir>
-    <GeneratedAssembliesDir>$(ILDir)GeneratedAssemblies\</GeneratedAssembliesDir>
-  </PropertyGroup>
-  
+    
   <PropertyGroup>
     <SignAssembly>True</SignAssembly>
     

--- a/build/miengine.targets
+++ b/build/miengine.targets
@@ -6,32 +6,8 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <CoreCompileDependsOn>GenerateAssemblies;GenerateAssemblyInfoFile;$(CoreCompileDependsOn)</CoreCompileDependsOn>
+    <CoreCompileDependsOn>GenerateAssemblyInfoFile;$(CoreCompileDependsOn)</CoreCompileDependsOn>
   </PropertyGroup>
-
-  <Target Name="GenerateAssemblies"
-          Condition="'@(GenerateAssembly)' != ''"
-          Inputs="@(GenerateAssembly)"
-          Outputs="@(GenerateAssembly->'$(GeneratedAssembliesDir)%(FileName).dll')"
-          BeforeTargets="ResolveAssemblyReferences">
-    <PropertyGroup>
-        <IlAsmCommand Condition="'$(IlAsmCommand)'==''">"$(FrameworkPathOverride)\ilasm.exe"</IlAsmCommand>
-        <IlAsmFlags>$(IlAsmFlags) /DLL /quiet</IlAsmFlags>
-    </PropertyGroup>
-    <MakeDir Condition="!Exists('$(GeneratedAssembliesDir)')" Directories="$(GeneratedAssembliesDir)" />
-    <Exec Command="$(IlAsmCommand) $(IlAsmFlags) /out=&quot;$(GeneratedAssembliesDir)%(FileName).dll&quot; @(GenerateAssembly->'&quot;%(Identity)&quot;')" />
-  </Target>
-  
-  <PropertyGroup>
-    <CleanDependsOn>
-        $(CleanDependsOn);
-        CleanGenerateAssemblies;
-    </CleanDependsOn>
-  </PropertyGroup>
-  
-  <Target Name="CleanGenerateAssemblies">
-    <RemoveDir Directories="$(GeneratedAssembliesDir)" />
-  </Target>
   
   <Target Name="GlassDirCopy" Condition="'@(GlassDirCopy)' != ''" AfterTargets="Build">
 	<MakeDir Condition="!Exists($(GlassDir))" Directories="$(GlassDir)" />

--- a/src/JDbgUnitTests/JDbgUnitTests.csproj
+++ b/src/JDbgUnitTests/JDbgUnitTests.csproj
@@ -1,6 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="..\packages\xunit.core.2.0.0\build\portable-net45+win+wpa81+wp80+monotouch+monoandroid+Xamarin.iOS\xunit.core.props" Condition="Exists('..\packages\xunit.core.2.0.0\build\portable-net45+win+wpa81+wp80+monotouch+monoandroid+Xamarin.iOS\xunit.core.props')" />
+  <Import Project="..\..\build\all_projects.settings.targets" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>

--- a/src/MICore/MICore.csproj
+++ b/src/MICore/MICore.csproj
@@ -100,13 +100,6 @@
       <SubType>Designer</SubType>
     </EmbeddedResource>
   </ItemGroup>
-  <!-- Genereate all necessary assemblies as part of MICore. Since everything depends on this, it guarantees they'll be there -->
-  <!-- TODO: Figure out something better than this, since the assemblies generated aren't dependencies of MICore -->
-  <ItemGroup>
-    <GenerateAssembly Include="$(ILDir)*.il">
-      <Visible>false</Visible>
-    </GenerateAssembly>
-  </ItemGroup>
   <ItemGroup>
     <GlassDirCopy Include="$(OutDir)$(AssemblyName)$(TargetExt)" />
   </ItemGroup>

--- a/src/MICoreUnitTests/MICoreUnitTests.csproj
+++ b/src/MICoreUnitTests/MICoreUnitTests.csproj
@@ -2,6 +2,7 @@
 <Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="..\packages\xunit.runner.visualstudio.2.0.0\build\net20\xunit.runner.visualstudio.props" Condition="Exists('..\packages\xunit.runner.visualstudio.2.0.0\build\net20\xunit.runner.visualstudio.props')" />
   <Import Project="..\packages\xunit.core.2.0.0\build\portable-net45+win+wpa81+wp80+monotouch+monoandroid+Xamarin.iOS\xunit.core.props" Condition="Exists('..\packages\xunit.core.2.0.0\build\portable-net45+win+wpa81+wp80+monotouch+monoandroid+Xamarin.iOS\xunit.core.props')" />
+  <Import Project="..\..\build\all_projects.settings.targets" />
   <Import Project="..\RequiredNetFX46FacadeAssemblies.targets" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>

--- a/src/MIDebugEngine.sln
+++ b/src/MIDebugEngine.sln
@@ -6,19 +6,35 @@ MinimumVisualStudioVersion = 10.0.40219.1
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Platform Launchers", "Platform Launchers", "{B864C337-1AA8-42B3-BF01-90901F55DE70}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "MIDebugPackage", "MIDebugPackage\MIDebugPackage.csproj", "{4F38F986-5C93-44CB-A387-AEF3737E6D22}"
+	ProjectSection(ProjectDependencies) = postProject
+		{95C0421F-D4C1-46E8-9177-6DAA4D71D0F2} = {95C0421F-D4C1-46E8-9177-6DAA4D71D0F2}
+	EndProjectSection
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "MICoreUnitTests", "MICoreUnitTests\MICoreUnitTests.csproj", "{6D565BAE-4764-40C3-9C0F-204B6FFA0389}"
+	ProjectSection(ProjectDependencies) = postProject
+		{95C0421F-D4C1-46E8-9177-6DAA4D71D0F2} = {95C0421F-D4C1-46E8-9177-6DAA4D71D0F2}
+	EndProjectSection
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "AndroidDebugLauncher", "AndroidDebugLauncher\AndroidDebugLauncher.csproj", "{E0844BFF-2D67-4CB0-8E2A-E9CD888F2EB0}"
 	ProjectSection(ProjectDependencies) = postProject
 		{78728205-DB3E-4B7B-A7D2-5CBE38E9C607} = {78728205-DB3E-4B7B-A7D2-5CBE38E9C607}
+		{95C0421F-D4C1-46E8-9177-6DAA4D71D0F2} = {95C0421F-D4C1-46E8-9177-6DAA4D71D0F2}
 	EndProjectSection
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "JDbg", "JDbg\JDbg.csproj", "{78728205-DB3E-4B7B-A7D2-5CBE38E9C607}"
+	ProjectSection(ProjectDependencies) = postProject
+		{95C0421F-D4C1-46E8-9177-6DAA4D71D0F2} = {95C0421F-D4C1-46E8-9177-6DAA4D71D0F2}
+	EndProjectSection
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "JDbgUnitTests", "JDbgUnitTests\JDbgUnitTests.csproj", "{207FD4CC-116B-466D-8893-F9565248A085}"
+	ProjectSection(ProjectDependencies) = postProject
+		{95C0421F-D4C1-46E8-9177-6DAA4D71D0F2} = {95C0421F-D4C1-46E8-9177-6DAA4D71D0F2}
+	EndProjectSection
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "IOSDebugLauncher", "IOSDebugLauncher\IOSDebugLauncher.csproj", "{D2A11674-F677-4B11-9989-2F6099A6F0A2}"
+	ProjectSection(ProjectDependencies) = postProject
+		{95C0421F-D4C1-46E8-9177-6DAA4D71D0F2} = {95C0421F-D4C1-46E8-9177-6DAA4D71D0F2}
+	EndProjectSection
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Android", "Android", "{2865BFC4-770D-4219-945A-75670F98A6A6}"
 EndProject
@@ -28,12 +44,26 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 	EndProjectSection
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "DebugEngineHost.Stub", "DebugEngineHost.Stub\DebugEngineHost.Stub.csproj", "{EA876A2D-AB0F-4204-97DD-DFB3B5568978}"
+	ProjectSection(ProjectDependencies) = postProject
+		{95C0421F-D4C1-46E8-9177-6DAA4D71D0F2} = {95C0421F-D4C1-46E8-9177-6DAA4D71D0F2}
+	EndProjectSection
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "MICore", "MICore\MICore.csproj", "{54C33AFA-438D-4932-A2F0-D0F2BB2FADC9}"
+	ProjectSection(ProjectDependencies) = postProject
+		{95C0421F-D4C1-46E8-9177-6DAA4D71D0F2} = {95C0421F-D4C1-46E8-9177-6DAA4D71D0F2}
+	EndProjectSection
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "MIDebugEngine", "MIDebugEngine\MIDebugEngine.csproj", "{A8B0230C-7806-407C-AF18-54B2CE21275E}"
+	ProjectSection(ProjectDependencies) = postProject
+		{95C0421F-D4C1-46E8-9177-6DAA4D71D0F2} = {95C0421F-D4C1-46E8-9177-6DAA4D71D0F2}
+	EndProjectSection
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "DebugEngineHost", "DebugEngineHost\DebugEngineHost.csproj", "{E659FEE3-7773-4A73-880A-83CE5C9634CC}"
+	ProjectSection(ProjectDependencies) = postProject
+		{95C0421F-D4C1-46E8-9177-6DAA4D71D0F2} = {95C0421F-D4C1-46E8-9177-6DAA4D71D0F2}
+	EndProjectSection
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "prebuild", "prebuild\prebuild.csproj", "{95C0421F-D4C1-46E8-9177-6DAA4D71D0F2}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -123,6 +153,14 @@ Global
 		{E659FEE3-7773-4A73-880A-83CE5C9634CC}.Release.Lab|Any CPU.Build.0 = Release.Lab|Any CPU
 		{E659FEE3-7773-4A73-880A-83CE5C9634CC}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{E659FEE3-7773-4A73-880A-83CE5C9634CC}.Release|Any CPU.Build.0 = Release|Any CPU
+		{95C0421F-D4C1-46E8-9177-6DAA4D71D0F2}.Debug.Lab|Any CPU.ActiveCfg = Debug|x86
+		{95C0421F-D4C1-46E8-9177-6DAA4D71D0F2}.Debug.Lab|Any CPU.Build.0 = Debug|x86
+		{95C0421F-D4C1-46E8-9177-6DAA4D71D0F2}.Debug|Any CPU.ActiveCfg = Debug|x86
+		{95C0421F-D4C1-46E8-9177-6DAA4D71D0F2}.Debug|Any CPU.Build.0 = Debug|x86
+		{95C0421F-D4C1-46E8-9177-6DAA4D71D0F2}.Release.Lab|Any CPU.ActiveCfg = Debug|x86
+		{95C0421F-D4C1-46E8-9177-6DAA4D71D0F2}.Release.Lab|Any CPU.Build.0 = Debug|x86
+		{95C0421F-D4C1-46E8-9177-6DAA4D71D0F2}.Release|Any CPU.ActiveCfg = Debug|x86
+		{95C0421F-D4C1-46E8-9177-6DAA4D71D0F2}.Release|Any CPU.Build.0 = Debug|x86
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/src/RequiredNetFX46FacadeAssemblies.targets
+++ b/src/RequiredNetFX46FacadeAssemblies.targets
@@ -4,13 +4,13 @@
   to be included in our setup in some way.
   -->
   <ItemGroup>
-    <RequiredNetFX46FacadeAssemblies Include="$(UserProfile)\.nuget\packages\System.IO.FileSystem\4.0.0\lib\net46\System.IO.FileSystem.dll"/>
-    <RequiredNetFX46FacadeAssemblies Include="$(UserProfile)\.nuget\packages\System.IO.FileSystem.Primitives\4.0.0\lib\net46\System.IO.FileSystem.Primitives.dll"/>
-    <RequiredNetFX46FacadeAssemblies Include="$(UserProfile)\.nuget\packages\System.Reflection.TypeExtensions\4.0.0\lib\net46\System.Reflection.TypeExtensions.dll"/>
-    <RequiredNetFX46FacadeAssemblies Include="$(UserProfile)\.nuget\packages\System.Threading.Thread\4.0.0-beta-23225\lib\net46\System.Threading.Thread.dll"/>
-    <RequiredNetFX46FacadeAssemblies Include="$(UserProfile)\.nuget\packages\System.Diagnostics.Process\4.0.0-beta-23225\ref\net46\System.Diagnostics.Process.dll"/>
-    <RequiredNetFX46FacadeAssemblies Include="$(UserProfile)\.nuget\packages\System.Net.Security\4.0.0-beta-23225\lib\net46\System.Net.Security.dll"/>
-    <RequiredNetFX46FacadeAssemblies Include="$(UserProfile)\.nuget\packages\System.Net.Sockets\4.0.0\lib\net46\System.Net.Sockets.dll"/>
-    <RequiredNetFX46FacadeAssemblies Include="$(UserProfile)\.nuget\packages\System.Security.Cryptography.X509Certificates\4.0.0-beta-23225\lib\net46\System.Security.Cryptography.X509Certificates.dll"/>
+    <RequiredNetFX46FacadeAssemblies Include="$(NuGetPackagesDirectory)\System.IO.FileSystem\4.0.0\lib\net46\System.IO.FileSystem.dll"/>
+    <RequiredNetFX46FacadeAssemblies Include="$(NuGetPackagesDirectory)\System.IO.FileSystem.Primitives\4.0.0\lib\net46\System.IO.FileSystem.Primitives.dll"/>
+    <RequiredNetFX46FacadeAssemblies Include="$(NuGetPackagesDirectory)\System.Reflection.TypeExtensions\4.0.0\lib\net46\System.Reflection.TypeExtensions.dll"/>
+    <RequiredNetFX46FacadeAssemblies Include="$(NuGetPackagesDirectory)\System.Threading.Thread\4.0.0-beta-23225\lib\net46\System.Threading.Thread.dll"/>
+    <RequiredNetFX46FacadeAssemblies Include="$(NuGetPackagesDirectory)\System.Diagnostics.Process\4.0.0-beta-23225\ref\net46\System.Diagnostics.Process.dll"/>
+    <RequiredNetFX46FacadeAssemblies Include="$(NuGetPackagesDirectory)\System.Net.Security\4.0.0-beta-23225\lib\net46\System.Net.Security.dll"/>
+    <RequiredNetFX46FacadeAssemblies Include="$(NuGetPackagesDirectory)\System.Net.Sockets\4.1.0-beta-23225\lib\net46\System.Net.Sockets.dll"/>
+    <RequiredNetFX46FacadeAssemblies Include="$(NuGetPackagesDirectory)\System.Security.Cryptography.X509Certificates\4.0.0-beta-23225\lib\net46\System.Security.Cryptography.X509Certificates.dll"/>
   </ItemGroup>
 </Project>

--- a/src/prebuild/prebuild.csproj
+++ b/src/prebuild/prebuild.csproj
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="..\..\build\all_projects.settings.targets" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{95C0421F-D4C1-46E8-9177-6DAA4D71D0F2}</ProjectGuid>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <GenerateAssembly Include="$(ILDir)*.il">
+      <Visible>false</Visible>
+    </GenerateAssembly>
+  </ItemGroup>
+
+  <Target Name="GenerateAssemblies"
+        Condition="'@(GenerateAssembly)' != ''"
+        Inputs="@(GenerateAssembly)"
+        Outputs="@(GenerateAssembly->'$(GeneratedAssembliesDir)%(FileName).dll')"
+        AfterTargets="Build">
+    <PropertyGroup>
+      <IlAsmCommand>"$(windir)\Microsoft.NET\Framework\v4.0.30319\ilasm.exe"</IlAsmCommand>
+      <IlAsmFlags>$(IlAsmFlags) /DLL /quiet</IlAsmFlags>
+    </PropertyGroup>
+    <MakeDir Condition="!Exists('$(GeneratedAssembliesDir)')" Directories="$(GeneratedAssembliesDir)" />
+    <Exec Command="$(IlAsmCommand) $(IlAsmFlags) /out=&quot;$(GeneratedAssembliesDir)%(FileName).dll&quot; @(GenerateAssembly->'&quot;%(Identity)&quot;')" />
+  </Target>
+  
+  <Target Name="Build">
+    <Exec Command="&quot;$(MIEngineRoot)tools\NuGet\NuGet.exe&quot; restore -PackagesDirectory &quot;$(NuGetPackagesDirectory)&quot; -MSBuildVersion 14 &quot;$(MIEngineRoot)src\MIDebugEngine.sln&quot;" />
+  </Target>
+
+  <Target Name="Clean">
+    <RemoveDir Directories="$(GeneratedAssembliesDir)" />
+  </Target>
+
+  <!--Empty targets to make msbuild happy-->
+  <Target Name="GetNativeManifest"/>
+  <Target Name="GetCopyToOutputDirectoryItems"/>
+  <Target Name="BuiltProjectOutputGroupDependencies"/>
+  <Target Name="BuiltProjectOutputGroup"/>
+  <Target Name="SatelliteDllsProjectOutputGroup"/>
+  <Target Name="DebugSymbolsProjectOutputGroup"/>
+</Project>


### PR DESCRIPTION
Summary: With this checkin, I am changing how we restore packages in
the MI Engine, and also, on a much more minor note, how we compile our
contract IL.

Problem: I couldn't figure out any normal way to set the package output
directory when NuGet restores of our project.json projects in the IDE.
I didn't like this, but could live with it if this was the only
problem. But on the PR machines packages were getting restored to some
unknown directory, so it wasn't working at all.

Solution:
1. Move package restore to the same spot in both the IDE build and the
build.cmd build by creating 'prebuild.csproj', and making all projects
depend on this project.

_NOTE_ when adding a new project, we need to add this new dependency.
To do so, bring up the project context menu and invoke:
  Build Dependencies->Project Dependencies

This will add a new item in the .sln file to declare the dependency, so
as long as we review .sln changes, we should be good.

2. Have prebuild.csproj set the package output switch (which actually
is respected)

3. Set the NuGetPackagesDirectory property in all projects, so projects
know where to look for their dependencies.

4. For good measure, I moved the .il compilation from MICore to
prebuild.csproj since that is really where it belongs.