### PR TITLE
Cleaned up remote debugger output

### DIFF
--- a/src/MICore/Debugger.cs
+++ b/src/MICore/Debugger.cs
@@ -1074,6 +1074,11 @@ namespace MICore
             }
             else
             {
+                // append a newline if the message didn't come with one
+                if (!cmd.EndsWith("\n"))
+                {
+                    cmd += "\n";
+                }
                 OnDebuggeeOutput("=" + cmd);
             }
         }

--- a/src/MICore/MIResults.cs
+++ b/src/MICore/MIResults.cs
@@ -617,13 +617,13 @@ namespace MICore
                 return string.Empty;
             }
 
-            input = input.Trim();
-            if (input[0] != '\"')   // not a Cstring, just return the string
+            string cstr = input.Trim();
+            if (cstr[0] != '\"')   // not a Cstring, just return the string
             {
                 return input;
             }
             string rest;
-            var s = ParseCString(input, out rest);
+            var s = ParseCString(cstr, out rest);
             return s == null ? string.Empty : s.AsString;
         }
 


### PR DESCRIPTION
Two simple changes to address most, if not all the issues with missing newlines and whitespace in debug output from the remote debugger.

1. Return the original untrimmed string when MIResults.ParseCString does not parse a quoted string. This preserves newlines and whitespace from remote printf statements.
2. Append a newline as needed to unhandled notification messages ("=thread-group-added", "=library-unloaded", etc.)