### PR TITLE
Fix dependencies for InstallToVSCode script

### DIFF
--- a/tools/InstallToVSCode/CLRDependencies/project.json.template
+++ b/tools/InstallToVSCode/CLRDependencies/project.json.template
@@ -5,6 +5,7 @@
   },
   "dependencies": {
     "NETStandard.Library": "1.5.0-rc2-24027",
+    "Newtonsoft.Json": "7.0.1",
     "System.Collections.Specialized":  "4.0.1-rc2-24027",
     "System.Collections.Immutable": "1.2.0-rc2-24027", 
     "System.Diagnostics.Process" : "4.1.0-rc2-24027",
@@ -21,7 +22,8 @@
     "System.ComponentModel.EventBasedAsync":  "4.0.11-rc2-24027",
     "System.Runtime.Serialization.Primitives": "4.1.1-rc2-24027",
     "System.Net.Http":  "4.0.1-rc2-24027",
-    "Microsoft.NETCore.TestHost": "1.0.0-beta-*"
+    "Microsoft.NETCore.TestHost": "1.0.0-beta-*",
+    "System.Threading.Tasks.Parallel": "4.0.1-rc2-24027"
   },
   "frameworks": {
     "netstandardapp1.5": {


### PR DESCRIPTION
InstallToVsCode needs to explicitly specify some dependencies that clrdbg package depends as the install script doesn't try to restore 'clrdbg' package but rather copies its binaries.
@gregg-miskelly @chuckries 