### PR TITLE
Add prerelease suffix for MIEngine nuget package

### DIFF
--- a/build/PackageNuGet.targets
+++ b/build/PackageNuGet.targets
@@ -3,7 +3,9 @@
   <Target Name="PackageNuGet" AfterTargets="DropFiles" Condition="$(Configuration.Contains('Lab'))">
     <PropertyGroup>
         <NuGetPath>$(ToolsHome)\nuget\nuget.exe</NuGetPath>
-        <NuGetPackageVersion Condition="'$(NuGetPackageVersion)'==''">$(MajorVersion).$(MinorVersion).$(BuildNumberMajor)</NuGetPackageVersion>
+        <NuGetPrerelease Condition="'$(NuGetPrerelease)'==''">true</NuGetPrerelease>
+        <NuGetVersionPrereleaseTag Condition="'$(NuGetPrerelease)'=='true'">-pb-$(BuildNumberMinor)</NuGetVersionPrereleaseTag>
+        <NuGetPackageVersion Condition="'$(NuGetPackageVersion)'==''">$(MajorVersion).$(MinorVersion).$(BuildNumberMajor)$(NuGetVersionPrereleaseTag)</NuGetPackageVersion>
         <NuGetPackageSuffix Condition="$(Configuration.Contains('Debug'))">.dev</NuGetPackageSuffix>
         <NuGetArguments>-NoPackageAnalysis -NonInteractive -BasePath $(OutDir) -OutputDirectory $(DropDir) -Version $(NuGetPackageVersion) -Properties suffix=$(NuGetPackageSuffix)</NuGetArguments>
     </PropertyGroup>


### PR DESCRIPTION
Without a suffix, multiple daily builds will produce the same version
nuget package which will break automatic deployment. This can be very
annoying in development scenarios. However, adding a '-pb-0', etc. to a
nuget package version makes it 'prerelease'. This changes adds an optional
prerelease suffix that we can turn on in daily builds and turn off in the
release build. It is on by default. To turn off the prerelease suffix, add
NuGetPrerelease=false to the msbuil paremeters.