### PR TITLE
[Bug Fix] Closing VSCode leaves a zombie process

### DIFF
--- a/src/MICore/Transports/StreamTransport.cs
+++ b/src/MICore/Transports/StreamTransport.cs
@@ -17,9 +17,12 @@ namespace MICore
         private ITransportCallback _callback;
         private Thread _thread;
         private bool _bQuit;
+        private CancellationTokenSource _streamReadCancellationTokenSource = new CancellationTokenSource();
         protected StreamReader _reader;
         protected StreamWriter _writer;
         private bool _filterStdout;
+        private Object _locker = new object();
+
         protected Logger Logger
         {
             get; private set;
@@ -44,7 +47,7 @@ namespace MICore
             StartThread(GetThreadName());
         }
 
-        public void StartThread(string name)
+        private void StartThread(string name)
         {
             _thread = new Thread(TransportLoop);
             _thread.Name = name;
@@ -58,37 +61,48 @@ namespace MICore
 
         private void TransportLoop()
         {
-            string line;
-
-            while (!_bQuit)
+            try
             {
-                line = GetLine();
-                if (line == null)
-                    break;
-
-                line = line.TrimEnd();
-                Logger?.WriteLine("->" + line);
-
-                try
+                while (!_bQuit)
                 {
-                    if (_filterStdout)
+                    string line = GetLine();
+                    if (line == null)
+                        break;
+
+                    line = line.TrimEnd();
+                    Logger?.WriteLine("->" + line);
+
+                    try
                     {
-                        line = FilterLine(line);
+                        if (_filterStdout)
+                        {
+                            line = FilterLine(line);
+                        }
+                        if (!String.IsNullOrWhiteSpace(line) && !line.StartsWith("-", StringComparison.Ordinal))
+                        {
+                            _callback.OnStdOutLine(line);
+                        }
                     }
-                    if (!String.IsNullOrWhiteSpace(line) && !line.StartsWith("-", StringComparison.Ordinal))
+                    catch (ObjectDisposedException)
                     {
-                        _callback.OnStdOutLine(line);
+                        Debug.Assert(_bQuit);
+                        break;
                     }
                 }
-                catch (ObjectDisposedException)
+                if (!_bQuit)
                 {
-                    Debug.Assert(_bQuit);
-                    break;
+                    OnReadStreamAborted();
                 }
             }
-            if (!_bQuit)
+            finally
             {
-                OnReadStreamAborted();
+                lock (_locker)
+                {
+                    _bQuit = true;
+                    _streamReadCancellationTokenSource.Dispose();
+                    _reader.Dispose();
+                    _writer.Dispose();
+                }
             }
         }
 
@@ -114,7 +128,17 @@ namespace MICore
         {
             try
             {
-                return _reader.ReadLine();
+                Task<string> task = _reader.ReadLineAsync();
+                task.Wait(_streamReadCancellationTokenSource.Token);
+                return task.Result;
+            }
+            catch (OperationCanceledException)
+            {
+                return null;
+            }
+            catch (ObjectDisposedException)
+            {
+                return null;
             }
             // I have seen the StreamReader throw both an ObjectDisposedException (which makes sense) and a NullReferenceException
             // (which seems like a bug) after it is closed. Since we have no exception back stop here, we are catching all exceptions
@@ -133,11 +157,13 @@ namespace MICore
 
         public virtual void Close()
         {
-            _bQuit = true;
-            if (_reader != null)
+            lock (_locker)
             {
-                _reader.Dispose(); // close the stream. This usually, but not always, causes the OS to give back our reader thread.
-                _reader = null;
+                if (!_bQuit)
+                {
+                    _bQuit = true;
+                    _streamReadCancellationTokenSource.Cancel();
+                }
             }
         }
 
@@ -152,4 +178,3 @@ namespace MICore
         }
     }
 }
-


### PR DESCRIPTION
The real cause is that StreamReader.ReadLine() hangs even if the file it is reading gets deleted. The fix is to use StreamReader.ReadLineAync(TimeOut) and check the status if thread is quitting.

Tested Scenarios:
For both Root and Normal User:
1. Launch VSCode
2. Start debugging
3. Close VSCode while it is still in debugging mode
4. Make sure  no zombie process left, especially "corerun OpenDebugAD7.dll" process.