### PR TITLE
Add .DS_Store to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,4 @@ packages/
 .vs/
 Microsoft.VisualStudio.Glass
 project.lock.json
+.DS_Store


### PR DESCRIPTION
From Wikipedia:
.DS_Store is the name of a file in the Apple OS X operating system for
storing custom attributes of a folder such as the position of icons or
the choice of a background image.