### PR TITLE
Fix FxCop warning in Natvis.cs

### DIFF
--- a/src/MICore/LaunchOptions.cs
+++ b/src/MICore/LaunchOptions.cs
@@ -475,7 +475,8 @@ namespace MICore
             settings.IgnoreWhitespace = true;
             settings.NameTable = new NameTable();
 
-            // set XmlResolver via reflection, if it exists, to satisfy FxCop
+            // set XmlResolver via reflection, if it exists. This is required for desktop CLR, as otherwise the XML reader may
+            // attempt to hit untrusted external resources.
             var xmlResolverProperty = settings.GetType().GetProperty("XmlResolver", BindingFlags.Public | BindingFlags.Instance);
             xmlResolverProperty?.SetValue(settings, null);
 


### PR DESCRIPTION
For some reason the previous CodeAnalysis run didn't report the XmlResolver issue in natvis.cs, even though the issue was in both spots. This fixes the issue there also.

I also updated the comment in LaunchOptions.cs, as when I was copy/pasting the code, I realized that the comment wasn't accurate.