### PR TITLE
Add plumbing for AD7 evaluation / property info flags

### DIFF
--- a/src/MICore/MICommandFactory.cs
+++ b/src/MICore/MICommandFactory.cs
@@ -941,7 +941,7 @@ namespace MICore
 
         public override async Task<Results> VarListChildren(string variableReference, enum_DEBUGPROP_INFO_FLAGS dwFlags, ResultClass resultClass = ResultClass.done)
         {
-            string command = string.Format("-var-list-children --simple-values \"{0}\" --propInfoFlags {1}", variableReference, dwFlags);
+            string command = string.Format("-var-list-children --simple-values \"{0}\" --propertyInfoFlags {1}", variableReference, (uint)dwFlags);
             Results results = await _debugger.CmdAsync(command, resultClass);
 
             return results;

--- a/src/MIDebugEngine/AD7.Impl/AD7Expression.cs
+++ b/src/MIDebugEngine/AD7.Impl/AD7Expression.cs
@@ -82,7 +82,7 @@ namespace Microsoft.MIDebugEngine
                 return Constants.S_OK;
             }
 
-            _var.SyncEval();
+            _var.SyncEval(dwFlags);
             ppResult = new AD7Property(_engine, _var);
             return Constants.S_OK;
         }

--- a/src/MIDebugEngine/AD7.Impl/AD7Property.cs
+++ b/src/MIDebugEngine/AD7.Impl/AD7Property.cs
@@ -113,6 +113,7 @@ namespace Microsoft.MIDebugEngine
         {
             ppEnum = null;
 
+            _variableInformation.PropertyInfoFlags = dwFields;
             _variableInformation.EnsureChildren();
 
             if (_variableInformation.CountChildren != 0)

--- a/src/MIDebugEngine/Natvis.Impl/Natvis.cs
+++ b/src/MIDebugEngine/Natvis.Impl/Natvis.cs
@@ -56,11 +56,12 @@ namespace Microsoft.MIDebugEngine.Natvis
             VariableInformation.AsyncErrorImpl(pExprCallback != null ? new EngineCallback(_engine, pExprCallback) : _engine.Callback, this, error);
         }
         public void AsyncEval(IDebugEventCallback2 pExprCallback) { Parent.AsyncEval(pExprCallback); }
-        public void SyncEval() { Parent.SyncEval(); }
+        public void SyncEval(enum_EVALFLAGS dwFlags) { Parent.SyncEval(dwFlags); }
         public ThreadContext ThreadContext { get { return Parent.ThreadContext; } }
         public VariableInformation FindChildByName(string name) { return Parent.FindChildByName(name); }
         public string EvalDependentExpression(string expr) { return Parent.EvalDependentExpression(expr); }
         public virtual bool IsVisualized { get { return Parent.IsVisualized; } }
+        public virtual enum_DEBUGPROP_INFO_FLAGS PropertyInfoFlags { get; set; }
     }
 
     internal class VisualizerWrapper : SimpleWrapper


### PR DESCRIPTION
- This change routes incoming evaluation / property flags to the debugger the MI engine is talking to.
- Currently, only clrdbg supports receiving these flags (via the override of VarCreate, VarListChildren) and other debuggers continue to work as before.