### PR TITLE
Add packaging target

### DIFF
--- a/BuildAndTest.proj
+++ b/BuildAndTest.proj
@@ -3,6 +3,8 @@
          DefaultTargets="BuildAndTest"
          xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
          
+  <Import Project="build\version.settings.targets" />
+         
   <UsingTask
     AssemblyFile="src\packages\xunit.runners.2.0.0\tools\xunit.runner.msbuild.dll"
     TaskName="Xunit.Runner.MSBuild.xunit" />
@@ -15,7 +17,7 @@
 	
 	<!--Don't run unit tests for lab builds -->
 	<TargetsToRun>Build;Test</TargetsToRun>
-	<TargetsToRun Condition="'$(Configuration)' == 'Lab.Release' OR '$(Configuration)' == 'Lab.Debug'">Build</TargetsToRun>
+	<TargetsToRun Condition="'$(Configuration)' == 'Lab.Release' OR '$(Configuration)' == 'Lab.Debug'">Build;Package</TargetsToRun>
   </PropertyGroup>
 
   <ItemGroup>
@@ -47,6 +49,16 @@
     
     <Exec Command="src\packages\xunit.runner.console.2.0.0\tools\xunit.console.exe @(TestAssemblies, ' ') -xml &quot;$(OutDir)TestResults.xml&quot;" />
     
+  </Target>
+  
+  <Target Name="Package">
+    <PropertyGroup>
+        <NuGetPath>$(ToolsHome)\nuget\nuget.exe</NuGetPath>
+        <NuGetPackageVersion Condition="'$(NuGetPackageVersion)'==''">$(MajorVersion).$(MinorVersion).$(BuildNumberMajor)</NuGetPackageVersion>
+        <NuGetPackageSuffix Condition="$(Configuration.Contains('Debug'))">.dev</NuGetPackageSuffix>
+        <NuGetArguments>-NoPackageAnalysis -NonInteractive -BasePath $(OutDir) -OutputDirectory $(OutDir) -Version $(NuGetPackageVersion) -Properties suffix=$(NuGetPackageSuffix)</NuGetArguments>
+    </PropertyGroup>
+    <Exec Command="$(NuGetPath) pack $(MSBuildThisFileDirectory)\MIEngine.clrdbg.nuspec $(NuGetArguments)" />
   </Target>
   
   <Target Name="BuildAndTest"

--- a/MIEngine.clrdbg.nuspec
+++ b/MIEngine.clrdbg.nuspec
@@ -1,0 +1,19 @@
+<?xml version="1.0"?>
+<package xmlns="http://schemas.microsoft.com/packaging/2011/08/nuspec.xsd">
+  <metadata>
+    <id>Microsoft.VisualStudio.clrdbg.MIEngine$suffix$</id>
+    <version>1.0</version>
+    <authors>Microsoft</authors>
+    <owners>Microsoft</owners>
+    <requireLicenseAcceptance>false</requireLicenseAcceptance>
+    <description>MIEngine for use with clrdbg via VSCode</description>
+    <releaseNotes />
+    <copyright>Copyright 2015</copyright>
+  </metadata>
+  <files>
+    <file src="Microsoft.MICore.dll" />
+    <file src="Microsoft.MIDebugEngine.dll" />
+    <file src="package.json" />
+    <file src="coreclr.ad7Engine.json" />
+  </files>
+</package>

--- a/build/all_projects.settings.targets
+++ b/build/all_projects.settings.targets
@@ -12,5 +12,6 @@
     <NuGetPackagesDirectory>$(MIEngineRoot)src\packages</NuGetPackagesDirectory>
     <GeneratedAssembliesDir>$(ILDir)GeneratedAssemblies\</GeneratedAssembliesDir>
     <MIDefaultOutputPath>$(MIEngineRoot)bin\$(Configuration)\</MIDefaultOutputPath>
+    <ToolsHome>$(MIEngineRoot)\tools</ToolsHome>
   </PropertyGroup>
 </Project>

--- a/build/miengine.settings.targets
+++ b/build/miengine.settings.targets
@@ -5,6 +5,7 @@
   -->
   
   <Import Project="all_projects.settings.targets"/>
+  <Import Project="version.settings.targets" />
 
   <Choose>
     <When Condition="'$(Configuration)' == 'Lab.Debug' Or '$(Configuration)' == 'Lab.Release'">
@@ -23,6 +24,7 @@
   </Choose>
   
   <PropertyGroup>
+    <SignAssembly>True</SignAssembly>
     <GlassDir>$(MSBuildThisFileDirectory)..\Microsoft.VisualStudio.Glass\</GlassDir>
     <DropConfigurationName>$(Configuration)</DropConfigurationName>
     <DefineConstants Condition="'$(Configuration)' == 'Lab.Debug' or '$(Configuration)' == 'Lab.Release'">$(DefineConstants);LAB</DefineConstants>
@@ -31,33 +33,5 @@
     <DropRootDir Condition="'$(TF_BUILD_BINARIESDIRECTORY)'!=''">$(TF_BUILD_BINARIESDIRECTORY)\$(DropConfigurationName)</DropRootDir>
     <DropRootDir Condition="'$(DropRootDir)'==''">$(MIEngineRoot)bin\$(DropConfigurationName)\drop</DropRootDir>
   </PropertyGroup>
-    
-  <PropertyGroup>
-    <SignAssembly>True</SignAssembly>
-    
-    <!--SxS: These three properties should be changed at the start of a new version, VersionZeroYear should be the year
-    before the start of the project. When updating the version, also update MIEngine\metadata.json.-->
-    <MajorVersion>14</MajorVersion>
-    <MinorVersion>0</MinorVersion>
-    <VersionZeroYear>2013</VersionZeroYear>
-
-    <!--Compute the major and minor build number-->
-    <!--Team build passes the build number in the TF_BUILD_BUILDNUMBER variable. It has the format 'Master_20140922.4' where
-    'Master' is the name of the definition, '2014' is the year, '09' is the month, '22' is the day, and '4' is the revision. 
-    TeamBuild also sets a 'BuildNumber' but that number is different from what we want, and msbuild will not let us clear it,
-    so do not use a property of that name.-->
-    <BuildDateRevision Condition="'$(TF_BUILD_BUILDNUMBER)'==''">$([System.DateTime]::Now.ToString(yyyyMMdd))</BuildDateRevision>
-    <BuildDateRevision Condition="'$(TF_BUILD_BUILDNUMBER)'!=''">$(TF_BUILD_BUILDNUMBER.Substring($([MSBuild]::Add($(TF_BUILD_BUILDNUMBER.LastIndexOf('_')),1))))</BuildDateRevision>
-    <BuildNumber_Year>$([MSBuild]::Subtract($([System.Int32]::Parse($(BuildDateRevision.Substring(0,4)))),$(VersionZeroYear)))</BuildNumber_Year>
-    <BuildNumber_Month>$(BuildDateRevision.Substring(4,2))</BuildNumber_Month>
-    <BuildNumber_Day>$(BuildDateRevision.Substring(6,2))</BuildNumber_Day>
-    <BuildNumberMajor>$(BuildNumber_Year)$(BuildNumber_Month)$(BuildNumber_Day)</BuildNumberMajor>
-    <BuildNumberMinor>0</BuildNumberMinor>
-    <BuildNumberMinor Condition="$(BuildDateRevision.Length) &gt; 9">$(BuildDateRevision.Substring(9))</BuildNumberMinor>
-
-    <AssemblyVersion Condition="'$(AssemblyVersion)'==''">$(MajorVersion).$(MinorVersion).0</AssemblyVersion>
-    <BuildVersion>$(MajorVersion).$(MinorVersion).$(BuildNumberMajor).$(BuildNumberMinor)</BuildVersion>
-    <BuildVersionExtended>$(BuildVersion)</BuildVersionExtended>
-    <BuildVersionExtended Condition="'$(TF_BUILD_SOURCEGETVERSION)'!=''">$(BuildVersionExtended) commit:$(TF_BUILD_SOURCEGETVERSION)</BuildVersionExtended>
-  </PropertyGroup>
+   
 </Project>

--- a/build/version.settings.targets
+++ b/build/version.settings.targets
@@ -1,0 +1,28 @@
+<Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003"> 
+  <PropertyGroup>    
+    <!--SxS: These three properties should be changed at the start of a new version, VersionZeroYear should be the year
+    before the start of the project. When updating the version, also update MIEngine\metadata.json.-->
+    <MajorVersion>14</MajorVersion>
+    <MinorVersion>0</MinorVersion>
+    <VersionZeroYear>2013</VersionZeroYear>
+
+    <!--Compute the major and minor build number-->
+    <!--Team build passes the build number in the TF_BUILD_BUILDNUMBER variable. It has the format 'Master_20140922.4' where
+    'Master' is the name of the definition, '2014' is the year, '09' is the month, '22' is the day, and '4' is the revision. 
+    TeamBuild also sets a 'BuildNumber' but that number is different from what we want, and msbuild will not let us clear it,
+    so do not use a property of that name.-->
+    <BuildDateRevision Condition="'$(TF_BUILD_BUILDNUMBER)'==''">$([System.DateTime]::Now.ToString(yyyyMMdd))</BuildDateRevision>
+    <BuildDateRevision Condition="'$(TF_BUILD_BUILDNUMBER)'!=''">$(TF_BUILD_BUILDNUMBER.Substring($([MSBuild]::Add($(TF_BUILD_BUILDNUMBER.LastIndexOf('_')),1))))</BuildDateRevision>
+    <BuildNumber_Year>$([MSBuild]::Subtract($([System.Int32]::Parse($(BuildDateRevision.Substring(0,4)))),$(VersionZeroYear)))</BuildNumber_Year>
+    <BuildNumber_Month>$(BuildDateRevision.Substring(4,2))</BuildNumber_Month>
+    <BuildNumber_Day>$(BuildDateRevision.Substring(6,2))</BuildNumber_Day>
+    <BuildNumberMajor>$(BuildNumber_Year)$(BuildNumber_Month)$(BuildNumber_Day)</BuildNumberMajor>
+    <BuildNumberMinor>0</BuildNumberMinor>
+    <BuildNumberMinor Condition="$(BuildDateRevision.Length) &gt; 9">$(BuildDateRevision.Substring(9))</BuildNumberMinor>
+
+    <AssemblyVersion Condition="'$(AssemblyVersion)'==''">$(MajorVersion).$(MinorVersion).0</AssemblyVersion>
+    <BuildVersion>$(MajorVersion).$(MinorVersion).$(BuildNumberMajor).$(BuildNumberMinor)</BuildVersion>
+    <BuildVersionExtended>$(BuildVersion)</BuildVersionExtended>
+    <BuildVersionExtended Condition="'$(TF_BUILD_SOURCEGETVERSION)'!=''">$(BuildVersionExtended) commit:$(TF_BUILD_SOURCEGETVERSION)</BuildVersionExtended>
+  </PropertyGroup>
+</Project>

--- a/src/MIDebugPackage/MIDebugPackage.csproj
+++ b/src/MIDebugPackage/MIDebugPackage.csproj
@@ -161,6 +161,14 @@
     <GlassDirCopy Include="@(RequiredNetFX46FacadeAssemblies)" />
   </ItemGroup>
   <ItemGroup>
+    <Content Include="$(ToolsHome)\InstallToVSCode\coreclr\package.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+    <Content Include="$(ToolsHome)\InstallToVSCode\coreclr\coreclr.ad7Engine.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+  </ItemGroup>
+  <ItemGroup>
     <DropUnsignedFile Include="$(OutDir)\Microsoft.Android.natvis" />
     <DropSignedFile Include="$(OutDir)\Microsoft.AndroidDebugLauncher.dll" />
     <DropUnsignedFile Include="$(OutDir)\Microsoft.AndroidDebugLauncher.pdb" />
@@ -201,7 +209,6 @@
     <DropUnsignedFile Include="$(OutDir)\Microsoft.MIDebugPackage.pkgdef" />
     <DropSignedFile Include="$(OutDir)\Microsoft.DebugEngineHost.dll" />
     <DropUnsignedFile Include="$(OutDir)\Microsoft.DebugEngineHost.pdb" />
-    <DropUnsignedFile Include="Install.cmd" />
     <DropUnsignedFile Include="@(RequiredNetFX46FacadeAssemblies)" />
   </ItemGroup>
   <ItemGroup>


### PR DESCRIPTION
With this change we will package the MIEngine bits for use with clrdbg as
part of the lab builds. An initial nuspec was added that includeds only
the assemblies needed for VSCode. Also, version.settings.targets was
abstracted out of miengine.settings.targets so it could be included in
buildandtest.proj in addition to all the projects under src.