### PR TITLE
Add handling for '\r'

### DIFF
--- a/src/MICore/MIResults.cs
+++ b/src/MICore/MIResults.cs
@@ -775,6 +775,7 @@ namespace MICore
                     switch (c)
                     {
                         case 'n': c = '\n'; break;
+                        case 'r': c = '\r'; break;
                         case 't': c = '\t'; break;
                         default: break;
                     }


### PR DESCRIPTION
The c string decoding code in the MI engine didn't handle '\r'. This adds code to handle that.