### PR TITLE
Fix InstallToVSCode for breaking CLI change

### DIFF
--- a/tools/InstallToVSCode/CLRDependencies/project.json.template
+++ b/tools/InstallToVSCode/CLRDependencies/project.json.template
@@ -27,4 +27,7 @@
       "imports": [ "portable-net45+win8", "dnxcore50" ]
     }
   },
+  "runtimes":{
+@current-OS@
+  }
 }

--- a/tools/InstallToVSCode/InstallToVSCode.cmd
+++ b/tools/InstallToVSCode/InstallToVSCode.cmd
@@ -63,8 +63,16 @@ if "%CSharpExtensionRoot%"=="" echo ERROR: C# extension is not installed in VS C
 call :SetupSymLink %CSharpExtensionRoot%\coreclr-debug\debugAdapters
 if NOT "%InstallError%"=="" exit /b -1
 
-pushd %~dp0CLRDependencies
-if NOT "%ERRORLEVEL%"=="0" echo ERROR: Unable to find CLRDependencies directory???& exit /b -1
+mkdir "%DESTDIR%\CLRDependencies"
+if NOT "%ERRORLEVEL%"=="0" echo ERROR: unable to create directory '%DESTDIR%\CLRDependencies'. &exit /b -1
+
+xcopy /s %~dp0CLRDependencies "%DESTDIR%\CLRDependencies"
+if NOT "%ERRORLEVEL%"=="0" echo ERROR: Unable to copy CLRDependencies directory???& exit /b -1
+
+pushd "%DESTDIR%\CLRDependencies"
+if NOT "%ERRORLEVEL%"=="0" echo ERROR: Unable to change to CLRDependencies directory???& exit /b -1
+
+for /f "tokens=1 delims=" %%l in (project.json.template) do if NOT "%%l"=="@current-OS@" (echo %%l>>project.json) else (echo     "win7-x64":{}>>project.json)
 
 dotnet restore
 if NOT "%ERRORLEVEL%"=="0" echo "ERROR: 'dotnet restore' failed." & exit /b -1


### PR DESCRIPTION
The CLI team previously indicated that a native host executable will not be dropped
unless the project.json explicitly indicates that the application wants to be
platform depentant. But builds from a few days ago were actually behaving nicer than
the way I told it should work.

Now things are actually behaving this way. So I am fixing up InstallToVSCode to generate
project.json on the fly so we can write out a runtime id.