### PR TITLE
Support server proxy startup in local debugging mode

### DIFF
--- a/src/MICore/Debugger.cs
+++ b/src/MICore/Debugger.cs
@@ -741,6 +741,18 @@ namespace MICore
             }
         }
 
+        void ITransportCallback.LogText(string line)
+        {
+            if (!line.EndsWith("\n", StringComparison.Ordinal))
+            {
+                line += "\n";
+            }
+            if (OutputStringEvent != null)
+            {
+                OutputStringEvent(this, line);
+            }
+        }
+
         #endregion
 
         // inherited classes can override this for thread marshalling etc

--- a/src/MICore/LaunchOptions.cs
+++ b/src/MICore/LaunchOptions.cs
@@ -148,6 +148,8 @@ namespace MICore
     /// </summary>
     public sealed class LocalLaunchOptions : LaunchOptions
     {
+        private const int DefaultLaunchTimeout = 10 * 1000; // 10 seconds
+
         public LocalLaunchOptions(string MIDebuggerPath, string MIDebuggerServerAddress, int processId, Xml.LaunchOptions.EnvironmentEntry[] environmentEntries)
         {
             if (string.IsNullOrEmpty(MIDebuggerPath))
@@ -169,6 +171,23 @@ namespace MICore
             this.Environment = new ReadOnlyCollection<EnvironmentEntry>(environmentList);
         }
 
+        private void InitializeServerOptions(Xml.LaunchOptions.LocalLaunchOptions source)
+        {
+            if (!String.IsNullOrWhiteSpace(source.DebugServer))
+            {
+                DebugServer = source.DebugServer;
+                DebugServerArgs = source.DebugServerArgs;
+                ServerStarted = source.ServerStarted;
+                FilterStderr = source.FilterStderr;
+                FilterStdout = source.FilterStdout;
+                if (!FilterStderr && !FilterStdout)
+                {
+                    FilterStdout = true;    // no pattern source specified, use stdout
+                }
+                ServerLaunchTimeout = source.ServerLaunchTimeoutSpecified ? source.ServerLaunchTimeout : DefaultLaunchTimeout; 
+            }
+        }
+
         static internal LocalLaunchOptions CreateFromXml(Xml.LaunchOptions.LocalLaunchOptions source)
         {
             var options = new LocalLaunchOptions(
@@ -177,6 +196,7 @@ namespace MICore
                 source.ProcessId,
                 source.Environment);
             options.InitializeCommonOptions(source);
+            options.InitializeServerOptions(source);
 
             return options;
         }
@@ -218,6 +238,36 @@ namespace MICore
         /// [Optional] List of environment variables to add to the launched process
         /// </summary>
         public ReadOnlyCollection<EnvironmentEntry> Environment { get; private set; }
+
+        /// <summary>
+        /// [Optional] MI Debugger Server exe, if non-null then the MIEngine will start the debug server before starting the debugger
+        /// </summary>
+        public string DebugServer { get; private set; }
+
+        /// <summary>
+        /// [Optional] Args for MI Debugger Server exe
+        /// </summary>
+        public string DebugServerArgs { get; private set; }
+
+        /// <summary>
+        /// [Optional] Server started pattern (in Regex format)
+        /// </summary>
+        public string ServerStarted { get; private set; }
+
+        /// <summary>
+        /// [Optional] Log strings written to stderr and examine for server started pattern
+        /// </summary>
+        public bool FilterStderr { get; private set; }
+
+        /// <summary>
+        /// [Optional] Log strings written to stdout and examine for server started pattern
+        /// </summary>
+        public bool FilterStdout { get; private set; }
+
+        /// <summary>
+        /// [Optional] Log strings written to stderr and examine for server started pattern
+        /// </summary>
+        public int ServerLaunchTimeout { get; private set; }
     }
 
     public sealed class SourceRoot

--- a/src/MICore/LaunchOptions.xsd
+++ b/src/MICore/LaunchOptions.xsd
@@ -226,6 +226,36 @@
               <xs:documentation>If supplied, the debugger will attach to the process rather than launching a new one. Note that some operating systems will require admin rights to do this.</xs:documentation>
             </xs:annotation>
           </xs:attribute>
+          <xs:attribute name="DebugServer" type="xs:string" use="optional">
+            <xs:annotation>
+              <xs:documentation>Full path to the server executable. If non-null then the MIEngine will start the server.</xs:documentation>
+            </xs:annotation>
+          </xs:attribute>
+          <xs:attribute name="DebugServerArgs" type="xs:string" use="optional">
+            <xs:annotation>
+              <xs:documentation>Arguments to the debug server.</xs:documentation>
+            </xs:annotation>
+          </xs:attribute>
+          <xs:attribute name="ServerStarted" type="xs:string" use="optional">
+            <xs:annotation>
+              <xs:documentation>Wait for a line containing this pattern in the debug server output. Pattern is a regular expression in Regex format.</xs:documentation>
+            </xs:annotation>
+          </xs:attribute>
+          <xs:attribute name="FilterStdout" type="xs:boolean" use="optional">
+            <xs:annotation>
+              <xs:documentation>Log stdout to debug output. Examine content for ServerStarted pattern</xs:documentation>
+            </xs:annotation>
+          </xs:attribute>
+          <xs:attribute name="FilterStderr" type="xs:boolean" use="optional">
+            <xs:annotation>
+              <xs:documentation>Log stderr to debug output. Examine content for ServerStarted pattern</xs:documentation>
+            </xs:annotation>
+          </xs:attribute>
+          <xs:attribute name="ServerLaunchTimeout" type="xs:int" use="optional">
+            <xs:annotation>
+              <xs:documentation>How long, in milliseconds, to wait for the DebugServer executable to start and ServerStarted pattern to be found.</xs:documentation>
+            </xs:annotation>
+          </xs:attribute>
         </xs:extension>
       </xs:complexContent>
     </xs:complexType>

--- a/src/MICore/LaunchOptions.xsd.types.desginer.cs
+++ b/src/MICore/LaunchOptions.xsd.types.desginer.cs
@@ -376,6 +376,42 @@ namespace MICore.Xml.LaunchOptions {
         /// <remarks/>
         [System.Xml.Serialization.XmlIgnoreAttribute()]
         public bool ProcessIdSpecified;
+        
+        /// <remarks/>
+        [System.Xml.Serialization.XmlAttributeAttribute()]
+        public string DebugServer;
+        
+        /// <remarks/>
+        [System.Xml.Serialization.XmlAttributeAttribute()]
+        public string DebugServerArgs;
+        
+        /// <remarks/>
+        [System.Xml.Serialization.XmlAttributeAttribute()]
+        public string ServerStarted;
+        
+        /// <remarks/>
+        [System.Xml.Serialization.XmlAttributeAttribute()]
+        public bool FilterStdout;
+        
+        /// <remarks/>
+        [System.Xml.Serialization.XmlIgnoreAttribute()]
+        public bool FilterStdoutSpecified;
+        
+        /// <remarks/>
+        [System.Xml.Serialization.XmlAttributeAttribute()]
+        public bool FilterStderr;
+        
+        /// <remarks/>
+        [System.Xml.Serialization.XmlIgnoreAttribute()]
+        public bool FilterStderrSpecified;
+        
+        /// <remarks/>
+        [System.Xml.Serialization.XmlAttributeAttribute()]
+        public int ServerLaunchTimeout;
+        
+        /// <remarks/>
+        [System.Xml.Serialization.XmlIgnoreAttribute()]
+        public bool ServerLaunchTimeoutSpecified;
     }
     
     /// <remarks/>

--- a/src/MICore/MICore.csproj
+++ b/src/MICore/MICore.csproj
@@ -34,7 +34,6 @@
     <Prefer32Bit>false</Prefer32Bit>
     <RunCodeAnalysis>true</RunCodeAnalysis>
     <CodeAnalysisRuleSet>..\IDECodeAnalysis.ruleset</CodeAnalysisRuleSet>
-    
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
@@ -100,11 +99,13 @@
     <Compile Include="MIResults.cs" />
     <Compile Include="NativeMethods.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="Transports\ClientServerTransport.cs" />
     <Compile Include="Transports\ITransport.cs" />
     <Compile Include="Transports\LocalTransport.cs" />
     <Compile Include="Transports\LocalLinuxTransport.cs" />
     <Compile Include="Transports\MockTransport.cs" />
     <Compile Include="Transports\PipeTransport.cs" />
+    <Compile Include="Transports\ServerTransport.cs" />
     <Compile Include="Transports\StreamTransport.cs" />
     <Compile Include="Transports\TcpTransport.cs" />
   </ItemGroup>

--- a/src/MICore/MICoreResources.Designer.cs
+++ b/src/MICore/MICoreResources.Designer.cs
@@ -102,6 +102,15 @@ namespace MICore {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Debug server process failed to initialize..
+        /// </summary>
+        public static string Error_DebugServerInitializationFailed {
+            get {
+                return ResourceManager.GetString("Error_DebugServerInitializationFailed", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Exception while processing MIEngine operation. {0}. If the problem continues restart debugging..
         /// </summary>
         public static string Error_ExceptionInOperation {

--- a/src/MICore/MICoreResources.resx
+++ b/src/MICore/MICoreResources.resx
@@ -133,6 +133,9 @@
 
 {1}</value>
   </data>
+  <data name="Error_DebugServerInitializationFailed" xml:space="preserve">
+    <value>Debug server process failed to initialize.</value>
+  </data>
   <data name="Error_ExceptionInOperation" xml:space="preserve">
     <value>Exception while processing MIEngine operation. {0}. If the problem continues restart debugging.</value>
   </data>

--- a/src/MICore/Transports/ClientServerTransport.cs
+++ b/src/MICore/Transports/ClientServerTransport.cs
@@ -1,0 +1,59 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Collections.Generic;
+using System.Text;
+using System.Threading;
+using System.Diagnostics;
+using System.IO;
+using System.Collections.Specialized;
+using System.Collections;
+using System.Text.RegularExpressions;
+
+namespace MICore
+{
+    // Manage both the client and server transports for a debugging session
+    public class ClientServerTransport : LocalTransport
+    {
+        private ServerTransport _serverTransport;
+        private ManualResetEvent _event;
+        private int _launchTimeout;
+
+        public static bool ShouldStartServer(LaunchOptions options)
+        {
+            return !string.IsNullOrWhiteSpace((options as LocalLaunchOptions)?.DebugServer);
+        }
+
+        public ClientServerTransport(bool filterStdout, bool filterStderr)
+        {
+            _event = new ManualResetEvent(false);
+            _serverTransport = new ServerTransport(_event, killOnClose:true, filterStderr: filterStderr, filterStdout: filterStdout);
+        }
+
+        public override void Init(ITransportCallback transportCallback, LaunchOptions options)
+        {
+            _launchTimeout = ((LocalLaunchOptions)options).ServerLaunchTimeout;
+            _serverTransport.Init(transportCallback, options);
+            WaitForStart();
+            if (!IsClosed)
+            {
+                base.Init(transportCallback, options);
+            }
+        }
+
+        private void WaitForStart()
+        {
+            if (!_event.WaitOne(_launchTimeout))  // wait for the server to start
+            {
+                _serverTransport.Close();
+                throw new TimeoutException(MICoreResources.Error_DebugServerInitializationFailed);
+            }
+        }
+        public override void Close()
+        {
+            base.Close();
+            _serverTransport.Close();
+        }
+    }
+}

--- a/src/MICore/Transports/ITransport.cs
+++ b/src/MICore/Transports/ITransport.cs
@@ -49,5 +49,11 @@ namespace MICore
         /// </summary>
         /// <param name="line">[Required] line of text to write</param>
         void AppendToInitializationLog(string line);
+
+        /// <summary>
+        /// Fired when the transport wishes to log a message to the debugger output window
+        /// </summary>
+        /// <param name="line">[Required] Line of text to be logged</param>
+        void LogText(string line);
     };
 }

--- a/src/MICore/Transports/ServerTransport.cs
+++ b/src/MICore/Transports/ServerTransport.cs
@@ -1,0 +1,62 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Collections.Generic;
+using System.Text;
+using System.Threading;
+using System.Diagnostics;
+using System.IO;
+using System.Collections.Specialized;
+using System.Collections;
+using System.Text.RegularExpressions;
+using System.Globalization;
+
+namespace MICore
+{
+    public class ServerTransport : PipeTransport
+    {
+        private string _startPattern;
+        public string _messagePrefix;
+        private bool _started;
+        private ManualResetEvent _event;
+
+        public ServerTransport(ManualResetEvent e, bool killOnClose, bool filterStderr = false, bool filterStdout = false) 
+            : base(killOnClose, filterStderr, filterStdout)
+        {
+            _event = e;
+        }
+
+        public override void InitStreams(LaunchOptions options, out StreamReader reader, out StreamWriter writer)
+        {
+            LocalLaunchOptions localOptions = (LocalLaunchOptions)options;
+            string miDebuggerDir = System.IO.Path.GetDirectoryName(localOptions.MIDebuggerPath);
+
+            Process proc = new Process();
+            proc.StartInfo.FileName = localOptions.DebugServer;
+            proc.StartInfo.Arguments = localOptions.DebugServerArgs;
+            proc.StartInfo.WorkingDirectory = miDebuggerDir;
+            _startPattern = localOptions.ServerStarted;
+            _messagePrefix = Path.GetFileNameWithoutExtension(localOptions.DebugServer);  
+
+            InitProcess(proc, out reader, out writer);
+        }
+
+        protected override string FilterLine(string line)
+        {
+            if (!_started && Regex.IsMatch(line, _startPattern, RegexOptions.None, new TimeSpan(0, 0, 0, 0, 10) /* 10 ms */))
+            {
+                _started = true;
+                _event.Set();
+            }
+
+            this.Callback.LogText(_messagePrefix + ": " + line);   // log to debug output
+            return null;
+        }
+
+        protected override string GetThreadName()
+        {
+            return "MI.ServerTransport";
+        }
+    }
+}

--- a/src/MIDebugEngine/Engine.Impl/DebuggedProcess.cs
+++ b/src/MIDebugEngine/Engine.Impl/DebuggedProcess.cs
@@ -170,7 +170,14 @@ namespace Microsoft.MIDebugEngine
                 }
                 else
                 {
-                    this.Init(new MICore.LocalTransport(), _launchOptions);
+                    if (MICore.ClientServerTransport.ShouldStartServer(_launchOptions))
+                    {
+                        this.Init(new MICore.ClientServerTransport(filterStdout: localLaunchOptions.FilterStdout, filterStderr: localLaunchOptions.FilterStderr), _launchOptions);
+                    }
+                    else
+                    {
+                        this.Init(new MICore.LocalTransport(), _launchOptions);
+                    }
                 }
             }
             else if (_launchOptions is PipeLaunchOptions)


### PR DESCRIPTION
 Change Description:

     1. Add new ServerTransport to manage the server proxy process
     2. Add new ClientServerTransport to wrap the connections to both client and server in one transport object
     3. Plumb new local debugging launch options into new transports