### PR TITLE
Fix ARM with new multi-arch gdb.exe from Android NDK >= r11

### DIFF
--- a/src/AndroidDebugLauncher/AndroidLaunchOptions.cs
+++ b/src/AndroidDebugLauncher/AndroidLaunchOptions.cs
@@ -52,6 +52,7 @@ namespace AndroidDebugLauncher
             }
 
             this.AdditionalSOLibSearchPath = xmlOptions.AdditionalSOLibSearchPath;
+            this.AbsolutePrefixSOLibSearchPath = xmlOptions.AbsolutePrefixSOLibSearchPath ?? "\"\"";
             this.DeviceId = LaunchOptions.RequireAttribute(xmlOptions.DeviceId, "DeviceId");
             this.LogcatServiceId = GetLogcatServiceIdAttribute(xmlOptions.LogcatServiceId);
             this.WaitDynamicLibLoad = xmlOptions.WaitDynamicLibLoad;
@@ -183,6 +184,11 @@ namespace AndroidDebugLauncher
         /// [Required] Directory where files from the device/emulator will be downloaded to.
         /// </summary>
         public string IntermediateDirectory { get; private set; }
+
+        /// <summary>
+        /// [Optional] Absolute prefix for directories to search for shared library symbols
+        /// </summary>
+        public string AbsolutePrefixSOLibSearchPath { get; private set; }
 
         /// <summary>
         /// [Optional] Additional directories to add to the search path

--- a/src/AndroidDebugLauncher/Launcher.cs
+++ b/src/AndroidDebugLauncher/Launcher.cs
@@ -6,6 +6,7 @@ using libadb;
 using JDbg;
 using System;
 using System.Collections.Generic;
+using System.Collections.ObjectModel;
 using System.Diagnostics;
 using System.Globalization;
 using System.IO;
@@ -435,6 +436,14 @@ namespace AndroidDebugLauncher
                 }
 
                 launchOptions.AdditionalSOLibSearchPath = _launchOptions.AdditionalSOLibSearchPath;
+                launchOptions.AbsolutePrefixSOLibSearchPath = _launchOptions.AbsolutePrefixSOLibSearchPath;
+
+                // The default ABI is 'Cygwin' in the Android NDK >= r11 for Windows.
+                launchOptions.SetupCommands = new ReadOnlyCollection<LaunchCommand>( new LaunchCommand[]
+                {
+                    new LaunchCommand("-gdb-set osabi GNU/Linux")
+                });
+
                 launchOptions.TargetArchitecture = _launchOptions.TargetArchitecture;
                 launchOptions.WorkingDirectory = _launchOptions.IntermediateDirectory;
 

--- a/src/MICore/LaunchOptions.cs
+++ b/src/MICore/LaunchOptions.cs
@@ -405,6 +405,20 @@ namespace MICore
             }
         }
 
+        private string _absolutePrefixSoLibSearchPath;
+        /// <summary>
+        /// [Optional] Absolute prefix for directories to search for shared library symbols
+        /// </summary>
+        public string AbsolutePrefixSOLibSearchPath
+        {
+            get { return _absolutePrefixSoLibSearchPath; }
+            set
+            {
+                VerifyCanModifyProperty("AbsolutePrefixSOLibSearchPath");
+                _absolutePrefixSoLibSearchPath = value;
+            }
+        }
+
         private string _additionalSOLibSearchPath;
         /// <summary>
         /// [Optional] Additional directories to search for shared library symbols
@@ -809,6 +823,9 @@ namespace MICore
                 else
                     this.AdditionalSOLibSearchPath = string.Concat(this.AdditionalSOLibSearchPath, ";", additionalSOLibSearchPath);
             }
+
+            if (string.IsNullOrEmpty(this.AbsolutePrefixSOLibSearchPath))
+                this.AbsolutePrefixSOLibSearchPath = source.AbsolutePrefixSOLibSearchPath;
         }
 
         public static string RequireAttribute(string attributeValue, string attributeName)

--- a/src/MICore/LaunchOptions.xsd
+++ b/src/MICore/LaunchOptions.xsd
@@ -190,6 +190,11 @@
   </xs:complexType>
   <xs:attributeGroup name="CommonAttributes">
     <xs:attribute name="TargetArchitecture" use="required" type="TargetArchitecture"/>
+    <xs:attribute name="AbsolutePrefixSOLibSearchPath" type="xs:string" use="optional">
+      <xs:annotation>
+        <xs:documentation>Absolute prefix for directories to search for shared library symbols</xs:documentation>
+      </xs:annotation>
+    </xs:attribute>
     <xs:attribute name="AdditionalSOLibSearchPath" type="xs:string" use="optional">
       <xs:annotation>
         <xs:documentation>Semicolon separated list of directories to use to search for .so files. Example: 'c:\dir1;c:\dir2'</xs:documentation>

--- a/src/MICore/LaunchOptions.xsd.types.desginer.cs
+++ b/src/MICore/LaunchOptions.xsd.types.desginer.cs
@@ -76,6 +76,10 @@ namespace MICore.Xml.LaunchOptions {
         
         /// <remarks/>
         [System.Xml.Serialization.XmlAttributeAttribute()]
+        public string AbsolutePrefixSOLibSearchPath;
+        
+        /// <remarks/>
+        [System.Xml.Serialization.XmlAttributeAttribute()]
         public string AdditionalSOLibSearchPath;
         
         /// <remarks/>
@@ -256,6 +260,10 @@ namespace MICore.Xml.LaunchOptions {
         
         /// <remarks/>
         [System.Xml.Serialization.XmlAttributeAttribute()]
+        public string AbsolutePrefixSOLibSearchPath;
+        
+        /// <remarks/>
+        [System.Xml.Serialization.XmlAttributeAttribute()]
         public string AdditionalSOLibSearchPath;
         
         /// <remarks/>
@@ -327,6 +335,10 @@ namespace MICore.Xml.LaunchOptions {
         /// <remarks/>
         [System.Xml.Serialization.XmlAttributeAttribute()]
         public TargetArchitecture TargetArchitecture;
+        
+        /// <remarks/>
+        [System.Xml.Serialization.XmlAttributeAttribute()]
+        public string AbsolutePrefixSOLibSearchPath;
         
         /// <remarks/>
         [System.Xml.Serialization.XmlAttributeAttribute()]

--- a/src/MICoreUnitTests/AndroidLauncherTests.cs
+++ b/src/MICoreUnitTests/AndroidLauncherTests.cs
@@ -33,6 +33,7 @@ namespace MICoreUnitTests
             Assert.Equal(options.TargetArchitecture, MICore.TargetArchitecture.ARM);
             Assert.Equal(options.IntermediateDirectory, temp);
             Assert.Equal(options.AdditionalSOLibSearchPath, "c:\\example\\bin\\debug;c:\\someotherdir\\bin\\debug");
+            Assert.Equal(options.AbsolutePrefixSOLibSearchPath, "\"\"");
             Assert.Equal(options.DeviceId, "default");
             Assert.False(options.IsAttach);
         }
@@ -109,6 +110,7 @@ namespace MICoreUnitTests
             Assert.Equal(options.TargetArchitecture, MICore.TargetArchitecture.ARM);
             Assert.Equal(options.IntermediateDirectory, temp);
             Assert.Equal(options.AdditionalSOLibSearchPath, "c:\\example\\bin\\debug;c:\\someotherdir\\bin\\debug");
+            Assert.Equal(options.AbsolutePrefixSOLibSearchPath, "\"\"");
             Assert.Equal(options.DeviceId, "default");
             Assert.Equal(options.IsAttach, true);
         }

--- a/src/MICoreUnitTests/BasicLaunchOptionsTests.cs
+++ b/src/MICoreUnitTests/BasicLaunchOptionsTests.cs
@@ -33,6 +33,7 @@ namespace MICoreUnitTests
             Assert.Equal(options.ExePath, fakeFilePath);
             Assert.Equal(options.TargetArchitecture, TargetArchitecture.ARM);
             Assert.True(string.IsNullOrEmpty(options.AdditionalSOLibSearchPath));
+            Assert.True(string.IsNullOrEmpty(options.AbsolutePrefixSOLibSearchPath));
             Assert.Equal(options.DebuggerMIMode, MIMode.Gdb);
             Assert.Equal(options.LaunchCompleteCommand, LaunchCompleteCommand.ExecRun);
             Assert.Null(options.CustomLaunchSetupCommands);
@@ -67,6 +68,7 @@ namespace MICoreUnitTests
             Assert.Equal(options.ExePath, fakeFilePath);
             Assert.Equal(options.TargetArchitecture, TargetArchitecture.ARM);
             Assert.True(string.IsNullOrEmpty(options.AdditionalSOLibSearchPath));
+            Assert.True(string.IsNullOrEmpty(options.AbsolutePrefixSOLibSearchPath));
             Assert.Equal(options.DebuggerMIMode, MIMode.Clrdbg);
             Assert.Equal(options.LaunchCompleteCommand, LaunchCompleteCommand.ExecRun);
             Assert.True(options.CustomLaunchSetupCommands != null && options.CustomLaunchSetupCommands.Count == 0);
@@ -127,6 +129,7 @@ namespace MICoreUnitTests
             Assert.Equal(options.ExeArguments, "arg1 arg2");
             Assert.Equal(options.TargetArchitecture, TargetArchitecture.X64);
             Assert.True(string.IsNullOrEmpty(options.AdditionalSOLibSearchPath));
+            Assert.True(string.IsNullOrEmpty(options.AbsolutePrefixSOLibSearchPath));
             Assert.Equal(options.DebuggerMIMode, MIMode.Gdb);
             Assert.Equal(options.LaunchCompleteCommand, LaunchCompleteCommand.ExecRun);
             Assert.True(options.CustomLaunchSetupCommands == null);
@@ -149,6 +152,7 @@ namespace MICoreUnitTests
                 "PipePath=\"", fakeFilePath, "\"\n",
                 "ExePath=\"/home/user/myname/foo\"\n",
                 "TargetArchitecture=\"x86_64\"\n",
+                "AbsolutePrefixSOLibSearchPath='/system/bin'\n",
                 "AdditionalSOLibSearchPath='/a/b/c;/a/b/c'\n",
                 "MIMode='lldb'\n",
                 ">\n",
@@ -165,6 +169,7 @@ namespace MICoreUnitTests
             Assert.Equal(options.PipePath, fakeFilePath);
             Assert.Equal(options.ExePath, "/home/user/myname/foo");
             Assert.Equal(options.TargetArchitecture, TargetArchitecture.X64);
+            Assert.Equal(options.AbsolutePrefixSOLibSearchPath, "/system/bin");
             string[] searchPaths = options.GetSOLibSearchPath().ToArray();
             Assert.Equal(searchPaths.Length, 2);
             Assert.Equal(searchPaths[0], "/home/user/myname");

--- a/src/MIDebugEngine/Engine.Impl/DebuggedProcess.cs
+++ b/src/MIDebugEngine/Engine.Impl/DebuggedProcess.cs
@@ -484,6 +484,13 @@ namespace Microsoft.MIDebugEngine
 
             commands.AddRange(_launchOptions.SetupCommands);
 
+            // If the absolute prefix so path has not been specified, then don't set it to null
+            // because the debugger might already have a default.
+            if (!string.IsNullOrEmpty(_launchOptions.AbsolutePrefixSOLibSearchPath))
+            {
+                commands.Add(new LaunchCommand("-gdb-set solib-absolute-prefix " + _launchOptions.AbsolutePrefixSOLibSearchPath));
+            }
+
             // On Windows ';' appears to correctly works as a path seperator and from the documentation, it is ':' on unix
             string pathEntrySeperator = _launchOptions.UseUnixSymbolPaths ? ":" : ";";
             string escappedSearchPath = string.Join(pathEntrySeperator, _launchOptions.GetSOLibSearchPath().Select(path => EscapePath(path, ignoreSpaces: true)));


### PR DESCRIPTION
The new version of gdb included in the new Android NDK (>=r11) has a couple of changes that MIEngine didn't account for:

- `sysroot` (aka `solib-absolute-prefix`) is now being set to `target:` by default. Previous versions had it set to `""`, which this change explicitly does for Android debugging sessions.
- the default ABI is now being set to `Cygwin`. Previous versions had it set to `GNU/Linux`, which this change explicitly does for Android debugging sessions.

I tested these changes with NDK r11c and r10e, as well as ARM, ARM64 and x86.

@gregg-miskelly @chuckries @jacdavis 