### PR TITLE
Add osxlaunchhelper.scpt to the CLRDBG MIEngine package

### DIFF
--- a/MIEngine.clrdbg.nuspec
+++ b/MIEngine.clrdbg.nuspec
@@ -17,5 +17,6 @@
     <file src="Microsoft.MICore.dll" target="lib\dnxcore50\Microsoft.MICore.dll" />
     <file src="Microsoft.MIDebugEngine.dll" target="lib\dnxcore50\Microsoft.MIDebugEngine.dll" />
     <file src="coreclr.ad7Engine.json" target="contentFiles\any\any" />
+    <file src="osxlaunchhelper.scpt" target="contentFiles\any\any" />
   </files>
 </package>

--- a/tools/InstallToVSCode/InstallToVSCode.sh
+++ b/tools/InstallToVSCode/InstallToVSCode.sh
@@ -265,6 +265,7 @@ for directory in $(ls -d $CLRDBGBITSDIR/*/); do
 done
 
 install_file "$script_dir/coreclr/coreclr.ad7Engine.json"
+install_file "$DropDir/osxlaunchhelper.scpt"
 
 for dll in Microsoft.MICore.dll Microsoft.MIDebugEngine.dll
 do 


### PR DESCRIPTION
This checkin adds osxlaunchhelper.scpt to the MIEngine package. With this I
was able to see the 'externalConsole' option work correctly on OSX.