### PR TITLE
Add the command used for core dump debugging in LLDB

### DIFF
--- a/src/MIDebugEngine/Engine.Impl/DebuggedProcess.cs
+++ b/src/MIDebugEngine/Engine.Impl/DebuggedProcess.cs
@@ -573,7 +573,7 @@ namespace Microsoft.MIDebugEngine
 
                     // Add core dump information (linux/mac does not support quotes around this path but spaces in the path do work)
                     string coreDump = _launchOptions.UseUnixSymbolPaths ? localLaunchOptions.CoreDumpPath : EscapePath(localLaunchOptions.CoreDumpPath);
-                    string coreDumpCommand = String.Concat("-target-select core ", coreDump);
+                    string coreDumpCommand = _launchOptions.DebuggerMIMode == MIMode.Lldb ? String.Concat("target create --core ", coreDump) : String.Concat("-target-select core ", coreDump);
                     string coreDumpDescription = String.Format(CultureInfo.CurrentCulture, ResourceStrings.LoadingCoreDumpMessage, localLaunchOptions.CoreDumpPath);
                     commands.Add(new LaunchCommand(coreDumpCommand, coreDumpDescription, ignoreFailures: false));
                 }


### PR DESCRIPTION
This was done by @jacdavis

There is no `-target-select core` command in lldb-mi. However, the MI Driver will translate CLI commands into MI commands if needed (when the command doesn't start with `-`).

/cc @gregg-miskelly @jacdavis 