### PR TITLE
Add handling for async return stack frames

### DIFF
--- a/src/MIDebugEngine/AD7.Impl/AD7DocumentContext.cs
+++ b/src/MIDebugEngine/AD7.Impl/AD7DocumentContext.cs
@@ -40,6 +40,12 @@ namespace Microsoft.MIDebugEngine
         int IDebugDocumentContext2.EnumCodeContexts(out IEnumDebugCodeContexts2 ppEnumCodeCxts)
         {
             ppEnumCodeCxts = null;
+
+            if (_codeContext == null)
+            {
+                return Constants.E_FAIL;
+            }
+
             try
             {
                 AD7MemoryAddress[] codeContexts = new AD7MemoryAddress[1];


### PR DESCRIPTION
This fixes a crash in MIEngine when there are managed return stack frames in the callstack. These frames have IL offsets and therefore text positions but no native offsets or CPU instruction addresses. The crash happens due to trying to set document context on a null code context object. In order to be able to properly show these frames and allow showing the source for them, changed the code to store the document context separately on the stack frame object and use that for GetDocumentContext call.
