### PR TITLE
Fix bound breakpoints to resolve to correct line when using gdb

### DIFF
--- a/src/MIDebugEngine/Engine.Impl/Breakpoints.cs
+++ b/src/MIDebugEngine/Engine.Impl/Breakpoints.cs
@@ -96,7 +96,21 @@ namespace Microsoft.MIDebugEngine
             process.VerifyNotDebuggingCoreDump();
 
             string basename = System.IO.Path.GetFileName(documentName);     // get basename from Windows path
-            return EvalBindResult(await process.MICommandFactory.BreakInsert(process.EscapePath(basename), line, condition, ResultClass.None), pbreak);
+            basename = process.EscapePath(basename);
+            BindResult bindResults = EvalBindResult(await process.MICommandFactory.BreakInsert(basename, line, condition, ResultClass.None), pbreak);
+
+            // On GDB, the returned line information is from the pending breakpoint instead of the bound breakpoint.
+            // Check the address mapping to make sure the line info is correct.
+            if (process.MICommandFactory.Mode == MIMode.Gdb &&
+                bindResults.BoundBreakpoints != null)
+            {
+                foreach (var boundBreakpoint in bindResults.BoundBreakpoints)
+                {
+                    boundBreakpoint.Line = await process.LineForStartAddress(basename, boundBreakpoint.Addr);
+                }
+            }
+
+            return bindResults;
         }
 
         private static BindResult EvalBindResult(Results bindResult, AD7PendingBreakpoint pbreak)
@@ -324,6 +338,26 @@ namespace Microsoft.MIDebugEngine
             }
 
             return new AD7DocumentContext(_textPosition, new AD7MemoryAddress(engine, Addr, this.FunctionName));
+        }
+
+        /// <summary>
+        /// Returns the start line of the breakpoint.
+        /// NOTE: If set this overwrites any column or multiline information.
+        /// </summary>
+        internal uint Line
+        {
+            get
+            {
+                return _textPosition.BeginPosition.dwLine;
+            }
+            set
+            {
+                if (this.Line == value || value == 0)
+                {
+                    return;
+                }
+                _textPosition = new MITextPosition(_textPosition.FileName, value);
+            }
         }
     }
 }

--- a/src/MIDebugEngine/Engine.Impl/MITextPosition.cs
+++ b/src/MIDebugEngine/Engine.Impl/MITextPosition.cs
@@ -25,6 +25,13 @@ namespace Microsoft.MIDebugEngine
             this.EndPosition = endPosition;
         }
 
+        public MITextPosition(string filename, uint line)
+        {
+            this.FileName = filename;
+            this.BeginPosition = new Microsoft.VisualStudio.Debugger.Interop.TEXT_POSITION() { dwLine = line - 1 };
+            this.EndPosition = this.BeginPosition;
+        }
+
         public static MITextPosition TryParse(TupleValue miTuple)
         {
             string filename = miTuple.TryFindString("fullname");

--- a/src/MIDebugEngine/Engine.Impl/SourceLine.cs
+++ b/src/MIDebugEngine/Engine.Impl/SourceLine.cs
@@ -11,12 +11,24 @@ using MICore;
 
 namespace Microsoft.MIDebugEngine
 {
+    public class SourceLineMap : Dictionary<ulong, SourceLine>
+    {
+        public SourceLineMap(int capacity)
+            : base(capacity)
+        { }
+
+        public void Add(ulong addr, uint line)
+        {
+            base.Add(addr, new SourceLine(line, addr));
+        }
+    }
+
     public struct SourceLine
     {
         public uint Line { get; private set; }
         public ulong AddrStart { get; private set; }
 
-        public void Set(uint line, ulong addr)
+        public SourceLine(uint line, ulong addr)
         {
             Line = line;
             AddrStart = addr;
@@ -27,15 +39,15 @@ namespace Microsoft.MIDebugEngine
 
     internal class SourceLineCache
     {
-        private Dictionary<string, SourceLine[]> _mapFileToLinenums;
+        private Dictionary<string, SourceLineMap> _mapFileToLinenums;
         private DebuggedProcess _process;
 
         public SourceLineCache(DebuggedProcess process)
         {
             _process = process;
-            _mapFileToLinenums = new Dictionary<string, SourceLine[]>();
+            _mapFileToLinenums = new Dictionary<string, SourceLineMap>();
         }
-        internal async Task<SourceLine[]> GetLinesForFile(string file)
+        internal async Task<SourceLineMap> GetLinesForFile(string file)
         {
             string fileKey = file;
             lock (_mapFileToLinenums)
@@ -45,26 +57,26 @@ namespace Microsoft.MIDebugEngine
                     return _mapFileToLinenums[fileKey];
                 }
             }
-            SourceLine[] lines = null;
-            lines = await LinesForFile(fileKey);
+            SourceLineMap linesMap = null;
+            linesMap = await LinesForFile(fileKey);
             lock (_mapFileToLinenums)
             {
                 if (_mapFileToLinenums.ContainsKey(fileKey))
                 {
                     return _mapFileToLinenums[fileKey];
                 }
-                if (lines != null)
+                if (linesMap != null)
                 {
-                    _mapFileToLinenums.Add(fileKey, lines);
+                    _mapFileToLinenums.Add(fileKey, linesMap);
                 }
                 else
                 {
-                    _mapFileToLinenums.Add(fileKey, new SourceLine[0]);    // empty list to prevent requerying. Release this list on dynamic library loading
+                    _mapFileToLinenums.Add(fileKey, new SourceLineMap(0));    // empty list to prevent requerying. Release this list on dynamic library loading
                 }
                 return _mapFileToLinenums[fileKey];
             }
         }
-        private async Task<SourceLine[]> LinesForFile(string file)
+        private async Task<SourceLineMap> LinesForFile(string file)
         {
             string cmd = "-symbol-list-lines " + _process.EscapePath(file);
             Results results = await _process.CmdAsync(cmd, ResultClass.None);
@@ -75,14 +87,14 @@ namespace Microsoft.MIDebugEngine
             }
 
             ValueListValue lines = results.Find<ValueListValue>("lines");
-            SourceLine[] list = new SourceLine[lines.Content.Length];
+            SourceLineMap linesMap = new SourceLineMap(lines.Content.Length);
             for (int i = 0; i < lines.Content.Length; ++i)
             {
                 ulong addr = lines.Content[i].FindAddr("pc");
                 uint line = lines.Content[i].FindUint("line");
-                list[i].Set(line, addr);
+                linesMap.Add(addr, line);
             }
-            return list;
+            return linesMap;
         }
 
         internal void OnLibraryLoad()
@@ -92,7 +104,7 @@ namespace Microsoft.MIDebugEngine
                 List<string> toDelete = new List<string>();
                 foreach (var l in _mapFileToLinenums)
                 {
-                    if (l.Value.Length == 0)
+                    if (l.Value.Count == 0)
                     {
                         toDelete.Add(l.Key);
                     }


### PR DESCRIPTION
GDB doesn't return the bound breakpoint line after creating a line breakpoint, this code will request the address to line mapping for the breakpoint and get the correct line if required.

I used the existing SourceLineCache code for doing the lookup, this gets the address mapping of every line in the file. Unfortunately gdb does not actually implement the mi call for "symbol-info-symbol" to request a single address lookup.

LLDB does not have this issue and returns the bound line from "break-insert".

@gregg-miskelly @jacdavis @chuckries @paulmaybee 
