### PR TITLE
Enable generation of MDB symbols

### DIFF
--- a/build/miengine.targets
+++ b/build/miengine.targets
@@ -8,6 +8,7 @@
   <PropertyGroup>
     <CoreCompileDependsOn>GenerateAssemblyInfoFile;$(CoreCompileDependsOn)</CoreCompileDependsOn>
     <BuildDependsOn Condition="'$(IsCoreClr)' == 'false'">DetermineCompilerBinary;$(BuildDependsOn)</BuildDependsOn>
+    <BuildDependsOn>$(BuildDependsOn);GenerateMonoSymbols</BuildDependsOn>
   </PropertyGroup>
 
   <UsingTask TaskName="GetRuntime" 
@@ -48,7 +49,13 @@
     <Exec Condition="'$(IsCoreClr)' == 'false'" 
           Command="&quot;$(MIEngineRoot)tools/NuGet/NuGet.exe&quot; restore -PackagesDirectory &quot;$(NuGetPackagesDirectory)&quot; &quot;$(ProjectDir)packages.config&quot;" />
   </Target>
-  
+
+  <Target Name="GenerateMonoSymbols"
+          Condition="'$(IsCoreClr)' == 'false' AND '$(IsMonoRuntime)' == 'false' AND '$(ShouldGenerateMonoSymbols)' == 'true'">
+    <!-- If we're building the Desktop config on Windows, run pdb2mdb to generate Mono symbols as well -->
+    <Exec Command="&quot;$(NugetPackagesDirectory)\Mono.Unofficial.pdb2mdb.4.2.3.4\tools\pdb2mdb.exe&quot; &quot;$(TargetPath)&quot;" />
+  </Target>
+
   <Target Name="GlassDirCopy" Condition="'@(GlassDirCopy)' != ''" AfterTargets="Build">
 	<MakeDir Condition="!Exists($(GlassDir))" Directories="$(GlassDir)" />
 	<Copy SourceFiles="@(GlassDirCopy)" DestinationFolder="$(GlassDir)" />

--- a/src/MICore/MICore.csproj
+++ b/src/MICore/MICore.csproj
@@ -20,6 +20,7 @@
     for all its methods, but it is also not a public assembly, and adding XML documentation for all its methods
     would take a fair amount of work.-->
     <NoWarn>$(NoWarn);1591</NoWarn>
+    <ShouldGenerateMonoSymbols>true</ShouldGenerateMonoSymbols>
   </PropertyGroup>
   <PropertyGroup Condition="'$(IsCoreClr)' == 'true'">
     <ProjectTypeGuids>$(ProjectTypeGuids);{786C830F-07A1-408B-BD7F-6EE04809D6DB};</ProjectTypeGuids>

--- a/src/MICore/packages.config
+++ b/src/MICore/packages.config
@@ -8,4 +8,5 @@
   <package id="System.Diagnostics.Process" version="4.0.0-beta-23225" targetFramework="net46" />
   <package id="System.Net.Sockets" version="4.1.0-beta-23225" targetFramework="net46" />
   <package id="System.Runtime.InteropServices.RuntimeInformation" version="4.0.0-beta-23225" targetFramework="net46" />
+  <package id="Mono.Unofficial.pdb2mdb" version="4.2.3.4" />
 </packages>

--- a/src/MIDebugEngine/MIDebugEngine.csproj
+++ b/src/MIDebugEngine/MIDebugEngine.csproj
@@ -15,6 +15,7 @@
     <FileAlignment>512</FileAlignment>
     <ProjectTypeGuids>{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
     <OutputPath>$(MIDefaultOutputPath)</OutputPath>
+    <ShouldGenerateMonoSymbols>true</ShouldGenerateMonoSymbols>
   </PropertyGroup>
   <PropertyGroup Condition="'$(IsCoreClr)' == 'true'">
     <ProjectTypeGuids>$(ProjectTypeGuids);{786C830F-07A1-408B-BD7F-6EE04809D6DB};</ProjectTypeGuids>

--- a/src/MIDebugEngine/packages.config
+++ b/src/MIDebugEngine/packages.config
@@ -1,4 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="Microsoft.VisualStudio.Debugger.Interop.Portable" version="1.0.1" targetFramework="net45" />
+  <package id="Mono.Unofficial.pdb2mdb" version="4.2.3.4" />
 </packages>


### PR DESCRIPTION
When building the Desktop target on Windows, we now invoke Mono's pdb2mdb tool to generate MDB symbols for the binaries we use in VSCode for debugging on Linux / OSX

Reviewers: @jacdavis @gregg-miskelly @chuckries @wiktork 