### PR TITLE
Add launch option for controlling external console

### DIFF
--- a/src/MICore/CommandFactories/MICommandFactory.cs
+++ b/src/MICore/CommandFactories/MICommandFactory.cs
@@ -504,7 +504,7 @@ namespace MICore
 
         #endregion
 
-        #region Abstract Methods
+        #region Other
 
         abstract protected Task<Results> ThreadFrameCmdAsync(string command, ResultClass expectedResultClass, int threadId, uint frameLevel);
         abstract protected Task<Results> ThreadCmdAsync(string command, ResultClass expectedResultClass, int threadId);
@@ -522,6 +522,16 @@ namespace MICore
         public virtual bool IsAsyncBreakSignal(Results results)
         {
             return (results.TryFindString("reason") == "signal-received" && results.TryFindString("signal-name") == "SIGINT");
+        }
+
+        /// <summary>
+        /// Determines if a new external console should be spawned on non-Windows platforms for the debugger+app
+        /// </summary>
+        /// <param name="localLaunchOptions">[required] local launch options</param>
+        /// <returns>True if an external console should be used</returns>
+        public virtual bool UseExternalConsoleForLocalLaunch(LocalLaunchOptions localLaunchOptions)
+        {
+            return localLaunchOptions.UseExternalConsole && String.IsNullOrEmpty(localLaunchOptions.MIDebuggerServerAddress) && !localLaunchOptions.IsCoreDump;
         }
 
         public Results IsModuleLoad(string cmd)

--- a/src/MICore/CommandFactories/gdb.cs
+++ b/src/MICore/CommandFactories/gdb.cs
@@ -38,6 +38,15 @@ namespace MICore
             return false;
         }
 
+        public override bool UseExternalConsoleForLocalLaunch(LocalLaunchOptions localLaunchOptions)
+        {
+            // NOTE: On Linux at least, there are issues if we try to have GDB launch the process as a child of VS 
+            // code -- it will cause a deadlock during debuggee launch. So we always use the external console 
+            // unless we are in a scenario where the debuggee will not be a child process. In the future we 
+            // might want to change this for other OSs.
+            return String.IsNullOrEmpty(localLaunchOptions.MIDebuggerServerAddress) && !localLaunchOptions.IsCoreDump;
+        }
+
         protected override async Task<Results> ThreadFrameCmdAsync(string command, ResultClass expectedResultClass, int threadId, uint frameLevel)
         {
             // first aquire an exclusive lock. This is used as we don't want to fight with other commands that also require the current

--- a/src/MICore/LaunchOptions.cs
+++ b/src/MICore/LaunchOptions.cs
@@ -149,6 +149,7 @@ namespace MICore
     public sealed class LocalLaunchOptions : LaunchOptions
     {
         private string _coreDumpPath;
+        private bool _useExternalConsole;
 
         private const int DefaultLaunchTimeout = 10 * 1000; // 10 seconds
 
@@ -218,6 +219,7 @@ namespace MICore
             options.InitializeCommonOptions(source);
             options.InitializeServerOptions(source);
             options.CoreDumpPath = source.CoreDumpPath;
+            options._useExternalConsole = source.ExternalConsole;
 
             // Ensure that CoreDumpPath and ProcessId are not specified at the same time
             if (!String.IsNullOrEmpty(source.CoreDumpPath) && source.ProcessId != 0)
@@ -293,6 +295,11 @@ namespace MICore
 
                 _coreDumpPath = value;
             }
+        }
+
+        public bool UseExternalConsole
+        {
+            get { return _useExternalConsole; }
         }
     }
 

--- a/src/MICore/LaunchOptions.xsd
+++ b/src/MICore/LaunchOptions.xsd
@@ -268,6 +268,12 @@
               <xs:documentation>Path to a core dump file for the specified executable.</xs:documentation>
             </xs:annotation>
           </xs:attribute>
+          <xs:attribute name="ExternalConsole" type="xs:boolean" use="optional">
+            <xs:annotation>
+              <xs:documentation>If enabled, this tells the MIEngine that the target process should run in a new console window which
+              is external to the debugger UI.</xs:documentation>
+            </xs:annotation>
+          </xs:attribute>
         </xs:extension>
       </xs:complexContent>
     </xs:complexType>

--- a/src/MICore/LaunchOptions.xsd.types.desginer.cs
+++ b/src/MICore/LaunchOptions.xsd.types.desginer.cs
@@ -440,6 +440,14 @@ namespace MICore.Xml.LaunchOptions {
         /// <remarks/>
         [System.Xml.Serialization.XmlAttributeAttribute()]
         public string CoreDumpPath;
+        
+        /// <remarks/>
+        [System.Xml.Serialization.XmlAttributeAttribute()]
+        public bool ExternalConsole;
+        
+        /// <remarks/>
+        [System.Xml.Serialization.XmlIgnoreAttribute()]
+        public bool ExternalConsoleSpecified;
     }
     
     /// <remarks/>

--- a/src/MICoreUnitTests/BasicLaunchOptionsTests.cs
+++ b/src/MICoreUnitTests/BasicLaunchOptionsTests.cs
@@ -38,6 +38,7 @@ namespace MICoreUnitTests
             Assert.Null(options.CustomLaunchSetupCommands);
             Assert.True(options.SetupCommands != null && options.SetupCommands.Count == 0);
             Assert.True(String.IsNullOrEmpty(options.CoreDumpPath));
+            Assert.False(options.UseExternalConsole);
             Assert.False(options.IsCoreDump);
         }
 
@@ -71,6 +72,7 @@ namespace MICoreUnitTests
             Assert.True(options.CustomLaunchSetupCommands != null && options.CustomLaunchSetupCommands.Count == 0);
             Assert.True(options.SetupCommands != null && options.SetupCommands.Count == 0);
             Assert.True(String.IsNullOrEmpty(options.CoreDumpPath));
+            Assert.False(options.UseExternalConsole);
             Assert.False(options.IsCoreDump);
         }
 


### PR DESCRIPTION
This checkin adds a new launch option for controlling if an external console should be
used and modifies the external console support so that it can be used with CLRDBG.

Remaining work:
* I am currently sometimes seeing an access violation which leads to a hang inside of
clrdbg during shutdown. This is inside of the JIT, so I want to try upgrading my CoreCLR
before investigating more.
* Support OSX