### PR TITLE
Ensure that both core dump and attach are not specified at the same time.

### DIFF
--- a/src/MICore/LaunchOptions.cs
+++ b/src/MICore/LaunchOptions.cs
@@ -219,6 +219,10 @@ namespace MICore
             options.InitializeServerOptions(source);
             options.CoreDumpPath = source.CoreDumpPath;
 
+            // Ensure that CoreDumpPath and ProcessId are not specified at the same time
+            if (!String.IsNullOrEmpty(source.CoreDumpPath) && source.ProcessId != 0)
+                throw new InvalidLaunchOptionsException(String.Format(CultureInfo.InvariantCulture, MICoreResources.Error_CannotSpecifyBoth, nameof(source.CoreDumpPath), nameof(source.ProcessId)));
+
             return options;
         }
 

--- a/src/MICore/MICoreResources.Designer.cs
+++ b/src/MICore/MICoreResources.Designer.cs
@@ -71,6 +71,15 @@ namespace MICore {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Both &apos;{0}&apos; and &apos;{1}&apos; cannot be specified at the same time..
+        /// </summary>
+        public static string Error_CannotSpecifyBoth {
+            get {
+                return ResourceManager.GetString("Error_CannotSpecifyBoth", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Internal error in MIEngine. Exception of type &apos;{0}&apos; was thrown.
         ///
         ///{1}.

--- a/src/MICore/MICoreResources.resx
+++ b/src/MICore/MICoreResources.resx
@@ -207,4 +207,7 @@ Error: {1}</value>
   <data name="Error_InvalidLocalCoreDumpPath" xml:space="preserve">
     <value>Invalid path to core dump file '{0}'. File must be a valid file name that exists on the computer.</value>
   </data>
+  <data name="Error_CannotSpecifyBoth" xml:space="preserve">
+    <value>Both '{0}' and '{1}' cannot be specified at the same time.</value>
+  </data>
 </root>


### PR DESCRIPTION
Prevent launch if both core dump path and process id are specified at the same time in order to disallow the ambiguity of attempting to debug a dump and attach to a process. If both are specified and the user attempts to launch, an error is shown stating "Unable to start debugging. Launch options string provided by the project system is invalid. Both 'CoreDumpPath' and 'ProcessId' cannot be specified at the same time.".