### PR TITLE
MIEngine exception telemetry

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,7 @@ BuildResults.xml
 intermediate
 *.metaproj
 *.tmp
+*.VC.opendb
 packages/
 .vs/
 Microsoft.VisualStudio.Glass

--- a/src/DebugEngineHost.Stub/DebugEngineHost.ref.cs
+++ b/src/DebugEngineHost.Stub/DebugEngineHost.ref.cs
@@ -379,5 +379,17 @@ namespace Microsoft.DebugEngineHost
         {
             throw new NotImplementedException();
         }
+
+        /// <summary>
+        /// Reports the current exception to Microsoft's telemetry service. 
+        /// 
+        /// *NOTE*: This should only be called from a 'catch(...) when' handler.
+        /// </summary>
+        /// <param name="currentException">Exception object to report.</param>
+        /// <param name="engineName">Name of the engine reporting the exception. Ex:Microsoft.MIEngine</param>
+        public static void ReportCurrentException(Exception currentException, string engineName)
+        {
+            throw new NotImplementedException();
+        }
     }
 }

--- a/src/DebugEngineHost/DebugEngineHost.csproj
+++ b/src/DebugEngineHost/DebugEngineHost.csproj
@@ -56,6 +56,9 @@
     <CodeAnalysisRuleSet>..\IDECodeAnalysis.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
   <ItemGroup>
+    <Reference Include="Microsoft.VisualStudio.Debugger.Engine, Version=1.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <Private>False</Private>
+    </Reference>
     <Reference Include="Microsoft.VisualStudio.Debugger.Interop.10.0, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <Private>False</Private>
     </Reference>

--- a/src/DebugEngineHost/HostTelemetry.cs
+++ b/src/DebugEngineHost/HostTelemetry.cs
@@ -8,6 +8,7 @@ using System.Linq;
 using Microsoft.Internal.VisualStudio.Shell;
 using Microsoft.Internal.VisualStudio.Shell.Interop;
 using Microsoft.VisualStudio.Shell;
+using System.Globalization;
 
 namespace Microsoft.DebugEngineHost
 {
@@ -45,6 +46,22 @@ namespace Microsoft.DebugEngineHost
                 // disable telemetry in the future so that we don't keep failing if types are unavailable
                 s_isDisabled = true;
             }
+#endif
+        }
+
+        /// <summary>
+        /// Reports the current exception to Microsoft's telemetry service. 
+        /// 
+        /// *NOTE*: This should only be called from a 'catch(...) when' handler.
+        /// </summary>
+        /// <param name="currentException">Exception object to report.</param>
+        /// <param name="engineName">Name of the engine reporting the exception. Ex:Microsoft.MIEngine</param>
+        public static void ReportCurrentException(Exception currentException, string engineName)
+        {
+            Debug.Fail(string.Format(CultureInfo.InvariantCulture, "{0} was raised and would normally be reported to telemetry.\n\nStack trace: {1}", currentException.GetType(), currentException.StackTrace));
+
+#if LAB
+            VisualStudio.Debugger.DkmComponentManager.ReportCurrentNonFatalException(currentException, engineName);
 #endif
         }
 

--- a/src/MICore/Debugger.cs
+++ b/src/MICore/Debugger.cs
@@ -306,7 +306,7 @@ namespace MICore
                 {
                     await item();
                 }
-                catch (Exception e)
+                catch (Exception e) when (ExceptionHelper.BeforeCatch(e, reportOnlyCorrupting:true))
                 {
                     if (firstException != null)
                     {

--- a/src/MICore/ExceptionHelper.cs
+++ b/src/MICore/ExceptionHelper.cs
@@ -1,0 +1,65 @@
+﻿using Microsoft.DebugEngineHost;
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Globalization;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace MICore
+{
+    public static class ExceptionHelper
+    {
+        /// <summary>
+        /// Exception filter function used to report exceptions to telemetry. This **ALWAYS** returns 'true'.
+        /// </summary>
+        /// <param name="currentException">The current exception which is about to be caught.</param>
+        /// <param name="reportOnlyCorrupting">If true, only corrupting exceptions are reported</param>
+        /// <returns>true</returns>
+        public static bool BeforeCatch(Exception currentException, bool reportOnlyCorrupting)
+        {
+            if (reportOnlyCorrupting && !IsCorruptingException(currentException))
+            {
+                return true; // ignore non-corrupting exceptions
+            }
+
+            try
+            {
+                HostTelemetry.ReportCurrentException(currentException, "Microsoft.MIDebugEngine");
+
+                Logger.WriteLine("EXCEPTION: " + currentException.GetType());
+                Logger.WriteTextBlock("EXCEPTION: ", currentException.StackTrace);
+            }
+            catch
+            {
+                // If anything goes wrong, ignore it. We want to report the original exception, not a telemetry problem
+            }
+
+            return true;
+        }
+
+        public static bool IsCorruptingException(Exception exception)
+        {
+            if (exception is NullReferenceException)
+                return true;
+            if (exception is ArgumentNullException)
+                return true;
+            if (exception is ArithmeticException)
+                return true;
+            if (exception is ArrayTypeMismatchException)
+                return true;
+            if (exception is DivideByZeroException)
+                return true;
+            if (exception is IndexOutOfRangeException)
+                return true;
+            if (exception is InvalidCastException)
+                return true;
+            if (exception is System.Runtime.InteropServices.SEHException)
+                return true;
+
+            return false;
+        }
+
+    }
+}

--- a/src/MICore/LaunchOptions.cs
+++ b/src/MICore/LaunchOptions.cs
@@ -803,7 +803,7 @@ namespace MICore
                     deviceAppLauncher.Initialize(configStore, eventCallback);
                     deviceAppLauncher.SetLaunchOptions(exePath, args, dir, launcherXmlOptions, targetEngine);
                 }
-                catch (Exception e) when (!(e is InvalidLaunchOptionsException))
+                catch (Exception e) when (!(e is InvalidLaunchOptionsException) && ExceptionHelper.BeforeCatch(e, reportOnlyCorrupting:true))
                 {
                     throw new InvalidLaunchOptionsException(e.Message);
                 }

--- a/src/MICore/MICore.csproj
+++ b/src/MICore/MICore.csproj
@@ -81,6 +81,7 @@
   <ItemGroup>
     <Compile Include="CommandLock.cs" />
     <Compile Include="Debugger.cs" />
+    <Compile Include="ExceptionHelper.cs" />
     <Compile Include="InvalidLaunchOptionsException.cs" />
     <Compile Include="LaunchCommand.cs" />
     <Compile Include="LaunchOptions.cs" />

--- a/src/MIDebugEngine/AD7.Impl/AD7Engine.cs
+++ b/src/MIDebugEngine/AD7.Impl/AD7Engine.cs
@@ -166,7 +166,7 @@ namespace Microsoft.MIDebugEngine
             {
                 return e.HResult;
             }
-            catch (Exception e)
+            catch (Exception e) when (ExceptionHelper.BeforeCatch(e, reportOnlyCorrupting:true))
             {
                 return EngineUtils.UnexpectedException(e);
             }
@@ -430,7 +430,7 @@ namespace Microsoft.MIDebugEngine
 
                 return Constants.S_OK;
             }
-            catch (Exception e)
+            catch (Exception e) when (ExceptionHelper.BeforeCatch(e, reportOnlyCorrupting: true))
             {
                 exception = e;
                 // Return from the catch block so that we can let the exception unwind - the stack can get kind of big
@@ -511,7 +511,7 @@ namespace Microsoft.MIDebugEngine
             {
                 return e.HResult;
             }
-            catch (Exception e)
+            catch (Exception e) when (ExceptionHelper.BeforeCatch(e, reportOnlyCorrupting: true))
             {
                 return EngineUtils.UnexpectedException(e);
             }

--- a/src/MIDebugEngine/Engine.Impl/DebuggedProcess.cs
+++ b/src/MIDebugEngine/Engine.Impl/DebuggedProcess.cs
@@ -298,7 +298,7 @@ namespace Microsoft.MIDebugEngine
 
                         _bLastModuleLoadFailed = false;
                     }
-                    catch (Exception e)
+                    catch (Exception e) when (ExceptionHelper.BeforeCatch(e, reportOnlyCorrupting: true))
                     {
                         if (this.ProcessState == MICore.ProcessState.Exited)
                         {
@@ -351,7 +351,7 @@ namespace Microsoft.MIDebugEngine
                 {
                     await HandleBreakModeEvent(results);
                 }
-                catch (Exception e)
+                catch (Exception e) when (ExceptionHelper.BeforeCatch(e, reportOnlyCorrupting: true))
                 {
                     if (this.ProcessState == MICore.ProcessState.Exited)
                     {

--- a/src/MIDebugEngine/Engine.Impl/EngineUtils.cs
+++ b/src/MIDebugEngine/Engine.Impl/EngineUtils.cs
@@ -252,7 +252,7 @@ namespace Microsoft.MIDebugEngine
 
         internal static string GetExceptionDescription(Exception exception)
         {
-            if (!IsCorruptingException(exception))
+            if (!ExceptionHelper.IsCorruptingException(exception))
             {
                 return exception.Message;
             }
@@ -260,28 +260,6 @@ namespace Microsoft.MIDebugEngine
             {
                 return string.Format(CultureInfo.CurrentCulture, MICoreResources.Error_CorruptingException, exception.GetType().FullName, exception.StackTrace);
             }
-        }
-
-        private static bool IsCorruptingException(Exception exception)
-        {
-            if (exception is NullReferenceException)
-                return true;
-            if (exception is ArgumentNullException)
-                return true;
-            if (exception is ArithmeticException)
-                return true;
-            if (exception is ArrayTypeMismatchException)
-                return true;
-            if (exception is DivideByZeroException)
-                return true;
-            if (exception is IndexOutOfRangeException)
-                return true;
-            if (exception is InvalidCastException)
-                return true;
-            if (exception is System.Runtime.InteropServices.SEHException)
-                return true;
-
-            return false;
         }
 
         internal class SignalMap : Dictionary<string, uint>

--- a/src/MIDebugEngine/Engine.Impl/OperationThread.cs
+++ b/src/MIDebugEngine/Engine.Impl/OperationThread.cs
@@ -9,6 +9,7 @@ using System.Diagnostics;
 using System.Threading.Tasks;
 using System.Runtime.ExceptionServices;
 using Microsoft.DebugEngineHost;
+using MICore;
 
 namespace Microsoft.MIDebugEngine
 {
@@ -300,7 +301,7 @@ namespace Microsoft.MIDebugEngine
                             {
                                 syncOp();
                             }
-                            catch (Exception opException)
+                            catch (Exception opException) when (ExceptionHelper.BeforeCatch(opException, reportOnlyCorrupting: true))
                             {
                                 runningOp.ExceptionDispatchInfo = ExceptionDispatchInfo.Capture(opException);
                             }
@@ -313,7 +314,7 @@ namespace Microsoft.MIDebugEngine
                             {
                                 runningOp.Task = asyncOp();
                             }
-                            catch (Exception opException)
+                            catch (Exception opException) when (ExceptionHelper.BeforeCatch(opException, reportOnlyCorrupting: true))
                             {
                                 runningOp.ExceptionDispatchInfo = ExceptionDispatchInfo.Capture(opException);
                             }
@@ -353,7 +354,7 @@ namespace Microsoft.MIDebugEngine
                         {
                             postedOperation();
                         }
-                        catch (Exception e)
+                        catch (Exception e) when (ExceptionHelper.BeforeCatch(e, reportOnlyCorrupting: false))
                         {
                             if (PostedOperationErrorEvent != null)
                             {


### PR DESCRIPTION
This checkin adds telemetry to the most important error paths in the MIEngine. This will generate non-fatal watsons in Visual Studio, and an exception telemetry report in VS Code.

I added a new file to the .gitignore.