### PR TITLE
Error handling improvements

### DIFF
--- a/src/MICore/MICommandFactory.cs
+++ b/src/MICore/MICommandFactory.cs
@@ -345,7 +345,7 @@ namespace MICore
             return results.FindString("path_expr");
         }
 
-        public async Task Terminate()
+        public virtual async Task Terminate()
         {
             string command = "-exec-abort";
             await _debugger.CmdAsync(command, ResultClass.None);
@@ -880,6 +880,12 @@ namespace MICore
                     state = ExceptionBreakpointState.None;
                     break;
             }
+        }
+
+        override public async Task Terminate()
+        {
+            string command = "-exec-abort";
+            await _debugger.CmdAsync(command, ResultClass.done);
         }
     }
 }

--- a/src/MICore/MICoreResources.Designer.cs
+++ b/src/MICore/MICoreResources.Designer.cs
@@ -11,7 +11,8 @@
 namespace MICore {
     using System;
     using System.Reflection;
-
+    
+    
     /// <summary>
     ///   A strongly-typed resource class, for looking up localized strings, etc.
     /// </summary>
@@ -70,7 +71,7 @@ namespace MICore {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Internal error in the GDB engine. Exception of type &apos;{0}&apos; was thrown.
+        ///   Looks up a localized string similar to Internal error in MIEngine. Exception of type &apos;{0}&apos; was thrown.
         ///
         ///{1}.
         /// </summary>
@@ -101,7 +102,7 @@ namespace MICore {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Exception while processing GDB operation. {0}. If the problem continues restart debugging..
+        ///   Looks up a localized string similar to Exception while processing MIEngine operation. {0}. If the problem continues restart debugging..
         /// </summary>
         public static string Error_ExceptionInOperation {
             get {
@@ -166,11 +167,20 @@ namespace MICore {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to GDB exited unexpectedly. Debugging will now abort..
+        ///   Looks up a localized string similar to {0} exited unexpectedly. Debugging will now abort..
         /// </summary>
-        public static string Error_MIDebuggerExited {
+        public static string Error_MIDebuggerExited_UnknownCode {
             get {
-                return ResourceManager.GetString("Error_MIDebuggerExited", resourceCulture);
+                return ResourceManager.GetString("Error_MIDebuggerExited_UnknownCode", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to {0} exited unexpectedly with exit code {1}. Debugging will now abort..
+        /// </summary>
+        public static string Error_MIDebuggerExited_WithCode {
+            get {
+                return ResourceManager.GetString("Error_MIDebuggerExited_WithCode", resourceCulture);
             }
         }
         
@@ -184,7 +194,7 @@ namespace MICore {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Unable to execute GDB command. There is no GDB process..
+        ///   Looks up a localized string similar to Unable to execute command. The MIEngine is not currently debugging any process..
         /// </summary>
         public static string Error_NoMIDebuggerProcess {
             get {
@@ -247,7 +257,7 @@ namespace MICore {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Unexpected GDB output from command &quot;{0}&quot;..
+        ///   Looks up a localized string similar to Unexpected {0} output from command &quot;{1}&quot;..
         /// </summary>
         public static string Error_UnexpectedMIOutput {
             get {

--- a/src/MICore/MICoreResources.resx
+++ b/src/MICore/MICoreResources.resx
@@ -121,7 +121,7 @@
     <value>Required attribute '{0}' is missing or has an invalid value.</value>
   </data>
   <data name="Error_CorruptingException" xml:space="preserve">
-    <value>Internal error in the GDB engine. Exception of type '{0}' was thrown.
+    <value>Internal error in MIEngine. Exception of type '{0}' was thrown.
 
 {1}</value>
   </data>
@@ -134,7 +134,7 @@
 {1}</value>
   </data>
   <data name="Error_ExceptionInOperation" xml:space="preserve">
-    <value>Exception while processing GDB operation. {0}. If the problem continues restart debugging.</value>
+    <value>Exception while processing MIEngine operation. {0}. If the problem continues restart debugging.</value>
   </data>
   <data name="Error_ExceptionProcessingModules" xml:space="preserve">
     <value>An error occurred while processing modules from the target process.
@@ -156,14 +156,19 @@ Error: {1}</value>
   <data name="Error_LauncherNotFound" xml:space="preserve">
     <value>Device App Launcher {0} could not be found.</value>
   </data>
-  <data name="Error_MIDebuggerExited" xml:space="preserve">
-    <value>GDB exited unexpectedly. Debugging will now abort.</value>
+  <data name="Error_MIDebuggerExited_UnknownCode" xml:space="preserve">
+    <value>{0} exited unexpectedly. Debugging will now abort.</value>
+    <comment>{0} is the name of the debugger</comment>
+  </data>
+  <data name="Error_MIDebuggerExited_WithCode" xml:space="preserve">
+    <value>{0} exited unexpectedly with exit code {1}. Debugging will now abort.</value>
+    <comment>{0} is the name of the debugger</comment>
   </data>
   <data name="Error_MissingAttribute" xml:space="preserve">
     <value>Required attribute '{0}' is missing.</value>
   </data>
   <data name="Error_NoMIDebuggerProcess" xml:space="preserve">
-    <value>Unable to execute GDB command. There is no GDB process.</value>
+    <value>Unable to execute command. The MIEngine is not currently debugging any process.</value>
   </data>
   <data name="Error_ProcessMustBeStopped" xml:space="preserve">
     <value>Commands are only accepted when the process is stopped.</value>
@@ -184,7 +189,8 @@ Error: {1}</value>
     <value>Unable to start debugging. {0}</value>
   </data>
   <data name="Error_UnexpectedMIOutput" xml:space="preserve">
-    <value>Unexpected GDB output from command "{0}".</value>
+    <value>Unexpected {0} output from command "{1}".</value>
+    <comment>{0} is the name of the debugger</comment>
   </data>
   <data name="Error_UnknownTargetArchitecture" xml:space="preserve">
     <value>Unknown or unsupported target architecture '{0}'.</value>

--- a/src/MICore/MIException.cs
+++ b/src/MICore/MIException.cs
@@ -62,16 +62,19 @@ namespace MICore
         //    MessageText:
         //      The message is improperly formatted or was damaged in transit
         private const int COMQC_E_BAD_MESSAGE = unchecked((int)0x80110604);
+        public readonly string _debuggerName;
         private readonly string _command;
         private readonly string _miError;
 
         /// <summary>
         /// Creates a new UnexpectedMIResultException
         /// </summary>
+        /// <param name="debuggerName">[Required] Name of the underlying MI debugger (ex: 'GDB')</param>
         /// <param name="command">[Required] MI command that was issued</param>
         /// <param name="mi">[Optional] Error message from MI</param>
-        public UnexpectedMIResultException(string command, string mi) : base(COMQC_E_BAD_MESSAGE)
+        public UnexpectedMIResultException(string debuggerName, string command, string mi) : base(COMQC_E_BAD_MESSAGE)
         {
+            _debuggerName = debuggerName;
             _command = command;
             _miError = mi;
         }
@@ -80,7 +83,7 @@ namespace MICore
         {
             get
             {
-                string message = string.Format(CultureInfo.CurrentCulture, MICoreResources.Error_UnexpectedMIOutput, _command);
+                string message = string.Format(CultureInfo.CurrentCulture, MICoreResources.Error_UnexpectedMIOutput, _debuggerName, _command);
                 if (!string.IsNullOrWhiteSpace(_miError))
                 {
                     message = string.Concat(message, " ", _miError);

--- a/src/MICore/Transports/ITransport.cs
+++ b/src/MICore/Transports/ITransport.cs
@@ -40,7 +40,8 @@ namespace MICore
         /// <summary>
         /// Fired when either the target process exits or when the stdout stream is closed.
         /// </summary>
-        void OnDebuggerProcessExit();
+        /// <param name="exitCode">[Optional] exit code from the target process. null if unknown.</param>
+        void OnDebuggerProcessExit(string exitCode);
 
         /// <summary>
         /// Appends a line of text to the initialization log which is dumped to the output

--- a/src/MICore/Transports/PipeTransport.cs
+++ b/src/MICore/Transports/PipeTransport.cs
@@ -72,7 +72,14 @@ namespace MICore
         {
             if (_writer != null)
             {
-                Echo("logout");
+                try
+                {
+                    Echo("logout");
+                }
+                catch (Exception)
+                {
+                    // Ignore errors if logout couldn't be written
+                }
             }
 
             base.Close();
@@ -98,7 +105,7 @@ namespace MICore
 
             try
             {
-                if (_process.WaitForExit(50))
+                if (_process.WaitForExit(1000))
                 {
                     // If the pipe process has already exited, or is just about to exit, we want to send the abort event from OnProcessExit
                     // instead of from here since that will have access to stderr

--- a/src/MICore/Transports/PipeTransport.cs
+++ b/src/MICore/Transports/PipeTransport.cs
@@ -176,14 +176,13 @@ namespace MICore
                 }
                 catch (InvalidOperationException)
                 {
-                    exitCode = "Unknown";
                 }
-                this.Callback.AppendToInitializationLog(string.Format(CultureInfo.InvariantCulture, "\"{0}\" exited with code {1}.", _process.StartInfo.FileName, exitCode));
+                this.Callback.AppendToInitializationLog(string.Format(CultureInfo.InvariantCulture, "\"{0}\" exited with code {1}.", _process.StartInfo.FileName, exitCode ?? "???"));
 
 
                 try
                 {
-                    this.Callback.OnDebuggerProcessExit();
+                    this.Callback.OnDebuggerProcessExit(exitCode);
                 }
                 catch
                 {

--- a/src/MICore/Transports/StreamTransport.cs
+++ b/src/MICore/Transports/StreamTransport.cs
@@ -74,7 +74,7 @@ namespace MICore
         {
             try
             {
-                _callback.OnDebuggerProcessExit();
+                _callback.OnDebuggerProcessExit(null);
             }
             catch
             {

--- a/src/MIDebugEngine/AD7.Impl/AD7Engine.cs
+++ b/src/MIDebugEngine/AD7.Impl/AD7Engine.cs
@@ -518,7 +518,7 @@ namespace Microsoft.MIDebugEngine
             }
             catch (ObjectDisposedException)
             {
-                // if we have already shutdown, ignore the failure
+                // Ignore failures caused by the connection already being dead.
             }
 
             return Constants.S_OK;

--- a/src/MIDebugEngine/AD7.Impl/AD7Engine.cs
+++ b/src/MIDebugEngine/AD7.Impl/AD7Engine.cs
@@ -342,26 +342,15 @@ namespace Microsoft.MIDebugEngine
             Debug.Assert(_engineCallback != null);
             Debug.Assert(_debuggedProcess != null);
 
-            try
-            {
-                AD_PROCESS_ID processId = EngineUtils.GetProcessId(process);
+            AD_PROCESS_ID processId = EngineUtils.GetProcessId(process);
 
-                if (EngineUtils.ProcIdEquals(processId, _debuggedProcess.Id))
-                {
-                    return Constants.S_OK;
-                }
-                else
-                {
-                    return Constants.S_FALSE;
-                }
-            }
-            catch (MIException e)
+            if (EngineUtils.ProcIdEquals(processId, _debuggedProcess.Id))
             {
-                return e.HResult;
+                return Constants.S_OK;
             }
-            catch (Exception e)
+            else
             {
-                return EngineUtils.UnexpectedException(e);
+                return Constants.S_FALSE;
             }
         }
 
@@ -516,27 +505,23 @@ namespace Microsoft.MIDebugEngine
             Debug.Assert(_engineCallback != null);
             Debug.Assert(_debuggedProcess != null);
 
+            AD_PROCESS_ID processId = EngineUtils.GetProcessId(process);
+            if (!EngineUtils.ProcIdEquals(processId, _debuggedProcess.Id))
+            {
+                return Constants.S_FALSE;
+            }
+
             try
             {
-                AD_PROCESS_ID processId = EngineUtils.GetProcessId(process);
-                if (!EngineUtils.ProcIdEquals(processId, _debuggedProcess.Id))
-                {
-                    return Constants.S_FALSE;
-                }
-
                 _pollThread.RunOperation(() => _debuggedProcess.CmdTerminate());
                 _debuggedProcess.Terminate();
+            }
+            catch (ObjectDisposedException)
+            {
+                // if we have already shutdown, ignore the failure
+            }
 
-                return Constants.S_OK;
-            }
-            catch (MIException e)
-            {
-                return e.HResult;
-            }
-            catch (Exception e)
-            {
-                return EngineUtils.UnexpectedException(e);
-            }
+            return Constants.S_OK;
         }
 
         #endregion

--- a/src/MIDebugEngine/Engine.Impl/DebuggedProcess.cs
+++ b/src/MIDebugEngine/Engine.Impl/DebuggedProcess.cs
@@ -208,7 +208,7 @@ namespace Microsoft.MIDebugEngine
                 Dispose();
             };
 
-            DebuggerAbortedEvent += delegate (object o, EventArgs args)
+            DebuggerAbortedEvent += delegate (object o, /*OPTIONAL*/ string debuggerExitCode)
             {
                 // NOTE: Exceptions leaked from this method may cause VS to crash, be careful
 
@@ -221,7 +221,13 @@ namespace Microsoft.MIDebugEngine
                             return;
                         }
 
-                        _callback.OnError(MICoreResources.Error_MIDebuggerExited);
+                        string message;
+                        if (string.IsNullOrEmpty(debuggerExitCode))
+                            message = string.Format(CultureInfo.CurrentCulture, MICoreResources.Error_MIDebuggerExited_UnknownCode, MICommandFactory.Name);
+                        else
+                            message = string.Format(CultureInfo.CurrentCulture, MICoreResources.Error_MIDebuggerExited_WithCode, MICommandFactory.Name, debuggerExitCode);
+
+                        _callback.OnError(message);
                         _callback.OnProcessExit(uint.MaxValue);
 
                         Dispose();
@@ -372,7 +378,7 @@ namespace Microsoft.MIDebugEngine
                         if (results.ResultClass == ResultClass.error && !command.IgnoreFailures)
                         {
                             string miError = results.FindString("msg");
-                            throw new UnexpectedMIResultException(command.CommandText, miError);
+                            throw new UnexpectedMIResultException(MICommandFactory.Name, command.CommandText, miError);
                         }
                     }
                     else


### PR DESCRIPTION
commit 41d14acb3618aabfcf3943a0f6de3b70dd673f70
Author: Gregg Miskelly <greggm@microsoft.com>
Date:   Fri Nov 6 10:31:05 2015 -0800

    Fix issues with reliably reporting the MI debugger exited on MacOS
    
    1. Sending the 'logout' command would raise an IOException because the pipe was already closed.
    2. The pipe would close before the process was reported as terminated, so we would often report the process without the exit code. I increased the timeout to prevent this.

commit 3108d04aa2690b4bdbeb1ee27150174313071c55
Author: Gregg Miskelly <greggm@microsoft.com>
Date:   Thu Nov 5 17:07:45 2015 -0800

    MIEngine error enhancements
    
    - Many of our error strings still had 'GDB' in them even if the underlying debugger wasn't GDB. Now we plumb through the name of the debugger.
    - For CLRDBG we stop ignoring the failure code from kill. We should probably eventually do this for LLDB also. But I don't have things setup to test LLDB at the second.
    - When gdb/lldb/clrdbg exits were wern't displaying the exit code. Now we do.
    - Stop catching exceptions in [Can]TerminateProcess. For TerminateProcess, I wanted to be able to get the message in OpenDebugAD7. For CanTerminateProcess, there didn't seem to be a reason to have a filter at all.
