### PR TITLE
Add support for non-absolute paths in 'ExePath'

### DIFF
--- a/src/MICore/LaunchCommand.cs
+++ b/src/MICore/LaunchCommand.cs
@@ -21,8 +21,9 @@ namespace MICore
         public readonly string Description;
         public readonly bool IgnoreFailures;
         public readonly bool IsMICommand;
+        public /*OPTIONAL*/ Action<string> FailureHandler { get; private set; }
 
-        public LaunchCommand(string commandText, string description = null, bool ignoreFailures = false)
+        public LaunchCommand(string commandText, string description = null, bool ignoreFailures = false, Action<string> failureHandler = null)
         {
             if (commandText == null)
                 throw new ArgumentNullException("commandText");
@@ -36,6 +37,7 @@ namespace MICore
                 this.Description = this.CommandText;
 
             this.IgnoreFailures = ignoreFailures;
+            this.FailureHandler = failureHandler;
         }
 
         public static ReadOnlyCollection<LaunchCommand> CreateCollectionFromXml(Xml.LaunchOptions.Command[] source)

--- a/src/MICore/LaunchOptions.cs
+++ b/src/MICore/LaunchOptions.cs
@@ -242,24 +242,6 @@ namespace MICore
         public int ProcessId { get; private set; }
 
         /// <summary>
-        /// [Required] Path to the executable file. This path must exist on the Visual Studio computer.
-        /// </summary>
-        public override string ExePath
-        {
-            get
-            {
-                return base.ExePath;
-            }
-            set
-            {
-                if (String.IsNullOrEmpty(value) || !LocalLaunchOptions.CheckPath(value))
-                    throw new ArgumentException(string.Format(CultureInfo.CurrentCulture, MICoreResources.Error_InvalidLocalExePath, value));
-
-                base.ExePath = value;
-            }
-        }
-
-        /// <summary>
         /// [Optional] List of environment variables to add to the launched process
         /// </summary>
         public ReadOnlyCollection<EnvironmentEntry> Environment { get; private set; }

--- a/src/MICore/Transports/LocalLinuxTransport.cs
+++ b/src/MICore/Transports/LocalLinuxTransport.cs
@@ -80,7 +80,19 @@ namespace MICore
                 throw new Exception(MICoreResources.Error_InvalidMiDebuggerPath);
             }
 
-            string debuggeeDir = System.IO.Path.GetDirectoryName(options.ExePath);
+            // Default working directory is next to the app
+            string debuggeeDir;
+            if (Path.IsPathRooted(options.ExePath) && File.Exists(options.ExePath))
+            {
+                debuggeeDir = System.IO.Path.GetDirectoryName(options.ExePath);
+            }
+            else
+            {
+                // If we don't know where the app is, default to HOME, and if we somehow can't get that, go with the root directory.
+                debuggeeDir = Environment.GetEnvironmentVariable("HOME");
+                if (string.IsNullOrEmpty(debuggeeDir))
+                    debuggeeDir = "/";
+            }
 
             string gdbStdInName = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());
             string gdbStdOutName = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());

--- a/src/MIDebugEngine/Engine.Impl/LaunchErrorException.cs
+++ b/src/MIDebugEngine/Engine.Impl/LaunchErrorException.cs
@@ -1,0 +1,11 @@
+﻿using System;
+
+namespace Microsoft.MIDebugEngine
+{
+    internal class LaunchErrorException : Exception
+    {
+        public LaunchErrorException(string message) : base(message)
+        {
+        }
+    }
+}

--- a/src/MIDebugEngine/MIDebugEngine.csproj
+++ b/src/MIDebugEngine/MIDebugEngine.csproj
@@ -98,6 +98,7 @@
     <Compile Include="Engine.Impl\EngineCallback.cs" />
     <Compile Include="Engine.Impl\EngineUtils.cs" />
     <Compile Include="Engine.Impl\ExceptionManager.cs" />
+    <Compile Include="Engine.Impl\LaunchErrorException.cs" />
     <Compile Include="Engine.Impl\MITextPosition.cs" />
     <Compile Include="Engine.Impl\OperationThread.cs" />
     <Compile Include="Engine.Impl\SourceLine.cs" />

--- a/src/MIDebugEngine/ResourceStrings.Designer.cs
+++ b/src/MIDebugEngine/ResourceStrings.Designer.cs
@@ -89,6 +89,17 @@ namespace Microsoft.MIDebugEngine {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Program path &apos;{0}&apos; is missing or invalid.
+        ///
+        ///{1} failed with message: {2}.
+        /// </summary>
+        internal static string Error_ExePathInvalid {
+            get {
+                return ResourceManager.GetString("Error_ExePathInvalid", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Error &quot;{0}&quot; while reading file: {1}.
         /// </summary>
         internal static string ErrorReadingFile {

--- a/src/MIDebugEngine/ResourceStrings.resx
+++ b/src/MIDebugEngine/ResourceStrings.resx
@@ -192,4 +192,12 @@
   <data name="MissingThreadBreakEvent" xml:space="preserve">
     <value>Failed to find thread {0} for break event</value>
   </data>
+  <data name="Error_ExePathInvalid" xml:space="preserve">
+    <value>Program path '{0}' is missing or invalid.
+
+{1} failed with message: {2}</value>
+    <comment>0: exe path passed in
+1: Name of the debugger (ex: 'GDB')
+2: Message from GDB</comment>
+  </data>
 </root>


### PR DESCRIPTION
The .NET CLI is making changes where we want to tell clrdbg to launch 'dotnet'. This makes some MIEngine tweaks so that we let clrdbg/gdb/lldb decide if the passed in program path is valid instead of having the MIEngine pre-validate it, and then do a reasonable job handling failures from the underlying debugger.