### PR TITLE
InstallToVSCode: Use CoreCLR/FX 1.0.0 RTM

### DIFF
--- a/tools/InstallToVSCode/CLRDependencies/project.json.template
+++ b/tools/InstallToVSCode/CLRDependencies/project.json.template
@@ -1,32 +1,31 @@
 {
   "name": "dummy",
-  "compilationOptions": {
+  "buildOptions": {
       "emitEntryPoint": true
   },
   "dependencies": {
-    "NETStandard.Library": "1.5.0-rc2-24027",
-    "System.Collections.Specialized":  "4.0.1-rc2-24027",
-    "System.Collections.Immutable": "1.2.0-rc2-24027", 
-    "System.Diagnostics.Process" : "4.1.0-rc2-24027",
-    "System.Diagnostics.StackTrace":  "4.0.1-rc2-24027",  
-    "System.Dynamic.Runtime": "4.0.11-rc2-24027",
-    "Microsoft.CSharp": "4.0.1-rc2-24027",
-    "System.Threading.Tasks.Dataflow": "4.6.0-rc2-24027",
-    "System.Threading.Thread": "4.0.0-rc2-24027", 
-    "System.Xml.XDocument": "4.0.11-rc2-24027",
-    "System.Xml.XmlDocument": "4.0.1-rc2-24027",  
-    "System.Xml.XmlSerializer": "4.0.11-rc2-24027",
-    "System.ComponentModel":  "4.0.1-rc2-24027",  
-    "System.ComponentModel.Annotations":  "4.1.0-rc2-24027",  
-    "System.ComponentModel.EventBasedAsync":  "4.0.11-rc2-24027",
-    "System.Runtime.Serialization.Primitives": "4.1.1-rc2-24027",
-    "System.Net.Http":  "4.0.1-rc2-24027",
-    "Microsoft.NETCore.TestHost": "1.0.0-beta-*"
+    "NETStandard.Library": "1.6.0",
+    "Microsoft.NETCore.Runtime.CoreCLR": "1.0.3",
+    "System.Collections.Specialized":  "4.0.1",
+    "System.Collections.Immutable": "1.2.0", 
+    "System.Diagnostics.Process" : "4.1.0",
+    "System.Diagnostics.StackTrace":  "4.0.1",  
+    "System.Dynamic.Runtime": "4.0.11",
+    "Microsoft.CSharp": "4.0.1",
+    "System.Threading.Tasks.Dataflow": "4.6.0",
+    "System.Threading.Thread": "4.0.0", 
+    "System.Xml.XDocument": "4.0.11",
+    "System.Xml.XmlDocument": "4.0.1",  
+    "System.Xml.XmlSerializer": "4.0.11",
+    "System.ComponentModel":  "4.0.1",  
+    "System.ComponentModel.Annotations":  "4.1.0",  
+    "System.ComponentModel.EventBasedAsync":  "4.0.11",
+    "System.Runtime.Serialization.Primitives": "4.1.1",
+    "System.Net.Http":  "4.1.0",
+    "Microsoft.NETCore.TestHost": "1.0.0"
   },
   "frameworks": {
-    "netstandardapp1.5": {
-      "imports": [ "dnxcore50", "portable-net45+win8" ]
-    }
+    "netcoreapp1.0": { }
   },
   "runtimes":{
 @current-OS@


### PR DESCRIPTION
This checkin changes the InstallToVSCode scripts to use CoreCLR/FX 1.0.0 RTM.

As part of this, I changed to more closely follow these instructions:
https://github.com/dotnet/core-docs/blob/master/docs/core/app-types.md#self-contained-application

Note however that I did NOT use Microsoft.NETCore.App as that includes extra ASP.NET
functionality that we don't need.