### PR TITLE
MIEngine: Add support for logging in VS Code

### DIFF
--- a/src/DebugEngineHost.Stub/HostConfigurationStore.cs
+++ b/src/DebugEngineHost.Stub/HostConfigurationStore.cs
@@ -30,7 +30,34 @@ namespace Microsoft.DebugEngineHost
             throw new NotImplementedException();
         }
 
-        public object GetOptionalValue(string section, string valueName)
+        /// <summary>
+        /// Checks if logging is enabled, and if so returns a logger object. 
+        /// 
+        /// In VS, this is wired up to read from the registry and return a logger which writes a log file to %TMP%\log-file-name.
+        /// In VS Code, this will check if the '--engineLogging' switch is enabled, and if so return a logger that wil write to the Console.
+        /// </summary>
+        /// <param name="enableLoggingSettingName">[Optional] In VS, the name of the settings key to check if logging is enabled. If not specified, this will check 'EnableLogging' in the AD7 Metrics.</param>
+        /// <param name="logFileName">[Required] name of the log file to open if logging is enabled.</param>
+        /// <returns>[Optional] If logging is enabled, the logging object.</returns>
+        public HostLogger GetLogger(string enableLoggingSettingName, string logFileName)
+        {
+            throw new NotImplementedException();
+        }
+    }
+
+    public sealed class HostLogger
+    {
+        private HostLogger()
+        {
+            throw new NotImplementedException();
+        }
+
+        public void WriteLine(string line)
+        {
+            throw new NotImplementedException();
+        }
+
+        public void Flush()
         {
             throw new NotImplementedException();
         }

--- a/src/DebugEngineHost/DebugEngineHost.csproj
+++ b/src/DebugEngineHost/DebugEngineHost.csproj
@@ -1,12 +1,10 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  
   <PropertyGroup>
     <!--Fix the assembly version for DebugEngineHost as all the versions of this dll must have the same assembly identity
     NOTE: Ths must be set BEFORE improting miengine.settings.targets-->
     <AssemblyVersion>1.0.0</AssemblyVersion>
   </PropertyGroup>
-  
   <Import Project="..\..\build\miengine.settings.targets" />
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
@@ -89,6 +87,7 @@
     <Compile Include="HostConfigurationSection.cs" />
     <Compile Include="HostConfigurationStore.cs" />
     <Compile Include="HostConfirigurationException.cs" />
+    <Compile Include="HostLogger.cs" />
     <Compile Include="VSImpl\VSEventCallbackWrapper.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="HostMarshal.cs" />

--- a/src/DebugEngineHost/HostLogger.cs
+++ b/src/DebugEngineHost/HostLogger.cs
@@ -1,0 +1,38 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Microsoft.DebugEngineHost
+{
+    public sealed class HostLogger
+    {
+        readonly StreamWriter _streamWriter;
+
+        internal HostLogger(StreamWriter streamWriter)
+        {
+            _streamWriter = streamWriter;
+        }
+
+        public void WriteLine(string line)
+        {
+            lock (_streamWriter)
+            {
+                _streamWriter.WriteLine(line);
+            }
+        }
+
+        public void Flush()
+        {
+            lock (_streamWriter)
+            {
+                _streamWriter.Flush();
+            }
+        }
+    }
+}

--- a/src/MICore/Logger.cs
+++ b/src/MICore/Logger.cs
@@ -23,9 +23,8 @@ namespace MICore
         private static bool s_isInitialized;
         private static bool s_isEnabled;
         private static DateTime s_initTime;
-
         // NOTE: We never clean this up
-        private static StreamWriter s_streamWriter;
+        private static HostLogger s_logger;
 
         public static void EnsureInitialized(HostConfigurationStore configStore)
         {
@@ -34,25 +33,10 @@ namespace MICore
                 s_isInitialized = true;
                 s_initTime = DateTime.Now;
 
-                object enableMILoggerValue = configStore.GetOptionalValue("Debugger", "EnableMIDebugLogger");
-                if (IsRegValueTrue(enableMILoggerValue))
+                s_logger = configStore.GetLogger("EnableMIDebugLogger", "Microsoft.MIDebug.log");
+                if (s_logger != null)
                 {
-                    string tempDirectory = Environment.GetEnvironmentVariable("TMP");
-                    if (!string.IsNullOrEmpty(tempDirectory) && Directory.Exists(tempDirectory))
-                    {
-                        string filePath = Path.Combine(tempDirectory, "Microsoft.MIDebug.log");
-
-                        try
-                        {
-                            FileStream stream = File.Open(filePath, FileMode.Create, FileAccess.Write, FileShare.Read);
-                            s_streamWriter = new StreamWriter(stream);
-                            s_isEnabled = true;
-                        }
-                        catch (IOException)
-                        {
-                            // ignore failures from the log being in use by another process
-                        }
-                    }
+                    s_isEnabled = true;
                 }
                 WriteLine("Initialized log at: " + s_initTime);
             }
@@ -122,29 +106,17 @@ namespace MICore
         [MethodImpl(MethodImplOptions.NoInlining)] // Disable inlining since logging is off by default, and we want to allow the public method to be inlined
         private static void WriteLineImpl(string line)
         {
-            if (s_streamWriter != null)
-            {
-                lock (s_streamWriter)
-                {
-                    s_streamWriter.WriteLine(String.Format(CultureInfo.CurrentCulture, "({0}) {1}", (int)(DateTime.Now - s_initTime).TotalMilliseconds, line));
-                }
-            }
-
+            string fullLine = String.Format(CultureInfo.CurrentCulture, "({0}) {1}", (int)(DateTime.Now - s_initTime).TotalMilliseconds, line);
+            s_logger?.WriteLine(fullLine);
 #if DEBUG
-            Debug.WriteLine("MS_MIDebug: " + String.Format(CultureInfo.CurrentCulture, "({0}) {1}", (int)(DateTime.Now - s_initTime).TotalMilliseconds, line));
+            Debug.WriteLine("MS_MIDebug: " + fullLine);
 #endif
         }
 
         [MethodImpl(MethodImplOptions.NoInlining)] // Disable inlining since logging is off by default, and we want to allow the public method to be inlined
         private static void FlushImpl()
         {
-            if (s_streamWriter != null)
-            {
-                lock (s_streamWriter)
-                {
-                    s_streamWriter.Flush();
-                }
-            }
+            s_logger?.Flush();
         }
 
         [MethodImpl(MethodImplOptions.NoInlining)] // Disable inlining since logging is off by default, and we want to allow the public method to be inlined
@@ -170,16 +142,6 @@ namespace MICore
                         WriteLineImpl(line);
                 }
             }
-        }
-
-        private static bool IsRegValueTrue(object enableMILoggerValue)
-        {
-            if (enableMILoggerValue == null)
-                return false;
-            if (!(enableMILoggerValue is int))
-                return false;
-
-            return ((int)enableMILoggerValue) != 0;
         }
     }
 }


### PR DESCRIPTION
This checking changes how we enable logging in the MIEngine so that the details of how we enable logging and where the logging winds up moves out of Microsoft.MICore.dll and into Microsoft.DebugEngineHost.dll. This way we can use console logging in VS Code, and log to a temp file in VS.