### PR TITLE
Fix for bug 197616. Issue is this debuggee has excercised an edge cas…

### DIFF
--- a/src/MIDebugEngine/Engine.Impl/DebuggedProcess.cs
+++ b/src/MIDebugEngine/Engine.Impl/DebuggedProcess.cs
@@ -602,6 +602,17 @@ namespace Microsoft.MIDebugEngine
             DebuggedThread thread = await ThreadCache.GetThread(tid);
             await ThreadCache.StackFrames(thread);  // prepopulate the break thread in the thread cache
             ThreadContext cxt = await ThreadCache.GetThreadContext(thread);
+
+            if (cxt == null)
+            {
+                // Something went seriously wrong. For instance, this can happen when the primary thread
+                // of an app exits on linux while background threads continue to run with pthread_exit on the main thread
+                // See https://devdiv.visualstudio.com/DefaultCollection/DevDiv/VS%20Diag%20IntelliTrace/_workItems?_a=edit&id=197616&triage=true
+                // for a repro
+                Debug.Fail("Failed to find thread on break event.");
+                throw new Exception(String.Format(CultureInfo.CurrentUICulture, ResourceStrings.MissingThreadBreakEvent, tid));
+            }
+
             ThreadCache.SendThreadEvents(this, null);   // make sure that new threads have been pushed to the UI
 
             //always delete breakpoints pending deletion on break mode

--- a/src/MIDebugEngine/ResourceStrings.Designer.cs
+++ b/src/MIDebugEngine/ResourceStrings.Designer.cs
@@ -179,6 +179,15 @@ namespace Microsoft.MIDebugEngine {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Failed to find thread {0} for break event.
+        /// </summary>
+        internal static string MissingThreadBreakEvent {
+            get {
+                return ResourceManager.GetString("MissingThreadBreakEvent", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Explicit refresh required for visualized expressions.
         /// </summary>
         internal static string NoSideEffectsVisualizerMessage {

--- a/src/MIDebugEngine/ResourceStrings.resx
+++ b/src/MIDebugEngine/ResourceStrings.resx
@@ -189,4 +189,7 @@
   <data name="LoadingCoreDumpMessage" xml:space="preserve">
     <value>Loading core dump {0}</value>
   </data>
+  <data name="MissingThreadBreakEvent" xml:space="preserve">
+    <value>Failed to find thread {0} for break event</value>
+  </data>
 </root>


### PR DESCRIPTION
…e in pthreads that allows the app to continue running after the main thread exits. GDB has a bug that it is reporting a stopping event for a bp on a background thread which then fails to report thread info as it believes the debuggee should be ripped down. While I can't fix that, I can stop the miengine from crashing which is what i've done here