### PR TITLE
Be more eager about cleaning up GDB variable objects

### DIFF
--- a/src/MIDebugEngine/Engine.Impl/DebuggedProcess.cs
+++ b/src/MIDebugEngine/Engine.Impl/DebuggedProcess.cs
@@ -23,6 +23,7 @@ namespace Microsoft.MIDebugEngine
         public AD_PROCESS_ID Id { get; private set; }
         public AD7Engine Engine { get; private set; }
         public List<string> VariablesToDelete { get; private set; }
+        public List<IVariableInformation> ActiveVariables { get; private set; }
 
         public SourceLineCache SourceLineCache { get; private set; }
         public ThreadCache ThreadCache { get; private set; }
@@ -74,6 +75,7 @@ namespace Microsoft.MIDebugEngine
             ExceptionManager = new ExceptionManager(MICommandFactory, _worker, _callback, configStore);
 
             VariablesToDelete = new List<string>();
+            this.ActiveVariables = new List<IVariableInformation>();
 
             OutputStringEvent += delegate (object o, string message)
             {
@@ -620,6 +622,17 @@ namespace Microsoft.MIDebugEngine
                 tid = results.Results.FindInt("thread-id");
             }
 
+            // Any existing variable objects at this point are from the last time we were in break mode, and are
+            //  therefore invalid.  Dispose them so they're marked for cleanup.
+            lock(this.ActiveVariables)
+            {
+                foreach (IVariableInformation varInfo in this.ActiveVariables)
+                {
+                    varInfo.Dispose();
+                }
+                this.ActiveVariables.Clear();
+            }
+
             ThreadCache.MarkDirty();
             MICommandFactory.DefineCurrentThread(tid);
 
@@ -644,14 +657,11 @@ namespace Microsoft.MIDebugEngine
 
             await _breakpointManager.DeleteBreakpointsPendingDeletion();
 
-            //delete varialbes that have been GC'd
-            List<string> variablesToDelete = new List<string>();
+            // Delete GDB variable objects that have been marked for cleanup
+            List<string> variablesToDelete = null;
             lock (VariablesToDelete)
             {
-                foreach (var variable in VariablesToDelete)
-                {
-                    variablesToDelete.Add(variable);
-                }
+                variablesToDelete = new List<string>(this.VariablesToDelete);
                 VariablesToDelete.Clear();
             }
 

--- a/src/MIDebugEngine/Engine.Impl/Variables.cs
+++ b/src/MIDebugEngine/Engine.Impl/Variables.cs
@@ -15,7 +15,7 @@ using System.Globalization;
 
 namespace Microsoft.MIDebugEngine
 {
-    internal interface IVariableInformation
+    internal interface IVariableInformation : IDisposable
     {
         string Name { get; }
         string Value { get; }
@@ -173,6 +173,11 @@ namespace Microsoft.MIDebugEngine
             _attribsFetched = false;
             Access = enum_DBG_ATTRIB_FLAGS.DBG_ATTRIB_NONE;
             _fullname = null;
+
+            lock(this._debuggedProcess.ActiveVariables)
+            {
+                this._debuggedProcess.ActiveVariables.Add(this);
+            }
         }
 
         //this constructor is used to create root nodes (local/params)
@@ -261,23 +266,6 @@ namespace Microsoft.MIDebugEngine
         {
             _attribsFetched = true;  // read-only attribute is passed in at construction
             _isReadonly = ro;
-        }
-
-        ~VariableInformation()
-        {
-            //mi -var-delete deletes all children, so only top level variables should be added to the delete list
-            //Additionally, we create variables for anything we try to evaluate. Only succesful evaluations get internal names, 
-            //so look for that.
-            if (!IsChild && !string.IsNullOrWhiteSpace(_internalName))
-            {
-                if (!_debuggedProcess.IsClosed)
-                {
-                    lock (_debuggedProcess.VariablesToDelete)
-                    {
-                        _debuggedProcess.VariablesToDelete.Add(_internalName);
-                    }
-                }
-            }
         }
 
         public ThreadContext ThreadContext { get { return _ctx; } }
@@ -403,6 +391,8 @@ namespace Microsoft.MIDebugEngine
 
         public string EvalDependentExpression(string expr)
         {
+            this.VerifyNotDisposed();
+
             string val = null;
             Task eval = Task.Run(async () =>
             {
@@ -414,6 +404,8 @@ namespace Microsoft.MIDebugEngine
 
         internal async Task Eval(enum_EVALFLAGS dwFlags = 0)
         {
+            this.VerifyNotDisposed();
+
             _engine.CurrentRadix();    // ensure the radix value is up-to-date
 
             string execCommandString = "-exec ";
@@ -510,6 +502,8 @@ namespace Microsoft.MIDebugEngine
 
         internal async Task Format()
         {
+            this.VerifyNotDisposed();
+
             Debug.Assert(_internalName != null);
             Debug.Assert(_format != null);
             Results results = await _engine.DebuggedProcess.MICommandFactory.VarSetFormat(_internalName, _format, ResultClass.None);
@@ -545,6 +539,8 @@ namespace Microsoft.MIDebugEngine
         }
         private async Task InternalFetchChildren()
         {
+            this.VerifyNotDisposed();
+
             Results results = await _engine.DebuggedProcess.MICommandFactory.VarListChildren(_internalName, PropertyInfoFlags, ResultClass.None);
 
             if (results.ResultClass == ResultClass.done)
@@ -682,6 +678,8 @@ namespace Microsoft.MIDebugEngine
                     return true;
                 }
 
+                this.VerifyNotDisposed();
+
                 string attribute = string.Empty;
 
                 _engine.DebuggedProcess.WorkerThread.RunOperation(async () =>
@@ -697,11 +695,58 @@ namespace Microsoft.MIDebugEngine
 
         public void Assign(string expression)
         {
+            this.VerifyNotDisposed();
+
             _engine.DebuggedProcess.WorkerThread.RunOperation(async () =>
             {
                 _engine.DebuggedProcess.FlushBreakStateData();
                 Value = await _engine.DebuggedProcess.MICommandFactory.VarAssign(_internalName, expression);
             });
         }
+
+        #region IDisposable Implementation
+
+        private bool _isDisposed = false;
+
+        private void VerifyNotDisposed()
+        {
+            if (this._isDisposed)
+            {
+                throw new ObjectDisposedException(this.GetType().FullName);
+            }
+        }
+
+        public void Dispose()
+        {
+            this.Dispose(true);
+
+            GC.SuppressFinalize(this);
+        }
+
+        private void Dispose(bool isDisposing)
+        {
+            this._isDisposed = true;
+
+            //mi -var-delete deletes all children, so only top level variables should be added to the delete list
+            //Additionally, we create variables for anything we try to evaluate. Only succesful evaluations get internal names, 
+            //so look for that.
+            if (!IsChild && !string.IsNullOrWhiteSpace(_internalName))
+            {
+                if (!_debuggedProcess.IsClosed)
+                {
+                    lock (_debuggedProcess.VariablesToDelete)
+                    {
+                        _debuggedProcess.VariablesToDelete.Add(_internalName);
+                    }
+                }
+            }
+        }
+
+        ~VariableInformation()
+        {
+            this.Dispose(false);
+        }
+
+        #endregion
     }
 }

--- a/src/MIDebugEngine/Natvis.Impl/Natvis.cs
+++ b/src/MIDebugEngine/Natvis.Impl/Natvis.cs
@@ -62,6 +62,10 @@ namespace Microsoft.MIDebugEngine.Natvis
         public string EvalDependentExpression(string expr) { return Parent.EvalDependentExpression(expr); }
         public virtual bool IsVisualized { get { return Parent.IsVisualized; } }
         public virtual enum_DEBUGPROP_INFO_FLAGS PropertyInfoFlags { get; set; }
+
+        public void Dispose()
+        {
+        }
     }
 
     internal class VisualizerWrapper : SimpleWrapper


### PR DESCRIPTION
Waiting for VariableInfo objects to be GC'ed before cleaning up the corresponding object on the GDB side means that GDB can end up with a lot of memory usage due to unused objects before the MIEngine side experiences enough memory pressure to trigger a GC.

We can fix this by keeping a list of active VariableInfo objects and disposing any that exist when we enter break mode, as they must have been created during an earlier break and are no longer valid anyway.

@jacdavis @gregg-miskelly @chuckries @paulmaybee 