### PR TITLE
Launch fixes

### DIFF
--- a/src/MICore/LaunchOptions.cs
+++ b/src/MICore/LaunchOptions.cs
@@ -429,7 +429,15 @@ namespace MICore
         {
             get
             {
-                return !RuntimeInformation.IsOSPlatform(OSPlatform.Windows);
+                if (this is LocalLaunchOptions)
+                {
+                    return !RuntimeInformation.IsOSPlatform(OSPlatform.Windows);
+                }
+                else
+                {
+                    // For now lets assume the debugger is on Unix if we are using Pipe/Tcp launch options
+                    return true;
+                }
             }
         }
 

--- a/tools/InstallToVSCode/coreclr/package.json
+++ b/tools/InstallToVSCode/coreclr/package.json
@@ -19,47 +19,104 @@
 
         "configurationAttributes": {
           "launch": {
-            "required": [ "runtimeExecutable", "cwd" ],
+            "required": [ "program", "cwd" ],
             "properties": {
+              "program": {
+                "type": "string",
+                "description": "Workspace relative path to the program (executable file) to launch. On Windows, a '.exe' suffix is appended if not specified already.",
+                "default": "bin/Debug/dnxcore50/<My-Project-Name>"
+              },
               "cwd": {
                 "type": "string",
-                "description": "Specifies the workspace relative or absolute path to the webserver root.",
+                "description": "Workspace relative or absolute path to the working directory of the program being debugged. Default is the current workspace.",
                 "default": "."
               },
-              "runtimeExecutable": {
-                  "type": "string",
-                  "description": "Workspace relative or absolute path to the runtime executable to be used.",
-                  "default": null
+              "args": {
+                "type": "array",
+                "description": "Command line arguments passed to the program.",
+                "items": { "type": "string" },
+                "default": [ ]
               },
-              "runtimeArgs": {
-                  "type": "array",
-                  "description": "Optional arguments passed to the runtime executable.",
-                  "items": { "type": "string" },
-                  "default": []
+              "stopAtEntry": {
+                "type": "boolean",
+                "description": "If true, the debugger should stop at the entry point of the target.",
+                "default": false
               },
+              // --- Begin common attributes. Copy these down to 'attach' if modified
               "sourceFileMap": {
-                  "type": "object",
-                  "description": "Optional source file mappings passed to the debug engine.",
-                  "default": {}
+                "type": "object",
+                "description": "Optional source file mappings passed to the debug engine.",
+                "default": { }
               },
               "justMyCode": {
                 "type": "boolean",
                 "description": "Optional flag to only show user code.",
                 "default": true
+              },
+              "symbolPath": {
+                "type": "array",
+                "description": "Array of directories to use to search for .pdb files. These directories will be searched in addition to the default locations -- next to the module and the path where the pdb was originally dropped to. Example: '[ \"/Volumes/symbols\" ]",
+                "items": { "type": "string" },
+                "default": [ ]
               }
+              // --- End common attributes. Copy these down to 'attach' if modified
+            }
+          },
+          "attach": {
+            "required": [ ],
+            "properties": {
+              "processName": {
+                "type": "string",
+                "description": "",
+                "default": "The process name to attach to. If this is used, 'processId' should not be used."
+              },
+              "processId": {
+                "type": "integer",
+                "description": "The process id to attach to. If this is used, 'processName' should not be used.",
+                "default": ""
+              },
+              // --- Begin common attributes. Copy these up to 'launch' if modified
+              "sourceFileMap": {
+                "type": "object",
+                "description": "Optional source file mappings passed to the debug engine.",
+                "default": { }
+              },
+              "justMyCode": {
+                "type": "boolean",
+                "description": "Optional flag to only show user code.",
+                "default": true
+              },
+              "symbolPath": {
+                "type": "array",
+                "description": "Array of directories to use to search for .pdb files. These directories will be searched in addition to the default locations -- next to the module and the path where the pdb was originally dropped to. Example: '[ \"~/symbols\" ]",
+                "items": { "type": "string" },
+                "default": [ ]
+              }
+              // --- End common attributes. Copy these up to 'launch' if modified
             }
           }
         },
 
         "initialConfigurations": [
           {
-            "name": "Launch dnx",
+            "name": ".NET Core Launch",
             "type": "coreclr",
             "request": "launch",
+            "preLaunchTask": "compile",
+            "program": "bin/Debug/dnxcore50/<My-Project-Name>",
+            "args": [ ],
             "cwd": ".",
-            "runtimeExecutable": "<path to dnx.exe>",
-            "runtimeArgs": [ "kestrel" ]
+            "stopAtEntry": false,
+            "sourceFileMap": { }
+          },
+          {
+            "name": ".NET Core Attach",
+            "type": "coreclr",
+            "request": "attach",
+            "processName": "<example>",
+            "sourceFileMap": { }
           }
+
         ]
       }
     ]


### PR DESCRIPTION
commit c7354755afa79e539055fa9064ec420e51b370ac
Author: Gregg Miskelly <greggm@microsoft.com>
Date:   Mon Jan 25 13:22:45 2016 -0800

    VS Code: Fix launch.json attributes for CLRDBG
    
    - Rename 'runtimeExecutable'->'program'
    - Rename 'runtimeArgs'->'args'
    - Add definition for 'stopAtEntry'. This doesn't work yet, but it will soon.
    - Add 'symbolPath'
    - Define attributes for attach
    - Update the template

commit cebd6b8ea730b39d0951d6c95a4181989c703d8b
Author: Gregg Miskelly <greggm@microsoft.com>
Date:   Mon Jan 25 13:18:57 2016 -0800

    Fix UseUnixSymbolPaths for non-local launch options
    
    Back before update 1, UseUnixSymbolPaths would return true for any non-local target. This was wrong for LocalLaunchOptions once we added support for running on non-Windows, so we fixed that. But we broke the scenario for non-LocalLaunchOptions. So this restores that code path. This still isn't completely correct since technically you could use Pipe/Tcp launch options to connect to Windows. But we don't have any scenarios yet where we want to do that.
