### PR TITLE
Move PackageNuGet target to its own file, add package to drop folder

### DIFF
--- a/BuildAndTest.proj
+++ b/BuildAndTest.proj
@@ -3,8 +3,6 @@
          DefaultTargets="BuildAndTest"
          xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
          
-  <Import Project="build\version.settings.targets" />
-         
   <UsingTask
     AssemblyFile="src\packages\xunit.runners.2.0.0\tools\xunit.runner.msbuild.dll"
     TaskName="Xunit.Runner.MSBuild.xunit" />
@@ -17,7 +15,7 @@
 	
 	<!--Don't run unit tests for lab builds -->
 	<TargetsToRun>Build;Test</TargetsToRun>
-	<TargetsToRun Condition="'$(Configuration)' == 'Lab.Release' OR '$(Configuration)' == 'Lab.Debug'">Build;Package</TargetsToRun>
+	<TargetsToRun Condition="'$(Configuration)' == 'Lab.Release' OR '$(Configuration)' == 'Lab.Debug'">Build</TargetsToRun>
   </PropertyGroup>
 
   <ItemGroup>
@@ -49,16 +47,6 @@
     
     <Exec Command="src\packages\xunit.runner.console.2.0.0\tools\xunit.console.exe @(TestAssemblies, ' ') -xml &quot;$(OutDir)TestResults.xml&quot;" />
     
-  </Target>
-  
-  <Target Name="Package">
-    <PropertyGroup>
-        <NuGetPath>$(ToolsHome)\nuget\nuget.exe</NuGetPath>
-        <NuGetPackageVersion Condition="'$(NuGetPackageVersion)'==''">$(MajorVersion).$(MinorVersion).$(BuildNumberMajor)</NuGetPackageVersion>
-        <NuGetPackageSuffix Condition="$(Configuration.Contains('Debug'))">.dev</NuGetPackageSuffix>
-        <NuGetArguments>-NoPackageAnalysis -NonInteractive -BasePath $(OutDir) -OutputDirectory $(OutDir) -Version $(NuGetPackageVersion) -Properties suffix=$(NuGetPackageSuffix)</NuGetArguments>
-    </PropertyGroup>
-    <Exec Command="$(NuGetPath) pack $(MSBuildThisFileDirectory)\MIEngine.clrdbg.nuspec $(NuGetArguments)" />
   </Target>
   
   <Target Name="BuildAndTest"

--- a/build/PackageNuGet.targets
+++ b/build/PackageNuGet.targets
@@ -1,0 +1,13 @@
+<Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+
+  <Target Name="PackageNuGet" AfterTargets="DropFiles" Condition="$(Configuration.Contains('Lab'))">
+    <PropertyGroup>
+        <NuGetPath>$(ToolsHome)\nuget\nuget.exe</NuGetPath>
+        <NuGetPackageVersion Condition="'$(NuGetPackageVersion)'==''">$(MajorVersion).$(MinorVersion).$(BuildNumberMajor)</NuGetPackageVersion>
+        <NuGetPackageSuffix Condition="$(Configuration.Contains('Debug'))">.dev</NuGetPackageSuffix>
+        <NuGetArguments>-NoPackageAnalysis -NonInteractive -BasePath $(OutDir) -OutputDirectory $(DropDir) -Version $(NuGetPackageVersion) -Properties suffix=$(NuGetPackageSuffix)</NuGetArguments>
+    </PropertyGroup>
+    <Exec Command="$(NuGetPath) pack $(MIEngineRoot)\MIEngine.clrdbg.nuspec $(NuGetArguments)" />
+  </Target>
+  
+</Project>

--- a/src/MIDebugPackage/MIDebugPackage.csproj
+++ b/src/MIDebugPackage/MIDebugPackage.csproj
@@ -246,6 +246,7 @@
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
   <Import Project="..\..\build\miengine.targets" />
   <Import Project="..\..\build\DropFiles.targets" />
+  <Import Project="..\..\build\PackageNuGet.targets" />
   <Import Project="$(VSToolsPath)\VSSDK\Microsoft.VsSDK.targets" Condition="'$(VSToolsPath)' != ''" />
   <!--
   Target to drop the built files into a directory.


### PR DESCRIPTION
With the last commit, the nuget package was being created but not ending
up in the drop folder so it was not getting placed on the drop server.
This commit moves the target into it's own file and includes it in
MIDebugPackage.csproj so that we can make use of the DropFiles properites.