### PR TITLE
Fix CodeAnalysis errors

### DIFF
--- a/src/DebugEngineHost/DebugEngineHost.csproj
+++ b/src/DebugEngineHost/DebugEngineHost.csproj
@@ -28,6 +28,7 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <CodeAnalysisRuleSet>..\IDECodeAnalysis.ruleset</CodeAnalysisRuleSet>
+    <RunCodeAnalysis>true</RunCodeAnalysis>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>

--- a/src/DebugEngineHost/HostConfirigurationException.cs
+++ b/src/DebugEngineHost/HostConfirigurationException.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
+using System.Globalization;
 
 namespace Microsoft.DebugEngineHost
 {
@@ -9,7 +10,7 @@ namespace Microsoft.DebugEngineHost
     {
         private const int E_DEBUG_ENGINE_NOT_REGISTERED = unchecked((int)0x80040019);
 
-        public HostConfirigurationException(string missingLocation) : base(string.Format("Missing configuration section '{0}'", missingLocation))
+        public HostConfirigurationException(string missingLocation) : base(string.Format(CultureInfo.InvariantCulture, "Missing configuration section '{0}'", missingLocation))
         {
             this.HResult = E_DEBUG_ENGINE_NOT_REGISTERED;
         }

--- a/src/MICore/LaunchOptions.cs
+++ b/src/MICore/LaunchOptions.cs
@@ -464,6 +464,8 @@ namespace MICore
             return launchOptions;
         }
 
+        [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Security.Xml", "CA3053: UseSecureXmlResolver.", 
+            Justification = "Usage is secure -- XmlResolver property is set to 'null' in desktop CLR, and is always null in CoreCLR. But CodeAnalysis cannot understand the invocation since it happens through reflection.")]
         public static XmlReader OpenXml(string content)
         {
             var settings = new XmlReaderSettings();

--- a/src/MICoreUnitTests/MICoreUnitTests.csproj
+++ b/src/MICoreUnitTests/MICoreUnitTests.csproj
@@ -108,6 +108,7 @@
     <ProjectReference Include="..\DebugEngineHost.Stub\DebugEngineHost.Stub.csproj">
       <Project>{ea876a2d-ab0f-4204-97dd-dfb3b5568978}</Project>
       <Name>DebugEngineHost.Stub</Name>
+      <Private>False</Private>
     </ProjectReference>
     <ProjectReference Include="..\MICore\MICore.csproj">
       <Project>{54c33afa-438d-4932-a2f0-d0f2bb2fadc9}</Project>


### PR DESCRIPTION
- Resolve two code analysis errors with MIEngine found in official builds
- DebugEngineHost accidentally didn't have code analysis enabled during the build, which led to one of the bugs. This turns it on.
- MICoreUnitTests.csproj was missing the 'Private' element on its reference to the stub definition of DebugEngineHost. Due to msbuild's super annoying reference system, this was dragging the stub definition of DebugEngineHost to the output directory, which was causing build races as that would sometimes overwrite the real version.