### PR TITLE
Validate the midebugtarget isn't a folder or non-existant file. Since…

### DIFF
--- a/src/MICore/MICoreResources.Designer.cs
+++ b/src/MICore/MICoreResources.Designer.cs
@@ -185,6 +185,15 @@ namespace MICore {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to The value of miDebuggerPath is invalid.
+        /// </summary>
+        public static string Error_InvalidMiDebuggerPath {
+            get {
+                return ResourceManager.GetString("Error_InvalidMiDebuggerPath", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Device App Launcher {0} could not be found..
         /// </summary>
         public static string Error_LauncherNotFound {

--- a/src/MICore/MICoreResources.resx
+++ b/src/MICore/MICoreResources.resx
@@ -210,4 +210,7 @@ Error: {1}</value>
   <data name="Error_CannotSpecifyBoth" xml:space="preserve">
     <value>Both '{0}' and '{1}' cannot be specified at the same time.</value>
   </data>
+  <data name="Error_InvalidMiDebuggerPath" xml:space="preserve">
+    <value>The value of miDebuggerPath is invalid</value>
+  </data>
 </root>

--- a/src/MICore/Transports/LocalLinuxTransport.cs
+++ b/src/MICore/Transports/LocalLinuxTransport.cs
@@ -25,9 +25,33 @@ namespace MICore
             }
         }
 
+        private bool IsValidMiDebuggerPath(string debuggerPath)
+        {
+            if (!File.Exists(debuggerPath))
+            {
+                return false;
+            }
+            else
+            {
+                // Verify the target is a file and not a directory
+                FileAttributes attr = File.GetAttributes(debuggerPath);
+                if ((attr & FileAttributes.Directory) != 0)
+                {
+                    return false;
+                }
+            }
+
+            return true;
+        }
+
         public override void InitStreams(LaunchOptions options, out StreamReader reader, out StreamWriter writer)
         {
             LocalLaunchOptions localOptions = (LocalLaunchOptions)options;
+
+            if (!this.IsValidMiDebuggerPath(localOptions.MIDebuggerPath))
+            {
+                throw new Exception(MICoreResources.Error_InvalidMiDebuggerPath);
+            }
 
             string debuggeeDir = System.IO.Path.GetDirectoryName(options.ExePath);
 


### PR DESCRIPTION
… this

is passed to bash we don't directly receive an error from the
proces.start. Note that doesn't protect valid exes that aren't gdb but the
name of gdb and lldb, and clrdbg can change drastically in different
scenarios so I don't see a good way to do that. (for instance, gdb can
have wildly different names in cross compiled scenarios)