### PR TITLE
Add support for cygwin on windows

### DIFF
--- a/src/MICore/Debugger.cs
+++ b/src/MICore/Debugger.cs
@@ -63,6 +63,7 @@ namespace MICore
 
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Security", "CA2104:DoNotDeclareReadOnlyMutableReferenceTypes")]
         protected readonly LaunchOptions _launchOptions;
+        public LaunchOptions LaunchOptions { get { return this._launchOptions; } }
 
         private Queue<Func<Task>> _internalBreakActions = new Queue<Func<Task>>();
         private TaskCompletionSource<object> _internalBreakActionCompletionSource;
@@ -574,7 +575,7 @@ namespace MICore
             return outStr.ToString();
         }
 
-        public async Task<string> ConsoleCmdAsync(string cmd)
+        public async Task<string> ConsoleCmdAsync(string cmd, bool ignoreFailures = false)
         {
             if (this.ProcessState != ProcessState.Stopped && this.ProcessState != ProcessState.NotConnected)
             {
@@ -608,7 +609,7 @@ namespace MICore
 
                 try
                 {
-                    await ExclusiveCmdAsync("-interpreter-exec console \"" + Escape(cmd) + "\"", ResultClass.done, lockToken);
+                    await ExclusiveCmdAsync("-interpreter-exec console \"" + Escape(cmd) + "\"", ignoreFailures ? ResultClass.None : ResultClass.done, lockToken);
 
                     return _consoleCommandOutput.ToString();
                 }

--- a/src/MICore/LaunchCommand.cs
+++ b/src/MICore/LaunchCommand.cs
@@ -22,8 +22,9 @@ namespace MICore
         public readonly bool IgnoreFailures;
         public readonly bool IsMICommand;
         public /*OPTIONAL*/ Action<string> FailureHandler { get; private set; }
+        public /*OPTIONAL*/ Action<string> SuccessHandler { get; private set; }
 
-        public LaunchCommand(string commandText, string description = null, bool ignoreFailures = false, Action<string> failureHandler = null)
+        public LaunchCommand(string commandText, string description = null, bool ignoreFailures = false, Action<string> failureHandler = null, Action<string> successHandler = null)
         {
             if (commandText == null)
                 throw new ArgumentNullException("commandText");
@@ -38,6 +39,7 @@ namespace MICore
 
             this.IgnoreFailures = ignoreFailures;
             this.FailureHandler = failureHandler;
+            this.SuccessHandler = successHandler;
         }
 
         public static ReadOnlyCollection<LaunchCommand> CreateCollectionFromXml(Xml.LaunchOptions.Command[] source)

--- a/src/MIDebugEngine/AD7.Impl/AD7DocumentContext.cs
+++ b/src/MIDebugEngine/AD7.Impl/AD7DocumentContext.cs
@@ -15,12 +15,14 @@ namespace Microsoft.MIDebugEngine
     {
         private readonly MITextPosition _textPosition;
         private AD7MemoryAddress _codeContext;
+        private readonly DebuggedProcess _debuggedProcess;
 
 
-        public AD7DocumentContext(MITextPosition textPosition, AD7MemoryAddress codeContext)
+        public AD7DocumentContext(MITextPosition textPosition, AD7MemoryAddress codeContext, DebuggedProcess debuggedProcess)
         {
             _textPosition = textPosition;
             _codeContext = codeContext;
+            _debuggedProcess = debuggedProcess;
         }
 
         #region IDebugDocumentContext2 Members
@@ -102,7 +104,15 @@ namespace Microsoft.MIDebugEngine
         // Gets the displayable name of the document that contains this document context.
         int IDebugDocumentContext2.GetName(enum_GETNAME_TYPE gnType, out string pbstrFileName)
         {
-            pbstrFileName = _textPosition.FileName;
+            if (_debuggedProcess.IsCygwin)
+            {
+                pbstrFileName = _debuggedProcess.CygwinFilePathMapper.MapCygwinToWindows(_textPosition.FileName);
+            }
+            else
+            {
+                pbstrFileName = _textPosition.FileName;
+            }
+            
             return Constants.S_OK;
         }
 

--- a/src/MIDebugEngine/AD7.Impl/AD7Engine.cs
+++ b/src/MIDebugEngine/AD7.Impl/AD7Engine.cs
@@ -643,7 +643,7 @@ namespace Microsoft.MIDebugEngine
                     pos.dwLine = line;
                     pos.dwColumn = 0;
                     MITextPosition textPosition = new MITextPosition(documentName, pos, pos);
-                    codeCxt.SetDocumentContext(new AD7DocumentContext(textPosition, codeCxt));
+                    codeCxt.SetDocumentContext(new AD7DocumentContext(textPosition, codeCxt, this.DebuggedProcess));
                     codeContexts.Add(codeCxt);
                 }
                 if (codeContexts.Count > 0)

--- a/src/MIDebugEngine/AD7.Impl/AD7PendingBreakpoint.cs
+++ b/src/MIDebugEngine/AD7.Impl/AD7PendingBreakpoint.cs
@@ -123,7 +123,7 @@ namespace Microsoft.MIDebugEngine
 
                 AD7MemoryAddress codeContext = new AD7MemoryAddress(_engine, address, functionName);
 
-                return new AD7DocumentContext(new MITextPosition(documentName, startPosition[0], startPosition[0]), codeContext);
+                return new AD7DocumentContext(new MITextPosition(documentName, startPosition[0], startPosition[0]), codeContext, this._engine.DebuggedProcess);
             }
             else
             {

--- a/src/MIDebugEngine/AD7.Impl/AD7StackFrame.cs
+++ b/src/MIDebugEngine/AD7.Impl/AD7StackFrame.cs
@@ -52,7 +52,7 @@ namespace Microsoft.MIDebugEngine
 
             if (_textPosition != null)
             {
-                _documentCxt = new AD7DocumentContext(_textPosition, _codeCxt);
+                _documentCxt = new AD7DocumentContext(_textPosition, _codeCxt, this.Engine.DebuggedProcess);
 
                 if (_codeCxt != null)
                 {

--- a/src/MIDebugEngine/Engine.Impl/Breakpoints.cs
+++ b/src/MIDebugEngine/Engine.Impl/Breakpoints.cs
@@ -399,7 +399,7 @@ namespace Microsoft.MIDebugEngine
                 return _parent.AD7breakpoint.GetDocumentContext(this.Addr, this.FunctionName);
             }
 
-            return new AD7DocumentContext(_textPosition, new AD7MemoryAddress(engine, Addr, this.FunctionName));
+            return new AD7DocumentContext(_textPosition, new AD7MemoryAddress(engine, Addr, this.FunctionName), engine.DebuggedProcess);
         }
 
         /// <summary>

--- a/src/MIDebugEngine/Engine.Impl/CygwinFileMapper.cs
+++ b/src/MIDebugEngine/Engine.Impl/CygwinFileMapper.cs
@@ -1,0 +1,256 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.Runtime.InteropServices;
+using Microsoft.Win32.SafeHandles;
+using System.IO;
+using System.Text;
+using System.Threading.Tasks;
+using MICore;
+
+namespace Microsoft.MIDebugEngine
+{
+    internal class CygwinFilePathMapper
+    {
+        private DebuggedProcess _debuggedProcess;
+        private Dictionary<string, string> _cygwinToWindows;
+
+        public CygwinFilePathMapper(DebuggedProcess debuggedProcess)
+        {
+            this._debuggedProcess = debuggedProcess;
+            this._cygwinToWindows = new Dictionary<string, string>();
+        }
+
+        public string MapCygwinToWindows(string origCygwinPath)
+        {
+            if (!(_debuggedProcess.LaunchOptions is LocalLaunchOptions))
+            {
+                return origCygwinPath;
+            }
+
+            LocalLaunchOptions localLaunchOptions = (LocalLaunchOptions)_debuggedProcess.LaunchOptions;
+
+            string cygwinPath = origCygwinPath.Replace('\\', '/');
+
+            string windowsPath = cygwinPath;
+
+            lock (this._cygwinToWindows)
+            {
+                if (!this._cygwinToWindows.TryGetValue(cygwinPath, out windowsPath))
+                {
+                    if (!LaunchCygPathAndReadResult(cygwinPath, localLaunchOptions.MIDebuggerPath, out windowsPath))
+                    {
+                        return origCygwinPath;
+                    }
+
+                    this._cygwinToWindows.Add(cygwinPath, windowsPath);
+                }
+            }
+
+            return windowsPath;
+        }
+
+        // There is an issue launching Cygwin apps that if a process is launched using a bitness mismatched console,
+        // process launch will fail. To avoid that, launch cygpath with its own console. This requires calling CreateProcess 
+        // directly because the creation flags are not exposed in System.Diagnostics.Process. 
+        //
+        // Return true if successful. False otherwise.
+        private bool LaunchCygPathAndReadResult(string cygwinPath, string miDebuggerPath, out string windowsPath)
+        {
+            windowsPath = "";
+            
+            if (String.IsNullOrEmpty(miDebuggerPath))
+            {
+                return false;
+            }
+
+            string cygpathPath = Path.Combine(Path.GetDirectoryName(miDebuggerPath), "cygpath.exe");
+            if (!File.Exists(cygpathPath))
+            {
+                return false;
+            }
+
+            List<IDisposable> disposableHandles = new List<IDisposable>();
+
+            try
+            {
+                // Create the anonymous pipe that will act as stdout for the cygpath process
+                SECURITY_ATTRIBUTES pPipeSec = new SECURITY_ATTRIBUTES();
+                pPipeSec.bInheritHandle = 1;
+                SafeFileHandle stdoutRead;
+                SafeFileHandle stdoutWrite;
+                if (!CreatePipe(out stdoutRead, out stdoutWrite, ref pPipeSec, 4096))
+                {
+                    Debug.Fail("Unexpected failure CreatePipe in LaunchCygPathAndReadResult");
+                    return false;
+                }
+                SetHandleInformation(stdoutRead, HANDLE_FLAGS.INHERIT, 0);
+                disposableHandles.Add(stdoutRead);
+                disposableHandles.Add(stdoutWrite);
+
+
+                const int STARTF_USESTDHANDLES = 0x00000100;
+                const int STARTF_USESHOWWINDOW = 0x00000001;
+                const int SW_HIDE = 0;
+                STARTUPINFO startupInfo = new STARTUPINFO();
+                startupInfo.dwFlags = STARTF_USESTDHANDLES | STARTF_USESHOWWINDOW;
+                startupInfo.hStdOutput = stdoutWrite;
+                startupInfo.wShowWindow = SW_HIDE;
+                startupInfo.cb = Marshal.SizeOf(startupInfo);
+
+                PROCESS_INFORMATION processInfo = new PROCESS_INFORMATION();
+                SECURITY_ATTRIBUTES processSecurityAttributes = new SECURITY_ATTRIBUTES();
+                SECURITY_ATTRIBUTES threadSecurityAttributes = new SECURITY_ATTRIBUTES();
+
+                processSecurityAttributes.nLength = Marshal.SizeOf(processSecurityAttributes);
+                threadSecurityAttributes.nLength = Marshal.SizeOf(threadSecurityAttributes);
+
+                const uint DETACHED_PROCESS = 0x00000008;
+                uint flags = DETACHED_PROCESS;
+                // ex: "C:\\cygwin64\\bin\\cygpath.exe -w " + cygwinPath, 
+                string command = String.Concat(cygpathPath, " -w ", cygwinPath);
+                if (!CreateProcess(
+                        null,
+                        command,
+                        ref processSecurityAttributes,
+                        ref threadSecurityAttributes,
+                        true,
+                        flags,
+                        IntPtr.Zero,
+                        null,
+                        ref startupInfo,
+                        out processInfo
+                        ))
+                {
+                    Debug.Fail("Launching cygpath for source mapping failed");
+                    return false;
+                }
+                SafeFileHandle processSH = new SafeFileHandle(processInfo.hProcess, true);
+                SafeFileHandle threadSH = new SafeFileHandle(processInfo.hThread, true);
+                disposableHandles.Add(processSH);
+                disposableHandles.Add(threadSH);
+
+                const int timeout = 5000;
+                if (WaitForSingleObject(processInfo.hProcess, timeout) != 0)
+                {
+                    Debug.Fail("cygpath failed to map source file.");
+                    return false;
+                }
+
+                uint exitCode = 0;
+                if (!GetExitCodeProcess(processInfo.hProcess, out exitCode))
+                {
+                    Debug.Fail("cygpath failed to get exit code from cygpath.");
+                    return false;
+                }
+
+                if (exitCode != 0)
+                {
+                    Debug.Fail("cygpath returned error exit code.");
+                    return false;
+                }
+
+                FileStream fs = new FileStream(stdoutRead, FileAccess.Read);
+                StreamReader sr = new StreamReader(fs);
+                windowsPath = sr.ReadLine();
+            }
+            finally
+            {
+                foreach (IDisposable h in disposableHandles)
+                {
+                    h.Dispose();
+                }
+            }
+
+            return true;
+        }
+
+        #region pinvoke definitions
+        [StructLayout(LayoutKind.Sequential, CharSet = CharSet.Unicode)]
+        private struct STARTUPINFO
+        {
+            public Int32 cb;
+            public string lpReserved;
+            public string lpDesktop;
+            public string lpTitle;
+            public Int32 dwX;
+            public Int32 dwY;
+            public Int32 dwXSize;
+            public Int32 dwYSize;
+            public Int32 dwXCountChars;
+            public Int32 dwYCountChars;
+            public Int32 dwFillAttribute;
+            public Int32 dwFlags;
+            public Int16 wShowWindow;
+            public Int16 cbReserved2;
+            public IntPtr lpReserved2;
+            public IntPtr hStdInput;
+            public SafeFileHandle hStdOutput;
+            public IntPtr hStdError;
+        }
+
+        [StructLayout(LayoutKind.Sequential)]
+        private struct PROCESS_INFORMATION
+        {
+            public IntPtr hProcess;
+            public IntPtr hThread;
+            public int dwProcessId;
+            public int dwThreadId;
+        }
+
+
+        [DllImport("kernel32.dll", SetLastError = true, CharSet = CharSet.Unicode)]
+        private static extern bool CreateProcess(
+            string lpApplicationName,
+            string lpCommandLine,
+            ref SECURITY_ATTRIBUTES lpProcessAttributes,
+            ref SECURITY_ATTRIBUTES lpThreadAttributes,
+            bool bInheritHandles,
+            uint dwCreationFlags,
+            IntPtr lpEnvironment,
+            string lpCurrentDirectory,
+            [In] ref STARTUPINFO lpStartupInfo,
+            out PROCESS_INFORMATION lpProcessInformation
+            );
+
+        [StructLayout(LayoutKind.Sequential)]
+        private struct SECURITY_ATTRIBUTES
+        {
+            public int nLength;
+            IntPtr lpSecurityDescriptor;
+            public int bInheritHandle;
+        }
+
+        [DllImport("kernel32.dll", SetLastError = true, PreserveSig = true)]
+        private static extern UInt32 WaitForSingleObject(IntPtr hHandle, UInt32 dwMilliseconds);
+
+        [DllImport("kernel32.dll", SetLastError = true, PreserveSig = true)]
+        private static extern bool CreatePipe(out SafeFileHandle hReadPipe, out SafeFileHandle hWritePipe, ref SECURITY_ATTRIBUTES lpPipeAttributes, uint nSize);
+
+        [DllImport("kernel32.dll", SetLastError = true, PreserveSig = true)]
+        [return: MarshalAs(UnmanagedType.Bool)]
+        private static extern bool GetExitCodeProcess(IntPtr hProcess, out uint lpExitCode);
+
+        [DllImport("kernel32.dll", SetLastError = true, PreserveSig = true)]
+        [return: MarshalAs(UnmanagedType.Bool)]
+        private static extern bool DuplicateHandle(SafeFileHandle hSourceProcessHandle, SafeFileHandle hSourceHandle, SafeFileHandle hTargetProcessHandle, out SafeFileHandle lpTargetHandle, uint dwDesiredAccess, [MarshalAs(UnmanagedType.Bool)] bool bInheritHandle, uint dwOptions);
+
+        [Flags]
+        enum HANDLE_FLAGS : uint
+        {
+            None = 0,
+            INHERIT = 1,
+            PROTECT_FROM_CLOSE = 2
+        }
+
+        [DllImport("kernel32.dll", SetLastError = true)]
+        static extern bool SetHandleInformation(SafeFileHandle hObject, HANDLE_FLAGS dwMask, uint flags);
+        #endregion
+    }
+}
+
+

--- a/src/MIDebugEngine/Engine.Impl/DebuggedProcess.cs
+++ b/src/MIDebugEngine/Engine.Impl/DebuggedProcess.cs
@@ -32,6 +32,8 @@ namespace Microsoft.MIDebugEngine
         public ThreadCache ThreadCache { get; private set; }
         public Disassembly Disassembly { get; private set; }
         public ExceptionManager ExceptionManager { get; private set; }
+        public bool IsCygwin { get; private set; }
+        public CygwinFilePathMapper CygwinFilePathMapper { get; private set; }
 
         private List<DebuggedModule> _moduleList;
         private ISampleEngineCallback _callback;
@@ -465,10 +467,21 @@ namespace Microsoft.MIDebugEngine
                                 throw new UnexpectedMIResultException(MICommandFactory.Name, command.CommandText, miError);
                             }
                         }
+                        else
+                        {
+                            if (command.SuccessHandler != null)
+                            {
+                                command.SuccessHandler(results.ToString());
+                            }
+                        }
                     }
                     else
                     {
-                        await ConsoleCmdAsync(command.CommandText);
+                        string resultString = await ConsoleCmdAsync(command.CommandText, command.IgnoreFailures);
+                        if (command.SuccessHandler != null)
+                        {
+                            command.SuccessHandler(resultString);
+                        }
                     }
                 }
 
@@ -592,6 +605,20 @@ namespace Microsoft.MIDebugEngine
                         this.MICommandFactory.UseExternalConsoleForLocalLaunch(localLaunchOptions))
                     {
                         commands.Add(new LaunchCommand("-gdb-set new-console on", ignoreFailures:true));
+                    }
+
+                    // If running locally on windows, determine if gdb is running from cygwin
+                    if (localLaunchOptions != null && PlatformUtilities.IsWindows() && this.MICommandFactory.Mode == MIMode.Gdb)
+                    {
+                        // mingw will not implement this command, but to be safe, also check if the results contains the string cygwin.
+                        LaunchCommand lc = new LaunchCommand("show configuration", null, true, null, new Action<string>((string resStr) => {
+                                if (resStr.Contains("cygwin"))
+                                {
+                                    this.IsCygwin = true;
+                                    this.CygwinFilePathMapper = new CygwinFilePathMapper(this);
+                                }
+                        }));
+                        commands.Add(lc);
                     }
 
                     // Send client version to clrdbg to set the capabilities appropriately
@@ -1142,7 +1169,7 @@ namespace Microsoft.MIDebugEngine
             TupleValue currentFrame = currentThread.Find<TupleValue>("frame");
 
             // Collect the addr, func, and args fields from the current frame as they are required.
-            // Collect the file, fullname, and line fileds if they are available. They may be missing if the frame is for
+            // Collect the file, fullname, and line fields if they are available. They may be missing if the frame is for
             // a binary that does not have symbols.
             TupleValue newFrame = currentFrame.Subset(
                 new string[] { "addr", "func", "args" },

--- a/src/MIDebugEngine/MIDebugEngine.csproj
+++ b/src/MIDebugEngine/MIDebugEngine.csproj
@@ -132,6 +132,7 @@
     <Compile Include="AD7.Impl\EngineConstants.cs" />
     <Compile Include="Engine.Impl\BreakpointManager.cs" />
     <Compile Include="Engine.Impl\Breakpoints.cs" />
+    <Compile Include="Engine.Impl\CygwinFileMapper.cs" />
     <Compile Include="Engine.Impl\DebuggedModule.cs" />
     <Compile Include="Engine.Impl\DebuggedProcess.cs" />
     <Compile Include="Engine.Impl\DebuggedThread.cs" />


### PR DESCRIPTION
Cygwin maps files from windows paths to unix style
paths. It has a utility called cygpath that will
automatically do the conversion. Calling that utility
proved to be quite difficult because cygwin will fail
to initialize stacks if a 64bit app is connected to a
32 bit console. Under vscode, the 32 bit console is
inherited from vscode. This works around this by launching
that utility with process_detached to force a new console.
Note that doing so requires pinvoking to createprocess
directly since the Process object doesn't expose the
raw flags.