### PR TITLE
Add the type to the name of the variable for base class variables.

### DIFF
--- a/src/MIDebugEngine/Engine.Impl/Variables.cs
+++ b/src/MIDebugEngine/Engine.Impl/Variables.cs
@@ -239,7 +239,7 @@ namespace Microsoft.MIDebugEngine
             {
                 // base classes show up with no value and exp==type 
                 // (sometimes underlying debugger does not follow this convention, when using typedefs in templated types so look for "::" in the field name too)
-                Name = "base";
+                Name = TypeName + " (base)";
                 Value = TypeName;
                 VariableNodeType = NodeType.BaseClass;
             }


### PR DESCRIPTION
This is required for VSCode because it makes sure all variables are unique
by the name.

![screenshot from 2016-03-24 17 24 43](https://cloud.githubusercontent.com/assets/637952/14034919/55343f82-f1e5-11e5-9797-1e6f01c2f84b.png)

/cc @jacdavis @gregg-miskelly @chuckries 