### PR TITLE
Add nuspec file for MDD

### DIFF
--- a/MIEngine.mdd.nuspec
+++ b/MIEngine.mdd.nuspec
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="utf-8"?>
+<package>
+  <metadata>
+    <id>VS.Redist.Debugger.MDD.MIEngine</id>
+    <version>0.0.0.0</version>
+    <authors>VSEng</authors>
+    <owners>VSEng</owners>
+    <requireLicenseAcceptance>false</requireLicenseAcceptance>
+    <description>Package containing VS.Redist.Debugger.MDD.MIEngine artifacts</description>
+    <releaseNotes></releaseNotes>
+    <copyright>Copyright 2016</copyright>
+    <tags></tags>
+  </metadata>
+  <files>
+    <file src="drop\Release\ReferenceAssemblies\*.xml" target="ref\dotnet" />
+    <file src="drop\Release\ReferenceAssemblies\Microsoft.DebugEngineHost.dll" target="ref\dotnet" />
+    <file src="drop\Release\Microsoft.MICore.dll" target="ref\dotnet" />
+    <file src="drop\Release\*" target="Release" exclude="drop\Release\Install.cmd;drop\Release\ReferenceAssemblies" />
+    <file src="drop\Debug\*" target="Debug" exclude="drop\Debug\Install.cmd;drop\Debug\ReferenceAssemblies" />
+    <file src="MicroBuildOutputs\metadata.json" target="" />
+  </files>
+</package>


### PR DESCRIPTION
This is needed for a release with the new process.

This is only used for the internal release process, but I can change the `author`, `owners`, etc. to match that of `MIEngine.clrdbg.nuspec`.

@gregg-miskelly @chuckries 