### PR TITLE
Drop additional files for Java debugger

### DIFF
--- a/build/DropFiles.targets
+++ b/build/DropFiles.targets
@@ -1,0 +1,19 @@
+﻿<Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  
+  <ItemGroup>
+    <FilesToSign Include="@(DropSignedFile)">
+      <Authenticode>Microsoft</Authenticode>
+      <StrongName>StrongName</StrongName>
+    </FilesToSign>
+  </ItemGroup>
+
+  <Target Name="DropFiles" AfterTargets="SignFiles;Build" Condition="'@(DropUnsignedFile);@(DropSignedFile)' != ''">
+    <PropertyGroup>
+      <DropDir>$(DropRootDir)</DropDir>
+      <DropDir Condition="'$(DropSubDir)'!=''">$(DropRootDir)\$(DropSubDir)</DropDir>
+    </PropertyGroup>
+    <MakeDir Condition="!Exists($(DropDir))" Directories="$(DropDir)" />
+    <Copy DestinationFolder="$(DropDir)" SourceFiles="@(DropUnsignedFile);@(DropSignedFile)" />
+  </Target>
+  
+</Project>

--- a/build/miengine.settings.targets
+++ b/build/miengine.settings.targets
@@ -24,6 +24,11 @@
   
   <PropertyGroup>
     <GlassDir>$(MSBuildThisFileDirectory)..\Microsoft.VisualStudio.Glass\</GlassDir>
+    <DropConfigurationName>$(Configuration)</DropConfigurationName>
+    <DropConfigurationName Condition="'$(Configuration)' == 'Debug.Lab'">Debug</DropConfigurationName>
+    <DropConfigurationName Condition="'$(Configuration)' == 'Release.Lab'">Release</DropConfigurationName>
+    <DropRootDir Condition="'$(TF_BUILD_BINARIESDIRECTORY)'!=''">$(TF_BUILD_BINARIESDIRECTORY)\$(DropConfigurationName)</DropRootDir>
+    <DropRootDir Condition="'$(DropRootDir)'==''">$(MIEngineRoot)bin\$(DropConfigurationName)\drop</DropRootDir>
   </PropertyGroup>
     
   <PropertyGroup>

--- a/src/DebugEngineHost.Stub/DebugEngineHost.Stub.csproj
+++ b/src/DebugEngineHost.Stub/DebugEngineHost.Stub.csproj
@@ -25,6 +25,7 @@
     <!--NOTE: This does NOT go to the same output directory as the rest of the MIEngine project as this is just the stub (contract) definition
     of DebugEngineHost, so we don't want to conflict with the real version. -->
     <OutputPath>bin\$(Configuration)</OutputPath>
+    <DocumentationFile>$(DropRootDir)\ReferenceAssemblies\$(AssemblyName).xml</DocumentationFile>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -74,8 +75,15 @@
     <Compile Include="DebugEngineHost.ref.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>
+  <PropertyGroup>
+    <DropSubDir>ReferenceAssemblies</DropSubDir>
+  </PropertyGroup>
+  <ItemGroup>
+    <DropSignedFile Include="$(OutDir)\Microsoft.DebugEngineHost.dll" />
+  </ItemGroup>
   <Import Project="$(MSBuildExtensionsPath32)\Microsoft\Portable\$(TargetFrameworkVersion)\Microsoft.Portable.CSharp.targets" />
   <Import Project="..\..\build\miengine.targets" />
+  <Import Project="..\..\build\DropFiles.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it.
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">

--- a/src/DebugEngineHost.Stub/DebugEngineHost.ref.cs
+++ b/src/DebugEngineHost.Stub/DebugEngineHost.ref.cs
@@ -236,6 +236,10 @@ namespace Microsoft.DebugEngineHost
     [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Naming", "CA1704:IdentifiersShouldBeSpelledCorrectly", MessageId = "Natvis")]
     public static class HostNatvisProject
     {
+        /// <summary>
+        /// Delegate which is fired to process a natvis file.
+        /// </summary>
+        /// <param name="path"></param>
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Naming", "CA1704:IdentifiersShouldBeSpelledCorrectly", MessageId = "Natvis")]
         public delegate void NatvisLoader(string path);
 

--- a/src/MICore/LaunchOptions.cs
+++ b/src/MICore/LaunchOptions.cs
@@ -799,6 +799,7 @@ namespace MICore
         /// <param name="args">[Optional] Arguments to the executable provided in the VsDebugTargetInfo by the project system. Some launchers may ignore this.</param>
         /// <param name="dir">[Optional] Working directory of the executable provided in the VsDebugTargetInfo by the project system. Some launchers may ignore this.</param>
         /// <param name="launcherXmlOptions">[Required] Deserialized XML options structure</param>
+        /// <param name="targetEngine">Indicates the type of debugging being done.</param>
         void SetLaunchOptions(string exePath, string args, string dir, object launcherXmlOptions, TargetEngine targetEngine);
 
         /// <summary>

--- a/src/MICore/MICommandFactory.cs
+++ b/src/MICore/MICommandFactory.cs
@@ -181,7 +181,6 @@ namespace MICore
         /// <param name="printValues"></param>
         /// <param name="threadId"></param>
         /// <param name="frameLevel"></param>
-        /// <param name="resultClass"></param>
         /// <returns>Returns an array of results for variables</returns>
         public async Task<ValueListValue> StackListVariables(PrintValues printValues, int threadId, uint frameLevel)
         {

--- a/src/MICore/MICore.csproj
+++ b/src/MICore/MICore.csproj
@@ -18,6 +18,11 @@
     </TargetFrameworkProfile>
     <TargetFrameworkVersion>v5.0</TargetFrameworkVersion>
     <OutputPath>$(MIDefaultOutputPath)</OutputPath>
+    <DocumentationFile>$(DropRootDir)\ReferenceAssemblies\$(AssemblyName).xml</DocumentationFile>
+    <!-- Disable warning about public API without XML documentation: it would be nice if MICore had documentation 
+    for all its methods, but it is also not a public assembly, and adding XML documentation for all its methods
+    would take a fair amount of work.-->
+    <NoWarn>$(NoWarn);1591</NoWarn>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -29,6 +34,8 @@
     <Prefer32Bit>false</Prefer32Bit>
     <RunCodeAnalysis>true</RunCodeAnalysis>
     <CodeAnalysisRuleSet>..\IDECodeAnalysis.ruleset</CodeAnalysisRuleSet>
+    
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>

--- a/src/MICore/MIException.cs
+++ b/src/MICore/MIException.cs
@@ -62,7 +62,7 @@ namespace MICore
         //    MessageText:
         //      The message is improperly formatted or was damaged in transit
         private const int COMQC_E_BAD_MESSAGE = unchecked((int)0x80110604);
-        public readonly string _debuggerName;
+        private readonly string _debuggerName;
         private readonly string _command;
         private readonly string _miError;
 

--- a/src/MICore/MIResults.cs
+++ b/src/MICore/MIResults.cs
@@ -658,11 +658,11 @@ namespace MICore
         }
 
         /// <summary>
-        /// GDB (on x86) sometimes returns a tuple list in a context requiring a tuple (<MULTIPLE> breakpoints). 
+        /// GDB (on x86) sometimes returns a tuple list in a context requiring a tuple (&lt;MULTIPLE&gt; breakpoints). 
         /// The grammer does not allow this, but we recognize it and accept it only in the special case when it is contained
         /// in a result value.
-        ///     tuplelist ==>  tuple ("," tuple)*
-        ///     value ==>const | tuple | tuplelist | list
+        ///     tuplelist --  tuple ("," tuple)*
+        ///     value -- const | tuple | tuplelist | list
         /// </summary>
         /// <returns></returns>
         private static ResultValue ParseResultValue(string resultStr, out string rest)

--- a/src/MIDebugPackage/MIDebugPackage.csproj
+++ b/src/MIDebugPackage/MIDebugPackage.csproj
@@ -205,12 +205,6 @@
     <DropUnsignedFile Include="@(RequiredNetFX46FacadeAssemblies)" />
   </ItemGroup>
   <ItemGroup>
-    <FilesToSign Include="@(DropSignedFile)">
-      <Authenticode>Microsoft</Authenticode>
-      <StrongName>StrongName</StrongName>
-    </FilesToSign>
-  </ItemGroup>
-  <ItemGroup>
     <ProjectReference Include="..\AndroidDebugLauncher\AndroidDebugLauncher.csproj">
       <Project>{e0844bff-2d67-4cb0-8e2a-e9cd888f2eb0}</Project>
       <Name>AndroidDebugLauncher</Name>
@@ -244,23 +238,14 @@
   </ItemGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
   <Import Project="..\..\build\miengine.targets" />
+  <Import Project="..\..\build\DropFiles.targets" />
   <Import Project="$(VSToolsPath)\VSSDK\Microsoft.VsSDK.targets" Condition="'$(VSToolsPath)' != ''" />
   <!--
   Target to drop the built files into a directory.
   For the official build, we need to drop files to the build share
   For normal builds, we drop files to <enlistment-root>\bin\debug\drop for easy sharing
   -->
-  <Target Name="DropFiles" AfterTargets="SignFiles;Build">
-    <PropertyGroup>
-      <DropConfigurationName>$(Configuration)</DropConfigurationName>
-      <DropConfigurationName Condition="'$(Configuration)' == 'Debug.Lab'">Debug</DropConfigurationName>
-      <DropConfigurationName Condition="'$(Configuration)' == 'Release.Lab'">Release</DropConfigurationName>
-      <DropLocation Condition="'$(TF_BUILD_BINARIESDIRECTORY)'!=''">$(TF_BUILD_BINARIESDIRECTORY)\$(DropConfigurationName)</DropLocation>
-      <DropLocation Condition="'$(DropLocation)'==''">$(MIEngineRoot)bin\$(DropConfigurationName)\drop</DropLocation>
-    </PropertyGroup>
-    <MakeDir Condition="!Exists($(DropLocation))" Directories="$(DropLocation)" />
-    <Copy DestinationFolder="$(DropLocation)" SourceFiles="@(DropUnsignedFile);@(DropSignedFile)" />
-  </Target>
+  
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">


### PR DESCRIPTION
This checkin outputs additional files that we will want to use in the java debugger from our official builds.