### PR TITLE
Fix crash in MIEngine when clrdbg sends breakpoint-modified

### DIFF
--- a/src/MIDebugEngine/Engine.Impl/Breakpoints.cs
+++ b/src/MIDebugEngine/Engine.Impl/Breakpoints.cs
@@ -209,7 +209,7 @@ namespace Microsoft.MIDebugEngine
             }
             else
             {
-                _breakState = StringToBreakpointState(bkpt.FindString("addr"));
+                _breakState = StringToBreakpointState(bkpt.TryFindString("addr"));
                 bbp = GetBoundBreakpoint(bkpt as TupleValue);
                 if (bbp != null)
                     resultList.Add(bbp);


### PR DESCRIPTION
CLRDBG doesn't provide "addr" values for breakpoints since breakpoints don't generally bind to CPU instruction addresses. Generally speaking, the MIEngine already handled this, but there was a code path in the breakpoint-modified processing which wasn't yet.