### PR TITLE
Add DropFile step to copy .mdb files out to the output 'bin' directory

### DIFF
--- a/src/MIDebugPackage/MIDebugPackage.csproj
+++ b/src/MIDebugPackage/MIDebugPackage.csproj
@@ -211,6 +211,10 @@
     <DropUnsignedFile Include="$(OutDir)\Microsoft.DebugEngineHost.pdb" />
     <DropUnsignedFile Include="@(RequiredNetFX46FacadeAssemblies)" />
   </ItemGroup>
+  <ItemGroup Condition="'$(IsCoreCLR)' == 'false'">
+      <DropUnsignedFile Include="$(OutDir)\Microsoft.MICore.dll.mdb" />
+      <DropUnsignedFile Include="$(OutDir)\Microsoft.MIDebugEngine.dll.mdb" />
+  </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\AndroidDebugLauncher\AndroidDebugLauncher.csproj">
       <Project>{e0844bff-2d67-4cb0-8e2a-e9cd888f2eb0}</Project>


### PR DESCRIPTION
@jacdavis @andrewcrawley @wiktork @chuckries @gregg-miskelly  - this change is to make sure we are getting the mdb files also in the out directory. 

Tested locally on Mono and non-Mono builds to make sure it didn't break.