### PR TITLE
Add support for debugging core dumps.

### DIFF
--- a/src/MICore/InvalidCoreDumpOperationException.cs
+++ b/src/MICore/InvalidCoreDumpOperationException.cs
@@ -1,0 +1,12 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+
+namespace MICore
+{
+    public sealed class InvalidCoreDumpOperationException :
+        InvalidOperationException
+    {
+    }
+}

--- a/src/MICore/LaunchOptions.xsd
+++ b/src/MICore/LaunchOptions.xsd
@@ -256,6 +256,11 @@
               <xs:documentation>How long, in milliseconds, to wait for the DebugServer executable to start and ServerStarted pattern to be found.</xs:documentation>
             </xs:annotation>
           </xs:attribute>
+          <xs:attribute name="CoreDumpPath" type="xs:string" use="optional">
+            <xs:annotation>
+              <xs:documentation>Path to a core dump file for the specified executable.</xs:documentation>
+            </xs:annotation>
+          </xs:attribute>
         </xs:extension>
       </xs:complexContent>
     </xs:complexType>

--- a/src/MICore/LaunchOptions.xsd.types.desginer.cs
+++ b/src/MICore/LaunchOptions.xsd.types.desginer.cs
@@ -412,6 +412,10 @@ namespace MICore.Xml.LaunchOptions {
         /// <remarks/>
         [System.Xml.Serialization.XmlIgnoreAttribute()]
         public bool ServerLaunchTimeoutSpecified;
+        
+        /// <remarks/>
+        [System.Xml.Serialization.XmlAttributeAttribute()]
+        public string CoreDumpPath;
     }
     
     /// <remarks/>

--- a/src/MICore/MICore.csproj
+++ b/src/MICore/MICore.csproj
@@ -82,6 +82,7 @@
     <Compile Include="CommandLock.cs" />
     <Compile Include="Debugger.cs" />
     <Compile Include="ExceptionHelper.cs" />
+    <Compile Include="InvalidCoreDumpOperationException.cs" />
     <Compile Include="InvalidLaunchOptionsException.cs" />
     <Compile Include="LaunchCommand.cs" />
     <Compile Include="LaunchOptions.cs" />

--- a/src/MICore/MICoreResources.Designer.cs
+++ b/src/MICore/MICoreResources.Designer.cs
@@ -158,6 +158,15 @@ namespace MICore {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Invalid path to core dump file &apos;{0}&apos;. File must be a valid file name that exists on the computer..
+        /// </summary>
+        public static string Error_InvalidLocalCoreDumpPath {
+            get {
+                return ResourceManager.GetString("Error_InvalidLocalCoreDumpPath", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Invalid path to executable file path &apos;{0}&apos;. File must be a valid file name that exists on the Visual Studio computer..
         /// </summary>
         public static string Error_InvalidLocalExePath {

--- a/src/MICore/MICoreResources.resx
+++ b/src/MICore/MICoreResources.resx
@@ -204,4 +204,7 @@ Error: {1}</value>
   <data name="Status_BreakpointPending" xml:space="preserve">
     <value>Module containing this breakpoint has not yet loaded or the breakpoint address could not be obtained.</value>
   </data>
+  <data name="Error_InvalidLocalCoreDumpPath" xml:space="preserve">
+    <value>Invalid path to core dump file '{0}'. File must be a valid file name that exists on the computer.</value>
+  </data>
 </root>

--- a/src/MICore/MIResults.cs
+++ b/src/MICore/MIResults.cs
@@ -403,6 +403,16 @@ namespace MICore
         {
             return FindAll(name).OfType<T>().ToArray();
         }
+
+        public TupleValue Subset(params string[] names)
+        {
+            List<NamedResultValue> values = new List<NamedResultValue>();
+            foreach (string name in names)
+            {
+                values.Add(new NamedResultValue(name, this.Find(name)));
+            }
+            return new TupleValue(values);
+        }
     }
 
     public abstract class ListValue : ResultValue

--- a/src/MICoreUnitTests/BasicLaunchOptionsTests.cs
+++ b/src/MICoreUnitTests/BasicLaunchOptionsTests.cs
@@ -37,6 +37,8 @@ namespace MICoreUnitTests
             Assert.Equal(options.LaunchCompleteCommand, LaunchCompleteCommand.ExecRun);
             Assert.Null(options.CustomLaunchSetupCommands);
             Assert.True(options.SetupCommands != null && options.SetupCommands.Count == 0);
+            Assert.True(String.IsNullOrEmpty(options.CoreDumpPath));
+            Assert.False(options.IsCoreDump);
         }
 
         [Fact]
@@ -68,6 +70,8 @@ namespace MICoreUnitTests
             Assert.Equal(options.LaunchCompleteCommand, LaunchCompleteCommand.ExecRun);
             Assert.True(options.CustomLaunchSetupCommands != null && options.CustomLaunchSetupCommands.Count == 0);
             Assert.True(options.SetupCommands != null && options.SetupCommands.Count == 0);
+            Assert.True(String.IsNullOrEmpty(options.CoreDumpPath));
+            Assert.False(options.IsCoreDump);
         }
 
         [Fact]

--- a/src/MIDebugEngine/AD7.Impl/AD7PendingBreakpoint.cs
+++ b/src/MIDebugEngine/AD7.Impl/AD7PendingBreakpoint.cs
@@ -175,6 +175,17 @@ namespace Microsoft.MIDebugEngine
             {
                 return e.HResult;
             }
+            catch (AggregateException e)
+            {
+                if (e.GetBaseException() is InvalidCoreDumpOperationException)
+                    return AD7_HRESULT.E_CRASHDUMP_UNSUPPORTED;
+                else
+                    return EngineUtils.UnexpectedException(e);
+            }
+            catch (InvalidCoreDumpOperationException)
+            {
+                return AD7_HRESULT.E_CRASHDUMP_UNSUPPORTED;
+            }
             catch (Exception e)
             {
                 return EngineUtils.UnexpectedException(e);
@@ -221,7 +232,6 @@ namespace Microsoft.MIDebugEngine
                     {
                         condition = _bpRequestInfo.bpCondition.bstrCondition;
                     }
-
                 }
                 PendingBreakpoint.BindResult bindResult;
                 // Bind all breakpoints that match this source and line number.

--- a/src/MIDebugEngine/Engine.Impl/Breakpoints.cs
+++ b/src/MIDebugEngine/Engine.Impl/Breakpoints.cs
@@ -86,11 +86,15 @@ namespace Microsoft.MIDebugEngine
 
         internal static async Task<BindResult> Bind(string functionName, DebuggedProcess process, string condition, AD7PendingBreakpoint pbreak)
         {
+            process.VerifyNotDebuggingCoreDump();
+
             return EvalBindResult(await process.MICommandFactory.BreakInsert(functionName, condition, ResultClass.None), pbreak);
         }
 
         internal static async Task<BindResult> Bind(string documentName, uint line, uint column, DebuggedProcess process, string condition, AD7PendingBreakpoint pbreak)
         {
+            process.VerifyNotDebuggingCoreDump();
+
             string basename = System.IO.Path.GetFileName(documentName);     // get basename from Windows path
             return EvalBindResult(await process.MICommandFactory.BreakInsert(process.EscapePath(basename), line, condition, ResultClass.None), pbreak);
         }

--- a/src/MIDebugEngine/ResourceStrings.Designer.cs
+++ b/src/MIDebugEngine/ResourceStrings.Designer.cs
@@ -143,6 +143,15 @@ namespace Microsoft.MIDebugEngine {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Loading core dump {0}.
+        /// </summary>
+        internal static string LoadingCoreDumpMessage {
+            get {
+                return ResourceManager.GetString("LoadingCoreDumpMessage", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Loading Symbols.
         /// </summary>
         internal static string LoadingSymbolCaption {

--- a/src/MIDebugEngine/ResourceStrings.resx
+++ b/src/MIDebugEngine/ResourceStrings.resx
@@ -186,4 +186,7 @@
   <data name="Failed_ExecCommandError" xml:space="preserve">
     <value>Error: {0}</value>
   </data>
+  <data name="LoadingCoreDumpMessage" xml:space="preserve">
+    <value>Loading core dump {0}</value>
+  </data>
 </root>


### PR DESCRIPTION
1. Changed local launch options schema to support specifying CoreDumpPath field and added additional LaunchCompleteOption enum value "core-dump".
2. Update DebuggedProcess initialization commands to debug core dumps.
3. Update DebuggedProcess transport initialization to use normal local transport since core dump debugging does not require a new terminal upon launch.
4. Update DebuggedProcess.ResumeFromLaunch to set initial state of debug engine to stopped with generated MI result record.
5. Block operations that are not allow during core dump debugging (e.g. continue, step, breakpoint binding, etc) by throwing exception. Catch exception at COM boundary and convert to appropriate result code.