### PR TITLE
Use the new location of gdb.exe (multi-arch) and parse source.properties

### DIFF
--- a/src/AndroidDebugLauncher/AndroidDebugLauncher.csproj
+++ b/src/AndroidDebugLauncher/AndroidDebugLauncher.csproj
@@ -74,6 +74,7 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="INDKFilePath.cs" />
     <Compile Include="InstallPaths.cs" />
     <Compile Include="Launcher.cs" />
     <Compile Include="AndroidLaunchOptions.cs" />
@@ -83,6 +84,7 @@
       <DesignTime>True</DesignTime>
       <DependentUpon>LauncherResources.resx</DependentUpon>
     </Compile>
+    <Compile Include="NDKPrebuiltFilePath.cs" />
     <Compile Include="NDKToolChainFilePath.cs" />
     <Compile Include="NdkToolVersion.cs" />
     <Compile Include="NdkReleaseId.cs" />

--- a/src/AndroidDebugLauncher/INDKFilePath.cs
+++ b/src/AndroidDebugLauncher/INDKFilePath.cs
@@ -1,0 +1,12 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace AndroidDebugLauncher
+{
+    public interface INDKFilePath
+    {
+        string PartialFilePath { get; }
+        string TryResolve(string ndkRoot);
+        string GetSearchPathDescription(string ndkRoot);
+    }
+}

--- a/src/AndroidDebugLauncher/InstallPaths.cs
+++ b/src/AndroidDebugLauncher/InstallPaths.cs
@@ -45,38 +45,57 @@ namespace AndroidDebugLauncher
                 ndkRoot = GetDirectoryFromRegistry(RegistryRoot.Value + @"\Setup\VS\SecondaryInstaller\AndroidNDK", "NDK_HOME", checkBothBitnesses: false, externalProductName: LauncherResources.ProductName_NDK);
             }
 
+            NdkReleaseId ndkReleaseId = new NdkReleaseId();
             string ndkReleaseVersionFile = Path.Combine(ndkRoot, "RELEASE.TXT");
-            if (!File.Exists(ndkReleaseVersionFile))
+            string ndkSourcePropertiesFile = Path.Combine(ndkRoot, "source.properties");
+
+            // NDK releases >= r11 have a source.properties file
+            if (File.Exists(ndkSourcePropertiesFile))
+            {
+                NdkReleaseId.TryParsePropertiesFile(ndkSourcePropertiesFile, out ndkReleaseId);
+            }
+            // NDK releases < r11 have a RELEASE.txt file
+            else if (File.Exists(ndkReleaseVersionFile))
+            {
+                NdkReleaseId.TryParseFile(ndkReleaseVersionFile, out ndkReleaseId);
+            }
+            else
             {
                 ThrowExternalFileNotFoundException(ndkReleaseVersionFile, LauncherResources.ProductName_NDK);
             }
 
-            NdkReleaseId ndkReleaseId;
-            NdkReleaseId.TryParseFile(ndkReleaseVersionFile, out ndkReleaseId);
             logger.WriteLine("Using NDK '{0}' from path '{1}'", ndkReleaseId, ndkRoot);
 
+            // 32 vs 64-bit doesn't matter when comparing
+            var r11 = new NdkReleaseId(11, 'a');
+            // In NDK r11 and later, gdb is multi-arch and there's only one binary
+            // in the prebuilt directory
+            bool usePrebuiltGDB = ndkReleaseId.CompareVersion(r11) >= 0;
+            IEnumerable<INDKFilePath> prebuiltGDBPath = NDKPrebuiltFilePath.GDBPaths();
+
             string targetArchitectureName;
-            NDKToolChainFilePath[] possibleGDBPaths;
+            IEnumerable<INDKFilePath> possibleGDBPaths;
+
             switch (launchOptions.TargetArchitecture)
             {
                 case MICore.TargetArchitecture.X86:
                     targetArchitectureName = "x86";
-                    possibleGDBPaths = NDKToolChainFilePath.x86_GDBPaths();
+                    possibleGDBPaths = usePrebuiltGDB ? prebuiltGDBPath: NDKToolChainFilePath.x86_GDBPaths();
                     break;
 
                 case MICore.TargetArchitecture.X64:
                     targetArchitectureName = "x64";
-                    possibleGDBPaths = NDKToolChainFilePath.x64_GDBPaths();
+                    possibleGDBPaths = usePrebuiltGDB ? prebuiltGDBPath : NDKToolChainFilePath.x64_GDBPaths();
                     break;
 
                 case MICore.TargetArchitecture.ARM:
                     targetArchitectureName = "arm";
-                    possibleGDBPaths = NDKToolChainFilePath.ARM_GDBPaths();
+                    possibleGDBPaths = usePrebuiltGDB ? prebuiltGDBPath : NDKToolChainFilePath.ARM_GDBPaths();
                     break;
 
                 case MICore.TargetArchitecture.ARM64:
                     targetArchitectureName = "arm64";
-                    possibleGDBPaths = NDKToolChainFilePath.ARM64_GDBPaths();
+                    possibleGDBPaths = usePrebuiltGDB ? prebuiltGDBPath : NDKToolChainFilePath.ARM64_GDBPaths();
                     break;
 
                 default:
@@ -84,7 +103,7 @@ namespace AndroidDebugLauncher
                     throw new InvalidOperationException();
             }
 
-            NDKToolChainFilePath matchedPath;
+            INDKFilePath matchedPath;
             result.GDBPath = GetNDKFilePath(
                 string.Concat("Android-", targetArchitectureName, "-GDBPath"),
                 ndkRoot,
@@ -93,7 +112,7 @@ namespace AndroidDebugLauncher
                 );
             if (launchOptions.TargetArchitecture == MICore.TargetArchitecture.X86 && matchedPath != null)
             {
-                var r10b = new NdkReleaseId(10, 'b', true);
+                var r10b = new NdkReleaseId(10, 'b');
 
                 // Before r10b, the 'windows-x86_64' ndk didn't support x86 debugging
                 if (ndkReleaseId.IsValid && ndkReleaseId.CompareVersion(r10b) < 0 && matchedPath.PartialFilePath.Contains(@"\windows-x86_64\"))
@@ -192,10 +211,10 @@ namespace AndroidDebugLauncher
         /// </summary>
         /// <param name="registryValueName">[Required] registry value to check first</param>
         /// <param name="ndkRoot">[Required] Path to the NDK</param>
-        /// <param name="possiblePaths">[Required] Array of possible paths with in the NDK where the file may be found</param>
+        /// <param name="possiblePaths">[Required] IEnumerable of possible paths with in the NDK where the file may be found</param>
         /// <param name="matchedPath">[Optional] If the returned path comes from an NDK location, returns the source object</param>
         /// <returns>[Required] value to use, file path will exist</returns>
-        private static string GetNDKFilePath(string registryValueName, string ndkRoot, NDKToolChainFilePath[] possiblePaths, out NDKToolChainFilePath matchedPath)
+        private static string GetNDKFilePath(string registryValueName, string ndkRoot, IEnumerable<INDKFilePath> possiblePaths, out INDKFilePath matchedPath)
         {
             matchedPath = null;
 
@@ -204,7 +223,7 @@ namespace AndroidDebugLauncher
                 throw new ArgumentNullException("ndkRoot");
             }
 
-            if (possiblePaths == null || possiblePaths.Length <= 0)
+            if (possiblePaths == null || !possiblePaths.Any())
             {
                 throw new ArgumentOutOfRangeException("possiblePaths");
             }
@@ -221,7 +240,7 @@ namespace AndroidDebugLauncher
             }
             else
             {
-                foreach (NDKToolChainFilePath pathObject in possiblePaths)
+                foreach (INDKFilePath pathObject in possiblePaths)
                 {
                     value = pathObject.TryResolve(ndkRoot);
                     if (value != null)

--- a/src/AndroidDebugLauncher/NDKPrebuiltFilePath.cs
+++ b/src/AndroidDebugLauncher/NDKPrebuiltFilePath.cs
@@ -1,0 +1,48 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.IO;
+
+namespace AndroidDebugLauncher
+{
+    public class NDKPrebuiltFilePath: INDKFilePath
+    {
+        public string PartialFilePath { get; }
+
+        private NDKPrebuiltFilePath(string partialFilePath)
+        {
+            this.PartialFilePath = partialFilePath;
+        }
+
+        public static NDKPrebuiltFilePath[] GDBPaths()
+        {
+            return new NDKPrebuiltFilePath[] {
+                new NDKPrebuiltFilePath(@"windows\bin\gdb.exe"), // windows-x86 NDK path
+                new NDKPrebuiltFilePath(@"windows-x86_64\bin\gdb.exe"), // windows-x86 NDK path
+            };
+        }
+
+        public string TryResolve(string ndkRoot)
+        {
+            string prebuiltDirectory = GetPrebuiltDirectory(ndkRoot);
+            string path = Path.Combine(prebuiltDirectory, PartialFilePath);
+            if (File.Exists(path))
+            {
+                return path;
+            }
+
+            return null;
+        }
+
+        public string GetSearchPathDescription(string ndkRoot)
+        {
+            return GetPrebuiltDirectory(ndkRoot);
+        }
+
+        private static string GetPrebuiltDirectory(string ndkRoot)
+        {
+            return Path.Combine(ndkRoot, "prebuilt");
+        }
+    }
+}

--- a/src/AndroidDebugLauncher/NDKToolChainFilePath.cs
+++ b/src/AndroidDebugLauncher/NDKToolChainFilePath.cs
@@ -15,11 +15,11 @@ namespace AndroidDebugLauncher
     /// <summary>
     /// Represents a relative path within the ndk_root\toolchains folder which does fuzzy matching for tool chain version.
     /// </summary>
-    internal class NDKToolChainFilePath
+    internal class NDKToolChainFilePath: INDKFilePath
     {
-        public readonly string ToolChainName;
-        public readonly string PreferredVersion;
-        public readonly string PartialFilePath;
+        public string ToolChainName { get; }
+        public string PreferredVersion { get; }
+        public string PartialFilePath { get; }
 
         private NDKToolChainFilePath(string toolChainName, string preferredVersion, string partialFilePath)
         {
@@ -95,6 +95,11 @@ namespace AndroidDebugLauncher
         public string GetSearchPathDescription(string ndkRoot)
         {
             return GetFullPath(GetToolChainsDirectory(ndkRoot), "*");
+        }
+
+        public string GetPartialFilePath()
+        {
+            return PartialFilePath;
         }
 
         private static string GetToolChainsDirectory(string ndkRoot)

--- a/src/MICoreUnitTests/NdkVersionTests.cs
+++ b/src/MICoreUnitTests/NdkVersionTests.cs
@@ -52,20 +52,20 @@ namespace MICoreUnitTests
         }
 
         [Fact]
-        public void TestNdkReleaseId1()
+        public void TestNdkReleaseIdReleaseFile()
         {
             NdkReleaseId r;
             Assert.True(NdkReleaseId.TryParse("r1", out r));
             Assert.Equal(r.ToString(), "r1");
 
             Assert.True(NdkReleaseId.TryParse("r1a", out r));
-            Assert.Equal(r.ToString(), "r1a");
+            Assert.Equal(r.ToString(), "r1");
 
             Assert.True(NdkReleaseId.TryParse("r10", out r));
             Assert.Equal(r.ToString(), "r10");
 
             Assert.True(NdkReleaseId.TryParse("r10b (64-bit)", out r));
-            Assert.Equal(r.ToString(), "r10b (64-bit)");
+            Assert.Equal(r.ToString(), "r10b");
 
             Assert.False(NdkReleaseId.TryParse("100", out r));
             Assert.False(NdkReleaseId.TryParse("r", out r));
@@ -75,19 +75,36 @@ namespace MICoreUnitTests
         }
 
         [Fact]
-        public void TestNdkReleaseId2()
+        public void TestNdkReleaseIdCompare()
         {
-            NdkReleaseId r10 = new NdkReleaseId(10, (char)0, true);
-            NdkReleaseId r10_64bit = new NdkReleaseId(10, (char)0, false);
-            NdkReleaseId r10b = new NdkReleaseId(10, 'b', true);
-            NdkReleaseId r9d = new NdkReleaseId(9, 'd', true);
+            NdkReleaseId r10 = new NdkReleaseId(10, (char)0);
+            NdkReleaseId r10b = new NdkReleaseId(10, 'b');
+            NdkReleaseId r9d = new NdkReleaseId(9, 'd');
 
             Assert.True(r10.CompareVersion(r10) == 0);
-            Assert.True(r10.CompareVersion(r10_64bit) == 0);
             Assert.True(r10.CompareVersion(r10b) < 0);
             Assert.True(r10b.CompareVersion(r10) > 0);
             Assert.True(r10.CompareVersion(r9d) > 0);
             Assert.True(r9d.CompareVersion(r10) < 0);
+        }
+
+        [Fact]
+        public void TestNdkReleaseIdPropertiesFile()
+        {
+            NdkReleaseId r;
+            Assert.True(NdkReleaseId.TryParseRevision("1.0.0", out r));
+            Assert.Equal("r1", r.ToString());
+
+            Assert.True(NdkReleaseId.TryParseRevision("1.0.1234", out r));
+            Assert.Equal("r1", r.ToString());
+
+            Assert.True(NdkReleaseId.TryParseRevision("13.2.0", out r));
+            Assert.Equal(r.ToString(), "r13c");
+
+            Assert.False(NdkReleaseId.TryParseRevision("100", out r));
+            Assert.False(NdkReleaseId.TryParseRevision("r11b", out r));
+            Assert.False(NdkReleaseId.TryParseRevision("-100", out r));
+            Assert.False(NdkReleaseId.TryParseRevision("10.0", out r));
         }
     }
 }


### PR DESCRIPTION
This PR has fixes to work with the new path to gdb in NDK  >= r11.

Also note that the RELEASE.txt file that used to be in the root of the NDK has been replaced by a source.properties file.