### PR TITLE
Fix for issues with paths in spaces

### DIFF
--- a/src/MIDebugEngine/Engine.Impl/DebuggedProcess.cs
+++ b/src/MIDebugEngine/Engine.Impl/DebuggedProcess.cs
@@ -491,15 +491,16 @@ namespace Microsoft.MIDebugEngine
             string escappedSearchPath = string.Join(pathEntrySeperator, _launchOptions.GetSOLibSearchPath().Select(path => EscapePath(path, ignoreSpaces: true)));
             if (!string.IsNullOrWhiteSpace(escappedSearchPath))
             {
-                if (!_launchOptions.UseUnixSymbolPaths)
+                if (_launchOptions.DebuggerMIMode == MIMode.Gdb)
                 {
-                    // surround so lib path with quotes on windows
-                    commands.Add(new LaunchCommand("-gdb-set solib-search-path \"" + escappedSearchPath + pathEntrySeperator + "\"", ResourceStrings.SettingSymbolSearchPath));
+                    // Do not place quotes around so paths for gdb
+                    commands.Add(new LaunchCommand("-gdb-set solib-search-path " + escappedSearchPath + pathEntrySeperator, ResourceStrings.SettingSymbolSearchPath));
+                    
                 }
                 else
                 {
-                    // Do not place quotes around so paths on linux/mac. Gdb will ignore the option on these platforms with quotes. Note that spaces do work without them
-                    commands.Add(new LaunchCommand("-gdb-set solib-search-path " + escappedSearchPath + pathEntrySeperator, ResourceStrings.SettingSymbolSearchPath));
+                    // surround so lib path with quotes in other cases
+                    commands.Add(new LaunchCommand("-gdb-set solib-search-path \"" + escappedSearchPath + pathEntrySeperator + "\"", ResourceStrings.SettingSymbolSearchPath));
                 }
             }
 

--- a/src/MIDebugEngine/Engine.Impl/DebuggedProcess.cs
+++ b/src/MIDebugEngine/Engine.Impl/DebuggedProcess.cs
@@ -491,7 +491,16 @@ namespace Microsoft.MIDebugEngine
             string escappedSearchPath = string.Join(pathEntrySeperator, _launchOptions.GetSOLibSearchPath().Select(path => EscapePath(path, ignoreSpaces: true)));
             if (!string.IsNullOrWhiteSpace(escappedSearchPath))
             {
-                commands.Add(new LaunchCommand("-gdb-set solib-search-path \"" + escappedSearchPath + pathEntrySeperator + "\"", ResourceStrings.SettingSymbolSearchPath));
+                if (!_launchOptions.UseUnixSymbolPaths)
+                {
+                    // surround so lib path with quotes on windows
+                    commands.Add(new LaunchCommand("-gdb-set solib-search-path \"" + escappedSearchPath + pathEntrySeperator + "\"", ResourceStrings.SettingSymbolSearchPath));
+                }
+                else
+                {
+                    // Do not place quotes around so paths on linux/mac. Gdb will ignore the option on these platforms with quotes. Note that spaces do work without them
+                    commands.Add(new LaunchCommand("-gdb-set solib-search-path " + escappedSearchPath + pathEntrySeperator, ResourceStrings.SettingSymbolSearchPath));
+                }
             }
 
             if (this.MICommandFactory.SupportsStopOnDynamicLibLoad())
@@ -522,8 +531,9 @@ namespace Microsoft.MIDebugEngine
                     // Add executable information
                     this.AddExecutablePathCommand(commands);
 
-                    // Add core dump information
-                    string coreDumpCommand = String.Concat("-target-select core ", EscapePath(localLaunchOptions.CoreDumpPath));
+                    // Add core dump information (linux/mac does not support quotes around this path but spaces in the path do work)
+                    string coreDump = _launchOptions.UseUnixSymbolPaths ? localLaunchOptions.CoreDumpPath : EscapePath(localLaunchOptions.CoreDumpPath);
+                    string coreDumpCommand = String.Concat("-target-select core ", coreDump);
                     string coreDumpDescription = String.Format(CultureInfo.CurrentCulture, ResourceStrings.LoadingCoreDumpMessage, localLaunchOptions.CoreDumpPath);
                     commands.Add(new LaunchCommand(coreDumpCommand, coreDumpDescription, ignoreFailures: false));
                 }
@@ -776,17 +786,20 @@ namespace Microsoft.MIDebugEngine
         internal string EscapePath(string path, bool ignoreSpaces = false)
         {
             if (_launchOptions.UseUnixSymbolPaths)
-                return path.Replace('\\', '/');
+            {
+                path = path.Replace('\\', '/');
+            }
             else
             {
                 path = path.Trim();
                 path = path.Replace(@"\", @"\\");
-                if (!ignoreSpaces && path.IndexOf(' ') != -1)
-                {
-                    path = '"' + path + '"';
-                }
-                return path;
             }
+
+            if (!ignoreSpaces && path.IndexOf(' ') != -1)
+            {
+                path = '"' + path + '"';
+            }
+            return path;
         }
 
         internal static string UnixPathToWindowsPath(string unixPath)


### PR DESCRIPTION
1) paths to binaries with spaces didn't work on linux/mac
2) paths to core files with spaces in path didn't work on linux/mac
3) paths to so files with spaces in the path didn't work on linux/mac

Note that in some of these, gdb requires quotes, and on others,
will not accept quotes.

Testing: Verified these scenarios end to end on linux. Verified the
assumptions on mac by manually executing the sceanrios since we don't yet
have a gdb build working on mac.

Bugs: 204605 and 204196