### PR TITLE
Fix glass tests for NDK r11c and fix androidtest.cmd

### DIFF
--- a/test/Android/Locals/TestScript.xml
+++ b/test/Android/Locals/TestScript.xml
@@ -265,11 +265,11 @@
     <LocalType>DerivedClass *</LocalType>
     <LocalIsExpandable>True</LocalIsExpandable>
     <Local>escaped</Local>
-    <LocalValue RegEx="0x[a-f0-9]{8} &lt;.L.str1&gt; &quot;Hello\\n\tWorld!\\n&quot;">0xa1b7fc26 &lt;.L.str1&gt; "Hello\n	World!\n"</LocalValue>
+    <LocalValue RegEx="0x[a-f0-9]{8} &lt;.L.str.?1&gt; &quot;Hello\\n(\\t|\t)World!\\n&quot;">0xa1b7fc26 &lt;.L.str.1&gt; "Hello\n\tWorld!\n"</LocalValue>
     <LocalType>char *</LocalType>
     <LocalIsExpandable>True</LocalIsExpandable>
     <Local>const_escaped</Local>
-    <LocalValue RegEx="0x[a-f0-9]{8} &lt;.L.str1&gt; &quot;Hello\\n\tWorld!\\n&quot;">0xa1b7fc26 &lt;.L.str1&gt; "Hello\n	World!\n"</LocalValue>
+    <LocalValue RegEx="0x[a-f0-9]{8} &lt;.L.str.?1&gt; &quot;Hello\\n(\\t|\t)World!\\n&quot;">0xa1b7fc26 &lt;.L.str.1&gt; "Hello\n\tWorld!\n"</LocalValue>
     <LocalType>const char *</LocalType>
     <LocalIsExpandable>True</LocalIsExpandable>
     <Local>state</Local>
@@ -339,11 +339,11 @@
     <LocalType>DerivedClass *</LocalType>
     <LocalIsExpandable>True</LocalIsExpandable>
     <Local>escaped</Local>
-    <LocalValue RegEx="0x[a-f0-9]{8} &lt;.L.str1&gt; &quot;Hello\\n\tWorld!\\n&quot;">0xa1b7fc26 &lt;.L.str1&gt; "Hello\n	World!\n"</LocalValue>
+    <LocalValue RegEx="0x[a-f0-9]{8} &lt;.L.str.?1&gt; &quot;Hello\\n(\\t|\t)World!\\n&quot;">0xa1b7fc26 &lt;.L.str.1&gt; "Hello\n\tWorld!\n"</LocalValue>
     <LocalType>char *</LocalType>
     <LocalIsExpandable>True</LocalIsExpandable>
     <Local>const_escaped</Local>
-    <LocalValue RegEx="0x[a-f0-9]{8} &lt;.L.str1&gt; &quot;Hello\\n\tWorld!\\n&quot;">0xa1b7fc26 &lt;.L.str1&gt; "Hello\n	World!\n"</LocalValue>
+    <LocalValue RegEx="0x[a-f0-9]{8} &lt;.L.str.?1&gt; &quot;Hello\\n(\\t|\t)World!\\n&quot;">0xa1b7fc26 &lt;.L.str.1&gt; "Hello\n\tWorld!\n"</LocalValue>
     <LocalType>const char *</LocalType>
     <LocalIsExpandable>True</LocalIsExpandable>
     <Local>state</Local>

--- a/test/Android/androidtest.cmd
+++ b/test/Android/androidtest.cmd
@@ -15,7 +15,7 @@ if not defined VisualStudioVersion (
 set _DeviceId=
 set _Platform=
 set _SdkRoot=%ProgramFiles(x86)%\Android\android-sdk
-set _NdkRoot=%ProgramData%\Microsoft\AndroidNDK\android-ndk-r10e
+set _NdkRoot=%ProgramData%\Microsoft\AndroidNDK\android-ndk-r11c
 set _LoopCount=
 set _Verbose=
 set _TestsToRun=
@@ -60,36 +60,36 @@ if /i "%~1"=="/Tests"       goto SetTests
 echo ERROR: Unknown argument '%~1'.&exit /b -1
 
 :NextArg
-shift
+shift /1
 goto ArgLoopStart
 
 :SetDeviceId
-shift
+shift /1
 set _DeviceId=%~1
 goto :NextArg
 
 :SetPlatform
-shift
+shift /1
 set _Platform=%~1&
 goto :NextArg
 
 :SetSdkRoot
-shift
+shift /1
 set _SdkRoot=%~1
 goto :NextArg
 
 :SetNdkRoot
-shift
+shift /1
 set _NdkRoot=%~1
 goto :NextArg
 
 :SetLoop
-shift
+shift /1
 set _LoopCount=%~1
 goto :NextArg
 
 :SetTests
-shift
+shift /1
 if "%~1"=="" goto SetTestsDone
 set _TestsToRun="%~1" %_TestsToRun%
 goto SetTests


### PR DESCRIPTION
The new gdb version in the NDK r11c formats the locals slightly different.

androidtest.cmd wouldn't work properly running all tests if any flag was
specified but `/Tests` was not because when using `shift`, the 0th argument was
being discarded, and hence `%~dp0` was changed to a different value than the
script's directory.

@faxue-msft @gregg-miskelly @chuckries