### PR TITLE
Fix gdb exit race condition

### DIFF
--- a/src/MICore/Debugger.cs
+++ b/src/MICore/Debugger.cs
@@ -55,22 +55,6 @@ namespace MICore
             }
         }
 
-        public bool IsDebuggerRunning
-        {
-            get
-            {
-                if (_localDebuggerPid > 0)
-                {
-                    if (PlatformUtilities.IsLinux() || PlatformUtilities.IsOSX())
-                    {
-                        return UnixNativeMethods.Kill(_localDebuggerPid, 0) == 0;
-                    }
-                }
-
-                return false;
-            }
-        }
-
         public uint MaxInstructionSize { get; private set; }
         public bool Is64BitArch { get; private set; }
         public CommandLock CommandLock { get { return _commandLock; } }
@@ -86,9 +70,9 @@ namespace MICore
         private TaskCompletionSource<object> _consoleDebuggerInitializeCompletionSource = new TaskCompletionSource<object>();
         private LinkedList<string> _initializationLog = new LinkedList<string>();
         private LinkedList<string> _initialErrors = new LinkedList<string>();
+        private int _localDebuggerPid = -1;
 
         protected bool _connected;
-        protected int _localDebuggerPid = -1;
 
         public class ResultEventArgs : EventArgs
         {
@@ -137,6 +121,32 @@ namespace MICore
             _debuggeePids = new Dictionary<string, int>();
             Logger = logger;
             _miResults = new MIResults(logger);
+        }
+
+        protected void SetDebuggerPid(int debuggerPid)
+        {
+            _localDebuggerPid = debuggerPid;
+        }
+
+        /// <summary>
+        /// Check if the local debugger process is running.
+        /// For Windows, it returns False always to avoid shortcuts taken when it returns True.
+        /// </summary>
+        /// <returns>True if the local debugger process is running and the platform is Linux or OS X.
+        /// False otherwise.</returns>
+        private bool IsUnixDebuggerRunning()
+        {
+            if (_localDebuggerPid > 0)
+            {
+                if (PlatformUtilities.IsLinux() || PlatformUtilities.IsOSX())
+                {
+                    // When 0 is passed as the signal to send in kill,
+                    // it will check the validity of the pid (e.g., does the pid exist?)
+                    return UnixNativeMethods.Kill(_localDebuggerPid, 0) == 0;
+                }
+            }
+
+            return false;
         }
 
         private void RetryBreak(object o)
@@ -1193,7 +1203,7 @@ namespace MICore
             {
                 ScheduleStdOutProcessing(@"*stopped,reason=""exited""");
 
-                if (!IsDebuggerRunning)
+                if (!IsUnixDebuggerRunning())
                 {
                     // Processing the fake "stopped" event sent above will normally cause the debugger to close, but if
                     // the debugger process is already gone (e.g. because the terminal window was closed), we won't get

--- a/src/MICore/Transports/ClientServerTransport.cs
+++ b/src/MICore/Transports/ClientServerTransport.cs
@@ -53,6 +53,14 @@ namespace MICore
 
         public bool IsClosed { get { return _clientTransport.IsClosed; } }
 
+        public int DebuggerPid
+        {
+            get
+            {
+                return _clientTransport.DebuggerPid;
+            }
+        }
+
         public void Send(string cmd)
         {
             _clientTransport.Send(cmd);

--- a/src/MICore/Transports/ITransport.cs
+++ b/src/MICore/Transports/ITransport.cs
@@ -16,6 +16,12 @@ namespace MICore
         void Send(string cmd);
         void Close();
         bool IsClosed { get; }
+
+        /// <summary>
+        /// It is used to know whether to fake a response from the debugger
+        /// acknowledging that it has exited
+        /// </summary>
+        int DebuggerPid { get; }
     }
     public interface ISignalingTransport: ITransport
     {

--- a/src/MICore/Transports/ITransport.cs
+++ b/src/MICore/Transports/ITransport.cs
@@ -18,8 +18,11 @@ namespace MICore
         bool IsClosed { get; }
 
         /// <summary>
+        /// Process ID of the debugger process (clrdbg/lldb/gdb).
+        /// This value is only valid when using local launch options. When using non-local
+        /// options this may throw (e.g., TcpTransport) or provide bogus data (e.g., PipeTransport).
         /// It is used to know whether to fake a response from the debugger
-        /// acknowledging that it has exited
+        /// acknowledging that it has exited.
         /// </summary>
         int DebuggerPid { get; }
     }

--- a/src/MICore/Transports/MockTransport.cs
+++ b/src/MICore/Transports/MockTransport.cs
@@ -62,6 +62,11 @@ namespace MICore
 
         public bool IsClosed { get { return _bQuit; } }
 
+        public int DebuggerPid
+        {
+            get { throw new NotImplementedException(); }
+        }
+
         private void TransportLoop()
         {
             _lineNumber = 0;

--- a/src/MICore/Transports/PipeTransport.cs
+++ b/src/MICore/Transports/PipeTransport.cs
@@ -36,6 +36,10 @@ namespace MICore
             return "MI.PipeTransport";
         }
 
+        /// <summary>
+        /// The value of this property reflects the pid for the debugger running
+        /// locally.
+        /// </summary>
         public override int DebuggerPid
         {
             get

--- a/src/MICore/Transports/PipeTransport.cs
+++ b/src/MICore/Transports/PipeTransport.cs
@@ -23,6 +23,7 @@ namespace MICore
         private ManualResetEvent _allReadersDone = new ManualResetEvent(false);
         private bool _killOnClose;
         private bool _filterStderr;
+        private int _debuggerPid = -1;
 
         public PipeTransport(bool killOnClose = false, bool filterStderr = false, bool filterStdout = false) : base(filterStdout)
         {
@@ -33,6 +34,14 @@ namespace MICore
         protected override string GetThreadName()
         {
             return "MI.PipeTransport";
+        }
+
+        public override int DebuggerPid
+        {
+            get
+            {
+                return _debuggerPid;
+            }
         }
 
         protected virtual void InitProcess(Process proc, out StreamReader stdout, out StreamWriter stdin)
@@ -53,6 +62,7 @@ namespace MICore
                 this.Callback.AppendToInitializationLog(string.Format(CultureInfo.InvariantCulture, "Starting: \"{0}\" {1}", _process.StartInfo.FileName, _process.StartInfo.Arguments));
                 _process.Start();
 
+                _debuggerPid = _process.Id;
                 stdout = _process.StandardOutput;
                 stdin = _process.StandardInput;
                 _stdErrReader = _process.StandardError;

--- a/src/MICore/Transports/StreamTransport.cs
+++ b/src/MICore/Transports/StreamTransport.cs
@@ -194,10 +194,7 @@ namespace MICore
             get { return _bQuit; }
         }
 
-        public virtual int DebuggerPid
-        {
-            get { throw new NotImplementedException(); }
-        }
+        public abstract int DebuggerPid { get; }
 
         protected ITransportCallback Callback
         {

--- a/src/MICore/Transports/TcpTransport.cs
+++ b/src/MICore/Transports/TcpTransport.cs
@@ -72,6 +72,13 @@ namespace MICore
             }
         }
 
+        public override int DebuggerPid {
+            get
+            {
+                throw new NotImplementedException();
+            }
+        }
+
         public override void Close()
         {
             base.Close();

--- a/src/MICore/UnixUtilities.cs
+++ b/src/MICore/UnixUtilities.cs
@@ -46,8 +46,10 @@ namespace MICore
             return string.Format(CultureInfo.InvariantCulture,
                "cd {0}; " +
                "DbgTerm=`tty`; " +
-               "trap 'echo {1} > {2}; rm {2}; rm {3}; rm {4}; rm {5}' EXIT; " +
+               "trap 'echo {1} > {2}; rm {2} {3} {4} {5}' EXIT; " +
                "{6} --interpreter=mi --tty=$DbgTerm < {3} > {4} & " +
+               // Clear the output of executing a process in the background: [job number] pid
+               "clear; " +
                "pid=$! ; " +
                "echo $pid > {5}; " +
                "wait $pid; ",

--- a/src/MICore/UnixUtilities.cs
+++ b/src/MICore/UnixUtilities.cs
@@ -12,8 +12,11 @@ namespace MICore
 {
     public static class UnixUtilities
     {
+        internal const string ExitString = "exit";
         internal const string FifoPrefix = "Microsoft-MIEngine-fifo-";
         internal const string SudoPath = "/usr/bin/sudo";
+        // Mono seems to hang when the is a large response unless we specify a larger buffer here
+        internal const int StreamBufferSize = 1024 * 4;
         private const string PKExecPath = "/usr/bin/pkexec";
 
         // Linux specific
@@ -26,19 +29,36 @@ namespace MICore
         /// signal handler for SIGHUP on the console (executing the two rm commands)
         /// </summary>
         /// <param name="debuggeeDir">Path to the debuggee directory</param>
-        /// <param name="debuggerCmd">Command to the debugger</param>
+        /// <param name="exitFifo">File where the exit event is written to</param>
         /// <param name="dbgStdInName">File where the stdin for the debugger process is redirected to</param>
         /// <param name="dbgStdOutName">File where the stdout for the debugger process is redirected to</param>
+        /// <param name="pidFifo">File where the debugger pid is written to</param>
+        /// <param name="debuggerCmd">Command to the debugger</param>
         /// <returns></returns>
-        internal static string LaunchLocalDebuggerCommand(string debuggeeDir, string debuggerCmd, string dbgStdInName, string dbgStdOutName)
+        internal static string LaunchLocalDebuggerCommand(
+            string debuggeeDir,
+            string exitFifo,
+            string dbgStdInName,
+            string dbgStdOutName,
+            string pidFifo,
+            string debuggerCmd)
         {
-             return string.Format(CultureInfo.InvariantCulture,
-                "cd {0}; DbgTerm=`tty`; trap 'rm {2}; rm {3}' EXIT; {1} --interpreter=mi --tty=$DbgTerm < {2} > {3};",
-                debuggeeDir,
-                debuggerCmd,
-                dbgStdInName,
-                dbgStdOutName
-                );
+            return string.Format(CultureInfo.InvariantCulture,
+               "cd {0}; " +
+               "DbgTerm=`tty`; " +
+               "trap 'echo {1} > {2}; rm {2}; rm {3}; rm {4}; rm {5}' EXIT; " +
+               "{6} --interpreter=mi --tty=$DbgTerm < {3} > {4} & " +
+               "pid=$! ; " +
+               "echo $pid > {5}; " +
+               "wait $pid; ",
+               debuggeeDir,
+               ExitString,
+               exitFifo,
+               dbgStdInName,
+               dbgStdOutName,
+               pidFifo,
+               debuggerCmd
+               );
         }
 
         internal static string GetDebuggerCommand(LocalLaunchOptions localOptions)

--- a/src/MICore/osxlaunchhelper.scpt
+++ b/src/MICore/osxlaunchhelper.scpt
@@ -7,8 +7,7 @@ on run argv
    set debuggerTitle to (item 1 of argv)
    set executeCommand to (item 2 of argv)
    -- Note: if other tabs are open in the terminal window that is opened by this script, this won't behave properly.
-   set command to "clear; " & ¬
-                  executeCommand & ¬
+   set command to executeCommand & ¬
                   "osascript -e 'tell application \"Terminal\" to close (every window whose tty is \"'\"$(tty)\"'\")' & exit"
 
     tell application "Terminal"

--- a/src/MIDebugEngine/Engine.Impl/DebuggedProcess.cs
+++ b/src/MIDebugEngine/Engine.Impl/DebuggedProcess.cs
@@ -209,11 +209,7 @@ namespace Microsoft.MIDebugEngine
                 // Only need to know the debugger pid on Linux and OS X local launch to detect whether
                 // the debugger is closed. If the debugger is not running anymore, the response (^exit)
                 // to the -gdb-exit command is faked to allow MIEngine to shut down.
-                _localDebuggerPid = localTransport.DebuggerPid;
-
-                // We are launching the debugger in the background, so the console will have
-                // "[job number] pid". So we clear that.
-                ResetConsole();
+                SetDebuggerPid(localTransport.DebuggerPid);
             }
             else if (_launchOptions is PipeLaunchOptions)
             {
@@ -307,7 +303,6 @@ namespace Microsoft.MIDebugEngine
 
                     // This is to work around a GDB bug of warning "Failed to set controlling terminal: Operation not permitted"
                     // Reset debuggee terminal after the first module load.
-                    // The clear is done by sending reset string (ESC, c) to terminal STDERR
                     await ResetConsole();
                 }
 
@@ -1650,6 +1645,10 @@ namespace Microsoft.MIDebugEngine
             return addresses;
         }
 
+        /// <summary>
+        /// The clear is done by sending reset string (ESC, c) to terminal STDERR
+        /// </summary>
+        /// <returns></returns>
         private Task<string> ResetConsole()
         {
             return ConsoleCmdAsync(@"shell echo -e \\033c 1>&2");


### PR DESCRIPTION
This PR makes the fake `-gdb-exit` event conditional on whether the debugger has already exited or not. This allows to uncomment the TODO block that used to be in the StreamTransport class for OS X.

I also removed the need for `FileSystemWatchers` by adding another fifo. `FileSystemWatchers` were flaky on OS X.


Verified:

Linux:
Launch:
- Close the terminal window
- Stop execution
- Let the program run to completion

Attach:
- Canceling the pkexec prompt (main use of the `FileSystemWatchers`)
- Dettaching
- Close the terminal window

OS X
Launch:
- Close the terminal window
- Stop execution
- Let the program run to completion

Attach:
- Dettaching
- Close the terminal window
