### PR TITLE
Add a warning if the debugger is not signed and running on OS X

### DIFF
--- a/src/MICore/UnixUtilities.cs
+++ b/src/MICore/UnixUtilities.cs
@@ -20,6 +20,9 @@ namespace MICore
         // Linux specific
         private const string PtraceScopePath = "/proc/sys/kernel/yama/ptrace_scope";
 
+        // OS X specific
+        private const string CodeSignPath = "/usr/bin/codesign";
+
         /// <summary>
         /// Launch a new terminal, spin up a new bash shell, cd to the working dir, execute a tty command to get the shell tty and store it.
         /// Start the debugger in mi mode setting the tty to the terminal defined earlier and redirect stdin/stdout
@@ -159,6 +162,29 @@ namespace MICore
             // When getting the process group ID, getpgid will return -1
             // if there is no process with the ID specified.
             return UnixNativeMethods.GetPGid(processId) >= 0;
+        }
+
+        public static bool IsBinarySigned(string filePath)
+        {
+            if (!PlatformUtilities.IsOSX())
+            {
+                throw new NotImplementedException();
+            }
+
+            Process p = new Process
+            {
+                StartInfo =
+                {
+                    CreateNoWindow = true,
+                    UseShellExecute = true,
+                    FileName = CodeSignPath,
+                    Arguments = "--display " + filePath
+                 }
+            };
+
+            p.Start();
+            p.WaitForExit();
+            return p.ExitCode == 0;
         }
     }
 }

--- a/src/MIDebugEngine/Engine.Impl/DebuggedProcess.cs
+++ b/src/MIDebugEngine/Engine.Impl/DebuggedProcess.cs
@@ -173,6 +173,17 @@ namespace Microsoft.MIDebugEngine
                     throw new Exception(MICoreResources.Error_InvalidMiDebuggerPath);
                 }
 
+                if (PlatformUtilities.IsOSX() &&
+                    localLaunchOptions.DebuggerMIMode != MIMode.Clrdbg &&
+                    !UnixUtilities.IsBinarySigned(localLaunchOptions.MIDebuggerPath))
+                {
+                    string message = String.Format(CultureInfo.CurrentCulture, ResourceStrings.Warning_DarwinDebuggerUnsigned, localLaunchOptions.MIDebuggerPath);
+                    _callback.OnOutputMessage(new OutputMessage(
+                        message + Environment.NewLine,
+                        enum_MESSAGETYPE.MT_MESSAGEBOX,
+                        OutputMessage.Severity.Warning));
+                }
+
                 ITransport localTransport = null;
                 // For local Linux and OS X launch, use the local Unix transport which creates a new terminal and
                 // uses fifos for debugger (e.g., gdb) communication.

--- a/src/MIDebugEngine/ResourceStrings.Designer.cs
+++ b/src/MIDebugEngine/ResourceStrings.Designer.cs
@@ -11,7 +11,7 @@
 namespace Microsoft.MIDebugEngine {
     using System;
     using System.Reflection;
-
+    
     
     /// <summary>
     ///   A strongly-typed resource class, for looking up localized strings, etc.
@@ -294,6 +294,15 @@ namespace Microsoft.MIDebugEngine {
         internal static string VisualizingExpressionMessage {
             get {
                 return ResourceManager.GetString("VisualizingExpressionMessage", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Debugger executable &apos;{0}&apos; is not signed. As a result, debugging may not work properly..
+        /// </summary>
+        internal static string Warning_DarwinDebuggerUnsigned {
+            get {
+                return ResourceManager.GetString("Warning_DarwinDebuggerUnsigned", resourceCulture);
             }
         }
         

--- a/src/MIDebugEngine/ResourceStrings.resx
+++ b/src/MIDebugEngine/ResourceStrings.resx
@@ -207,4 +207,8 @@
   <data name="Warning_UsingDefaultArchitecture" xml:space="preserve">
     <value>Warning: Debuggee TargetArchitecture not detected, assuming x86_64.</value>
   </data>
+  <data name="Warning_DarwinDebuggerUnsigned" xml:space="preserve">
+    <value>Debugger executable '{0}' is not signed. As a result, debugging may not work properly.</value>
+    <comment>0 = debugger path</comment>
+  </data>
 </root>


### PR DESCRIPTION
Previously at https://github.com/Microsoft/MIEngine/pull/328