### PR TITLE
Enable attach in lldb

### DIFF
--- a/src/MIDebugEngine/Engine.Impl/DebuggedProcess.cs
+++ b/src/MIDebugEngine/Engine.Impl/DebuggedProcess.cs
@@ -549,6 +549,13 @@ namespace Microsoft.MIDebugEngine
 
                     int pid = localLaunchOptions.ProcessId;
                     commands.Add(new LaunchCommand(String.Format(CultureInfo.CurrentUICulture, "-target-attach {0}", pid), ignoreFailures: false));
+
+                    if (this.MICommandFactory.Mode == MIMode.Lldb)
+                    {
+                        // LLDB finishes attach in break mode. Gdb does finishes in run mode. Issue a continue in lldb to match the gdb behavior
+                        commands.Add(new LaunchCommand("-exec-continue", ignoreFailures: false));
+                    }
+
                     return commands;
                 }
                 else


### PR DESCRIPTION
Enable attach in lldb
Attach wasn't working with lldb on linux because lldb ends the
attach process in break mode whereas gdb ends in run mode. Issue
a continue after the attach in lldb to make the behavior match
gdb.

NOTE: if externalConsole is not enabled, and you issue an
attach, the elevation dialog will not be displayed. This will
need to be resolved at some point.