### PR TITLE
Glass test improvements

### DIFF
--- a/src/DebugEngineHost/DebugEngineHost.csproj
+++ b/src/DebugEngineHost/DebugEngineHost.csproj
@@ -116,6 +116,9 @@
     <Compile Include="HostLoader.cs" />
     <Compile Include="HostWaitLoop.cs" />
   </ItemGroup>
+  <ItemGroup>
+    <GlassDirCopy Include="$(OutDir)$(AssemblyName)$(TargetExt)" />
+  </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Import Project="..\..\build\miengine.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 

--- a/src/MIDebugPackage/MIDebugPackage.csproj
+++ b/src/MIDebugPackage/MIDebugPackage.csproj
@@ -158,6 +158,7 @@
   </ItemGroup>
   <ItemGroup>
     <VSIXSourceItem Include="@(RequiredNetFX46FacadeAssemblies)" />
+    <GlassDirCopy Include="@(RequiredNetFX46FacadeAssemblies)" />
   </ItemGroup>
   <ItemGroup>
     <DropUnsignedFile Include="$(OutDir)\Microsoft.Android.natvis" />


### PR DESCRIPTION
commit ea8c7b0a7908d7ec4de9434cfbe5448059edae36
Author: Gregg Miskelly <greggm@microsoft.com>
Date:   Fri Nov 13 11:22:03 2015 -0800

    Add basic looping support to AndroidTest.cmd
    
    I was trying to track down some test flakyness, and so I needed some basic looping support in AndroidTest.cmd. This adds it. The '/Loop ###' can now be used to run a test repeatedly. We will stop running the test if it fails.

commit a0888b4217b51cd5319560ec0d570e2847d35303
Author: Gregg Miskelly <greggm@microsoft.com>
Date:   Fri Nov 13 10:46:12 2015 -0800

    Improvements to AndroidTest.cmd
    
    1. Before AndroidTest.cmd would not register glass if glass was registered to any path. Now we check to make sure that it is registered in the right place before deciding that we don't need to register it.
    
    2. Before we would ignore failures from RegisterGlass. This was especially a problem because it will fail if called from a non-elevated prompt. Now we fail it.
    
    3. The example had a device id which is very different than what the device id looks like for the emulator, at least on my computer. So I updated the example device id to look like what I see. Hopefully this isn't just my computer.
    
    4. The failure message when a test failed referenced the wrong name of the script.

commit a8a5d2de44adc0a54fa6c9a2795614f4f8d61b8b
Author: Gregg Miskelly <greggm@microsoft.com>
Date:   Fri Nov 13 10:42:19 2015 -0800

    Fix glass tests
    
    Glass tests were broken because we weren't copying all the necessary assemblies to the glass directory. Now we are.
