### PR TITLE
[Bug Fix] Make sure termination sequence for attach works as expected

### DIFF
--- a/src/MICore/Debugger.cs
+++ b/src/MICore/Debugger.cs
@@ -466,10 +466,16 @@ namespace MICore
         {
             await MICommandFactory.Terminate();
 
-            if (IsLocalGdbAttach())
+            return new Results(ResultClass.done);
+        }
+
+        public async Task<Results> CmdDetach()
+        {
+            if (ProcessState == ProcessState.Running)
             {
-                CmdExitAsync();
+                await CmdBreak();
             }
+            CmdExitAsync();
 
             return new Results(ResultClass.done);
         }

--- a/src/MIDebugEngine/AD7.Impl/AD7Engine.cs
+++ b/src/MIDebugEngine/AD7.Impl/AD7Engine.cs
@@ -590,10 +590,7 @@ namespace Microsoft.MIDebugEngine
         {
             _breakpointManager.ClearBoundBreakpoints();
 
-            _pollThread.RunOperation(new Operation(delegate
-            {
-                _debuggedProcess.Detach();
-            }));
+            _pollThread.RunOperation(() => _debuggedProcess.CmdDetach());
 
             return Constants.S_OK;
         }


### PR DESCRIPTION
1. In attaching mode, send "-gdb-exit" to detach from debuggee.
2. In launching mode, send "kill" to stop debuggee. 
3. In attaching mode, send "-execute-interrupt" only when debuggee is in run mode before detaching from debuggee.
