### PR TITLE
Fix VSCode not entering stop mode when debug terminal closes

### DIFF
--- a/src/MICore/Debugger.cs
+++ b/src/MICore/Debugger.cs
@@ -302,7 +302,7 @@ namespace MICore
                 {
                     await item();
                 }
-                catch (Exception e) when (ExceptionHelper.BeforeCatch(e, Logger, reportOnlyCorrupting:true))
+                catch (Exception e) when (ExceptionHelper.BeforeCatch(e, Logger, reportOnlyCorrupting: true))
                 {
                     if (firstException != null)
                     {
@@ -1172,6 +1172,11 @@ namespace MICore
             if (isThreadGroupEmpty)
             {
                 ScheduleStdOutProcessing(@"*stopped,reason=""exited""");
+
+                // Processing the fake "stopped" event sent above will normally cause the debugger to close, but if
+                //  the debugger process is already gone (e.g. because the terminal window was closed), we won't get
+                //  a response, so queue a fake "exit" event for processing as well, just to be sure.
+                ScheduleStdOutProcessing("^exit");
             }
         }
 


### PR DESCRIPTION
When the debuggee exits, we queue a fake "stopped" event.  In the normal case, MIEngine processes this event and send a "-gdb-exit" command, then responds to the "^exit" event and shuts down.  In the case where the debugger is already closed (e.g. because the terminal window was closed), we won't receive the "^exit" event from the debugger, and so we'll stay in debug mode forever.  As a workaround, when we queue the fake "stopped" event, we can queue a fake "exit" event as well.

@jacdavis @gregg-miskelly @chuckries @paulmaybee @xingshenglu 