### PR TITLE
Collect source info for core dumps for top frame only if available.

### DIFF
--- a/src/MICore/MIResults.cs
+++ b/src/MICore/MIResults.cs
@@ -404,13 +404,35 @@ namespace MICore
             return FindAll(name).OfType<T>().ToArray();
         }
 
-        public TupleValue Subset(params string[] names)
+        /// <summary>
+        /// Creates a new TupleValue with a subset of values from this TupleValue.
+        /// </summary>
+        /// <param name="requiredNames">The list of names that must be added to the TupleValue.</param>
+        /// <param name="optionalNames">The list of names that will be added to the TupleValue if they exist in this TupleValue.</param>
+        public TupleValue Subset(IEnumerable<string> requiredNames, IEnumerable<string> optionalNames = null)
         {
             List<NamedResultValue> values = new List<NamedResultValue>();
-            foreach (string name in names)
+            
+            // Iterate the required list and add the values.
+            // Will throw if a name cannot be found.
+            foreach (string name in requiredNames)
             {
                 values.Add(new NamedResultValue(name, this.Find(name)));
             }
+
+            // Iterate the optional list and add the values of the name exists.
+            if (null != optionalNames)
+            {
+                foreach (string name in optionalNames)
+                {
+                    ResultValue value;
+                    if (this.TryFind(name, out value))
+                    {
+                        values.Add(new NamedResultValue(name, value));
+                    }
+                }
+            }
+
             return new TupleValue(values);
         }
     }

--- a/src/MIDebugEngine/Engine.Impl/DebuggedProcess.cs
+++ b/src/MIDebugEngine/Engine.Impl/DebuggedProcess.cs
@@ -995,10 +995,17 @@ namespace Microsoft.MIDebugEngine
             // Get the frame of the current thread
             TupleValue currentFrame = currentThread.Find<TupleValue>("frame");
 
+            // Collect the addr, func, and args fields from the current frame as they are required.
+            // Collect the file, fullname, and line fileds if they are available. They may be missing if the frame is for
+            // a binary that does not have symbols.
+            TupleValue newFrame = currentFrame.Subset(
+                new string[] { "addr", "func", "args" },
+                new string[] { "file", "fullname", "line" });
+
             // Create result that emulates a signal received from the debuggee with the frame and thread information
             List<NamedResultValue> values = new List<NamedResultValue>();
             values.Add(new NamedResultValue("reason", new ConstValue("signal-received")));
-            values.Add(new NamedResultValue("frame", currentFrame.Subset("addr", "func", "args", "file", "fullname", "line")));
+            values.Add(new NamedResultValue("frame", newFrame));
             values.Add(new NamedResultValue("thread-id", new ConstValue(currentThreadId)));
             return new Results(ResultClass.done, values);
         }


### PR DESCRIPTION
This fixes an issue that occurs while attempting to debug a core dump where the stack frame that causes the crash belongs to a binary that does not appropriate symbol information. In this situation, an exception would be throw with a message similar to "Unrecognized format of field "file" in result: {level=0,addr=0x000000000040070a,func=main,args=[]}".

Previously, it required that the file, filename, and line fields of the frame to exist, but they don't exist if the binary doesn't have the debugging information in it. These fields are now included only if they are available.