### PR TITLE
Add missing StringComparison

### DIFF
--- a/src/MICore/Debugger.cs
+++ b/src/MICore/Debugger.cs
@@ -1071,7 +1071,7 @@ namespace MICore
             else
             {
                 // append a newline if the message didn't come with one
-                if (!cmd.EndsWith("\n"))
+                if (!cmd.EndsWith("\n", StringComparison.Ordinal))
                 {
                     cmd += "\n";
                 }


### PR DESCRIPTION
Couldn't build solution compiler was issuing the following error:

Error	CA1307	Because the behavior of 'string.EndsWith(string)' could vary based on the current user's locale settings, replace this call in 'Debugger.OnNotificationOutput(string)' with a call to 'string.EndsWith(string, StringComparison)'. If the result of 'string.EndsWith(string, StringComparison)' will be displayed to the user, such as when sorting a list of items for display in a list box, specify 'StringComparison.CurrentCulture' or 'StringComparison.CurrentCultureIgnoreCase' as the 'StringComparison' parameter. If comparing case-insensitive identifiers, such as file paths, environment variables, or registry keys and values, specify 'StringComparison.OrdinalIgnoreCase'. Otherwise, if comparing case-sensitive identifiers, specify 'StringComparison.Ordinal'.	MICore	E:\GitHub\MIEngine\src\MICore\Debugger.cs	1074	Active