### PR TITLE
Implement IDebugEngine3.SetEngineGuid

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,9 +19,12 @@ intermediate
 *.metaproj
 *.tmp
 *.VC.opendb
+*.VC.db
 packages/
 packages.Desktop/
 .vs/
 Microsoft.VisualStudio.Glass
 project.lock.json
+src/*/*.nuget.props
+src/*/*.nuget.targets
 .DS_Store

--- a/src/DebugEngineHost.Stub/DebugEngineHost.ref.cs
+++ b/src/DebugEngineHost.Stub/DebugEngineHost.ref.cs
@@ -85,8 +85,16 @@ namespace Microsoft.DebugEngineHost
         /// In Visual Studio, this will be something like 'Software\\Microsoft\\VisualStudio\\14.0'. 
         /// In VS Code this will not really be a registry value but rather a key used to 
         /// find the right configuration file.</param>
-        /// <param name="engineId">The engine id of this engine.</param>
-        public HostConfigurationStore(string registryRoot, string engineId)
+        public HostConfigurationStore(string registryRoot)
+        {
+            throw new NotImplementedException();
+        }
+
+        /// <summary>
+        /// Sets the Guid of the engine being hosted. This should only be set once for each HostConfigurationStore instance.
+        /// </summary>
+        /// <param name="value">The new engine GUID to set</param>
+        public void SetEngineGuid(Guid value)
         {
             throw new NotImplementedException();
         }

--- a/src/MIDebugEngine/AD7.Impl/AD7ProgramNode.cs
+++ b/src/MIDebugEngine/AD7.Impl/AD7ProgramNode.cs
@@ -15,10 +15,12 @@ namespace Microsoft.MIDebugEngine
     internal class AD7ProgramNode : IDebugProgramNode2
     {
         private readonly AD_PROCESS_ID _processId;
+        private readonly Guid _engineGuid;
 
-        public AD7ProgramNode(AD_PROCESS_ID processId)
+        public AD7ProgramNode(AD_PROCESS_ID processId, Guid engineGuid)
         {
             _processId = processId;
+            _engineGuid = engineGuid;
         }
 
         #region IDebugProgramNode2 Members
@@ -27,7 +29,7 @@ namespace Microsoft.MIDebugEngine
         int IDebugProgramNode2.GetEngineInfo(out string engineName, out Guid engineGuid)
         {
             engineName = ResourceStrings.EngineName;
-            engineGuid = new Guid(EngineConstants.EngineId);
+            engineGuid = _engineGuid;
 
             return Constants.S_OK;
         }

--- a/src/MIDebugEngine/Engine.Impl/ExceptionManager.cs
+++ b/src/MIDebugEngine/Engine.Impl/ExceptionManager.cs
@@ -250,12 +250,7 @@ namespace Microsoft.MIDebugEngine
             {
                 // Setting the exception category will clear all the existing rules in that category
 
-                using (var settingsUpdateHolder = categorySettings.GetSettingsUpdate())
-                {
-                    settingsUpdateHolder.Value.NewCategoryState = newState;
-                    settingsUpdateHolder.Value.RulesToAdd.Clear();
-                    settingsUpdateHolder.Value.RulesToRemove.Clear();
-                }
+                SetCategory(categorySettings, newState);
             }
             else
             {
@@ -271,6 +266,26 @@ namespace Microsoft.MIDebugEngine
                     settingsUpdateHolder.Value.RulesToRemove.Remove(exceptionName);
                     settingsUpdateHolder.Value.RulesToAdd[exceptionName] = newState;
                 }
+            }
+        }
+        
+        public void SetAllExceptions(enum_EXCEPTION_STATE dwState)
+        {
+            var newState = ToExceptionBreakpointState(dwState);
+
+            foreach (var pair in _categoryMap)
+            {
+                SetCategory(pair.Value, newState);
+            }
+        }
+
+        private static void SetCategory(ExceptionCategorySettings categorySettings, ExceptionBreakpointState newState)
+        {
+            using (var settingsUpdateHolder = categorySettings.GetSettingsUpdate())
+            {
+                settingsUpdateHolder.Value.NewCategoryState = newState;
+                settingsUpdateHolder.Value.RulesToAdd.Clear();
+                settingsUpdateHolder.Value.RulesToRemove.Clear();
             }
         }
 
@@ -526,5 +541,6 @@ namespace Microsoft.MIDebugEngine
             // For C++, we have a bunch of C++ projection exceptions that we will not want to send down to GDB. Ignore these.
             return valueName.IndexOf('^') < 0;
         }
+
     }
 }


### PR DESCRIPTION
This checkin implements IDebugEngine3 in the MIEngine. The reason for this is
to provide support for SetEngineGuid, which allows registering the MIEngine
for an alternate engine GUID without needing to change the code.

The value of this is that, for the SSH port supplier, we can use a different
engine GUID to differentiate between LLDB/GDB/clrdbg and thus offer multiple
types of code debugging using the same gestures that the attach to process
dialog already knows (engine selection).