### PR TITLE
Disable detach when using clrdbg

### DIFF
--- a/src/MICore/CommandFactories/MICommandFactory.cs
+++ b/src/MICore/CommandFactories/MICommandFactory.cs
@@ -547,6 +547,11 @@ namespace MICore
 
         abstract public bool AllowCommandsWhileRunning();
 
+        public virtual bool CanDetach()
+        {
+            return true;
+        }
+
         abstract public Task<List<ulong>> StartAddressesForLine(string file, uint line);
 
         /// <summary>

--- a/src/MICore/CommandFactories/clrdbg.cs
+++ b/src/MICore/CommandFactories/clrdbg.cs
@@ -41,6 +41,12 @@ namespace MICore
             return true;
         }
 
+        public override bool CanDetach()
+        {
+            // clrdbg doesn't support detach yet
+            return false;
+        }
+
         public override async Task<bool> SetJustMyCode(bool enabled)
         {
             string command = "-gdb-set just-my-code " + (enabled ? "1" : "0");

--- a/src/MIDebugEngine/AD7.Impl/AD7Engine.cs
+++ b/src/MIDebugEngine/AD7.Impl/AD7Engine.cs
@@ -564,8 +564,8 @@ namespace Microsoft.MIDebugEngine
         // Determines if a debug engine (DE) can detach from the program.
         public int CanDetach()
         {
-            // The sample engine always supports detach
-            return Constants.S_OK;
+            bool canDetach = _debuggedProcess != null && _debuggedProcess.MICommandFactory.CanDetach();
+            return canDetach ? Constants.S_OK : Constants.S_FALSE;
         }
 
         // The debugger calls CauseBreak when the user clicks on the pause button in VS. The debugger should respond by entering


### PR DESCRIPTION
CLRDBG doesn't yet support detach. This checkin changes the MIEngine so that when it is
talking to CLRDBG it will not report that detach is supported.