### PR TITLE
Make sure a breakpoint has been reported as hit

### DIFF
--- a/src/MIDebugEngine/Engine.Impl/DebuggedProcess.cs
+++ b/src/MIDebugEngine/Engine.Impl/DebuggedProcess.cs
@@ -845,9 +845,10 @@ namespace Microsoft.MIDebugEngine
                 string bkptno = results.Results.FindString("bkptno");
                 ulong addr = cxt.pc ?? 0;
 
-                bool fContinue;
                 TupleValue frame = results.Results.TryFind<TupleValue>("frame");
-                AD7BoundBreakpoint[] bkpt = _breakpointManager.FindHitBreakpoints(bkptno, addr, frame, out fContinue);
+                Tuple<AD7BoundBreakpoint[], bool> result = await _breakpointManager.FindHitBreakpoints(bkptno, addr, frame);
+                AD7BoundBreakpoint[] bkpt = result.Item1;
+                bool fContinue = result.Item2;
                 if (bkpt != null)
                 {
                     if (frame != null && addr != 0)


### PR DESCRIPTION
There is a problem when a breakpoint has been set on `main`, but the breakpoint actually hasn't been hit when the `EntryPoint` event is being triggered. This can happen if the user-added breakpoint has a condition that evaluates to false.

In this PR, I add a check to make sure every breakpoint reported in `FindHitBreakpoints` has actually been hit. I believe this will only work with GDB, as the other debuggers don't implement the `-break-info` command.

/cc @gregg-miskelly @jacdavis 