### PR TITLE
Determine debugger path from $PATH if not specified

### DIFF
--- a/src/MICore/LaunchOptions.cs
+++ b/src/MICore/LaunchOptions.cs
@@ -211,8 +211,36 @@ namespace MICore
 
         static internal LocalLaunchOptions CreateFromXml(Xml.LaunchOptions.LocalLaunchOptions source)
         {
+            string miDebuggerPath = source.MIDebuggerPath;
+
+            // If no path to the debugger was specified, look for the proper binary in the user's $PATH
+            if (String.IsNullOrEmpty(miDebuggerPath))
+            {
+                string debuggerBinary = null;
+                switch (source.MIMode)
+                {
+                    case Xml.LaunchOptions.MIMode.gdb:
+                        debuggerBinary = "gdb";
+                        break;
+
+                    case Xml.LaunchOptions.MIMode.lldb:
+                        debuggerBinary = "lldb-mi";
+                        break;
+                }
+
+                if (!String.IsNullOrEmpty(debuggerBinary))
+                {
+                    miDebuggerPath = LocalLaunchOptions.ResolveFromPath(debuggerBinary);
+                }
+
+                if (String.IsNullOrEmpty(miDebuggerPath))
+                {
+                    throw new InvalidLaunchOptionsException(MICoreResources.Error_NoMiDebuggerPath);
+                }
+            }
+
             var options = new LocalLaunchOptions(
-                RequireAttribute(source.MIDebuggerPath, "MIDebuggerPath"),
+                RequireAttribute(miDebuggerPath, "MIDebuggerPath"),
                 source.MIDebuggerServerAddress,
                 source.ProcessId,
                 source.Environment);
@@ -226,6 +254,25 @@ namespace MICore
                 throw new InvalidLaunchOptionsException(String.Format(CultureInfo.InvariantCulture, MICoreResources.Error_CannotSpecifyBoth, nameof(source.CoreDumpPath), nameof(source.ProcessId)));
 
             return options;
+        }
+
+        private static string ResolveFromPath(string command)
+        {
+            string pathVar = System.Environment.GetEnvironmentVariable("PATH");
+
+            // Check each portion of the PATH environment variable to see if it contains the requested file
+            foreach (string pathPart in pathVar.Split(Path.PathSeparator))
+            {
+                string candidate = Path.Combine(pathPart, command);
+
+                // If the file exists, use it
+                if (File.Exists(candidate))
+                {
+                    return candidate;
+                }
+            }
+
+            return null;
         }
 
         /// <summary>

--- a/src/MICore/MICoreResources.Designer.cs
+++ b/src/MICore/MICoreResources.Designer.cs
@@ -230,6 +230,15 @@ namespace MICore {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Unable to determine path to debugger.  Please specify the &quot;MIDebuggerPath&quot; option..
+        /// </summary>
+        public static string Error_NoMiDebuggerPath {
+            get {
+                return ResourceManager.GetString("Error_NoMiDebuggerPath", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Unable to execute command. The MIEngine is not currently debugging any process..
         /// </summary>
         public static string Error_NoMIDebuggerProcess {

--- a/src/MICore/MICoreResources.resx
+++ b/src/MICore/MICoreResources.resx
@@ -216,4 +216,7 @@ Error: {1}</value>
   <data name="Error_NoTerminalAvailable_Linux" xml:space="preserve">
     <value>No terminal is available to launch the debugger.  Please install Gnome Terminal or XTerm.</value>
   </data>
+  <data name="Error_NoMiDebuggerPath" xml:space="preserve">
+    <value>Unable to determine path to debugger.  Please specify the "MIDebuggerPath" option.</value>
+  </data>
 </root>

--- a/src/MICore/Transports/LocalTransport.cs
+++ b/src/MICore/Transports/LocalTransport.cs
@@ -19,9 +19,34 @@ namespace MICore
         {
         }
 
+        private bool IsValidMiDebuggerPath(string debuggerPath)
+        {
+            if (!File.Exists(debuggerPath))
+            {
+                return false;
+            }
+            else
+            {
+                // Verify the target is a file and not a directory
+                FileAttributes attr = File.GetAttributes(debuggerPath);
+                if ((attr & FileAttributes.Directory) != 0)
+                {
+                    return false;
+                }
+            }
+
+            return true;
+        }
+
         public override void InitStreams(LaunchOptions options, out StreamReader reader, out StreamWriter writer)
         {
             LocalLaunchOptions localOptions = (LocalLaunchOptions)options;
+
+            if (!this.IsValidMiDebuggerPath(localOptions.MIDebuggerPath))
+            {
+                throw new Exception(MICoreResources.Error_InvalidMiDebuggerPath);
+            }
+
             string miDebuggerDir = System.IO.Path.GetDirectoryName(localOptions.MIDebuggerPath);
 
             Process proc = new Process();


### PR DESCRIPTION
If the "miDebuggerPath" is omitted from the launch options, we will now attempt to determine the correct path based on the "MIMode" option and the user's $PATH.  "miDebuggerPath" can still be specified to override the path if necessary.

This change also adds some additional path checking to the LocalTransport, so we get better error messages on OSX if the path is invalid.

Please review: @jacdavis @gregg-miskelly @chuckries @paulmaybee 