### PR TITLE
Recognize coreclr embedded breakpoints

### DIFF
--- a/src/MIDebugEngine/Engine.Impl/DebuggedProcess.cs
+++ b/src/MIDebugEngine/Engine.Impl/DebuggedProcess.cs
@@ -661,6 +661,10 @@ namespace Microsoft.MIDebugEngine
                     _bEntrypointHit = true;
                     _callback.OnEntryPoint(thread);
                 }
+                else if (bkptno == "<EMBEDDED>")
+                {
+                    _callback.OnBreakpoint(thread, new ReadOnlyCollection<object>(new AD7BoundBreakpoint[] { }));
+                }
                 else
                 {
                     if (fContinue)


### PR DESCRIPTION
Embedded breakpoints in coreclr (e.g. `Debugger.Break()` commands) are sent with an `<EMBEDDED>` id, as they don't correlate to any bound breakpoints. Add a case to check for them and send an empty breakpoint list instead of defaulting to the `else` clause and immediately continuing from them.