### PR TITLE
Set hint path Microsoft.VisualStudio.Debugger.Engine.dll

### DIFF
--- a/src/DebugEngineHost/DebugEngineHost.csproj
+++ b/src/DebugEngineHost/DebugEngineHost.csproj
@@ -19,6 +19,13 @@
     <FileAlignment>512</FileAlignment>
     <TargetFrameworkProfile />
     <OutputPath>$(MIDefaultOutputPath)</OutputPath>
+    <!--Work out the root to the Visual Studio SDK-->
+    <VSSDKRoot>$(VSSDK140Install)</VSSDKRoot>
+    <VSSDKRoot Condition="'$(VSSDKRoot)'==''">$(registry:HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\VisualStudio\VSIP\14.0\@InstallDir)</VSSDKRoot>
+    <VSSDKRoot Condition="'$(VSSDKRoot)'==''">$(registry:HKEY_LOCAL_MACHINE\SOFTWARE\WOW6432Node\Microsoft\VisualStudio\VSIP\14.0\@InstallDir)</VSSDKRoot>
+    <!--This should expand out to something like:
+    C:\Program Files (x86)\Microsoft Visual Studio 14.0\VSSDK\VisualStudioIntegration\Common\Assemblies\v4.0\Microsoft.VisualStudio.Debugger.Engine.dll-->
+    <MicrosoftVisualStudioDebuggerEnginePath>$(VSSDKRoot)VisualStudioIntegration\Common\Assemblies\v4.0\Microsoft.VisualStudio.Debugger.Engine.dll</MicrosoftVisualStudioDebuggerEnginePath>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -58,6 +65,8 @@
   <ItemGroup>
     <Reference Include="Microsoft.VisualStudio.Debugger.Engine, Version=1.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <Private>False</Private>
+      <!--Use a HintPath to try and force the Dev14 version to be used. -->
+      <HintPath>$(MicrosoftVisualStudioDebuggerEnginePath)</HintPath>
     </Reference>
     <Reference Include="Microsoft.VisualStudio.Debugger.Interop.10.0, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <Private>False</Private>
@@ -129,10 +138,15 @@
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Import Project="..\..\build\miengine.targets" />
+  
+  <!--Verify that we will be able to find the correct build of Microsoft.VisualStudio.Debugger.Engine-->
+  <Target Name="BeforeBuild">
+    <Error Condition="'$(VSSDKRoot)'==''" Text="'VSSDKRoot' is not defined. Unable to find Visual Studio SDK install root."/>
+    <Error Condition="!Exists('$(MicrosoftVisualStudioDebuggerEnginePath)')"  Text="$(MicrosoftVisualStudioDebuggerEnginePath) cannot be found."/>
+  </Target>
+  
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.
-  <Target Name="BeforeBuild">
-  </Target>
   <Target Name="AfterBuild">
   </Target>
   -->


### PR DESCRIPTION
The official build is failing because it is using the VS 12 version of Microsoft.VisualStudio.Debugger.Engine.dll. This makes changes to DebugEngineHost so that it should force the 14 version to be used.