### PR TITLE
MIEngine changes to allow debugging MIEngine with MIEngine on a Mac

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -7,3 +7,6 @@
 # Treat pkgdef files as text
 ###############################################################################
 *.pkgdef text
+
+# Use unix line endings on shell scripts so that they can be run on unix
+*.sh text eol=lf

--- a/src/AndroidDebugLauncher/AndroidDebugLauncher.csproj
+++ b/src/AndroidDebugLauncher/AndroidDebugLauncher.csproj
@@ -50,6 +50,17 @@
     <ErrorReport>prompt</ErrorReport>
     <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug-PortablePDB|AnyCPU'">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>portable</DebugType>
+    <Optimize>false</Optimize>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+    <Prefer32Bit>false</Prefer32Bit>
+    <RunCodeAnalysis>true</RunCodeAnalysis>
+    <CodeAnalysisRuleSet>..\IDECodeAnalysis.ruleset</CodeAnalysisRuleSet>
+  </PropertyGroup>
   <ItemGroup>
     <Reference Include="libadb.dll">
       <Private>False</Private>

--- a/src/DebugEngineHost.Stub/DebugEngineHost.Stub.csproj
+++ b/src/DebugEngineHost.Stub/DebugEngineHost.Stub.csproj
@@ -1,12 +1,11 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-
   <PropertyGroup>
     <!--Fix the assembly version for DebugEngineHost as all the versions of this dll must have the same assembly identity
     NOTE: Ths must be set BEFORE improting miengine.settings.targets-->
     <AssemblyVersion>1.0.0</AssemblyVersion>
-  </PropertyGroup>  
-  
+  </PropertyGroup>
+
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <Import Project="..\..\build\miengine.settings.targets" />
   <PropertyGroup>
@@ -55,6 +54,14 @@
     <DebugType>pdbonly</DebugType>
     <Optimize>true</Optimize>
     <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug-PortablePDB|AnyCPU'">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>portable</DebugType>
+    <Optimize>false</Optimize>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>

--- a/src/IOSDebugLauncher/IOSDebugLauncher.csproj
+++ b/src/IOSDebugLauncher/IOSDebugLauncher.csproj
@@ -48,6 +48,14 @@
     <ErrorReport>prompt</ErrorReport>
     <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug-PortablePDB|AnyCPU'">
+    <DebugSymbols>true</DebugSymbols>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <DebugType>portable</DebugType>
+    <PlatformTarget>AnyCPU</PlatformTarget>
+    <ErrorReport>prompt</ErrorReport>
+    <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
+  </PropertyGroup>
   <ItemGroup>
     <Reference Include="Newtonsoft.Json, Version=6.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
       <HintPath>..\packages\Newtonsoft.Json.6.0.4\lib\net45\Newtonsoft.Json.dll</HintPath>

--- a/src/JDbg/JDbg.csproj
+++ b/src/JDbg/JDbg.csproj
@@ -47,6 +47,14 @@
     <ErrorReport>prompt</ErrorReport>
     <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug-PortablePDB|AnyCPU'">
+    <DebugSymbols>true</DebugSymbols>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <DebugType>portable</DebugType>
+    <PlatformTarget>AnyCPU</PlatformTarget>
+    <ErrorReport>prompt</ErrorReport>
+    <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
+  </PropertyGroup>
   <ItemGroup>
     <Reference Include="System" />
     <Reference Include="System.Core" />
@@ -67,7 +75,7 @@
     <Compile Include="Utils.cs" />
   </ItemGroup>
   <ItemGroup>
-	<GlassDirCopy Include="$(OutDir)$(AssemblyName)$(TargetExt)" />
+    <GlassDirCopy Include="$(OutDir)$(AssemblyName)$(TargetExt)" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Import Project="..\..\build\miengine.targets" />

--- a/src/MICore/MICore.csproj
+++ b/src/MICore/MICore.csproj
@@ -54,6 +54,17 @@
     <ErrorReport>prompt</ErrorReport>
     <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug-PortablePDB|AnyCPU'">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>portable</DebugType>
+    <Optimize>false</Optimize>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+    <Prefer32Bit>false</Prefer32Bit>
+    <RunCodeAnalysis>true</RunCodeAnalysis>
+    <CodeAnalysisRuleSet>..\IDECodeAnalysis.ruleset</CodeAnalysisRuleSet>
+  </PropertyGroup>
   <ItemGroup>
     <None Include="LaunchOptions.xsd" />
     <None Include="project.json" />
@@ -67,10 +78,10 @@
     <Compile Include="InvalidLaunchOptionsException.cs" />
     <Compile Include="LaunchCommand.cs" />
     <Compile Include="LaunchOptions.cs" />
-     <Compile Include="LaunchOptions.xsd.types.desginer.cs">
-       <AutoGen>True</AutoGen>
-       <DependentUpon>LaunchOptions.xsd</DependentUpon>
-     </Compile>
+    <Compile Include="LaunchOptions.xsd.types.desginer.cs">
+      <AutoGen>True</AutoGen>
+      <DependentUpon>LaunchOptions.xsd</DependentUpon>
+    </Compile>
     <Compile Include="Logger.cs" />
     <Compile Include="MICommandFactory.cs" />
     <Compile Include="MICoreResources.Designer.cs">
@@ -131,7 +142,6 @@
     <!--Update the checked in types designer file if it is out of date-->
     <Exec Command="ValidateDesignerFile.cmd LaunchOptions.xsd.types.desginer.cs $(IntermediateOutputPath)LaunchOptions.xsd.types.desginer-candidate.cs &quot;$(IntermediateOutputPath)&quot;" />
   </Target>
-
   <!--This target is used to generate an XML serializers assembly for the types in LaunchOptions.xsd. We can't embed these types
   into MICore as CoreCLR doesn't expose the types needed to make that code work.-->
   <Target Name="GenerateXmlSerializersAssembly" AfterTargets="Compile" Inputs="LaunchOptions.xsd.types.desginer.cs;$(AssemblyOriginatorKeyFile)" Outputs="$(IntermediateOutputPath)sgen\$(AssemblyName).XmlSerializers.dll">
@@ -143,14 +153,13 @@
     <Error Condition="'$(MSBuildBinPath)'==''" Text="MSBuildBinPath msbuild property is undefined" />
     <Error Condition="!Exists('$(SDK40ToolsPath)sgen.exe')" Text="sgen.exe does not exist in the SDK40ToolsPath ($(SDK40ToolsPath)xsd.exe)." />
     <Error Condition="!Exists('$(MSBuildBinPath)\csc.exe')" Text="csc.exe does not exist in MSBuildBinPath ($(MSBuildBinPath))" />
-    <RemoveDir Condition="Exists('$(IntermediateOutputPath)sgen')" Directories="$(IntermediateOutputPath)sgen"/>
-    <MakeDir Directories="$(IntermediateOutputPath)sgen"/>
+    <RemoveDir Condition="Exists('$(IntermediateOutputPath)sgen')" Directories="$(IntermediateOutputPath)sgen" />
+    <MakeDir Directories="$(IntermediateOutputPath)sgen" />
     <!--Compile the types file into an assembly that we can use as input to sgen. We don't want to pass our real assembly as we have some things that sgen doesn't like.-->
     <Exec Command="&quot;$(MSBuildBinPath)\csc.exe&quot; LaunchOptions.xsd.types.desginer.cs $(GeneratedAssemblyInfoFile) /out:$(IntermediateOutputPath)sgen\$(AssemblyName).dll /target:library /noconfig $(SereializationSigningCompilerOptions) /r:$(MSBuildFrameworkToolsPath)\System.dll /r:$(MSBuildFrameworkToolsPath)\System.XML.dll" />
     <!--Now generate the serialization assembly-->
-    <Exec Command="&quot;$(SDK40ToolsPath)sgen.exe&quot; $(IntermediateOutputPath)sgen\$(AssemblyName).dll /force /compiler:&quot;$(SereializationSigningCompilerOptions)&quot; /keep"/>
+    <Exec Command="&quot;$(SDK40ToolsPath)sgen.exe&quot; $(IntermediateOutputPath)sgen\$(AssemblyName).dll /force /compiler:&quot;$(SereializationSigningCompilerOptions)&quot; /keep" />
   </Target>
-  
   <!--To get the seralization assembly copied to the vsix, and also to the output directory, we have this target
   which adds the XmlSerializers as if it was a source item in our project with a 'CopyToOutputDirectory' child
   node. See the 'GetCopyToOutputDirectoryItems' target in C:\Program Files (x86)\MSBuild\14.0\Bin\Microsoft.Common.CurrentVersion.targets

--- a/src/MIDebugEngine.sln
+++ b/src/MIDebugEngine.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 14
-VisualStudioVersion = 14.0.23107.0
+VisualStudioVersion = 14.0.24623.0
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Platform Launchers", "Platform Launchers", "{B864C337-1AA8-42B3-BF01-90901F55DE70}"
 EndProject
@@ -69,6 +69,7 @@ Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug.Lab|Any CPU = Debug.Lab|Any CPU
 		Debug|Any CPU = Debug|Any CPU
+		Debug-PortablePDB|Any CPU = Debug-PortablePDB|Any CPU
 		Release.Lab|Any CPU = Release.Lab|Any CPU
 		Release|Any CPU = Release|Any CPU
 	EndGlobalSection
@@ -77,6 +78,7 @@ Global
 		{4F38F986-5C93-44CB-A387-AEF3737E6D22}.Debug.Lab|Any CPU.Build.0 = Debug.Lab|Any CPU
 		{4F38F986-5C93-44CB-A387-AEF3737E6D22}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{4F38F986-5C93-44CB-A387-AEF3737E6D22}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{4F38F986-5C93-44CB-A387-AEF3737E6D22}.Debug-PortablePDB|Any CPU.ActiveCfg = Debug|Any CPU
 		{4F38F986-5C93-44CB-A387-AEF3737E6D22}.Release.Lab|Any CPU.ActiveCfg = Release.Lab|Any CPU
 		{4F38F986-5C93-44CB-A387-AEF3737E6D22}.Release.Lab|Any CPU.Build.0 = Release.Lab|Any CPU
 		{4F38F986-5C93-44CB-A387-AEF3737E6D22}.Release|Any CPU.ActiveCfg = Release|Any CPU
@@ -85,6 +87,7 @@ Global
 		{6D565BAE-4764-40C3-9C0F-204B6FFA0389}.Debug.Lab|Any CPU.Build.0 = Debug.Lab|Any CPU
 		{6D565BAE-4764-40C3-9C0F-204B6FFA0389}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{6D565BAE-4764-40C3-9C0F-204B6FFA0389}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{6D565BAE-4764-40C3-9C0F-204B6FFA0389}.Debug-PortablePDB|Any CPU.ActiveCfg = Debug|Any CPU
 		{6D565BAE-4764-40C3-9C0F-204B6FFA0389}.Release.Lab|Any CPU.ActiveCfg = Release.Lab|Any CPU
 		{6D565BAE-4764-40C3-9C0F-204B6FFA0389}.Release.Lab|Any CPU.Build.0 = Release.Lab|Any CPU
 		{6D565BAE-4764-40C3-9C0F-204B6FFA0389}.Release|Any CPU.ActiveCfg = Release|Any CPU
@@ -93,6 +96,7 @@ Global
 		{E0844BFF-2D67-4CB0-8E2A-E9CD888F2EB0}.Debug.Lab|Any CPU.Build.0 = Debug.Lab|Any CPU
 		{E0844BFF-2D67-4CB0-8E2A-E9CD888F2EB0}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{E0844BFF-2D67-4CB0-8E2A-E9CD888F2EB0}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{E0844BFF-2D67-4CB0-8E2A-E9CD888F2EB0}.Debug-PortablePDB|Any CPU.ActiveCfg = Debug-PortablePDB|Any CPU
 		{E0844BFF-2D67-4CB0-8E2A-E9CD888F2EB0}.Release.Lab|Any CPU.ActiveCfg = Release.Lab|Any CPU
 		{E0844BFF-2D67-4CB0-8E2A-E9CD888F2EB0}.Release.Lab|Any CPU.Build.0 = Release.Lab|Any CPU
 		{E0844BFF-2D67-4CB0-8E2A-E9CD888F2EB0}.Release|Any CPU.ActiveCfg = Release|Any CPU
@@ -101,6 +105,7 @@ Global
 		{78728205-DB3E-4B7B-A7D2-5CBE38E9C607}.Debug.Lab|Any CPU.Build.0 = Debug.Lab|Any CPU
 		{78728205-DB3E-4B7B-A7D2-5CBE38E9C607}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{78728205-DB3E-4B7B-A7D2-5CBE38E9C607}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{78728205-DB3E-4B7B-A7D2-5CBE38E9C607}.Debug-PortablePDB|Any CPU.ActiveCfg = Debug-PortablePDB|Any CPU
 		{78728205-DB3E-4B7B-A7D2-5CBE38E9C607}.Release.Lab|Any CPU.ActiveCfg = Release.Lab|Any CPU
 		{78728205-DB3E-4B7B-A7D2-5CBE38E9C607}.Release.Lab|Any CPU.Build.0 = Release.Lab|Any CPU
 		{78728205-DB3E-4B7B-A7D2-5CBE38E9C607}.Release|Any CPU.ActiveCfg = Release|Any CPU
@@ -109,6 +114,7 @@ Global
 		{207FD4CC-116B-466D-8893-F9565248A085}.Debug.Lab|Any CPU.Build.0 = Debug.Lab|Any CPU
 		{207FD4CC-116B-466D-8893-F9565248A085}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{207FD4CC-116B-466D-8893-F9565248A085}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{207FD4CC-116B-466D-8893-F9565248A085}.Debug-PortablePDB|Any CPU.ActiveCfg = Debug|Any CPU
 		{207FD4CC-116B-466D-8893-F9565248A085}.Release.Lab|Any CPU.ActiveCfg = Release.Lab|Any CPU
 		{207FD4CC-116B-466D-8893-F9565248A085}.Release.Lab|Any CPU.Build.0 = Release.Lab|Any CPU
 		{207FD4CC-116B-466D-8893-F9565248A085}.Release|Any CPU.ActiveCfg = Release|Any CPU
@@ -117,6 +123,7 @@ Global
 		{D2A11674-F677-4B11-9989-2F6099A6F0A2}.Debug.Lab|Any CPU.Build.0 = Debug.Lab|Any CPU
 		{D2A11674-F677-4B11-9989-2F6099A6F0A2}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{D2A11674-F677-4B11-9989-2F6099A6F0A2}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{D2A11674-F677-4B11-9989-2F6099A6F0A2}.Debug-PortablePDB|Any CPU.ActiveCfg = Debug-PortablePDB|Any CPU
 		{D2A11674-F677-4B11-9989-2F6099A6F0A2}.Release.Lab|Any CPU.ActiveCfg = Release.Lab|Any CPU
 		{D2A11674-F677-4B11-9989-2F6099A6F0A2}.Release.Lab|Any CPU.Build.0 = Release.Lab|Any CPU
 		{D2A11674-F677-4B11-9989-2F6099A6F0A2}.Release|Any CPU.ActiveCfg = Release|Any CPU
@@ -125,6 +132,8 @@ Global
 		{EA876A2D-AB0F-4204-97DD-DFB3B5568978}.Debug.Lab|Any CPU.Build.0 = Debug.Lab|Any CPU
 		{EA876A2D-AB0F-4204-97DD-DFB3B5568978}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{EA876A2D-AB0F-4204-97DD-DFB3B5568978}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{EA876A2D-AB0F-4204-97DD-DFB3B5568978}.Debug-PortablePDB|Any CPU.ActiveCfg = Debug-PortablePDB|Any CPU
+		{EA876A2D-AB0F-4204-97DD-DFB3B5568978}.Debug-PortablePDB|Any CPU.Build.0 = Debug-PortablePDB|Any CPU
 		{EA876A2D-AB0F-4204-97DD-DFB3B5568978}.Release.Lab|Any CPU.ActiveCfg = Release.Lab|Any CPU
 		{EA876A2D-AB0F-4204-97DD-DFB3B5568978}.Release.Lab|Any CPU.Build.0 = Release.Lab|Any CPU
 		{EA876A2D-AB0F-4204-97DD-DFB3B5568978}.Release|Any CPU.ActiveCfg = Release|Any CPU
@@ -133,6 +142,8 @@ Global
 		{54C33AFA-438D-4932-A2F0-D0F2BB2FADC9}.Debug.Lab|Any CPU.Build.0 = Debug.Lab|Any CPU
 		{54C33AFA-438D-4932-A2F0-D0F2BB2FADC9}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{54C33AFA-438D-4932-A2F0-D0F2BB2FADC9}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{54C33AFA-438D-4932-A2F0-D0F2BB2FADC9}.Debug-PortablePDB|Any CPU.ActiveCfg = Debug-PortablePDB|Any CPU
+		{54C33AFA-438D-4932-A2F0-D0F2BB2FADC9}.Debug-PortablePDB|Any CPU.Build.0 = Debug-PortablePDB|Any CPU
 		{54C33AFA-438D-4932-A2F0-D0F2BB2FADC9}.Release.Lab|Any CPU.ActiveCfg = Release.Lab|Any CPU
 		{54C33AFA-438D-4932-A2F0-D0F2BB2FADC9}.Release.Lab|Any CPU.Build.0 = Release.Lab|Any CPU
 		{54C33AFA-438D-4932-A2F0-D0F2BB2FADC9}.Release|Any CPU.ActiveCfg = Release|Any CPU
@@ -141,6 +152,8 @@ Global
 		{A8B0230C-7806-407C-AF18-54B2CE21275E}.Debug.Lab|Any CPU.Build.0 = Debug.Lab|Any CPU
 		{A8B0230C-7806-407C-AF18-54B2CE21275E}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{A8B0230C-7806-407C-AF18-54B2CE21275E}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{A8B0230C-7806-407C-AF18-54B2CE21275E}.Debug-PortablePDB|Any CPU.ActiveCfg = Debug-PortablePDB|Any CPU
+		{A8B0230C-7806-407C-AF18-54B2CE21275E}.Debug-PortablePDB|Any CPU.Build.0 = Debug-PortablePDB|Any CPU
 		{A8B0230C-7806-407C-AF18-54B2CE21275E}.Release.Lab|Any CPU.ActiveCfg = Release.Lab|Any CPU
 		{A8B0230C-7806-407C-AF18-54B2CE21275E}.Release.Lab|Any CPU.Build.0 = Release.Lab|Any CPU
 		{A8B0230C-7806-407C-AF18-54B2CE21275E}.Release|Any CPU.ActiveCfg = Release|Any CPU
@@ -149,6 +162,7 @@ Global
 		{E659FEE3-7773-4A73-880A-83CE5C9634CC}.Debug.Lab|Any CPU.Build.0 = Debug.Lab|Any CPU
 		{E659FEE3-7773-4A73-880A-83CE5C9634CC}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{E659FEE3-7773-4A73-880A-83CE5C9634CC}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{E659FEE3-7773-4A73-880A-83CE5C9634CC}.Debug-PortablePDB|Any CPU.ActiveCfg = Debug|Any CPU
 		{E659FEE3-7773-4A73-880A-83CE5C9634CC}.Release.Lab|Any CPU.ActiveCfg = Release.Lab|Any CPU
 		{E659FEE3-7773-4A73-880A-83CE5C9634CC}.Release.Lab|Any CPU.Build.0 = Release.Lab|Any CPU
 		{E659FEE3-7773-4A73-880A-83CE5C9634CC}.Release|Any CPU.ActiveCfg = Release|Any CPU
@@ -157,6 +171,8 @@ Global
 		{95C0421F-D4C1-46E8-9177-6DAA4D71D0F2}.Debug.Lab|Any CPU.Build.0 = Debug.Lab|Any CPU
 		{95C0421F-D4C1-46E8-9177-6DAA4D71D0F2}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{95C0421F-D4C1-46E8-9177-6DAA4D71D0F2}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{95C0421F-D4C1-46E8-9177-6DAA4D71D0F2}.Debug-PortablePDB|Any CPU.ActiveCfg = Debug-PortablePDB|Any CPU
+		{95C0421F-D4C1-46E8-9177-6DAA4D71D0F2}.Debug-PortablePDB|Any CPU.Build.0 = Debug-PortablePDB|Any CPU
 		{95C0421F-D4C1-46E8-9177-6DAA4D71D0F2}.Release.Lab|Any CPU.ActiveCfg = Release.Lab|Any CPU
 		{95C0421F-D4C1-46E8-9177-6DAA4D71D0F2}.Release.Lab|Any CPU.Build.0 = Release.Lab|Any CPU
 		{95C0421F-D4C1-46E8-9177-6DAA4D71D0F2}.Release|Any CPU.ActiveCfg = Release|Any CPU

--- a/src/MIDebugEngine/MIDebugEngine.csproj
+++ b/src/MIDebugEngine/MIDebugEngine.csproj
@@ -54,6 +54,17 @@
     <ErrorReport>prompt</ErrorReport>
     <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug-PortablePDB|AnyCPU'">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>portable</DebugType>
+    <Optimize>false</Optimize>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+    <Prefer32Bit>false</Prefer32Bit>
+    <RunCodeAnalysis>true</RunCodeAnalysis>
+    <CodeAnalysisRuleSet>..\IDECodeAnalysis.ruleset</CodeAnalysisRuleSet>
+  </PropertyGroup>
   <ItemGroup>
     <None Include="project.json" />
   </ItemGroup>

--- a/src/prebuild/prebuild.csproj
+++ b/src/prebuild/prebuild.csproj
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="..\..\build\all_projects.settings.targets" />
   <PropertyGroup>
@@ -11,18 +11,14 @@
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' " />
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug.Lab|AnyCPU' " />
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release.Lab|AnyCPU' " />
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug-PortablePDB|AnyCPU'" />
 
   <ItemGroup>
     <GenerateAssembly Include="$(ILDir)*.il">
       <Visible>false</Visible>
     </GenerateAssembly>
   </ItemGroup>
-
-  <Target Name="GenerateAssemblies"
-        Condition="'@(GenerateAssembly)' != ''"
-        Inputs="@(GenerateAssembly)"
-        Outputs="@(GenerateAssembly->'$(GeneratedAssembliesDir)%(FileName).dll')"
-        AfterTargets="Build">
+  <Target Name="GenerateAssemblies" Condition="'@(GenerateAssembly)' != ''" Inputs="@(GenerateAssembly)" Outputs="@(GenerateAssembly->'$(GeneratedAssembliesDir)%(FileName).dll')" AfterTargets="Build">
     <PropertyGroup>
       <IlAsmCommand>"$(windir)\Microsoft.NET\Framework\v4.0.30319\ilasm.exe"</IlAsmCommand>
       <IlAsmFlags>$(IlAsmFlags) /DLL /quiet</IlAsmFlags>
@@ -30,20 +26,17 @@
     <MakeDir Condition="!Exists('$(GeneratedAssembliesDir)')" Directories="$(GeneratedAssembliesDir)" />
     <Exec Command="$(IlAsmCommand) $(IlAsmFlags) /out=&quot;$(GeneratedAssembliesDir)%(FileName).dll&quot; @(GenerateAssembly->'&quot;%(Identity)&quot;')" />
   </Target>
-  
   <Target Name="Build">
     <Exec Command="&quot;$(MIEngineRoot)tools\NuGet\NuGet.exe&quot; restore -PackagesDirectory &quot;$(NuGetPackagesDirectory)&quot; -MSBuildVersion 14 &quot;$(MIEngineRoot)src\MIDebugEngine.sln&quot;" />
   </Target>
-
   <Target Name="Clean">
     <RemoveDir Directories="$(GeneratedAssembliesDir)" />
   </Target>
-
   <!--Empty targets to make msbuild happy-->
-  <Target Name="GetNativeManifest"/>
-  <Target Name="GetCopyToOutputDirectoryItems"/>
-  <Target Name="BuiltProjectOutputGroupDependencies"/>
-  <Target Name="BuiltProjectOutputGroup"/>
-  <Target Name="SatelliteDllsProjectOutputGroup"/>
-  <Target Name="DebugSymbolsProjectOutputGroup"/>
+  <Target Name="GetNativeManifest" />
+  <Target Name="GetCopyToOutputDirectoryItems" />
+  <Target Name="BuiltProjectOutputGroupDependencies" />
+  <Target Name="BuiltProjectOutputGroup" />
+  <Target Name="SatelliteDllsProjectOutputGroup" />
+  <Target Name="DebugSymbolsProjectOutputGroup" />
 </Project>

--- a/tools/InstallToVSCode/InstallToVSCode.sh
+++ b/tools/InstallToVSCode/InstallToVSCode.sh
@@ -1,0 +1,188 @@
+#!/bin/bash
+
+DefaultDestDir=$HOME/.vscode/extensions/coreclr-debug
+script_dir=`dirname $0`
+
+print_help()
+{
+    echo 'InstallToVSCode.sh <-c|-l> [--pdbs] <OpenDebugAD7-dir> [destination-dir]'
+    echo ''
+    echo 'This script is used to copy files needed to enable MIEngine based debugging'
+    echo 'into VS Code.'
+    echo ''
+    echo ' -l : Create links to files instead of copying them. With this mode, it'
+    echo '   is possible to rebuild MIEngine or OpenDebugAD7 without re-running this'
+    echo '   script.'
+    echo ' -c : Copy files to the output directory'
+    echo ' --pdbs : Copy PDB files in addition to the dlls'
+    echo ' open-debug-ad7-dir : Directory which contains OpenDebugAD7.exe'
+    echo ' destination-dir: Directory to install to. By default this is:'
+    echo "    $DefaultDestDir"
+    echo ''
+    echo 'Example:'
+    echo "$script_dir/InstallToVSCode.sh -l --pdbs /Volumes/OpenDebugAD7/bin/Debug-PortablePDB $HOME/OpenDebugAD7-debug"
+}
+
+# Copies a file to another file or directory
+# arg1: source file
+# arg2: destination file or directory
+copy_file()
+{
+    echo "cp $1 $2"
+    cp $1 $2
+    if [ $? -ne 0 ]
+    then
+        echo "ERROR: Failed to copy '$1'"
+        InstallError=1
+    fi
+}
+
+# Links one file to the other
+# arg1: Source file
+# arg2: Destination file
+link_file()
+{
+    if [ ! -f "$1" ]
+    then
+        echo "ERROR: '$1' does not exist"
+        InstallError=1
+        return 1
+    fi
+
+    if [ -f "$2" ]
+    then
+        rm $2
+        if [ $? -ne 0 ]
+        then
+            echo "ERROR: Unable to remove link target file '$2'"
+            InstallError=1
+            return 1
+        fi
+    fi
+
+    echo "ln -fs $1 $2"
+    ln -fs $1 $2
+    if [ $? -ne 0 ]
+    then
+        echo "ERROR: Failed to link file '$1'"
+        InstallError=1
+        return 1
+    fi
+
+    return 0
+}
+
+install_file()
+{
+    $InstallAction $1 $DESTDIR/$2/$(basename $1)
+}
+
+install_module()
+{
+    modulPath=$1
+    moduleName=$(basename $modulPath)
+    $InstallAction $modulPath $DESTDIR/$2/$moduleName
+    if [ $? -ne 0 ]; then
+        return $?
+    fi
+
+    if [ "$install_pdbs" == "1" ]; then
+        sourcePdb=${modulPath%\.[^.]*}.pdb
+        if [ ! -f "$sourcePdb" ]; then
+            if [ "$3" == "ignoreMissingPdbs" ]; then
+                return 0
+            fi
+        fi
+
+        $InstallAction $sourcePdb $DESTDIR/$2/${moduleName%\.[^.]*}.pdb
+    fi
+}
+
+InstallAction=
+if [ -z "$1" ]; then
+    print_help
+    exit 1
+elif [ "$1" == "-h" ]; then
+    print_help
+    exit 1
+elif [ "$1" == "-l" ]; then
+    InstallAction=link_file
+elif [ "$1" == "-c" ]; then
+    InstallAction=copy_file
+else
+    echo "ERROR: Unexpected first argument '$1'. Expected '-l' or '-c'."
+    exit 1
+fi
+
+install_pdbs=0
+if [ "$2" == "--pdbs" ]; then
+    install_pdbs=1
+    shift
+fi
+
+OpenDebugAD7Dir=${2:?"ERROR: OpenDebugAD7 binaries directory must be specified. See -h for usage."}
+[ ! -f "$OpenDebugAD7Dir/OpenDebugAD7.exe" ] && echo "ERROR: $OpenDebugAD7Dir/OpenDebugAD7.exe does not exist." && exit 1
+
+DropDir=$script_dir/../../bin/Debug-PortablePDB
+if [ ! -f "$DropDir/Microsoft.MIDebugEngine.dll" ]
+then
+    echo "ERROR: '$DropDir/Microsoft.MIDebugEngine.dll' has not been built."
+    exit 1
+fi
+
+# Remove the relative path from DropDir
+pushd $DropDir
+DropDir=$(pwd)
+popd
+
+DESTDIR=$3
+if [ -z "$DESTDIR" ]
+then
+    DESTDIR=$DefaultDestDir
+fi
+
+if [ ! -d "$DESTDIR" ]
+then
+    mkdir "$DESTDIR"
+    if [ $? -ne 0 ]
+    then
+        echo "ERROR: unable to create destination directory '$DESTDIR'."
+        exit 1
+    fi
+fi
+
+if [ ! -d "$DESTDIR/debugAdapters" ]
+then
+    mkdir "$DESTDIR/debugAdapters"
+    if [ $? -ne 0 ]
+    then
+        echo "ERROR: unable to create destination directory '$DESTDIR/debugAdapters'."
+        exit 1
+    fi
+fi
+
+set InstallError=
+install_module "$OpenDebugAD7Dir/OpenDebugAD7.exe" debugAdapters
+for dll in $(ls $OpenDebugAD7Dir/*.dll); do
+    install_module "$dll" debugAdapters ignoreMissingPdbs
+done
+
+copy_file "$script_dir/coreclr/example-package.json" $DESTDIR/package.json
+
+install_file "$script_dir/coreclr/coreclr.ad7Engine.json" debugAdapters
+
+for dll in Microsoft.MICore.dll Microsoft.MIDebugEngine.dll
+do 
+    install_module "$DropDir/$dll" debugAdapters
+done
+
+echo ''
+if [ ! -z "$InstallError" ]; then
+    echo "ERROR: Failed to copy one or more files."
+    echo ''
+    exit 1
+fi
+
+echo 'InstallToVSCode.sh succeeded.'
+echo ''
+exit 0


### PR DESCRIPTION
This doesn't quite work yet, but these commits add the functionality that we need to be able to debug MIEngine with MIEngine on a Mac.

commit 1f28e850ef2b291ecd293044363a513e5ad363ee
Author: Gregg Miskelly <greggm@microsoft.com>
Date:   Wed Oct 28 16:28:23 2015 -0700

    Add InstallToVSCode.sh
    
    This checkin adds a bash script equivilant to InstallToVSCode.cmd.
    This is working for me on OSX.

commit c1f5a913eb88848cddf2033979ae8d4668e648c7
Author: Gregg Miskelly <greggm@microsoft.com>
Date:   Tue Oct 27 18:23:35 2015 -0700

    Create Debug-PortablePDB configuration
    
    This checkin creates a new build configuration that compiles our code with portable PDBs enabled.
