### PR TITLE
Remove global DebuggedProcess variable

### DIFF
--- a/src/MIDebugEngine/AD7.Impl/AD7Engine.cs
+++ b/src/MIDebugEngine/AD7.Impl/AD7Engine.cs
@@ -690,7 +690,7 @@ namespace Microsoft.MIDebugEngine
         // In order for this to be called, the Disassembly capability must be set in the registry for this Engine
         public int GetDisassemblyStream(enum_DISASSEMBLY_STREAM_SCOPE dwScope, IDebugCodeContext2 codeContext, out IDebugDisassemblyStream2 disassemblyStream)
         {
-            disassemblyStream = new AD7DisassemblyStream(dwScope, codeContext);
+            disassemblyStream = new AD7DisassemblyStream(this, dwScope, codeContext);
             return Constants.S_OK;
         }
 

--- a/src/MIDebugEngine/AD7.Impl/AD7Events.cs
+++ b/src/MIDebugEngine/AD7.Impl/AD7Events.cs
@@ -347,23 +347,25 @@ namespace Microsoft.MIDebugEngine
 
     internal sealed class AD7ExpressionCompleteEvent : AD7AsynchronousEvent, IDebugExpressionEvaluationCompleteEvent2
     {
+        AD7Engine _engine;
         public const string IID = "C0E13A85-238A-4800-8315-D947C960A843";
 
-        public AD7ExpressionCompleteEvent(IVariableInformation var, IDebugProperty2 prop = null)
+        public AD7ExpressionCompleteEvent(AD7Engine engine, IVariableInformation var, IDebugProperty2 prop = null)
         {
+            _engine = engine;
             _var = var;
             _prop = prop;
         }
 
         public int GetExpression(out IDebugExpression2 expr)
         {
-            expr = new AD7Expression(_var);
+            expr = new AD7Expression(_engine, _var);
             return Constants.S_OK;
         }
 
         public int GetResult(out IDebugProperty2 prop)
         {
-            prop = _prop != null ? _prop : new AD7Property(_var);
+            prop = _prop != null ? _prop : new AD7Property(_engine, _var);
             return Constants.S_OK;
         }
 

--- a/src/MIDebugEngine/AD7.Impl/AD7MemoryAddress.cs
+++ b/src/MIDebugEngine/AD7.Impl/AD7MemoryAddress.cs
@@ -161,7 +161,7 @@ namespace Microsoft.MIDebugEngine
 
                 if ((dwFields & enum_CONTEXT_INFO_FIELDS.CIF_ADDRESS) != 0)
                 {
-                    pinfo[0].bstrAddress = EngineUtils.AsAddr(_address);
+                    pinfo[0].bstrAddress = EngineUtils.AsAddr(_address, _engine.DebuggedProcess.Is64BitArch);
                     pinfo[0].dwFields |= enum_CONTEXT_INFO_FIELDS.CIF_ADDRESS;
                 }
 
@@ -169,7 +169,7 @@ namespace Microsoft.MIDebugEngine
                 if ((dwFields & enum_CONTEXT_INFO_FIELDS.CIF_ADDRESSOFFSET) != 0) { }
                 if ((dwFields & enum_CONTEXT_INFO_FIELDS.CIF_ADDRESSABSOLUTE) != 0)
                 {
-                    pinfo[0].bstrAddressAbsolute = EngineUtils.AsAddr(_address);
+                    pinfo[0].bstrAddressAbsolute = EngineUtils.AsAddr(_address, _engine.DebuggedProcess.Is64BitArch);
                     pinfo[0].dwFields |= enum_CONTEXT_INFO_FIELDS.CIF_ADDRESSABSOLUTE;
                 }
                 if ((dwFields & enum_CONTEXT_INFO_FIELDS.CIF_MODULEURL) != 0)

--- a/src/MIDebugEngine/AD7.Impl/AD7RegProperty.cs
+++ b/src/MIDebugEngine/AD7.Impl/AD7RegProperty.cs
@@ -11,11 +11,13 @@ namespace Microsoft.MIDebugEngine
 {
     public class AD7RegGroupProperty : IDebugProperty2
     {
+        private readonly AD7Engine _engine;
         private readonly RegisterGroup _group;
         private readonly Tuple<int, string>[] _values;
         public readonly DEBUG_PROPERTY_INFO PropertyInfo;
-        public AD7RegGroupProperty(enum_DEBUGPROP_INFO_FLAGS dwFields, RegisterGroup grp, Tuple<int, string>[] values)
+        public AD7RegGroupProperty(AD7Engine engine, enum_DEBUGPROP_INFO_FLAGS dwFields, RegisterGroup grp, Tuple<int, string>[] values)
         {
+            _engine = engine;
             _group = grp;
             _values = values;
             PropertyInfo = CreateInfo(dwFields);
@@ -52,7 +54,7 @@ namespace Microsoft.MIDebugEngine
         {
             DEBUG_PROPERTY_INFO[] properties = new DEBUG_PROPERTY_INFO[_group.Count];
             int i = 0;
-            foreach (var reg in DebuggedProcess.g_Process.GetRegisterDescriptions())
+            foreach (var reg in _engine.DebuggedProcess.GetRegisterDescriptions())
             {
                 if (reg.Group == _group)
                 {

--- a/src/MIDebugEngine/AD7.Impl/AD7StackFrame.cs
+++ b/src/MIDebugEngine/AD7.Impl/AD7StackFrame.cs
@@ -290,7 +290,7 @@ namespace Microsoft.MIDebugEngine
             {
                 for (int i = 0; i < _locals.Count; i++)
                 {
-                    AD7Property property = new AD7Property(_locals[i]);
+                    AD7Property property = new AD7Property(Engine, _locals[i]);
                     propInfo[i] = property.ConstructDebugPropertyInfo(dwFields);
                 }
             }
@@ -299,7 +299,7 @@ namespace Microsoft.MIDebugEngine
             {
                 for (int i = 0; i < _parameters.Count; i++)
                 {
-                    AD7Property property = new AD7Property(_parameters[i]);
+                    AD7Property property = new AD7Property(Engine, _parameters[i]);
                     propInfo[localsLength + i] = property.ConstructDebugPropertyInfo(dwFields);
                 }
             }
@@ -315,7 +315,7 @@ namespace Microsoft.MIDebugEngine
 
             for (int i = 0; i < propInfo.Length; i++)
             {
-                AD7Property property = new AD7Property(_locals[i]);
+                AD7Property property = new AD7Property(Engine, _locals[i]);
                 propInfo[i] = property.ConstructDebugPropertyInfo(dwFields);
             }
 
@@ -330,7 +330,7 @@ namespace Microsoft.MIDebugEngine
 
             for (int i = 0; i < propInfo.Length; i++)
             {
-                AD7Property property = new AD7Property(_parameters[i]);
+                AD7Property property = new AD7Property(Engine, _parameters[i]);
                 propInfo[i] = property.ConstructDebugPropertyInfo(dwFields);
             }
 
@@ -351,7 +351,7 @@ namespace Microsoft.MIDebugEngine
             int i = 0;
             foreach (var grp in registerGroups)
             {
-                AD7RegGroupProperty regProp = new AD7RegGroupProperty(dwFields, grp, values);
+                AD7RegGroupProperty regProp = new AD7RegGroupProperty(Engine, dwFields, grp, values);
                 propInfo[i] = regProp.PropertyInfo;
                 i++;
             }
@@ -581,7 +581,7 @@ namespace Microsoft.MIDebugEngine
             try
             {
                 // we have no "parser" as such, so we accept anything that isn't blank and let the Evaluate method figure out the errors
-                ppExpr = new AD7Expression(Engine.DebuggedProcess.Natvis.GetVariable(pszCode, this));
+                ppExpr = new AD7Expression(Engine, Engine.DebuggedProcess.Natvis.GetVariable(pszCode, this));
                 return Constants.S_OK;
             }
             catch (MIException e)

--- a/src/MIDebugEngine/AD7.Impl/AD7Thread.cs
+++ b/src/MIDebugEngine/AD7.Impl/AD7Thread.cs
@@ -289,7 +289,7 @@ namespace Microsoft.MIDebugEngine
             {
                 return Constants.S_FALSE;
             }
-            string result = frame.EvaluateExpression("$pc=" + EngineUtils.AsAddr(addr));
+            string result = frame.EvaluateExpression("$pc=" + EngineUtils.AsAddr(addr, _engine.DebuggedProcess.Is64BitArch));
             if (result != null)
             {
                 _engine.DebuggedProcess.ThreadCache.MarkDirty();

--- a/src/MIDebugEngine/Engine.Impl/DebuggedProcess.cs
+++ b/src/MIDebugEngine/Engine.Impl/DebuggedProcess.cs
@@ -20,7 +20,6 @@ namespace Microsoft.MIDebugEngine
 {
     internal class DebuggedProcess : MICore.Debugger
     {
-        public static DebuggedProcess g_Process; // TODO: Remove
         public AD_PROCESS_ID Id { get; private set; }
         public AD7Engine Engine { get; private set; }
         public List<string> VariablesToDelete { get; private set; }
@@ -48,7 +47,6 @@ namespace Microsoft.MIDebugEngine
         public DebuggedProcess(bool bLaunched, LaunchOptions launchOptions, ISampleEngineCallback callback, WorkerThread worker, BreakpointManager bpman, AD7Engine engine, HostConfigurationStore configStore) : base(launchOptions)
         {
             uint processExitCode = 0;
-            g_Process = this;
             _pendingMessages = new StringBuilder(400);
             _worker = worker;
             _breakpointManager = bpman;
@@ -1024,7 +1022,7 @@ namespace Microsoft.MIDebugEngine
 
         internal async Task<uint> ReadProcessMemory(ulong address, uint count, byte[] bytes)
         {
-            string cmd = "-data-read-memory-bytes " + EngineUtils.AsAddr(address) + " " + count.ToString();
+            string cmd = "-data-read-memory-bytes " + EngineUtils.AsAddr(address, Is64BitArch) + " " + count.ToString();
             Results results = await CmdAsync(cmd, ResultClass.None);
             if (results.ResultClass == ResultClass.error)
             {

--- a/src/MIDebugEngine/Engine.Impl/Disassembly.cs
+++ b/src/MIDebugEngine/Engine.Impl/Disassembly.cs
@@ -198,7 +198,7 @@ namespace Microsoft.MIDebugEngine
         // this is inefficient so we try and grab everything in one gulp
         internal static async Task<DisasmInstruction[]> Disassemble(DebuggedProcess process, ulong startAddr, ulong endAddr)
         {
-            string cmd = "-data-disassemble -s " + EngineUtils.AsAddr(startAddr) + " -e " + EngineUtils.AsAddr(endAddr) + " -- 0";
+            string cmd = "-data-disassemble -s " + EngineUtils.AsAddr(startAddr, process.Is64BitArch) + " -e " + EngineUtils.AsAddr(endAddr, process.Is64BitArch) + " -- 0";
             Results results = await process.CmdAsync(cmd, ResultClass.None);
             if (results.ResultClass != ResultClass.done)
             {

--- a/src/MIDebugEngine/Engine.Impl/EngineCallback.cs
+++ b/src/MIDebugEngine/Engine.Impl/EngineCallback.cs
@@ -207,7 +207,7 @@ namespace Microsoft.MIDebugEngine
 
         public void OnExpressionEvaluationComplete(IVariableInformation var, IDebugProperty2 prop = null)
         {
-            AD7ExpressionCompleteEvent eventObject = new AD7ExpressionCompleteEvent(var, prop);
+            AD7ExpressionCompleteEvent eventObject = new AD7ExpressionCompleteEvent(_engine, var, prop);
             Send(eventObject, AD7ExpressionCompleteEvent.IID, var.Client);
         }
 

--- a/src/MIDebugEngine/Engine.Impl/EngineUtils.cs
+++ b/src/MIDebugEngine/Engine.Impl/EngineUtils.cs
@@ -15,9 +15,9 @@ namespace Microsoft.MIDebugEngine
 {
     public static class EngineUtils
     {
-        internal static string AsAddr(ulong addr)
+        internal static string AsAddr(ulong addr, bool is64bit)
         {
-            string addrFormat = DebuggedProcess.g_Process.Is64BitArch ? "x16" : "x8";
+            string addrFormat = is64bit ? "x16" : "x8";
             return "0x" + addr.ToString(addrFormat, CultureInfo.InvariantCulture);
         }
 
@@ -51,7 +51,7 @@ namespace Microsoft.MIDebugEngine
 
             if (location == null)
             {
-                string addrFormat = DebuggedProcess.g_Process.Is64BitArch ? "x16" : "x8";
+                string addrFormat = proc.Is64BitArch ? "x16" : "x8";
                 location = ip.ToString(addrFormat, CultureInfo.InvariantCulture);
             }
 


### PR DESCRIPTION
This does not completely pave the way for multiple process debugging from
MIEngine, but it sets the stage. This removes the evil global variable
storing the one and only DebuggedProcess object.

TODO: remove the DebuggedProcess property from AD7Engine and allow for
multiple DebuggedProcess objects to be created and managed.