### PR TITLE
Use '-gdb-set new-console' on Windows

### DIFF
--- a/src/MIDebugEngine/Engine.Impl/DebuggedProcess.cs
+++ b/src/MIDebugEngine/Engine.Impl/DebuggedProcess.cs
@@ -587,13 +587,11 @@ namespace Microsoft.MIDebugEngine
                         commands.Add(new LaunchCommand("-environment-cd " + escappedDir));
                     }
 
-                    // On Windows, with CLRDBG, if we should launch a new console, set the TTY
                     if (localLaunchOptions != null &&
-                        this.MICommandFactory.Mode == MIMode.Clrdbg &&
                         PlatformUtilities.IsWindows() &&
                         this.MICommandFactory.UseExternalConsoleForLocalLaunch(localLaunchOptions))
                     {
-                        commands.Add(new LaunchCommand("-inferior-tty-set <new-console>"));
+                        commands.Add(new LaunchCommand("-gdb-set new-console on", ignoreFailures:true));
                     }
 
                     // Send client version to clrdbg to set the capabilities appropriately


### PR DESCRIPTION
On Windows, GDB has an option to launch using a new console. CLRDBG was changed to use the same syntax. This changes the MIEngine to use this syntax, and I removed the 'if clrdbg' check.

Note that I don't believe that LLDB supports this option yet. But this shouldn't blow up as we are ignoring failures.