### PR TITLE
Update CoreCLR version

### DIFF
--- a/src/MICore/Transports/LocalTransport.cs
+++ b/src/MICore/Transports/LocalTransport.cs
@@ -9,6 +9,7 @@ using System.Diagnostics;
 using System.IO;
 using System.Collections.Specialized;
 using System.Collections;
+using System.Runtime.InteropServices;
 
 namespace MICore
 {
@@ -28,8 +29,10 @@ namespace MICore
             proc.StartInfo.Arguments = "--interpreter=mi";
             proc.StartInfo.WorkingDirectory = miDebuggerDir;
 
-            //GDB locally requires that the directory be on the PATH, being the working directory isn't good enough
-            if (proc.StartInfo.Environment.ContainsKey("PATH"))
+            // On Windows, GDB locally requires that the directory be on the PATH, being the working directory isn't good enough
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows) &&
+                options.DebuggerMIMode == MIMode.Gdb &&
+                proc.StartInfo.Environment.ContainsKey("PATH"))
             {
                 proc.StartInfo.Environment["PATH"] = proc.StartInfo.Environment["PATH"] + ";" + miDebuggerDir;
             }

--- a/src/MICore/Transports/StreamTransport.cs
+++ b/src/MICore/Transports/StreamTransport.cs
@@ -101,7 +101,23 @@ namespace MICore
                     _bQuit = true;
                     _streamReadCancellationTokenSource.Dispose();
                     _reader.Dispose();
-                    _writer.Dispose();
+
+                    try
+                    {
+                        _writer.Dispose();
+                    }
+                    catch
+                    {
+                        // This can fail flush side effects if the debugger goes down. When this happens we don't want
+                        // to crash OpenDebugAD7/VS. Stack:
+                        //   System.IO.UnixFileStream.WriteNative(Byte[] array, Int32 offset, Int32 count)
+                        //   System.IO.UnixFileStream.FlushWriteBuffer()
+                        //   System.IO.UnixFileStream.Dispose(Boolean disposing)
+                        //   System.IO.FileStream.Dispose(Boolean disposing)
+                        //   System.IO.Stream.Close()
+                        //   System.IO.StreamWriter.Dispose(Boolean disposing)
+                        //   System.IO.TextWriter.Dispose()
+                    }
                 }
             }
         }

--- a/tools/InstallToVSCode/CLRDependencies/project.json
+++ b/tools/InstallToVSCode/CLRDependencies/project.json
@@ -4,25 +4,27 @@
       "emitEntryPoint": true
   },
   "dependencies": {
-    "NETStandard.Library": "1.0.0-rc3-23829",
-    "System.Collections.Specialized":  "4.0.1-rc3-23829",
-    "System.Collections.Immutable": "1.2.0-rc3-23829", 
-    "System.Diagnostics.Process" : "4.1.0-rc3-23829",
-    "System.Diagnostics.StackTrace":  "4.0.1-rc3-23829",  
-    "System.Dynamic.Runtime": "4.0.11-rc3-23829",
-    "Microsoft.CSharp": "4.0.1-rc3-23829",
-    "System.Threading.Tasks.Dataflow": "4.6.0-rc3-23829",
-    "System.Threading.Thread": "4.0.0-rc3-23829", 
-    "System.Xml.XDocument": "4.0.11-rc3-23829",
-    "System.Xml.XmlDocument": "4.0.1-rc3-23829",  
-    "System.Xml.XmlSerializer": "4.0.11-rc3-23829",
-    "System.ComponentModel":  "4.0.1-rc3-23829",  
-    "System.ComponentModel.Annotations":  "4.1.0-rc3-23829",  
-    "System.ComponentModel.EventBasedAsync":  "4.0.11-rc3-23829",
-    "System.Runtime.Serialization.Primitives": "4.1.0-rc3-23829",
-    "System.Net.Http":  "4.0.1-rc3-23829"
+    "NETStandard.Library": "1.5.0-rc2-23931",
+    "System.Collections.Specialized":  "4.0.1-rc2-23931",
+    "System.Collections.Immutable": "1.2.0-rc2-23931", 
+    "System.Diagnostics.Process" : "4.1.0-rc2-23931",
+    "System.Diagnostics.StackTrace":  "4.0.1-rc2-23931",  
+    "System.Dynamic.Runtime": "4.0.11-rc2-23931",
+    "Microsoft.CSharp": "4.0.1-rc2-23931",
+    "System.Threading.Tasks.Dataflow": "4.6.0-rc2-23931",
+    "System.Threading.Thread": "4.0.0-rc2-23931", 
+    "System.Xml.XDocument": "4.0.11-rc2-23931",
+    "System.Xml.XmlDocument": "4.0.1-rc2-23931",  
+    "System.Xml.XmlSerializer": "4.0.11-rc2-23931",
+    "System.ComponentModel":  "4.0.1-rc2-23931",  
+    "System.ComponentModel.Annotations":  "4.1.0-rc2-23931",  
+    "System.ComponentModel.EventBasedAsync":  "4.0.11-rc2-23931",
+    "System.Runtime.Serialization.Primitives": "4.1.1-rc2-23931",
+    "System.Net.Http":  "4.0.1-rc2-23931"
   },
   "frameworks": {
-    "dnxcore50": { }
-  }
+    "netstandardapp1.5": {
+      "imports": [ "portable-net45+win8", "dnxcore50" ]
+    }
+  },
 }


### PR DESCRIPTION
commit cc670121793cef49c452fb2274768cef3600dd46
Author: Gregg Miskelly <greggm@microsoft.com>
Date:   Thu Mar 31 12:09:23 2016 -0700

    Update CoreCLR version
    
    This updates the CoreCLR version when using InstallToVSCode.

commit e4dc11aa48edea4b51f0194a8c3022ff83cd2aae
Author: Gregg Miskelly <greggm@microsoft.com>
Date:   Thu Mar 31 12:07:55 2016 -0700

    Fix intermitent crash in SteamTransport
    
    On Unix, the stream transport was sometimes crashing on debugger
    abort as it still had unflushed data. This catches the exception.

commit 7cb30a6ecdb6fe8ad3ada63052684e6f3f513108
Author: Gregg Miskelly <greggm@microsoft.com>
Date:   Thu Mar 31 12:03:37 2016 -0700

    LocalTransport: Stop corrupting the PATH environment variable
    
    LocalTransport had some code meant for working around a bug with GDB on
    Windows where the GDB directory needed to be on the path. However,
    it was doing this in all scenarios.
    
    It's possible that there are other scenarios where this code might be useful,
    but in that case it needs to use the ':' separator on UNIX instead of
    corrupting the path. For now, I just went with the easy fix of turning it off
    except for where we know we need it.
