### PR TITLE
Update Microsoft.VisualStudio.Debugger.Interop.Portable to 1.0.1

### DIFF
--- a/src/DebugEngineHost.Stub/project.json
+++ b/src/DebugEngineHost.Stub/project.json
@@ -6,7 +6,7 @@
   "dependencies": {
     "Microsoft.NETCore": "5.0.0",
     "Microsoft.NETCore.Portable.Compatibility": "1.0.0",
-    "Microsoft.VisualStudio.Debugger.Interop.Portable": "1.0.0"
+    "Microsoft.VisualStudio.Debugger.Interop.Portable": "1.0.1"
   },
   "frameworks": {
     "dotnet": {

--- a/src/MIDebugEngine/project.json
+++ b/src/MIDebugEngine/project.json
@@ -6,7 +6,7 @@
   "dependencies": {
     "Microsoft.NETCore": "5.0.0",
     "Microsoft.NETCore.Portable.Compatibility": "1.0.0",
-    "Microsoft.VisualStudio.Debugger.Interop.Portable": "1.0.0"
+    "Microsoft.VisualStudio.Debugger.Interop.Portable": "1.0.1"
   },
   "frameworks": {
     "dotnet": {


### PR DESCRIPTION
Microsoft.VisualStudio.Debugger.Interop.Portable v1.0.0 had a bug that
we block types from loading on MacOS/Linux. This switches to the fixed
version.