### PR TITLE
Don't crash VS on non-UInt32 debugger exit code

### DIFF
--- a/src/MIDebugEngine/Engine.Impl/DebuggedProcess.cs
+++ b/src/MIDebugEngine/Engine.Impl/DebuggedProcess.cs
@@ -192,8 +192,11 @@ namespace Microsoft.MIDebugEngine
                     // GDB sometimes returns exit codes, which don't fit into uint, like "030000000472".
                     // And we can't throw from here, because it crashes VS.
                     // Full exit code will still usually be reported in the Output window,
-                    // but let VS think it was "0" in this case.
-                    uint.TryParse(results.Results.FindString("exit-code"), out processExitCode);
+                    // but here let's return "uint.MaxValue" just to indicate that something went wrong.
+                    if (!uint.TryParse(results.Results.FindString("exit-code"), out processExitCode))
+                    {
+                        processExitCode = uint.MaxValue;
+                    }
                 }
 
                 // quit MI Debugger

--- a/src/MIDebugEngine/Engine.Impl/DebuggedProcess.cs
+++ b/src/MIDebugEngine/Engine.Impl/DebuggedProcess.cs
@@ -189,7 +189,11 @@ namespace Microsoft.MIDebugEngine
 
                 if (results.Results.Contains("exit-code"))
                 {
-                    processExitCode = results.Results.FindUint("exit-code");
+                    // GDB sometimes returns exit codes, which don't fit into uint, like "030000000472".
+                    // And we can't throw from here, because it crashes VS.
+                    // Full exit code will still usually be reported in the Output window,
+                    // but let VS think it was "0" in this case.
+                    uint.TryParse(results.Results.FindString("exit-code"), out processExitCode);
                 }
 
                 // quit MI Debugger


### PR DESCRIPTION
This fixes a crash reported for VisualRust extension: PistonDevelopers/VisualRust#190 (to reproduce the crash, just install the Visual Rust extension in Visual Studio and follow the steps from the linked issue).

Let me know if there's a better way to address this. The assumption in several places across MIEngine seems to be that the exit code always fits into UInt32.

Alternatively here we could truncate the string to fit into uint, or report a hardcoded non-zero exit code for VS, but I'm not sure it adds any value, it may still be confusing that in the Output window VS shows a different exit code than what's in the GDB output...
