### PR TITLE
Send MIEngine version to clrdbg

### DIFF
--- a/src/MIDebugEngine/Engine.Impl/DebuggedProcess.cs
+++ b/src/MIDebugEngine/Engine.Impl/DebuggedProcess.cs
@@ -13,6 +13,7 @@ using System.Threading.Tasks;
 using System.IO;
 using System.Linq;
 using System.Globalization;
+using System.Reflection;
 using System.Runtime.InteropServices;
 using Microsoft.DebugEngineHost;
 
@@ -571,6 +572,20 @@ namespace Microsoft.MIDebugEngine
                         this.MICommandFactory.UseExternalConsoleForLocalLaunch(localLaunchOptions))
                     {
                         commands.Add(new LaunchCommand("-inferior-tty-set <new-console>"));
+                    }
+
+                    // Send client version to clrdbg to set the capabilities appropriately
+                    if (this.MICommandFactory.Mode == MIMode.Clrdbg)
+                    {
+                        string version = string.Empty;
+                        var attribute = this.GetType().GetTypeInfo().Assembly.GetCustomAttribute(typeof(System.Reflection.AssemblyFileVersionAttribute)) as AssemblyFileVersionAttribute;
+                        
+                        if (attribute != null)
+                        {
+                            version = attribute.Version;
+                        }
+
+                        commands.Add(new LaunchCommand("-gdb-set client-version \"" + version + "\""));
                     }
 
                     this.AddExecutablePathCommand(commands);


### PR DESCRIPTION
Send MIEngine version to clrdbg on initialize so that it can set capabilities correctly.