### PR TITLE
Fix Kofe engine with latest MIEngine

### DIFF
--- a/src/DebugEngineHost/HostConfigurationStore.cs
+++ b/src/DebugEngineHost/HostConfigurationStore.cs
@@ -36,6 +36,12 @@ namespace Microsoft.DebugEngineHost
             }
         }
 
+        // This is a legacy verion of this constructor which is used by Kofe
+        public HostConfigurationStore(string registryRoot, string engineId) : this(registryRoot)
+        {
+            SetEngineGuid(Guid.Parse(engineId));
+        }
+
         /// <summary>
         /// Sets the Guid of the engine being hosted. This should only be set once for each HostConfigurationStore instance.
         /// </summary>


### PR DESCRIPTION
The Kofe engine was still using the old constructor for MIEngine, which was
removed with commit f6bb8986a159d1ee2a24143904ab47591d8dcdac
(Implement IDebugEngine3.SetEngineGuid).

This puts it back.