### PR TITLE
Changing entry points for System.Native calls.

### DIFF
--- a/src/MICore/Debugger.cs
+++ b/src/MICore/Debugger.cs
@@ -485,7 +485,8 @@ namespace MICore
 
         public Task CmdBreakInternal()
         {
-            if (IsLocalGdbAttach())
+            //TODO May need to fix attach on windows and osx.
+            if (IsLocalGdbAttach() && RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
             {
                 // for local linux debugging with attach, send a signal to one of the debugee processes rather than 
                 // using -exec-interrupt. -exec-interrupt does not work with attach. End result is either

--- a/src/MICore/Debugger.cs
+++ b/src/MICore/Debugger.cs
@@ -647,7 +647,7 @@ namespace MICore
             // This will cause gdb to async-break. This is necessary because gdb does not support async break
             // when attached.
             const int sigint = 2;
-            NativeMethods.Kill(debugeePid, sigint);
+            LinuxNativeMethods.Kill(debugeePid, sigint);
 
             return Task.FromResult<Results>(new Results(ResultClass.done));
         }

--- a/src/MICore/LinuxNativeMethods.cs
+++ b/src/MICore/LinuxNativeMethods.cs
@@ -6,7 +6,7 @@ using System.Runtime.InteropServices;
 
 namespace MICore
 {
-    internal class NativeMethods
+    internal class LinuxNativeMethods
     {
         private const string Libc = "libc";
 

--- a/src/MICore/MICore.csproj
+++ b/src/MICore/MICore.csproj
@@ -97,7 +97,7 @@
     </Compile>
     <Compile Include="MIException.cs" />
     <Compile Include="MIResults.cs" />
-    <Compile Include="NativeMethods.cs" />
+    <Compile Include="LinuxNativeMethods.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Transports\ClientServerTransport.cs" />
     <Compile Include="Transports\ITransport.cs" />

--- a/src/MICore/NativeMethods.cs
+++ b/src/MICore/NativeMethods.cs
@@ -8,15 +8,15 @@ namespace MICore
 {
     internal class NativeMethods
     {
-        // TODO: It would be better to route these to the correct .so files directly rather than pasing through system.native. 
+        private const string Libc = "libc";
 
-        [DllImport("System.Native", SetLastError = true)]
+        [DllImport(Libc, EntryPoint = "kill", SetLastError = true)]
         internal static extern int Kill(int pid, int mode);
 
-        [DllImport("System.Native", SetLastError = true)]
+        [DllImport(Libc, EntryPoint = "mkfifo", SetLastError = true)]
         internal static extern int MkFifo(string name, int mode);
 
-        [DllImport("System.Native", SetLastError = true)]
+        [DllImport(Libc, EntryPoint = "geteuid", SetLastError = true)]
         internal static extern uint GetEUid();
     }
 }

--- a/src/MICore/Transports/LocalLinuxTransport.cs
+++ b/src/MICore/Transports/LocalLinuxTransport.cs
@@ -15,7 +15,7 @@ namespace MICore
         {
             // Mod is normally in octal, but C# has no octal values. This is 384 (rw owner, no rights anyone else)
             const int rw_owner = 384;
-            int result = NativeMethods.MkFifo(path, rw_owner);
+            int result = LinuxNativeMethods.MkFifo(path, rw_owner);
 
             if (result != 0)
             {
@@ -42,7 +42,7 @@ namespace MICore
             System.IO.FileStream gdbStdOutStream = new FileStream(gdbStdOutName, FileMode.Open);
 
             // If running as root, make sure the new console is also root. 
-            bool isRoot = NativeMethods.GetEUid() == 0;
+            bool isRoot = LinuxNativeMethods.GetEUid() == 0;
 
             // Spin up a new bash shell, cd to the working dir, execute a tty command to get the shell tty and store it
             // start the debugger in mi mode setting the tty to the terminal defined earlier and redirect stdin/stdout


### PR DESCRIPTION
- Newer version of the CLR uses different names.