### PR TITLE
Enable Microbuild.Core on relevant projects for Microbuild v2.

### DIFF
--- a/build/miengine.settings.targets
+++ b/build/miengine.settings.targets
@@ -31,6 +31,7 @@
     <DropConfigurationName Condition="'$(Configuration)' == 'Lab.Debug'">Debug</DropConfigurationName>
     <DropConfigurationName Condition="'$(Configuration)' == 'Lab.Release'">Release</DropConfigurationName>
     <DropRootDir Condition="'$(TF_BUILD_BINARIESDIRECTORY)'!=''">$(TF_BUILD_BINARIESDIRECTORY)\$(DropConfigurationName)</DropRootDir>
+    <DropRootDir Condition="'$(BUILD_BINARIESDIRECTORY)'!=''">$(BUILD_BINARIESDIRECTORY)\$(DropConfigurationName)</DropRootDir>
     <DropRootDir Condition="'$(DropRootDir)'==''">$(MIEngineRoot)bin\$(DropConfigurationName)\drop</DropRootDir>
   </PropertyGroup>
    

--- a/src/DebugEngineHost.Stub/project.json
+++ b/src/DebugEngineHost.Stub/project.json
@@ -4,6 +4,7 @@
     "dnxcore50.app": {}
   },
   "dependencies": {
+    "MicroBuild.Core": "0.2.0",
     "Microsoft.NETCore": "5.0.0",
     "Microsoft.NETCore.Portable.Compatibility": "1.0.0",
     "Microsoft.VisualStudio.Debugger.Interop.Portable": "1.0.1"

--- a/src/MICore/project.json
+++ b/src/MICore/project.json
@@ -4,6 +4,7 @@
     "dnxcore50.app": {}
   },
   "dependencies": {
+    "MicroBuild.Core": "0.2.0",
     "Microsoft.NETCore": "5.0.0",
     "Microsoft.NETCore.Portable.Compatibility": "1.0.0",
     "System.Diagnostics.Process": "4.0.0-beta-23225",

--- a/src/MIDebugEngine/project.json
+++ b/src/MIDebugEngine/project.json
@@ -4,6 +4,7 @@
     "dnxcore50.app": {}
   },
   "dependencies": {
+    "MicroBuild.Core": "0.2.0",
     "Microsoft.NETCore": "5.0.0",
     "Microsoft.NETCore.Portable.Compatibility": "1.0.0",
     "Microsoft.VisualStudio.Debugger.Interop.Portable": "1.0.1"

--- a/src/MIDebugPackage/MIDebugPackage.csproj
+++ b/src/MIDebugPackage/MIDebugPackage.csproj
@@ -1,5 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003" ToolsVersion="14.0">
+  <Import Project="..\packages\MicroBuild.Core.0.2.0\build\MicroBuild.Core.props" Condition="Exists('..\packages\MicroBuild.Core.0.2.0\build\MicroBuild.Core.props')" />
   <Import Project="..\..\build\miengine.settings.targets" />
   <PropertyGroup>
     <MinimumVisualStudioVersion>14.0</MinimumVisualStudioVersion>
@@ -139,6 +140,7 @@
     </EmbeddedResource>
   </ItemGroup>
   <ItemGroup>
+    <None Include="packages.config" />
     <None Include="source.extension.vsixmanifest">
       <SubType>Designer</SubType>
     </None>
@@ -166,25 +168,6 @@
     </Content>
   </ItemGroup>
   <ItemGroup>
-    <DropUnsignedFile Include="$(OutDir)\Microsoft.Android.natvis" />
-    <DropSignedFile Include="$(OutDir)\Microsoft.AndroidDebugLauncher.dll" />
-    <DropUnsignedFile Include="$(OutDir)\Microsoft.AndroidDebugLauncher.pdb" />
-    <DropUnsignedFile Include="$(OutDir)\Microsoft.AndroidDebugLauncher.pkgdef" />
-    <DropSignedFile Include="$(OutDir)\Microsoft.IOSDebugLauncher.dll" />
-    <DropUnsignedFile Include="$(OutDir)\Microsoft.IOSDebugLauncher.pdb" />
-    <DropUnsignedFile Include="$(OutDir)\Microsoft.IOSDebugLauncher.pkgdef" />
-    <DropSignedFile Include="$(OutDir)\Microsoft.JDbg.dll" />
-    <DropUnsignedFile Include="$(OutDir)\Microsoft.JDbg.pdb" />
-    <DropSignedFile Include="$(OutDir)\Microsoft.MICore.dll" />
-    <DropUnsignedFile Include="$(OutDir)\Microsoft.MICore.pdb" />
-    <DropSignedFile Include="$(OutDir)\Microsoft.MIDebugEngine.dll" />
-    <DropUnsignedFile Include="$(OutDir)\Microsoft.MIDebugEngine.pdb" />
-    <DropUnsignedFile Include="$(OutDir)\Microsoft.MIDebugEngine.pkgdef" />
-    <DropSignedFile Include="$(OutDir)\Microsoft.MIDebugPackage.dll" />
-    <DropUnsignedFile Include="$(OutDir)\Microsoft.MIDebugPackage.pdb" />
-    <DropUnsignedFile Include="$(OutDir)\Microsoft.MIDebugPackage.pkgdef" />
-    <DropSignedFile Include="$(OutDir)\Microsoft.DebugEngineHost.dll" />
-    <DropUnsignedFile Include="$(OutDir)\Microsoft.DebugEngineHost.pdb" />
     <DropUnsignedFile Include="Install.cmd" />
     <DropUnsignedFile Include="$(OutDir)\Microsoft.Android.natvis" />
     <DropSignedFile Include="$(OutDir)\Microsoft.AndroidDebugLauncher.dll" />
@@ -245,12 +228,19 @@
   <Import Project="..\..\build\DropFiles.targets" />
   <Import Project="..\..\build\PackageNuGet.targets" />
   <Import Project="$(VSToolsPath)\VSSDK\Microsoft.VsSDK.targets" Condition="'$(VSToolsPath)' != ''" />
+  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
+    <PropertyGroup>
+      <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
+    </PropertyGroup>
+    <Error Condition="!Exists('..\packages\MicroBuild.Core.0.2.0\build\MicroBuild.Core.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\MicroBuild.Core.0.2.0\build\MicroBuild.Core.props'))" />
+    <Error Condition="!Exists('..\packages\MicroBuild.Core.0.2.0\build\MicroBuild.Core.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\MicroBuild.Core.0.2.0\build\MicroBuild.Core.targets'))" />
+  </Target>
+  <Import Project="..\packages\MicroBuild.Core.0.2.0\build\MicroBuild.Core.targets" Condition="Exists('..\packages\MicroBuild.Core.0.2.0\build\MicroBuild.Core.targets')" />
   <!--
   Target to drop the built files into a directory.
   For the official build, we need to drop files to the build share
   For normal builds, we drop files to <enlistment-root>\bin\debug\drop for easy sharing
   -->
-  
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">

--- a/src/MIDebugPackage/packages.config
+++ b/src/MIDebugPackage/packages.config
@@ -1,0 +1,4 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="MicroBuild.Core" version="0.2.0" targetFramework="net46" />
+</packages>


### PR DESCRIPTION
@wiktork @jacdavis @gregg-miskelly @chuckries 

Updated pull requests to add Microbuild.Core to allow the plugins to run as part of Microbuild v2. also removed duplicate signing lines (was getting a warning when it was running that it was duplicated).