### PR TITLE
Child debugging: phase 1, remove/protect writable static vars

### DIFF
--- a/src/AndroidDebugLauncher/InstallPaths.cs
+++ b/src/AndroidDebugLauncher/InstallPaths.cs
@@ -26,7 +26,7 @@ namespace AndroidDebugLauncher
         /// <param name="token">token to check for cancelation</param>
         /// <param name="launchOptions">[Required] launch options object</param>
         /// <returns>[Required] Created InstallPaths object</returns>
-        public static InstallPaths Resolve(CancellationToken token, AndroidLaunchOptions launchOptions)
+        public static InstallPaths Resolve(CancellationToken token, AndroidLaunchOptions launchOptions, MICore.Logger logger)
         {
             var result = new InstallPaths();
 
@@ -53,7 +53,7 @@ namespace AndroidDebugLauncher
 
             NdkReleaseId ndkReleaseId;
             NdkReleaseId.TryParseFile(ndkReleaseVersionFile, out ndkReleaseId);
-            MICore.Logger.WriteLine("Using NDK '{0}' from path '{1}'", ndkReleaseId, ndkRoot);
+            logger.WriteLine("Using NDK '{0}' from path '{1}'", ndkReleaseId, ndkRoot);
 
             string targetArchitectureName;
             NDKToolChainFilePath[] possibleGDBPaths;

--- a/src/AndroidDebugLauncher/Launcher.cs
+++ b/src/AndroidDebugLauncher/Launcher.cs
@@ -40,6 +40,7 @@ namespace AndroidDebugLauncher
 
         private const string LogcatServiceMessage_SourceId = "1CED0608-638C-4B00-A1D2-CE56B1B672FA";
         private const int LogcatServiceMessage_NewProcess = 0;
+        private MICore.Logger Logger { get; set; }
 
         void IPlatformAppLauncher.Initialize(HostConfigurationStore configStore, IDeviceAppLauncherEventCallback eventCallback)
         {
@@ -50,6 +51,7 @@ namespace AndroidDebugLauncher
 
             _eventCallback = eventCallback;
             RegistryRoot.Set(configStore.RegistryRoot);
+            Logger = MICore.Logger.EnsureInitialized(configStore);
         }
 
         void IPlatformAppLauncher.SetLaunchOptions(string exePath, string args, string dir, object launcherXmlOptions, TargetEngine targetEngine)
@@ -174,7 +176,7 @@ namespace AndroidDebugLauncher
 
                 actions.Add(new NamedAction(LauncherResources.Step_ResolveInstallPaths, () =>
                 {
-                    _installPaths = InstallPaths.Resolve(token, _launchOptions);
+                    _installPaths = InstallPaths.Resolve(token, _launchOptions, Logger);
                 }));
 
                 actions.Add(new NamedAction(LauncherResources.Step_ConnectToDevice, () =>
@@ -806,7 +808,7 @@ namespace AndroidDebugLauncher
                     }
                     catch (JDbg.JdwpException e)
                     {
-                        MICore.Logger.WriteLine("JdwpException: {0}", e.Message);
+                        Logger.WriteLine("JdwpException: {0}", e.Message);
 
                         string message = LauncherResources.Warning_JDbgResumeFailure;
 

--- a/src/MICore/ExceptionHelper.cs
+++ b/src/MICore/ExceptionHelper.cs
@@ -15,9 +15,10 @@ namespace MICore
         /// Exception filter function used to report exceptions to telemetry. This **ALWAYS** returns 'true'.
         /// </summary>
         /// <param name="currentException">The current exception which is about to be caught.</param>
+        /// <param name="logger">For logging messages</param>
         /// <param name="reportOnlyCorrupting">If true, only corrupting exceptions are reported</param>
         /// <returns>true</returns>
-        public static bool BeforeCatch(Exception currentException, bool reportOnlyCorrupting)
+        public static bool BeforeCatch(Exception currentException, Logger logger, bool reportOnlyCorrupting)
         {
             if (reportOnlyCorrupting && !IsCorruptingException(currentException))
             {
@@ -28,8 +29,8 @@ namespace MICore
             {
                 HostTelemetry.ReportCurrentException(currentException, "Microsoft.MIDebugEngine");
 
-                Logger.WriteLine("EXCEPTION: " + currentException.GetType());
-                Logger.WriteTextBlock("EXCEPTION: ", currentException.StackTrace);
+                logger?.WriteLine("EXCEPTION: " + currentException.GetType());
+                logger?.WriteTextBlock("EXCEPTION: ", currentException.StackTrace);
             }
             catch
             {

--- a/src/MICore/LaunchOptions.cs
+++ b/src/MICore/LaunchOptions.cs
@@ -528,7 +528,7 @@ namespace MICore
             }
         }
 
-        public static LaunchOptions GetInstance(HostConfigurationStore configStore, string exePath, string args, string dir, string options, IDeviceAppLauncherEventCallback eventCallback, TargetEngine targetEngine)
+        public static LaunchOptions GetInstance(HostConfigurationStore configStore, string exePath, string args, string dir, string options, IDeviceAppLauncherEventCallback eventCallback, TargetEngine targetEngine, Logger logger)
         {
             if (string.IsNullOrWhiteSpace(exePath))
                 throw new ArgumentNullException("exePath");
@@ -536,7 +536,7 @@ namespace MICore
             if (string.IsNullOrWhiteSpace(options))
                 throw new InvalidLaunchOptionsException(MICoreResources.Error_StringIsNullOrEmpty);
 
-            Logger.WriteTextBlock("LaunchOptions", options);
+            logger?.WriteTextBlock("LaunchOptions", options);
 
             LaunchOptions launchOptions = null;
             Guid clsidLauncher = Guid.Empty;
@@ -607,7 +607,7 @@ namespace MICore
 
             if (clsidLauncher != Guid.Empty)
             {
-                launchOptions = ExecuteLauncher(configStore, clsidLauncher, exePath, args, dir, launcherXmlOptions, eventCallback, targetEngine);
+                launchOptions = ExecuteLauncher(configStore, clsidLauncher, exePath, args, dir, launcherXmlOptions, eventCallback, targetEngine, logger);
             }
 
             if (targetEngine == TargetEngine.Native)
@@ -825,7 +825,7 @@ namespace MICore
             return attributeValue;
         }
 
-        private static LaunchOptions ExecuteLauncher(HostConfigurationStore configStore, Guid clsidLauncher, string exePath, string args, string dir, object launcherXmlOptions, IDeviceAppLauncherEventCallback eventCallback, TargetEngine targetEngine)
+        private static LaunchOptions ExecuteLauncher(HostConfigurationStore configStore, Guid clsidLauncher, string exePath, string args, string dir, object launcherXmlOptions, IDeviceAppLauncherEventCallback eventCallback, TargetEngine targetEngine, Logger logger)
         {
             var deviceAppLauncher = (IPlatformAppLauncher)HostLoader.VsCoCreateManagedObject(configStore, clsidLauncher);
             if (deviceAppLauncher == null)
@@ -842,7 +842,7 @@ namespace MICore
                     deviceAppLauncher.Initialize(configStore, eventCallback);
                     deviceAppLauncher.SetLaunchOptions(exePath, args, dir, launcherXmlOptions, targetEngine);
                 }
-                catch (Exception e) when (!(e is InvalidLaunchOptionsException) && ExceptionHelper.BeforeCatch(e, reportOnlyCorrupting: true))
+                catch (Exception e) when (!(e is InvalidLaunchOptionsException) && ExceptionHelper.BeforeCatch(e, logger, reportOnlyCorrupting: true))
                 {
                     throw new InvalidLaunchOptionsException(e.Message);
                 }

--- a/src/MICore/MICommandFactory.cs
+++ b/src/MICore/MICommandFactory.cs
@@ -528,7 +528,8 @@ namespace MICore
             Results results = null;
             if (cmd.StartsWith("library-loaded,", StringComparison.Ordinal))
             {
-                results = MIResults.ParseResultList(cmd.Substring(15));
+                MIResults res = new MIResults(_debugger.Logger);
+                results = res.ParseResultList(cmd.Substring(15));
             }
             return results;
         }

--- a/src/MICore/MIResults.cs
+++ b/src/MICore/MIResults.cs
@@ -572,13 +572,20 @@ namespace MICore
         }
     };
 
-    public static class MIResults
+    public class MIResults
     {
+        private Logger Logger { get; set; }
+
+        public MIResults(Logger logger)
+        {
+            Logger = logger;
+        }
+
         /// <summary>
         /// result-record ==> result-class ( "," result )* 
         /// </summary>
         /// <param name="output"></param>
-        public static Results ParseCommandOutput(string output)
+        public Results ParseCommandOutput(string output)
         {
             output = output.Trim();
             int comma = output.IndexOf(',');
@@ -597,7 +604,7 @@ namespace MICore
             return results;
         }
 
-        public static Results ParseResultList(string listStr, ResultClass resultClass = ResultClass.None)
+        public Results ParseResultList(string listStr, ResultClass resultClass = ResultClass.None)
         {
             listStr = listStr.Trim();
             string rest;
@@ -616,7 +623,7 @@ namespace MICore
             return new Results(resultClass, list);
         }
 
-        public static string ParseCString(string input)
+        public string ParseCString(string input)
         {
             if (input == null)
             {
@@ -641,7 +648,7 @@ namespace MICore
         /// value ==>const | tuple | list
         /// </summary>
         /// <returns></returns>
-        private static ResultValue ParseValue(string resultStr, out string rest)
+        private ResultValue ParseValue(string resultStr, out string rest)
         {
             ResultValue value = null;
             rest = String.Empty;
@@ -675,7 +682,7 @@ namespace MICore
         ///     value -- const | tuple | tuplelist | list
         /// </summary>
         /// <returns></returns>
-        private static ResultValue ParseResultValue(string resultStr, out string rest)
+        private ResultValue ParseResultValue(string resultStr, out string rest)
         {
             ResultValue value = null;
             rest = String.Empty;
@@ -714,7 +721,7 @@ namespace MICore
         /// </summary>
         /// <param name="resultStr">trimmed input string</param>
         /// <param name="rest">trimmed remainder after result</param>
-        private static NamedResultValue ParseResult(string resultStr, out string rest)
+        private NamedResultValue ParseResult(string resultStr, out string rest)
         {
             rest = String.Empty;
             int equals = resultStr.IndexOf('=');
@@ -749,7 +756,7 @@ namespace MICore
             }
         }
 
-        private static ConstValue ParseCString(string input, out string rest)
+        private ConstValue ParseCString(string input, out string rest)
         {
             rest = input;
             StringBuilder output = new StringBuilder(input.Length);
@@ -803,7 +810,7 @@ namespace MICore
 
         private delegate bool EdgeCondition(string s, ref int i);
 
-        private static List<NamedResultValue> ParseResultList(EdgeCondition begin, EdgeCondition end, string input, out string rest)
+        private List<NamedResultValue> ParseResultList(EdgeCondition begin, EdgeCondition end, string input, out string rest)
         {
             rest = string.Empty;
             List<NamedResultValue> list = new List<NamedResultValue>();
@@ -850,7 +857,7 @@ namespace MICore
             return list;
         }
 
-        private static List<NamedResultValue> ParseResultList(char begin, char end, string input, out string rest)
+        private List<NamedResultValue> ParseResultList(char begin, char end, string input, out string rest)
         {
             return ParseResultList((string s, ref int i) =>
             {
@@ -875,7 +882,7 @@ namespace MICore
         /// tuple ==> "{}" | "{" result ( "," result )* "}" 
         /// </summary>
         /// <returns>if one tuple found a TupleValue, otherwise a ValueListValue of TupleValues</returns>
-        private static ResultValue ParseResultTuple(string input, out string rest)
+        private ResultValue ParseResultTuple(string input, out string rest)
         {
             var list = ParseResultList('{', '}', input, out rest);
             if (list == null)
@@ -903,7 +910,7 @@ namespace MICore
         /// <summary>
         /// tuple ==> "{}" | "{" result ( "," result )* "}" 
         /// </summary>
-        private static TupleValue ParseTuple(string input, out string rest)
+        private TupleValue ParseTuple(string input, out string rest)
         {
             var list = ParseResultList('{', '}', input, out rest);
             if (list == null)
@@ -916,7 +923,7 @@ namespace MICore
         /// <summary>
         /// list ==> "[]" | "[" value ( "," value )* "]" | "[" result ( "," result )* "]"  
         /// </summary>
-        private static ResultValue ParseList(string input, out string rest)
+        private ResultValue ParseList(string input, out string rest)
         {
             rest = string.Empty;
             if (input[0] != '[')
@@ -942,7 +949,7 @@ namespace MICore
         /// <summary>
         /// list ==>  "[" value ( "," value )* "]"   
         /// </summary>
-        private static ValueListValue ParseValueList(string input, out string rest)
+        private ValueListValue ParseValueList(string input, out string rest)
         {
             rest = string.Empty;
             List<ResultValue> list = new List<ResultValue>();
@@ -985,7 +992,7 @@ namespace MICore
         /// <summary>
         /// list ==>  "[" result ( "," result )* "]"  
         /// </summary>
-        private static ResultListValue ParseResultList(string input, out string rest)
+        private ResultListValue ParseResultList(string input, out string rest)
         {
             var list = ParseResultList('[', ']', input, out rest);
             if (list == null)
@@ -995,11 +1002,11 @@ namespace MICore
             return new ResultListValue(list);
         }
 
-        private static void ParseError(string message, string input)
+        private void ParseError(string message, string input)
         {
             Debug.Fail(message + ": " + input);
 #if DEBUG
-            Logger.WriteLine(String.Format(CultureInfo.CurrentCulture, "MI parsing error: {0}: \"{1}\"", message, input));
+            Logger?.WriteLine(String.Format(CultureInfo.CurrentCulture, "MI parsing error: {0}: \"{1}\"", message, input));
 #endif
         }
     }

--- a/src/MICore/Transports/ClientServerTransport.cs
+++ b/src/MICore/Transports/ClientServerTransport.cs
@@ -26,14 +26,14 @@ namespace MICore
             _serverTransport = serverTransport;
         }
 
-        public void Init(ITransportCallback transportCallback, LaunchOptions options)
+        public void Init(ITransportCallback transportCallback, LaunchOptions options, Logger logger)
         {
             _launchTimeout = ((LocalLaunchOptions)options).ServerLaunchTimeout;
-            _serverTransport.Init(transportCallback, options);
+            _serverTransport.Init(transportCallback, options, logger);
             WaitForStart();
             if (!_clientTransport.IsClosed)
             {
-                _clientTransport.Init(transportCallback, options);
+                _clientTransport.Init(transportCallback, options, logger);
             }
         }
 

--- a/src/MICore/Transports/ITransport.cs
+++ b/src/MICore/Transports/ITransport.cs
@@ -12,7 +12,7 @@ namespace MICore
 
     public interface ITransport
     {
-        void Init(ITransportCallback transportCallback, LaunchOptions options);
+        void Init(ITransportCallback transportCallback, LaunchOptions options, Logger logger);
         void Send(string cmd);
         void Close();
         bool IsClosed { get; }

--- a/src/MICore/Transports/LocalLinuxTransport.cs
+++ b/src/MICore/Transports/LocalLinuxTransport.cs
@@ -20,7 +20,7 @@ namespace MICore
             if (result != 0)
             {
                 // Failed to create the fifo. Bail.
-                Logger.WriteLine("Failed to create gdb fifo");
+                Logger?.WriteLine("Failed to create gdb fifo");
                 throw new ArgumentException("MakeGdbFifo failed to create fifo at path {0}", path);
             }
         }
@@ -69,7 +69,7 @@ namespace MICore
                     );
 
             terminalProcess.StartInfo.Arguments = !isRoot ? argumentString : String.Concat(terminalPath, " ", argumentString);
-            Logger.WriteLine("LocalLinuxTransport command: " + terminalProcess.StartInfo.FileName + " " + terminalProcess.StartInfo.Arguments);
+            Logger?.WriteLine("LocalLinuxTransport command: " + terminalProcess.StartInfo.FileName + " " + terminalProcess.StartInfo.Arguments);
 
             if (localOptions.Environment != null)
             {

--- a/src/MICore/Transports/MockTransport.cs
+++ b/src/MICore/Transports/MockTransport.cs
@@ -33,7 +33,7 @@ namespace MICore
             _filename = logfilename;
         }
 
-        public void Init(ITransportCallback transportCallback, LaunchOptions options)
+        public void Init(ITransportCallback transportCallback, LaunchOptions options, Logger logger)
         {
             _bQuit = false;
             _callback = transportCallback;

--- a/src/MICore/Transports/StreamTransport.cs
+++ b/src/MICore/Transports/StreamTransport.cs
@@ -19,7 +19,11 @@ namespace MICore
         private bool _bQuit;
         protected StreamReader _reader;
         protected StreamWriter _writer;
-        bool _filterStdout;
+        private bool _filterStdout;
+        protected Logger Logger
+        {
+            get; private set;
+        }
 
         protected StreamTransport()
         { }
@@ -32,8 +36,9 @@ namespace MICore
         public abstract void InitStreams(LaunchOptions options, out StreamReader reader, out StreamWriter writer);
         protected virtual string GetThreadName() { return "MI.StreamTransport"; }
 
-        public virtual void Init(ITransportCallback transportCallback, LaunchOptions options)
+        public virtual void Init(ITransportCallback transportCallback, LaunchOptions options, Logger logger)
         {
+            Logger = logger;
             _callback = transportCallback;
             InitStreams(options, out _reader, out _writer);
             StartThread(GetThreadName());
@@ -62,7 +67,7 @@ namespace MICore
                     break;
 
                 line = line.TrimEnd();
-                Logger.WriteLine("->" + line);
+                Logger?.WriteLine("->" + line);
 
                 try
                 {
@@ -100,7 +105,7 @@ namespace MICore
         }
         protected void Echo(string cmd)
         {
-            Logger.WriteLine("<-" + cmd);
+            Logger?.WriteLine("<-" + cmd);
             _writer.WriteLine(cmd);
             _writer.Flush();
         }

--- a/src/MICoreUnitTests/BasicLaunchOptionsTests.cs
+++ b/src/MICoreUnitTests/BasicLaunchOptionsTests.cs
@@ -295,7 +295,7 @@ namespace MICoreUnitTests
 
         private LaunchOptions GetLaunchOptions(string content)
         {
-            return LaunchOptions.GetInstance(null, "bogus-exe-path", null, null, content, null, TargetEngine.Native);
+            return LaunchOptions.GetInstance(null, "bogus-exe-path", null, null, content, null, TargetEngine.Native, null);
         }
     }
 }

--- a/src/MICoreUnitTests/MIResultsTests.cs
+++ b/src/MICoreUnitTests/MIResultsTests.cs
@@ -16,20 +16,22 @@ namespace MICoreUnitTests
 
             Assert.Throws<ArgumentNullException>(delegate
             {
-                MIResults.ParseCString(miString);
+                MIResults r = new MIResults(null);
+                r.ParseCString(miString);
             });
         }
 
         [Fact]
         public void TestParseCStringEmpty()
         {
+            MIResults r = new MIResults(null);
             string miString = ""; // input = <empty>
-            string result = MIResults.ParseCString(miString);
+            string result = r.ParseCString(miString);
 
             Assert.Equal(String.Empty, result);
 
             miString = "\"\""; // input = ""
-            result = MIResults.ParseCString(miString);
+            result = r.ParseCString(miString);
 
             Assert.Equal(String.Empty, result);
         }
@@ -37,32 +39,34 @@ namespace MICoreUnitTests
         [Fact]
         public void TestParseCString()
         {
+            MIResults r = new MIResults(null);
             string miString = "\"hello\""; //input = "hello"
-            string result = MIResults.ParseCString(miString);
+            string result = r.ParseCString(miString);
             Assert.Equal("hello", result);
 
             miString = "\"\\tHello\\n\""; //input = "\tHello\n"
-            result = MIResults.ParseCString(miString);
+            result = r.ParseCString(miString);
             Assert.Equal("\tHello\n", result);
 
             miString = "\"    \""; //input = <four spaces>
-            result = MIResults.ParseCString(miString);
+            result = r.ParseCString(miString);
             Assert.Equal("    ", result);
 
             miString = "    \"Hello\"     "; //input = <leading spaces>"Hello"<trailing spaces>
-            result = MIResults.ParseCString(miString);
+            result = r.ParseCString(miString);
             Assert.Equal("Hello", result);
 
             miString = "\"\"\"\"\"\""; //input = """"""
-            result = MIResults.ParseCString(miString);
+            result = r.ParseCString(miString);
             Assert.Equal("\"\"", result);
         }
 
         [Fact]
         public void TestParseResultListConstValues()
         {
+            MIResults r = new MIResults(null);
             string miString = @"name=""value"""; // name="value"
-            Results results = MIResults.ParseResultList(miString);
+            Results results = r.ParseResultList(miString);
 
             Assert.Equal(1, results.Content.Length);
             Assert.Equal("name", results.Content[0].Name);
@@ -71,7 +75,7 @@ namespace MICoreUnitTests
             Assert.Equal("value", results.FindString("name"));
 
             miString = @"name1=""value1"",name2=""value2"""; // name1="value1",name2="value2"
-            results = MIResults.ParseResultList(miString);
+            results = r.ParseResultList(miString);
 
             Assert.Equal(2, results.Content.Length);
             Assert.Equal("name1", results.Content[0].Name);

--- a/src/MIDebugEngine/Engine.Impl/DebuggedProcess.cs
+++ b/src/MIDebugEngine/Engine.Impl/DebuggedProcess.cs
@@ -46,7 +46,7 @@ namespace Microsoft.MIDebugEngine
         private readonly EngineTelemetry _engineTelemetry = new EngineTelemetry();
         private bool _needTerminalReset;
 
-        public DebuggedProcess(bool bLaunched, LaunchOptions launchOptions, ISampleEngineCallback callback, WorkerThread worker, BreakpointManager bpman, AD7Engine engine, HostConfigurationStore configStore) : base(launchOptions)
+        public DebuggedProcess(bool bLaunched, LaunchOptions launchOptions, ISampleEngineCallback callback, WorkerThread worker, BreakpointManager bpman, AD7Engine engine, HostConfigurationStore configStore) : base(launchOptions, engine.Logger)
         {
             uint processExitCode = 0;
             _pendingMessages = new StringBuilder(400);
@@ -306,7 +306,7 @@ namespace Microsoft.MIDebugEngine
 
                         _bLastModuleLoadFailed = false;
                     }
-                    catch (Exception e) when (ExceptionHelper.BeforeCatch(e, reportOnlyCorrupting: true))
+                    catch (Exception e) when (ExceptionHelper.BeforeCatch(e, Logger, reportOnlyCorrupting: true))
                     {
                         if (this.ProcessState == MICore.ProcessState.Exited)
                         {
@@ -363,7 +363,7 @@ namespace Microsoft.MIDebugEngine
                 {
                     await HandleBreakModeEvent(results);
                 }
-                catch (Exception e) when (ExceptionHelper.BeforeCatch(e, reportOnlyCorrupting: true))
+                catch (Exception e) when (ExceptionHelper.BeforeCatch(e, Logger, reportOnlyCorrupting: true))
                 {
                     if (this.ProcessState == MICore.ProcessState.Exited)
                     {

--- a/src/MIDebugEngine/Engine.Impl/DebuggedThread.cs
+++ b/src/MIDebugEngine/Engine.Impl/DebuggedThread.cs
@@ -98,7 +98,7 @@ namespace Microsoft.MIDebugEngine
             }
             catch (UnexpectedMIResultException)
             {
-                Logger.WriteLine("Stack walk failed on thread: " + thread.TargetId);
+                _debugger.Logger.WriteLine("Stack walk failed on thread: " + thread.TargetId);
                 _stateChange = true;   // thread may have been deleted. Force a resync
             }
             lock (_threadList)
@@ -153,7 +153,7 @@ namespace Microsoft.MIDebugEngine
             TupleValue[] frameinfo = await _debugger.MICommandFactory.StackListFrames(thread.Id, 0, 1000);
             if (frameinfo == null)
             {
-                Logger.WriteLine("Failed to get frame info");
+                _debugger.Logger.WriteLine("Failed to get frame info");
             }
             else
             {

--- a/src/MIDebugEngine/Engine.Impl/Disassembly.cs
+++ b/src/MIDebugEngine/Engine.Impl/Disassembly.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
+using System.Threading;
 using System.Threading.Tasks;
 using System.Diagnostics;
 using MICore;
@@ -24,8 +25,8 @@ namespace Microsoft.MIDebugEngine
     };
     internal class DisassemblyBlock
     {
-        static private ulong s_touchCount = 0;
-        internal ulong Touch;
+        static private long s_touchCount = 0;
+        internal long Touch;
 
         private readonly DisasmInstruction[] _instructions;
 
@@ -49,7 +50,7 @@ namespace Microsoft.MIDebugEngine
                 return false;
             }
             i += cnt;
-            Touch = ++s_touchCount;
+            Touch = Interlocked.Increment(ref s_touchCount);
             return 0 <= i && i <= _instructions.Length;
         }
 
@@ -147,7 +148,7 @@ namespace Microsoft.MIDebugEngine
                     DeleteRangeFromCache(block);    // removes any entry with the same key
                     if (_disassemlyCache.Count >= cacheSize)
                     {
-                        ulong max = 0;
+                        long max = 0;
                         int toDelete = -1;
                         for (int i = 0; i < _disassemlyCache.Count; ++i)
                         {

--- a/src/MIDebugEngine/Engine.Impl/OperationThread.cs
+++ b/src/MIDebugEngine/Engine.Impl/OperationThread.cs
@@ -71,8 +71,11 @@ namespace Microsoft.MIDebugEngine
         private Thread _thread;
         private volatile bool _isClosed;
 
-        public WorkerThread()
+        public Logger Logger { get; private set; }
+
+        public WorkerThread(Logger logger)
         {
+            Logger = logger;
             _opSet = new AutoResetEvent(false);
             _runningOpCompleteEvent = new ManualResetEvent(true);
             _postedOperations = new Queue<Operation>();
@@ -301,7 +304,7 @@ namespace Microsoft.MIDebugEngine
                             {
                                 syncOp();
                             }
-                            catch (Exception opException) when (ExceptionHelper.BeforeCatch(opException, reportOnlyCorrupting: true))
+                            catch (Exception opException) when (ExceptionHelper.BeforeCatch(opException, Logger, reportOnlyCorrupting: true))
                             {
                                 runningOp.ExceptionDispatchInfo = ExceptionDispatchInfo.Capture(opException);
                             }
@@ -314,7 +317,7 @@ namespace Microsoft.MIDebugEngine
                             {
                                 runningOp.Task = asyncOp();
                             }
-                            catch (Exception opException) when (ExceptionHelper.BeforeCatch(opException, reportOnlyCorrupting: true))
+                            catch (Exception opException) when (ExceptionHelper.BeforeCatch(opException, Logger, reportOnlyCorrupting: true))
                             {
                                 runningOp.ExceptionDispatchInfo = ExceptionDispatchInfo.Capture(opException);
                             }
@@ -354,7 +357,7 @@ namespace Microsoft.MIDebugEngine
                         {
                             postedOperation();
                         }
-                        catch (Exception e) when (ExceptionHelper.BeforeCatch(e, reportOnlyCorrupting: false))
+                        catch (Exception e) when (ExceptionHelper.BeforeCatch(e, Logger, reportOnlyCorrupting: false))
                         {
                             if (PostedOperationErrorEvent != null)
                             {

--- a/src/MIDebugEngine/Engine.Impl/Variables.cs
+++ b/src/MIDebugEngine/Engine.Impl/Variables.cs
@@ -425,7 +425,7 @@ namespace Microsoft.MIDebugEngine
 
                 try
                 {
-                    consoleResults = await MIDebugCommandDispatcher.ExecuteCommand(consoleCommand);
+                    consoleResults = await MIDebugCommandDispatcher.ExecuteCommand(consoleCommand, _debuggedProcess);
                     Value = String.Empty;
                     this.TypeName = null;
                 }

--- a/src/MIDebugEngine/MIDebugCommandDispatcher.cs
+++ b/src/MIDebugEngine/MIDebugCommandDispatcher.cs
@@ -16,9 +16,6 @@ namespace Microsoft.MIDebugEngine
 
         public static Task<string> ExecuteCommand(string command)
         {
-            if (string.IsNullOrWhiteSpace(command))
-                throw new ArgumentNullException("command");
-
             DebuggedProcess lastProcess;
             lock (s_processes)
             {
@@ -29,16 +26,28 @@ namespace Microsoft.MIDebugEngine
 
                 lastProcess = s_processes[s_processes.Count - 1];
             }
+            return ExecuteCommand(command, lastProcess);
+        }
+
+        internal static Task<string> ExecuteCommand(string command, DebuggedProcess process)
+        {
+            if (string.IsNullOrWhiteSpace(command))
+                throw new ArgumentNullException("command");
+
+            if (process == null)
+            {
+                throw new InvalidOperationException(MICoreResources.Error_NoMIDebuggerProcess);
+            }
 
             command = command.Trim();
 
             if (command[0] == '-')
             {
-                return ExecuteMiCommand(lastProcess, command);
+                return ExecuteMiCommand(process, command);
             }
             else
             {
-                return lastProcess.ConsoleCmdAsync(command);
+                return process.ConsoleCmdAsync(command);
             }
         }
 

--- a/src/MIDebugEngine/Natvis.Impl/Natvis.cs
+++ b/src/MIDebugEngine/Natvis.Impl/Natvis.cs
@@ -241,7 +241,7 @@ namespace Microsoft.MIDebugEngine.Natvis
                             if (o is VisualizerType)
                             {
                                 VisualizerType v = (VisualizerType)o;
-                                TypeName t = TypeName.Parse(v.Name);
+                                TypeName t = TypeName.Parse(v.Name, _process.Logger);
                                 if (t != null)
                                 {
                                     lock (_typeVisualizers)
@@ -254,7 +254,7 @@ namespace Microsoft.MIDebugEngine.Natvis
                                 {
                                     foreach (var a in v.AlternativeType)
                                     {
-                                        t = TypeName.Parse(a.Name);
+                                        t = TypeName.Parse(a.Name, _process.Logger);
                                         if (t != null)
                                         {
                                             lock (_typeVisualizers)
@@ -268,7 +268,7 @@ namespace Microsoft.MIDebugEngine.Natvis
                             else if (o is AliasType)
                             {
                                 AliasType a = (AliasType)o;
-                                TypeName t = TypeName.Parse(a.Name);
+                                TypeName t = TypeName.Parse(a.Name, _process.Logger);
                                 if (t != null)
                                 {
                                     lock (_typeVisualizers)
@@ -329,7 +329,7 @@ namespace Microsoft.MIDebugEngine.Natvis
             {
                 // don't allow natvis to mess up debugging
                 // eat any exceptions and return the variable's value
-                Logger.WriteLine("natvis FormatDisplayString: " + e.Message);
+                _process.Logger.WriteLine("natvis FormatDisplayString: " + e.Message);
             }
             finally
             {
@@ -376,7 +376,7 @@ namespace Microsoft.MIDebugEngine.Natvis
             }
             catch (Exception e)
             {
-                Logger.WriteLine("natvis Expand: " + e.Message);    // TODO: add telemetry
+                _process.Logger.WriteLine("natvis Expand: " + e.Message);    // TODO: add telemetry
                 return variable.Children;
             }
         }
@@ -850,7 +850,7 @@ namespace Microsoft.MIDebugEngine.Natvis
                     }
 
                     string newName = ReplaceNamesInExpression(alias.Alias.Value, null, scopedNames);
-                    name = TypeName.Parse(newName);
+                    name = TypeName.Parse(newName, _process.Logger);
                     aliasChain++;
                     if (aliasChain > MAX_ALIAS_CHAIN)
                     {
@@ -872,7 +872,7 @@ namespace Microsoft.MIDebugEngine.Natvis
             {
                 return _vizCache[variable.TypeName];
             }
-            TypeName parsedName = TypeName.Parse(variable.TypeName);
+            TypeName parsedName = TypeName.Parse(variable.TypeName, _process.Logger);
             IVariableInformation var = variable;
             while (parsedName != null)
             {
@@ -891,7 +891,7 @@ namespace Microsoft.MIDebugEngine.Natvis
                 {
                     break;
                 }
-                parsedName = TypeName.Parse(var.TypeName);
+                parsedName = TypeName.Parse(var.TypeName, _process.Logger);
             }
             return null;
         }

--- a/src/MIDebugEngine/Natvis.Impl/NatvisNames.cs
+++ b/src/MIDebugEngine/Natvis.Impl/NatvisNames.cs
@@ -144,7 +144,7 @@ namespace Microsoft.MIDebugEngine.Natvis
         /// </summary>
         /// <param name="fullyQualifiedName"></param>
         /// <returns></returns>
-        public static TypeName Parse(string fullyQualifiedName)
+        public static TypeName Parse(string fullyQualifiedName, Logger logger)
         {
             if (String.IsNullOrEmpty(fullyQualifiedName))
                 return null;
@@ -152,7 +152,7 @@ namespace Microsoft.MIDebugEngine.Natvis
             TypeName t = MatchTypeName(fullyQualifiedName.Trim(), out rest);
             if (!String.IsNullOrWhiteSpace(rest))
             {
-                Logger.WriteLine("Natvis failed to parse typename: " + fullyQualifiedName);
+                logger.WriteLine("Natvis failed to parse typename: " + fullyQualifiedName);
                 return null;
             }
             return t;


### PR DESCRIPTION
The logger is the primary shared object that changes. Each process will now get a Logger object which supports the WriteLine functionality. Writeline prefaces each output line with the number of the process ("1:" below).
Example 
1: (550) <-1001-gdb-set target-async on