### PR TITLE
InstallToVSCode and package.json fixes

### DIFF
--- a/tools/InstallToVSCode/CLRDependencies/NuGet.Config
+++ b/tools/InstallToVSCode/CLRDependencies/NuGet.Config
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <packageSources>
+    <!--To inherit the global NuGet package sources remove the <clear/> line below -->
+    <clear />
+    <add key="dotnet-core" value="https://www.myget.org/F/dotnet-core/api/v3/index.json" />
+    <add key="api.nuget.org" value="https://api.nuget.org/v3/index.json" />
+  </packageSources>
+</configuration>

--- a/tools/InstallToVSCode/CLRDependencies/dummy.cs
+++ b/tools/InstallToVSCode/CLRDependencies/dummy.cs
@@ -1,0 +1,13 @@
+using System;
+
+namespace Dummy
+{
+    class Dummy
+    {
+        static void Main(string[] args) {
+            // empty boilerplate required by dotnet build/publish to emit an entry point
+            // The entrypoint created is dummy[.exe], which we rename to OpenDebugAD7[.exe]
+            // The generated entry point will then run OpenDebugAD7.dll for us
+        }
+    }
+}

--- a/tools/InstallToVSCode/CLRDependencies/project.json
+++ b/tools/InstallToVSCode/CLRDependencies/project.json
@@ -1,0 +1,28 @@
+{
+  "name": "dummy",
+  "compilationOptions": {
+      "emitEntryPoint": true
+  },
+  "dependencies": {
+    "NETStandard.Library": "1.0.0-rc3-23803",
+    "System.Collections.Specialized":  "4.0.1-rc3-23803",
+    "System.Collections.Immutable": "1.2.0-rc3-23803", 
+    "System.Diagnostics.Process" : "4.1.0-rc3-23803",
+    "System.Diagnostics.StackTrace":  "4.0.1-rc3-23803",  
+    "System.Dynamic.Runtime": "4.0.11-rc3-23803",
+    "Microsoft.CSharp": "4.0.1-rc3-23803",
+    "System.Threading.Tasks.Dataflow": "4.6.0-rc3-23803",
+    "System.Threading.Thread": "4.0.0-rc3-23803", 
+    "System.Xml.XDocument": "4.0.11-rc3-23803",
+    "System.Xml.XmlDocument": "4.0.1-rc3-23803",  
+    "System.Xml.XmlSerializer": "4.0.11-rc3-23803",
+    "System.ComponentModel":  "4.0.1-rc3-23803",  
+    "System.ComponentModel.Annotations":  "4.1.0-rc3-23803",  
+    "System.ComponentModel.EventBasedAsync":  "4.0.11-rc3-23803",
+    "System.Runtime.Serialization.Primitives": "4.1.0-rc3-23803",
+    "System.Net.Http":  "4.0.1-rc3-23803"
+  },
+  "frameworks": {
+    "dnxcore50": { }
+  }
+}

--- a/tools/InstallToVSCode/InstallToVSCode.cmd
+++ b/tools/InstallToVSCode/InstallToVSCode.cmd
@@ -1,5 +1,7 @@
 @echo off
 setlocal
+set COMPLUS_InstallRoot=
+set COMPLUS_Version=
 
 set DefaultDestDir=%USERPROFILE%\.vscode\extensions\coreclr-debug
 
@@ -18,53 +20,60 @@ echo ERROR: Unexpected first argument '%~1'. Expected '-l' or '-c'.& exit /b -1
 :InstallActionSet
 
 if not exist %2 echo ERROR: open-debug-ad7-dir '%~2' does not exist.& exit /b -1
-if not exist "%~2\OpenDebugAD7.exe" echo ERROR: OpenDebugAD7.exe does not exist in open-debug-ad7-dir '%~2'.& exit /b -1
+if not exist "%~2\OpenDebugAD7.dll" echo ERROR: OpenDebugAD7.dll does not exist in open-debug-ad7-dir '%~2'.& exit /b -1
 set OpenDebugAD7Dir=%~2
 
 set DropDir=%~dp0..\..\bin\Debug\drop\
 if not exist "%DropDir%Microsoft.MIDebugEngine.dll" echo ERROR: Microsoft.MIDebugEngine.dll has not been built & exit /b -1
 
-if "%~3"=="-d" (
-    if "%~4" == "" echo ERROR: Clrdbg binaries directory not set &exit /b -1
-    set CLRDBGBITSDIR=%~4
-    set DESTDIR=%~5
-) else (
-    set DESTDIR=%~3
-)
+if NOT "%~3"=="-d" echo ERROR: Bad command line argument. Expected '-d ^<clrdbg-dir^>'. & exit /b -1
+if "%~4" == "" echo ERROR: Clrdbg binaries directory not set &exit /b -1
+set CLRDBGBITSDIR=%~4
+if not exist "%CLRDBGBITSDIR%\libclrdbg.dll" echo ERROR: %CLRDBGBITSDIR%\libclrdbg.dll does not exist. & exit /b -1
 
+set DESTDIR=%~f5
 if "%DESTDIR%"=="" set DESTDIR=%DefaultDestDir%
 
-if exist "%DESTDIR%" goto DESTDIR_Done
-mkdir "%DESTDIR%"
-if NOT "%ERRORLEVEL%"=="0" echo ERROR: unable to create destination directory '%DESTDIR%'. &exit /b -1
+if exist "%DESTDIR%" rmdir /s /q "%DESTDIR%"
+if exist "%DESTDIR%" echo ERROR: Unable to clean destination directory '%DESTDIR%' & exit /b -1
 
-:DESTDIR_Done
 echo Installing files to %DESTDIR%
 echo.
-if exist "%DESTDIR%\debugAdapters" goto DEBUGADAPTERDIR_Done
+
 mkdir "%DESTDIR%\debugAdapters"
 if NOT "%ERRORLEVEL%"=="0" echo ERROR: unable to create debug adapter directory '%DESTDIR%\debugAdapters'. &exit /b -1
-:DEBUGADAPTERDIR_Done
+
+pushd %~dp0CLRDependencies
+if NOT "%ERRORLEVEL%"=="0" echo ERROR: Unable to find CLRDependencies directory???& exit /b -1
+
+dotnet restore
+if NOT "%ERRORLEVEL%"=="0" echo "ERROR: 'dotnet restore' failed." & exit /b -1
+
+dotnet publish -o %DESTDIR%\debugAdapters
+if NOT "%ERRORLEVEL%"=="0" echo "ERROR: 'dotnet publish' failed." & exit /b -1
+popd
+
+pushd %DESTDIR%\debugAdapters
+ren dummy.exe OpenDebugAD7.exe
+if NOT "%ERRORLEVEL%"=="0" echo ERROR: Unable to rename OpenDebugAD7.exe???& exit /b -1
+popd
 
 set InstallError=
-for %%f in (OpenDebugAD7.exe) do call :InstallFile "%OpenDebugAD7Dir%\%%f" debugAdapters\
 for %%f in (dar.exe) do call :InstallFile "%OpenDebugAD7Dir%\%%f" debugAdapters\
 for %%f in (xunit.console.netcore.exe) do call :InstallFile "%OpenDebugAD7Dir%\%%f" debugAdapters\
 for %%f in (%OpenDebugAD7Dir%\*.dll) do call :InstallFile "%%f" debugAdapters\
 
-if NOT "%CLRDBGBITSDIR%" == "" (
+echo.
+echo Installing clrdbg bits from %CLRDBGBITSDIR%...
+for %%f in (%CLRDBGBITSDIR%\*.dll) do call :InstallFile "%%f" debugAdapters\
+for %%f in (%CLRDBGBITSDIR%\*.exe) do call :InstallFile "%%f" debugAdapters\
+for %%f in (%CLRDBGBITSDIR%\*.vsdconfig) do call :InstallFile "%%f" debugAdapters\
+for %%f in (%CLRDBGBITSDIR%\version.txt) do call :InstallFile "%%f" debugAdapters\
+for /D %%d in (%CLRDBGBITSDIR%\*) do (
     echo.
-    echo Installing clrdbg bits from %CLRDBGBITSDIR%...
-    for %%f in (%CLRDBGBITSDIR%\*.dll) do call :InstallFile "%%f" debugAdapters\
-    for %%f in (%CLRDBGBITSDIR%\*.exe) do call :InstallFile "%%f" debugAdapters\
-    for %%f in (%CLRDBGBITSDIR%\*.vsdconfig) do call :InstallFile "%%f" debugAdapters\
-    for %%f in (%CLRDBGBITSDIR%\version.txt) do call :InstallFile "%%f" debugAdapters\
-    for /D %%d in (%CLRDBGBITSDIR%\*) do (
-      echo.
-      echo Installing clrdbg bits from %%d... to debugAdapters\%%~nd
-      if NOT exist "%DESTDIR%\debugAdapters\%%~nd" mkdir "%DESTDIR%\debugAdapters\%%~nd
-      for %%f in (%%d\*.dll) do call :InstallFile "%%f" debugAdapters\%%~nd\
-    )
+    echo Installing clrdbg bits from %%d... to debugAdapters\%%~nd
+    if NOT exist "%DESTDIR%\debugAdapters\%%~nd" mkdir "%DESTDIR%\debugAdapters\%%~nd
+    for %%f in (%%d\*.dll) do call :InstallFile "%%f" debugAdapters\%%~nd\
 )
 
 REM NOTE: The code that deals with starting the adapter can be found in Monaco\src\vs\workbench\parts\debug\node\rawDebugSession.ts.
@@ -76,10 +85,7 @@ for %%f in (Microsoft.MICore.dll Microsoft.MIDebugEngine.dll) do call :InstallFi
 
 echo.
 if NOT "%InstallError%"=="" echo ERROR: Failed to copy one or more files.& exit /b -1
-echo InstallToVSCode.cmd succeeded. To complete setup:
-echo  Create a link or copy the corerun runtime next to the debug adapter. Ex:
-echo.
-echo    mklink /d %DESTDIR%\runtime \\vsdbgqa\x-plat\runtime-windows\x64
+echo InstallToVSCode.cmd succeeded.
 echo.
 exit /b 0
 
@@ -103,7 +109,7 @@ if NOT "%ERRORLEVEL%"=="0" set InstallError=1& echo ERROR: Unable to create link
 goto eof
 
 :Help
-echo InstallToVSCode ^<-l^|-c^> ^<open-debug-ad7-dir^> [-d ^<clrdbg-binaries^>] [destination-dir]
+echo InstallToVSCode ^<-l^|-c^> ^<open-debug-ad7-dir^> -d ^<clrdbg-binaries^> [destination-dir]
 echo.
 echo This script is used to copy files needed to enable MIEngine based debugging 
 echo into VS Code.
@@ -116,6 +122,9 @@ echo  open-debug-ad7-dir : Directory which contains OpenDebugAD7.exe
 echo  clrdbg-binaries: Directory which contains clrdbg binaries
 echo  destination-dir: Directory to install to. By default this is:
 echo     %DefaultDestDir%
+echo.
+echo Example: 
+echo .\InstallToVSCode.cmd -l c:\dd\OpenDebugAD7\bin\Debug -d c:\dd\vs1\out\binaries\amd64chk\Debugger\x-plat\clrdbg %USERPROFILE%\.vscode-alpha\extensions\coreclr-debug
 echo.
 
 :eof

--- a/tools/InstallToVSCode/InstallToVSCode.sh
+++ b/tools/InstallToVSCode/InstallToVSCode.sh
@@ -169,6 +169,10 @@ dotnet publish -o "$DESTDIR/debugAdapters"
 
 popd >/dev/null
 
+# Work arround https://github.com/dotnet/coreclr/issues/3164
+[ -f $DESTDIR/debugAdapters/libcoreclrtraceptprovider.so ] && rm $DESTDIR/debugAdapters/libcoreclrtraceptprovider.so
+[ -f $DESTDIR/debugAdapters/libcoreclrtraceptprovider.dylib ] && rm $DESTDIR/debugAdapters/libcoreclrtraceptprovider.dylib
+
 mv "$DESTDIR/debugAdapters/dummy" "$DESTDIR/debugAdapters/OpenDebugAD7"
 [ $? -ne 0 ] && echo "ERROR: Unable to move OpenDebugAD7 executable." && exit 1
 

--- a/tools/InstallToVSCode/coreclr/package.json
+++ b/tools/InstallToVSCode/coreclr/package.json
@@ -9,13 +9,13 @@
     "debuggers": [
       {
         "type": "coreclr",
+        "label": ".NET Core",
         "enableBreakpointsFor": { "languageIds": [ "csharp", "fsharp" ] },
 
-        "runtime": "./runtime/corerun",
-        "win": { "runtime": "./runtime/CoreRun.exe" },
-        "runtimeArgs": [],
-
-        "program": "./debugAdapters/OpenDebugAD7.exe",
+        "program": "./debugAdapters/OpenDebugAD7",
+        "windows": {
+          "program": "./debugAdapters/OpenDebugAD7.exe"
+        },
 
         "configurationAttributes": {
           "launch": {
@@ -23,13 +23,13 @@
             "properties": {
               "program": {
                 "type": "string",
-                "description": "Workspace relative path to the program (executable file) to launch. On Windows, a '.exe' suffix is appended if not specified already.",
-                "default": "bin/Debug/dnxcore50/<My-Project-Name>"
+                "description": "Path to the program (executable file) to launch. On Windows, a '.exe' suffix is appended if not specified already.",
+                "default": "${workspaceRoot}/bin/Debug/dnxcore50/<My-Project-Name>"
               },
               "cwd": {
                 "type": "string",
-                "description": "Workspace relative or absolute path to the working directory of the program being debugged. Default is the current workspace.",
-                "default": "."
+                "description": "Path to the working directory of the program being debugged. Default is the current workspace.",
+                "default": "${workspaceRoot}"
               },
               "args": {
                 "type": "array",
@@ -102,10 +102,10 @@
             "name": ".NET Core Launch",
             "type": "coreclr",
             "request": "launch",
-            "preLaunchTask": "compile",
-            "program": "bin/Debug/dnxcore50/<My-Project-Name>",
+            "preLaunchTask": "build",
+            "program": "${workspaceRoot}/bin/Debug/dnxcore50/<My-Project-Name>",
             "args": [ ],
-            "cwd": ".",
+            "cwd": "${workspaceRoot}",
             "stopAtEntry": false,
             "sourceFileMap": { }
           },


### PR DESCRIPTION
commit abeebec39221c654bd69a0d2bcadca6a4a0d0392
Author: Gregg Miskelly <greggm@microsoft.com>
Date:   Mon Feb 15 12:18:05 2016 -0800

    InstallToVSCode fixes
    
    Fix package.json so that:
    * It doesn't use CoreRun
    * It has a better label name in the template
    * It doesn't assume that 'program' and 'cwd' are relative paths
    * It uses 'build' instead of 'compile' for dotnet
    
    Fix InstallToVSCode to pull CoreCLR dependencies from nuget, and to make the path to clrdbg a required argument.

commit 7e1d1ee10859487186bd81f1aa3601c3005aa2ae
Author: Gregg Miskelly <greggm@microsoft.com>
Date:   Mon Feb 15 13:52:57 2016 -0800

    Add work around for CoreCLR 3164
    
    The CoreCLR has a bug where abort is called if multiple versions of libcoreclrtraceptprovider load. This works around it by removing our copy.
