### PR TITLE
Manage server process (e.g. OpenOCD) on linux

### DIFF
--- a/src/MICore/LaunchOptions.cs
+++ b/src/MICore/LaunchOptions.cs
@@ -188,6 +188,11 @@ namespace MICore
             }
         }
 
+        public bool ShouldStartServer()
+        {
+            return !string.IsNullOrWhiteSpace(DebugServer);
+        }
+
         static internal LocalLaunchOptions CreateFromXml(Xml.LaunchOptions.LocalLaunchOptions source)
         {
             var options = new LocalLaunchOptions(

--- a/src/MICore/Transports/ITransport.cs
+++ b/src/MICore/Transports/ITransport.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections.Generic;
 using System.Text;
+using System.Threading;
 
 namespace MICore
 {
@@ -14,7 +15,13 @@ namespace MICore
         void Init(ITransportCallback transportCallback, LaunchOptions options);
         void Send(string cmd);
         void Close();
+        bool IsClosed { get; }
     }
+    public interface ISignalingTransport: ITransport
+    {
+        ManualResetEvent StartedEvent { get; }
+    }
+
 
     /// <summary>
     /// Interface implemented by the Debugger class to recieve notifications from the transport

--- a/src/MICore/Transports/MockTransport.cs
+++ b/src/MICore/Transports/MockTransport.cs
@@ -60,6 +60,8 @@ namespace MICore
             }
         }
 
+        public bool IsClosed { get { return _bQuit; } }
+
         private void TransportLoop()
         {
             _lineNumber = 0;

--- a/src/MICore/Transports/ServerTransport.cs
+++ b/src/MICore/Transports/ServerTransport.cs
@@ -14,17 +14,18 @@ using System.Globalization;
 
 namespace MICore
 {
-    public class ServerTransport : PipeTransport
+    public class ServerTransport : PipeTransport, ISignalingTransport
     {
         private string _startPattern;
         public string _messagePrefix;
         private bool _started;
-        private ManualResetEvent _event;
 
-        public ServerTransport(ManualResetEvent e, bool killOnClose, bool filterStderr = false, bool filterStdout = false) 
+        public ManualResetEvent StartedEvent { get; }
+
+        public ServerTransport(bool killOnClose, bool filterStderr = false, bool filterStdout = false) 
             : base(killOnClose, filterStderr, filterStdout)
         {
-            _event = e;
+            StartedEvent = new ManualResetEvent(false);
         }
 
         public override void InitStreams(LaunchOptions options, out StreamReader reader, out StreamWriter writer)
@@ -47,7 +48,7 @@ namespace MICore
             if (!_started && Regex.IsMatch(line, _startPattern, RegexOptions.None, new TimeSpan(0, 0, 0, 0, 10) /* 10 ms */))
             {
                 _started = true;
-                _event.Set();
+                StartedEvent.Set();
             }
 
             this.Callback.LogText(_messagePrefix + ": " + line);   // log to debug output

--- a/src/MIDebugEngine/Engine.Impl/DebuggedProcess.cs
+++ b/src/MIDebugEngine/Engine.Impl/DebuggedProcess.cs
@@ -166,13 +166,30 @@ namespace Microsoft.MIDebugEngine
                     // For local linux launch, use the local linux transport which creates a new terminal and uses fifos for gdb communication.
                     // CONSIDER: add new flag and only do this if new terminal is true? Note that setting this to false on linux will cause a deadlock
                     // during debuggee launch
-                    this.Init(new MICore.LocalLinuxTransport(), _launchOptions);
+                    if (localLaunchOptions.ShouldStartServer())
+                    {
+                        this.Init(new MICore.ClientServerTransport
+                            (
+                                        new LocalLinuxTransport(),
+                                        new ServerTransport(killOnClose: true, filterStdout: localLaunchOptions.FilterStdout, filterStderr: localLaunchOptions.FilterStderr)
+                                  ), _launchOptions
+                            );
+                    }
+                    else
+                    {
+                        this.Init(new MICore.LocalLinuxTransport(), _launchOptions);
+                    }
                 }
                 else
                 {
-                    if (MICore.ClientServerTransport.ShouldStartServer(_launchOptions))
+                    if (localLaunchOptions.ShouldStartServer())
                     {
-                        this.Init(new MICore.ClientServerTransport(filterStdout: localLaunchOptions.FilterStdout, filterStderr: localLaunchOptions.FilterStderr), _launchOptions);
+                        this.Init(new MICore.ClientServerTransport
+                            (
+                                        new LocalTransport(),
+                                        new ServerTransport(killOnClose: true, filterStdout: localLaunchOptions.FilterStdout, filterStderr: localLaunchOptions.FilterStderr)
+                                  ), _launchOptions
+                            );
                     }
                     else
                     {


### PR DESCRIPTION
1. Allow ClientServerTransport to handle different client (linux/windws) and server types
2. (linux) kill server process tree on exit