### PR TITLE
Users/jacdavis

### DIFF
--- a/src/MICore/Debugger.cs
+++ b/src/MICore/Debugger.cs
@@ -42,6 +42,9 @@ namespace MICore
         private int _exiting;
         public ProcessState ProcessState { get; private set; }
         private MIResults _miResults;
+
+        public bool EntrypointHit { get; protected set; }
+
         public bool IsCygwin { get; protected set; }
 
         public virtual void FlushBreakStateData()
@@ -1071,12 +1074,11 @@ namespace MICore
                     !this.IsCygwin
                     )
                 {
-                    // mingw enters break mode with no status during attach. All of the processing 
-                    // for *stopped expects status or it will assume the event is a module load.
-                    // to avoid regressing that code path, manufacture a fake frame. This will not
-                    // be seen by the user as it is continued during attach.
-                    string fakeMingwAttachFrame = "frame={addr=\"0x0000000000000000\",func=\"fakemodule!fakeMingwAttachFrame\"},thread-id=\"1\",stopped-threads=\"all\"";
-                    OnStateChanged("stopped", fakeMingwAttachFrame);
+                    // mingw enters break mode with no status flags on the mi response during attach.
+                    // In order to keey the entrypoint state correct, set it to true and continue
+                    // the break.
+                    this.EntrypointHit = true;
+                    CmdContinueAsync();
                 }
                 else
                 {

--- a/src/MIDebugEngine/Engine.Impl/DebuggedProcess.cs
+++ b/src/MIDebugEngine/Engine.Impl/DebuggedProcess.cs
@@ -32,7 +32,6 @@ namespace Microsoft.MIDebugEngine
         public ThreadCache ThreadCache { get; private set; }
         public Disassembly Disassembly { get; private set; }
         public ExceptionManager ExceptionManager { get; private set; }
-        public bool IsCygwin { get; private set; }
         public CygwinFilePathMapper CygwinFilePathMapper { get; private set; }
 
         private List<DebuggedModule> _moduleList;

--- a/src/MIDebugEngine/Engine.Impl/Variables.cs
+++ b/src/MIDebugEngine/Engine.Impl/Variables.cs
@@ -417,7 +417,7 @@ namespace Microsoft.MIDebugEngine
 
                 try
                 {
-                    consoleResults = await MIDebugCommandDispatcher.ExecuteCommand(consoleCommand, _debuggedProcess);
+                    consoleResults = await MIDebugCommandDispatcher.ExecuteCommand(consoleCommand, _debuggedProcess, ignoreFailures:true);
                     Value = String.Empty;
                     this.TypeName = null;
                 }

--- a/src/MIDebugEngine/MIDebugCommandDispatcher.cs
+++ b/src/MIDebugEngine/MIDebugCommandDispatcher.cs
@@ -29,7 +29,7 @@ namespace Microsoft.MIDebugEngine
             return ExecuteCommand(command, lastProcess);
         }
 
-        internal static Task<string> ExecuteCommand(string command, DebuggedProcess process)
+        internal static Task<string> ExecuteCommand(string command, DebuggedProcess process, bool ignoreFailures=false)
         {
             if (string.IsNullOrWhiteSpace(command))
                 throw new ArgumentNullException("command");
@@ -43,17 +43,17 @@ namespace Microsoft.MIDebugEngine
 
             if (command[0] == '-')
             {
-                return ExecuteMiCommand(process, command);
+                return ExecuteMiCommand(process, command, ignoreFailures);
             }
             else
             {
-                return process.ConsoleCmdAsync(command);
+                return process.ConsoleCmdAsync(command, ignoreFailures);
             }
         }
 
-        private static async Task<string> ExecuteMiCommand(DebuggedProcess lastProcess, string command)
+        private static async Task<string> ExecuteMiCommand(DebuggedProcess lastProcess, string command, bool ignoreFailures)
         {
-            Results results = await lastProcess.CmdAsync(command, ResultClass.None);
+            Results results = await lastProcess.CmdAsync(command, ignoreFailures ? ResultClass.None : ResultClass.done);
             return results.ToString();
         }
 


### PR DESCRIPTION
mingw enters break mode after an attach with a …  
bogus stopped record. This causes attach to fail.
Because the code paths past that point use the lack
of a frame to identify a module load, I created
a hack to generate a fake frame. No, I'm not proud
of it.
 