### PR TITLE
Fix an assert for stop debugging a running debuggee

### DIFF
--- a/src/MICore/Debugger.cs
+++ b/src/MICore/Debugger.cs
@@ -78,6 +78,7 @@ namespace MICore
         private int _localDebuggerPid = -1;
 
         protected bool _connected;
+        protected bool _terminating;
 
         public class ResultEventArgs : EventArgs
         {
@@ -572,12 +573,16 @@ namespace MICore
 
         public async Task<Results> CmdTerminate()
         {
-            if (ProcessState == ProcessState.Running && this.MICommandFactory.Mode != MIMode.Clrdbg)
+            if (!_terminating)
             {
-                await CmdBreak(BreakRequest.Async);
-            }
+                _terminating = true;
+                if (ProcessState == ProcessState.Running && this.MICommandFactory.Mode != MIMode.Clrdbg)
+                {
+                    await CmdBreak(BreakRequest.Async);
+                }
 
-            await MICommandFactory.Terminate();
+                await MICommandFactory.Terminate();
+            }
 
             return new Results(ResultClass.done);
         }

--- a/src/MIDebugEngine/Engine.Impl/DebuggedProcess.cs
+++ b/src/MIDebugEngine/Engine.Impl/DebuggedProcess.cs
@@ -787,6 +787,14 @@ namespace Microsoft.MIDebugEngine
             MICommandFactory.DefineCurrentThread(tid);
 
             DebuggedThread thread = await ThreadCache.GetThread(tid);
+            if (thread == null)
+            {
+                // It's possible that the stop event happens during stop debugging and the thread cache has been cleaned up
+                // See https://devdiv.visualstudio.com/DevDiv/VS%20Diag%20IntelliTrace/_workItems?_a=edit&id=236275&triage=true
+                // for a repro
+                return;
+            }
+
             await ThreadCache.StackFrames(thread);  // prepopulate the break thread in the thread cache
             ThreadContext cxt = await ThreadCache.GetThreadContext(thread);
 


### PR DESCRIPTION
This to fix a bug of NullReferenceException when stop debugging from run mode, Gdb will need to send a signal to debuggee to stop it and end up with a *stop event. MIEngine try to get the thread information when handling the *stop event, but can't get it since all threads has exit and the thread cache has been cleaned up.