### PR TITLE
1) Fix issue that breakpoints were only matched against bkptno result…

### DIFF
--- a/src/MIDebugEngine/AD7.Impl/AD7BoundBreakpoint.cs
+++ b/src/MIDebugEngine/AD7.Impl/AD7BoundBreakpoint.cs
@@ -26,6 +26,7 @@ namespace Microsoft.MIDebugEngine
         internal bool Enabled { get { return _enabled; } }
         internal bool Deleted { get { return _deleted; } }
         internal ulong Addr { get; private set; }
+        internal AD7PendingBreakpoint PendingBreakpoint { get { return _pendingBreakpoint; } }
 
         public AD7BoundBreakpoint(AD7Engine engine, ulong address, AD7PendingBreakpoint pendingBreakpoint, AD7BreakpointResolution breakpointResolution, BoundBreakpoint bp)
         {

--- a/src/MIDebugEngine/Engine.Impl/DebuggedProcess.cs
+++ b/src/MIDebugEngine/Engine.Impl/DebuggedProcess.cs
@@ -593,14 +593,14 @@ namespace Microsoft.MIDebugEngine
             {
                 string bkptno = results.Results.FindString("bkptno");
                 ulong addr = cxt.pc ?? 0;
-                AD7BoundBreakpoint bkpt = null;
+                
                 bool fContinue;
                 TupleValue frame = results.Results.TryFind<TupleValue>("frame");
-                bkpt = _breakpointManager.FindHitBreakpoint(bkptno, addr, frame, out fContinue); // use breakpoint number to resolve breakpoint
+                AD7BoundBreakpoint[] bkpt = _breakpointManager.FindHitBreakpoints(bkptno, addr, frame, out fContinue);
                 if (bkpt != null)
                 {
                     List<object> bplist = new List<object>();
-                    bplist.Add(bkpt);
+                    bplist.AddRange(bkpt);
                     _callback.OnBreakpoint(thread, bplist.AsReadOnly());
                 }
                 else if (!_bEntrypointHit)


### PR DESCRIPTION
…ing in bugs when multple bps bind to the same place such as the entrypoint bp. 2) Use the trap command to setup a signal that cleans up the fifos in the local linux case if the user closes the debuggee terminal