### PR TITLE
readd missing closing quote to linux local launch options. Note that …

### DIFF
--- a/src/MICore/Transports/LocalLinuxTransport.cs
+++ b/src/MICore/Transports/LocalLinuxTransport.cs
@@ -61,7 +61,7 @@ namespace MICore
             terminalProcess.StartInfo.FileName = !isRoot ? terminalPath : sudoPath;
 
             string argumentString = string.Format(System.Globalization.CultureInfo.InvariantCulture,
-                    "--title DebuggerTerminal -x bash -c \"cd {0}; DbgTerm=`tty`; trap 'rm {2}; rm {3}' EXIT; {1} --interpreter=mi --tty=$DbgTerm < {2} > {3};",
+                    "--title DebuggerTerminal -x bash -c \"cd {0}; DbgTerm=`tty`; trap 'rm {2}; rm {3}' EXIT; {1} --interpreter=mi --tty=$DbgTerm < {2} > {3};\"",
                     debuggeeDir,
                     localOptions.MIDebuggerPath,
                     gdbStdInName,


### PR DESCRIPTION
…this didn't have any impact on coreclr but broke on some other runtimes we're investigating