### PR TITLE
Monitor the shell pid and remove the exit fifo

### DIFF
--- a/src/MICore/Debugger.cs
+++ b/src/MICore/Debugger.cs
@@ -140,9 +140,7 @@ namespace MICore
             {
                 if (PlatformUtilities.IsLinux() || PlatformUtilities.IsOSX())
                 {
-                    // When 0 is passed as the signal to send in kill,
-                    // it will check the validity of the pid (e.g., does the pid exist?)
-                    return UnixNativeMethods.Kill(_localDebuggerPid, 0) == 0;
+                    return UnixUtilities.IsProcessRunning(_localDebuggerPid);
                 }
             }
 

--- a/src/MICore/MICore.csproj
+++ b/src/MICore/MICore.csproj
@@ -156,6 +156,7 @@
     <Compile Include="MIException.cs" />
     <Compile Include="MIResults.cs" />
     <Compile Include="PlatformUtilities.cs" />
+    <Compile Include="ProcessMonitor.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="TerminalLauncher.cs" />
     <Compile Include="Transports\ClientServerTransport.cs" />

--- a/src/MICore/ProcessMonitor.cs
+++ b/src/MICore/ProcessMonitor.cs
@@ -1,0 +1,51 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Threading;
+
+namespace MICore
+{
+    public class ProcessMonitor: IDisposable
+    {
+        private readonly TimeSpan EXIT_POLL_DELTA = TimeSpan.FromMilliseconds(200);
+        private int _processId;
+        private Timer _exitMonitorTimer;
+
+        public ProcessMonitor(int processId)
+        {
+            if (!PlatformUtilities.IsLinux() && !PlatformUtilities.IsOSX())
+            {
+                throw new NotImplementedException();
+            }
+
+            _processId = processId;
+        }
+
+        public void Start()
+        {
+            _exitMonitorTimer = new Timer(MonitorForExit, null, TimeSpan.FromMilliseconds(0), EXIT_POLL_DELTA);
+        }
+
+        public event EventHandler ProcessExited;
+
+        private bool HasExited()
+        {
+            return !UnixUtilities.IsProcessRunning(_processId);
+        }
+
+        private void MonitorForExit(object o)
+        {
+            if (HasExited())
+            {
+                _exitMonitorTimer.Change(Timeout.Infinite, Timeout.Infinite);
+                ProcessExited?.Invoke(this, null);
+            }
+        }
+
+        public void Dispose()
+        {
+            _exitMonitorTimer.Dispose();
+        }
+    }
+}

--- a/src/MICore/ProcessMonitor.cs
+++ b/src/MICore/ProcessMonitor.cs
@@ -38,14 +38,14 @@ namespace MICore
         {
             if (HasExited())
             {
-                _exitMonitorTimer.Change(Timeout.Infinite, Timeout.Infinite);
+                _exitMonitorTimer.Dispose();
                 ProcessExited?.Invoke(this, null);
             }
         }
 
         public void Dispose()
         {
-            _exitMonitorTimer.Dispose();
+            _exitMonitorTimer?.Dispose();
         }
     }
 }

--- a/src/MICore/Transports/LocalUnixTerminalTransport.cs
+++ b/src/MICore/Transports/LocalUnixTerminalTransport.cs
@@ -61,7 +61,7 @@ namespace MICore
             using (StreamReader pidReader = new StreamReader(pidStream, Encoding.UTF8, true, UnixUtilities.StreamBufferSize))
             {
                 Task<string> readShellPidTask = pidReader.ReadLineAsync();
-                if (readShellPidTask.Wait(TimeSpan.FromSeconds(5)))
+                if (readShellPidTask.Wait(TimeSpan.FromSeconds(10)))
                 {
                     shellPid = int.Parse(readShellPidTask.Result, CultureInfo.InvariantCulture);
                 }

--- a/src/MICore/UnixNativeMethods.cs
+++ b/src/MICore/UnixNativeMethods.cs
@@ -18,5 +18,8 @@ namespace MICore
 
         [DllImport(Libc, EntryPoint = "geteuid", SetLastError = true)]
         internal static extern uint GetEUid();
+
+        [DllImport(Libc, EntryPoint = "getpgid", SetLastError = true)]
+        internal static extern int GetPGid(int pid);
     }
 }


### PR DESCRIPTION
The exit fifo was causing issues in the case that MIEngine had already exited
but the shell started executing the `EXIT` trap. In that case, it would block on
echoing 'exit' to a fifo since there were no readers.

Use `getpgid` instead of `kill -0` to find if a process is running

@jacdavis @andrewcrawley @gregg-miskelly 