### PR TITLE
Fix regression caused by earlier async frame fix

### DIFF
--- a/src/MIDebugEngine/AD7.Impl/AD7StackFrame.cs
+++ b/src/MIDebugEngine/AD7.Impl/AD7StackFrame.cs
@@ -226,7 +226,7 @@ namespace Microsoft.MIDebugEngine
 
             if ((dwFieldSpec & enum_FRAMEINFO_FLAGS.FIF_FLAGS) != 0)
             {
-                if (_documentCxt == null)
+                if (_codeCxt == null && _documentCxt == null)
                 {
                     frameInfo.m_dwFlags |= (uint)enum_FRAMEINFO_FLAGS_VALUES.FIFV_ANNOTATEDFRAME;
                 }


### PR DESCRIPTION
Previously the MIEngine code would mark a frame as “annotated” if there was no code context for it. I changed that logic to look for a document context to decide whether a frame was annotated. This was so that we can switch to the virtual async frame. However, this brought up the issue where the frame for an exception thrown in external code would also be marked as annotated since it has a code context but no document context. 

Changed the code so that a frame is marked annotated if there is no code context and no document context.