### PR TITLE
put _internalName in quotes in VariableInformation.InternalFetchChildren

### DIFF
--- a/src/MIDebugEngine/Engine.Impl/Variables.cs
+++ b/src/MIDebugEngine/Engine.Impl/Variables.cs
@@ -483,7 +483,7 @@ namespace Microsoft.MIDebugEngine
         }
         private async Task InternalFetchChildren()
         {
-            Results results = await _engine.DebuggedProcess.CmdAsync(string.Format("-var-list-children --simple-values {0}", _internalName), ResultClass.None);
+            Results results = await _engine.DebuggedProcess.CmdAsync(string.Format("-var-list-children --simple-values \"{0}\"", _internalName), ResultClass.None);
 
             if (results.ResultClass == ResultClass.done)
             {


### PR DESCRIPTION
_internalName can contain spaces (template typenames), which leads to
invalid usage error in gdb's `mi_cmd_var_list_children()` because it thinks
its additional parameters