### PR TITLE
Do not acquire lock when enable/disable breakpoint

### DIFF
--- a/src/MIDebugEngine/AD7.Impl/AD7PendingBreakpoint.cs
+++ b/src/MIDebugEngine/AD7.Impl/AD7PendingBreakpoint.cs
@@ -432,12 +432,14 @@ namespace Microsoft.MIDebugEngine
         // Toggles the enabled state of this pending breakpoint.
         int IDebugPendingBreakpoint2.Enable(int fEnable)
         {
-            lock (_boundBreakpoints)
+            bool newValue = fEnable == 0 ? false : true;
+            if (_enabled != newValue)
             {
-                _enabled = fEnable == 0 ? false : true;
-                if (_bp != null)
+                _enabled = newValue;
+                PendingBreakpoint bp = _bp;
+                if (bp != null)
                 {
-                    _bp.Enable(_enabled, _engine.DebuggedProcess);
+                    bp.Enable(_enabled, _engine.DebuggedProcess);
                 }
             }
 


### PR DESCRIPTION
I don't see a reason why we need to lock on _boundBreakpoints when enable/disable breakpoints. The problem is that this lldb-mi may send out breakpoint related messages before MIEngine receive "done" for enable/disable breakpoint, and that will cause deadlock.
I'm removing some lldb outputs to reduce the chance of deadlock, but because lldb-mi send breakpoint output on response to a lot of lldb breakpoint related Events, there is still a chance that lldb will send out breakpoint message in a bad timing and cause a deadlock.