### PR TITLE
Forgot a change for removing the mingw work around. 

### DIFF
--- a/src/MICore/CommandFactories/MICommandFactory.cs
+++ b/src/MICore/CommandFactories/MICommandFactory.cs
@@ -555,27 +555,6 @@ namespace MICore
                 {
                     isAsyncBreak = true;
                 }
-                else if (results.TryFindString("signal-name") == "SIGTRAP")
-                {
-                    // Mingw has no way to send the sigint and using windows console control won't work with the debuggee
-                    // redirected. This means mingw will see SIGTRAP on async-break.
-                    if (this._debugger.IsRequestingInternalAsyncBreak || this._debugger.IsRequestingRealAsyncBreak)
-                    {
-                        if (this._debugger.IsLocalGdb() && PlatformUtilities.IsWindows() && !this._debugger.IsCygwin)
-                        {
-                            ResultValue frameResult;
-                            if (results.TryFind("frame", out frameResult))
-                            {
-                                // The top frame will be in an unknown function for break injected bps since it is actually
-                                // an injected frame in ntdll doing a debug break.
-                                // NOTE: if it were possible to get the windows stack that shows the inserted break frames,
-                                // it would be better. Unfornately, gdb doesn't show them. Perhaps check if the address
-                                // lands in ntdll or kernel32?
-                                isAsyncBreak = frameResult.TryFindString("func") == "??";
-                            }
-                        }
-                    }
-                }
             }
 
             return isAsyncBreak;


### PR DESCRIPTION
Forgot a change for removing the mingw work around. No longer try and special case sigtrap as aysnc-break