### PR TITLE
Handle invalid threads in Continue

### DIFF
--- a/src/MIDebugEngine/AD7.Impl/AD7Engine.cs
+++ b/src/MIDebugEngine/AD7.Impl/AD7Engine.cs
@@ -570,7 +570,7 @@ namespace Microsoft.MIDebugEngine
         public int Continue(IDebugThread2 pThread)
         {
             AD7Thread thread = pThread as AD7Thread;
-            _pollThread.RunOperation(() => _debuggedProcess.Continue(thread != null ? thread.GetDebuggedThread() : null));
+            _pollThread.RunOperation(() => _debuggedProcess.Continue(thread?.GetDebuggedThread()));
 
             return Constants.S_OK;
         }

--- a/src/MIDebugEngine/AD7.Impl/AD7Engine.cs
+++ b/src/MIDebugEngine/AD7.Impl/AD7Engine.cs
@@ -569,9 +569,8 @@ namespace Microsoft.MIDebugEngine
         // and the debugger does not want to actually enter break mode.
         public int Continue(IDebugThread2 pThread)
         {
-            AD7Thread thread = (AD7Thread)pThread;
-
-            _pollThread.RunOperation(() => _debuggedProcess.Continue(thread.GetDebuggedThread()));
+            AD7Thread thread = pThread as AD7Thread;
+            _pollThread.RunOperation(() => _debuggedProcess.Continue(thread != null ? thread.GetDebuggedThread() : null));
 
             return Constants.S_OK;
         }


### PR DESCRIPTION
VS Code is giving a thread Id of 0 when continuing from async break. Update Continue method to better handle cases where we can't get a debugged thread from the given pThread.