### PR TITLE
Add a second check for a late HostLogger load (attempt 2)

### DIFF
--- a/src/MICore/Logger.cs
+++ b/src/MICore/Logger.cs
@@ -41,11 +41,7 @@ namespace MICore
                 s_isInitialized = true;
                 s_initTime = DateTime.Now;
 
-                s_logger = configStore.GetLogger("EnableMIDebugLogger", "Microsoft.MIDebug.log");
-                if (s_logger != null)
-                {
-                    s_isEnabled = true;
-                }
+                LoadMIDebugLogger(configStore);
                 res.WriteLine("Initialized log at: " + s_initTime);
             }
 
@@ -56,6 +52,18 @@ namespace MICore
             }
 #endif
             return res;
+        }
+
+        public static void LoadMIDebugLogger(HostConfigurationStore configStore)
+        {
+            if (s_logger == null)
+            {
+                s_logger = configStore.GetLogger("EnableMIDebugLogger", "Microsoft.MIDebug.log");
+                if (s_logger != null)
+                {
+                    s_isEnabled = true;
+                }
+            }
         }
 
         /// <summary>

--- a/src/MIDebugEngine/AD7.Impl/AD7Engine.cs
+++ b/src/MIDebugEngine/AD7.Impl/AD7Engine.cs
@@ -414,6 +414,9 @@ namespace Microsoft.MIDebugEngine
             Debug.Assert(_debuggedProcess == null);
             Debug.Assert(_ad7ProgramId == Guid.Empty);
 
+            // Check if the logger was enabled late.
+            Logger.LoadMIDebugLogger(_configStore);
+
             process = null;
 
             _engineCallback = new EngineCallback(this, ad7Callback);


### PR DESCRIPTION
Engine logging will currently only be recognized if the logger is set on startup. Add a second check before creating a new DebuggedProcess to accept engine logging requests sent later in the pipeline.