### PR TITLE
Support Detach.

### DIFF
--- a/src/MICore/Debugger.cs
+++ b/src/MICore/Debugger.cs
@@ -175,7 +175,7 @@ namespace MICore
         {
             string reason = results.TryFindString("reason");
 
-            if (reason.StartsWith("exited"))
+            if (reason.StartsWith("exited") || reason.StartsWith("disconnected"))
             {
                 if (this.ProcessState != ProcessState.Exited)
                 {

--- a/src/MIDebugEngine/AD7.Impl/AD7Engine.cs
+++ b/src/MIDebugEngine/AD7.Impl/AD7Engine.cs
@@ -611,7 +611,7 @@ namespace Microsoft.MIDebugEngine
             _breakpointManager.ClearBoundBreakpoints();
 
             _pollThread.RunOperation(() => _debuggedProcess.CmdDetach());
-
+            _debuggedProcess.Detach();
             return Constants.S_OK;
         }
 

--- a/src/MIDebugEngine/Engine.Impl/DebuggedProcess.cs
+++ b/src/MIDebugEngine/Engine.Impl/DebuggedProcess.cs
@@ -1169,8 +1169,13 @@ namespace Microsoft.MIDebugEngine
 
         public void Detach()
         {
-            // Fake stopped message to send ProgramDestroyEvent.
-            ScheduleStdOutProcessing(@"*stopped,reason=""disconnected""");
+            // Special casing sending the fake stopped event for clrdbg. 
+            // GDB prints out thread group exit events on mi command "-target-detach" which is handed by method HandleThreadGroupExited
+            // GDB or the debuggee can terminate and those are handled by Terminate and TerminateProcess methods.
+            if (MICommandFactory.Mode != MIMode.Clrdbg)
+            {
+                ScheduleStdOutProcessing(@"*stopped,reason=""disconnected""");
+            }
         }
 
         public DebuggedModule[] GetModules()

--- a/src/MIDebugEngine/Engine.Impl/DebuggedProcess.cs
+++ b/src/MIDebugEngine/Engine.Impl/DebuggedProcess.cs
@@ -1167,7 +1167,12 @@ namespace Microsoft.MIDebugEngine
             ScheduleStdOutProcessing(@"*stopped,reason=""exited"",exit-code=""42""");
         }
 
-        public void Detach() { }
+        public void Detach()
+        {
+            // Fake stopped message to send ProgramDestroyEvent.
+            ScheduleStdOutProcessing(@"*stopped,reason=""disconnected""");
+        }
+
         public DebuggedModule[] GetModules()
         {
             lock (_moduleList)


### PR DESCRIPTION
Sending "stopped" message with reason as "disconnected" to avoid the confusion.