### PR TITLE
Remove async break on terminate with clrdbg

### DIFF
--- a/src/MICore/Debugger.cs
+++ b/src/MICore/Debugger.cs
@@ -572,7 +572,7 @@ namespace MICore
 
         public async Task<Results> CmdTerminate()
         {
-            if (ProcessState == ProcessState.Running)
+            if (ProcessState == ProcessState.Running && this.MICommandFactory.Mode != MIMode.Clrdbg)
             {
                 await CmdBreak(BreakRequest.Async);
             }


### PR DESCRIPTION
Remove async break on terminate with clrdbg as it's not needed and causes asserts on clrdbg shutdown with chk bits.