### PR TITLE
Add error message on launch when no terminal is available

### DIFF
--- a/src/MICore/MICoreResources.Designer.cs
+++ b/src/MICore/MICoreResources.Designer.cs
@@ -239,6 +239,15 @@ namespace MICore {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to No terminal is available to launch the debugger.  Please install Gnome Terminal or XTerm..
+        /// </summary>
+        public static string Error_NoTerminalAvailable_Linux {
+            get {
+                return ResourceManager.GetString("Error_NoTerminalAvailable_Linux", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Commands are only accepted when the process is stopped..
         /// </summary>
         public static string Error_ProcessMustBeStopped {

--- a/src/MICore/MICoreResources.resx
+++ b/src/MICore/MICoreResources.resx
@@ -213,4 +213,7 @@ Error: {1}</value>
   <data name="Error_InvalidMiDebuggerPath" xml:space="preserve">
     <value>The value of miDebuggerPath is invalid</value>
   </data>
+  <data name="Error_NoTerminalAvailable_Linux" xml:space="preserve">
+    <value>No terminal is available to launch the debugger.  Please install Gnome Terminal or XTerm.</value>
+  </data>
 </root>

--- a/src/MICore/Transports/LocalLinuxTransport.cs
+++ b/src/MICore/Transports/LocalLinuxTransport.cs
@@ -105,10 +105,14 @@ namespace MICore
                 terminalCmd = GnomeTerminalPath;
                 bashCommandPrefix = "--title DebuggerTerminal -x";
             }
-            else
+            else if (File.Exists(XTermPath))
             {
                 terminalCmd = XTermPath;
                 bashCommandPrefix = "-title DebuggerTerminal -e";
+            }
+            else
+            {
+                throw new FileNotFoundException(MICoreResources.Error_NoTerminalAvailable_Linux);
             }
 
             // Spin up a new bash shell, cd to the working dir, execute a tty command to get the shell tty and store it


### PR DESCRIPTION
This detects the case where neither of our supported terminals are available and presents a better error message.  Previously, the user would get a gigantic error containing the full commandline and exception text.