### PR TITLE
Add null check in case thread is null;

### DIFF
--- a/src/MIDebugEngine/AD7.Impl/AD7Engine.cs
+++ b/src/MIDebugEngine/AD7.Impl/AD7Engine.cs
@@ -170,7 +170,7 @@ namespace Microsoft.MIDebugEngine
             {
                 return e.HResult;
             }
-            catch (Exception e) when (ExceptionHelper.BeforeCatch(e, Logger, reportOnlyCorrupting:true))
+            catch (Exception e) when (ExceptionHelper.BeforeCatch(e, Logger, reportOnlyCorrupting: true))
             {
                 return EngineUtils.UnexpectedException(e);
             }
@@ -769,6 +769,11 @@ namespace Microsoft.MIDebugEngine
 
             try
             {
+                if (null == thread || null == thread.GetDebuggedThread())
+                {
+                    return Constants.E_FAIL;
+                }
+
                 _debuggedProcess.WorkerThread.RunOperation(() => _debuggedProcess.Step(thread.GetDebuggedThread().Id, kind, unit));
             }
             catch (InvalidCoreDumpOperationException)


### PR DESCRIPTION
In some instances, if a user steps over on the last line of main, it can throw a NullReferenceException in the Step method. The only place I can see this happening was either thread or the _debuggedthread being null.

Added checks that will return E_FAIL if it is null. 

@jacdavis @chuckries @gregg-miskelly