### PR TITLE
Enable mingw debugging to async-break. 

### DIFF
--- a/src/MICore/CommandFactories/MICommandFactory.cs
+++ b/src/MICore/CommandFactories/MICommandFactory.cs
@@ -547,7 +547,38 @@ namespace MICore
 
         public virtual bool IsAsyncBreakSignal(Results results)
         {
-            return (results.TryFindString("reason") == "signal-received" && results.TryFindString("signal-name") == "SIGINT");
+            bool isAsyncBreak = false;
+            
+            if (results.TryFindString("reason") == "signal-received")
+            {
+                if (results.TryFindString("signal-name") == "SIGINT")
+                {
+                    isAsyncBreak = true;
+                }
+                else if (results.TryFindString("signal-name") == "SIGTRAP")
+                {
+                    // Mingw has no way to send the sigint and using windows console control won't work with the debuggee
+                    // redirected. This means mingw will see SIGTRAP on async-break.
+                    if (this._debugger.IsRequestingInternalAsyncBreak || this._debugger.IsRequestingRealAsyncBreak)
+                    {
+                        if (this._debugger.IsLocalGdb() && PlatformUtilities.IsWindows() && !this._debugger.IsCygwin)
+                        {
+                            ResultValue frameResult;
+                            if (results.TryFind("frame", out frameResult))
+                            {
+                                // The top frame will be in an unknown function for break injected bps since it is actually
+                                // an injected frame in ntdll doing a debug break.
+                                // NOTE: if it were possible to get the windows stack that shows the inserted break frames,
+                                // it would be better. Unfornately, gdb doesn't show them. Perhaps check if the address
+                                // lands in ntdll or kernel32?
+                                isAsyncBreak = frameResult.TryFindString("func") == "??";
+                            }
+                        }
+                    }
+                }
+            }
+
+            return isAsyncBreak;
         }
 
         /// <summary>

--- a/src/MICore/MICore.csproj
+++ b/src/MICore/MICore.csproj
@@ -170,6 +170,7 @@
     <Compile Include="Transports\TcpTransport.cs" />
     <Compile Include="UnixNativeMethods.cs" />
     <Compile Include="UnixUtilities.cs" />
+    <Compile Include="WindowsNativeMethods.cs" />
   </ItemGroup>
   <ItemGroup>
     <Content Include="ExampleLaunchOptions.xml" />
@@ -189,9 +190,7 @@
   <Import Condition="'$(IsCoreClr)' == 'true'" Project="$(MSBuildExtensionsPath32)\Microsoft\Portable\$(TargetFrameworkVersion)\Microsoft.Portable.CSharp.targets" />
   <Import Condition="'$(IsCoreClr)' == 'false'" Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Import Project="..\..\build\miengine.targets" />
-
   <Import Project="GenerateXmlSerializersAssembly.targets" />
-
   <!-- To get the seralization assembly copied to the vsix, and also to the output directory, we have this target
   which adds the XmlSerializers as if it was a source item in our project with a 'CopyToOutputDirectory' child
   node. See the 'GetCopyToOutputDirectoryItems' target in C:\Program Files (x86)\MSBuild\14.0\Bin\Microsoft.Common.CurrentVersion.targets

--- a/src/MICore/MIResults.cs
+++ b/src/MICore/MIResults.cs
@@ -38,7 +38,7 @@ namespace MICore
             throw new MIResultFormatException(name, this);
         }
 
-        public virtual bool TryFind(string name, ResultValue result)
+        public virtual bool TryFind(string name, out ResultValue result)
         {
             if (Contains(name))
             {

--- a/src/MICore/WindowsNativeMethods.cs
+++ b/src/MICore/WindowsNativeMethods.cs
@@ -1,0 +1,23 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Diagnostics;
+using System.IO;
+using System.Runtime.InteropServices;
+using Microsoft.Win32.SafeHandles;
+
+namespace MICore
+{
+    internal class WindowsNativeMethods
+    {
+#if CORECLR
+        [DllImport("kernel32")]
+        internal static extern bool DebugBreakProcess(SafeHandle hProcess);
+#else
+        [DllImport("kernel32")]
+        internal static extern bool DebugBreakProcess(IntPtr hProcess);
+#endif
+
+    }
+}

--- a/src/MIDebugEngine/Engine.Impl/CygwinFileMapper.cs
+++ b/src/MIDebugEngine/Engine.Impl/CygwinFileMapper.cs
@@ -7,9 +7,6 @@ using System.Diagnostics;
 using System.IO;
 using System.Runtime.InteropServices;
 using Microsoft.Win32.SafeHandles;
-using System.IO;
-using System.Text;
-using System.Threading.Tasks;
 using MICore;
 
 namespace Microsoft.MIDebugEngine


### PR DESCRIPTION
Enable mingw debugging to async-break. This is used for breakpoint
setting in run mode and for async-break. Note that this does not
work for cygwin which has a number of issues blocking async-break.
For the first release, the user will have to manually ctrl-c the
debuggee on cygwin.