### PR TITLE
Fix issue that signal based exceptions in lldb were not working. 

### DIFF
--- a/src/MICore/Debugger.cs
+++ b/src/MICore/Debugger.cs
@@ -190,16 +190,17 @@ namespace MICore
             }
 
             //if this is an exception reported from LLDB, it will not currently contain a frame object in the MI
-            //if we don't have a frame, check if this is an excpetion and retrieve the frame
+            //if we don't have a frame, check if this is an exception and retrieve the frame
             if (!results.Contains("frame") &&
-                string.Compare(reason, "exception-received", StringComparison.OrdinalIgnoreCase) == 0
+                (string.Compare(reason, "exception-received", StringComparison.OrdinalIgnoreCase) == 0 ||
+                string.Compare(reason, "signal-received", StringComparison.OrdinalIgnoreCase) == 0)
                 )
             {
                 //get the info for the current frame
                 Results frameResult = await MICommandFactory.StackInfoFrame();
 
                 //add the frame to the stopping results
-                results.Add("frame", frameResult.Find("frame"));
+                results = results.Add("frame", frameResult.Find("frame"));
             }
 
             bool fIsAsyncBreak = MICommandFactory.IsAsyncBreakSignal(results);


### PR DESCRIPTION
This isbecause a hack in miengine that adds frame info to the results class
wasn't accounting for signal-received events resulting in engine assuming
this is a module load event. Note that this hack (assuming any event
without a frame is a mod-load) seems wrong but removing it would be a bit
risky. It may be better to account for mod loads by directly checking for
them. Also, the existing hack no longer works as results.add returns a new 
results class. Fixed that as well. 