### PR TITLE
Fix enable breakpoint under run mode

### DIFF
--- a/src/MICore/CommandFactories/MICommandFactory.cs
+++ b/src/MICore/CommandFactories/MICommandFactory.cs
@@ -409,7 +409,7 @@ namespace MICore
 
         #region Breakpoints
 
-        protected virtual StringBuilder BuildBreakInsert(string condition)
+        protected virtual StringBuilder BuildBreakInsert(string condition, bool enabled)
         {
             StringBuilder cmd = new StringBuilder("-break-insert -f ");
             if (condition != null)
@@ -418,12 +418,16 @@ namespace MICore
                 cmd.Append(condition);
                 cmd.Append("\" ");
             }
+            if (!enabled)
+            {
+                cmd.Append("-d ");
+            }
             return cmd;
         }
 
-        public virtual async Task<Results> BreakInsert(string filename, uint line, string condition, IEnumerable<Checksum> checksums = null, ResultClass resultClass = ResultClass.done)
+        public virtual async Task<Results> BreakInsert(string filename, uint line, string condition, bool enabled, IEnumerable<Checksum> checksums = null, ResultClass resultClass = ResultClass.done)
         {
-            StringBuilder cmd = BuildBreakInsert(condition);
+            StringBuilder cmd = BuildBreakInsert(condition, enabled);
 
             if (checksums != null && checksums.Count() != 0)
             {
@@ -438,17 +442,17 @@ namespace MICore
             return await _debugger.CmdAsync(cmd.ToString(), resultClass);
         }
 
-        public virtual async Task<Results> BreakInsert(string functionName, string condition, ResultClass resultClass = ResultClass.done)
+        public virtual async Task<Results> BreakInsert(string functionName, string condition, bool enabled, ResultClass resultClass = ResultClass.done)
         {
-            StringBuilder cmd = BuildBreakInsert(condition);
+            StringBuilder cmd = BuildBreakInsert(condition, enabled);
             // TODO: Add support of break function type filename:function locations
             cmd.Append(functionName);
             return await _debugger.CmdAsync(cmd.ToString(), resultClass);
         }
 
-        public virtual async Task<Results> BreakInsert(ulong codeAddress, string condition, ResultClass resultClass = ResultClass.done)
+        public virtual async Task<Results> BreakInsert(ulong codeAddress, string condition, bool enabled, ResultClass resultClass = ResultClass.done)
         {
-            StringBuilder cmd = BuildBreakInsert(condition);
+            StringBuilder cmd = BuildBreakInsert(condition, enabled);
             cmd.Append('*');
             cmd.Append(codeAddress);
             return await _debugger.CmdAsync(cmd.ToString(), resultClass);

--- a/src/MICore/CommandFactories/lldb.cs
+++ b/src/MICore/CommandFactories/lldb.cs
@@ -46,7 +46,7 @@ namespace MICore
             }
         }
 
-        protected override StringBuilder BuildBreakInsert(string condition)
+        protected override StringBuilder BuildBreakInsert(string condition, bool enabled)
         {
             // LLDB's use of the pending flag requires an optional parameter or else it fails.
             // We will use "on" for now. 
@@ -61,6 +61,10 @@ namespace MICore
                 cmd.Append("-c \"");
                 cmd.Append(condition);
                 cmd.Append("\" ");
+            }
+            if (!enabled)
+            {
+                cmd.Append("-d ");
             }
             return cmd;
         }

--- a/src/MIDebugEngine/AD7.Impl/AD7BoundBreakpoint.cs
+++ b/src/MIDebugEngine/AD7.Impl/AD7BoundBreakpoint.cs
@@ -20,10 +20,20 @@ namespace Microsoft.MIDebugEngine
         private AD7Engine _engine;
         private BoundBreakpoint _bp;
 
-        private bool _enabled;
         private bool _deleted;
 
-        internal bool Enabled { get { return _enabled; } }
+        internal bool Enabled
+        {
+            get
+            {
+                return _bp.Enabled;
+            }
+            set
+            {
+                _bp.Enabled = value;
+            }
+        }
+
         internal bool Deleted { get { return _deleted; } }
         internal ulong Addr
         {
@@ -38,7 +48,6 @@ namespace Microsoft.MIDebugEngine
             _engine = engine;
             _pendingBreakpoint = pendingBreakpoint;
             _breakpointResolution = breakpointResolution;
-            _enabled = true;
             _deleted = false;
             _bp = bp;
         }
@@ -65,7 +74,7 @@ namespace Microsoft.MIDebugEngine
         // Called by the debugger UI when the user is enabling or disabling a breakpoint.
         int IDebugBoundBreakpoint2.Enable(int fEnable)
         {
-            _enabled = fEnable == 0 ? false : true;
+            Enabled = fEnable == 0 ? false : true;
             return Constants.S_OK;
         }
 
@@ -92,11 +101,11 @@ namespace Microsoft.MIDebugEngine
             {
                 pState[0] = enum_BP_STATE.BPS_DELETED;
             }
-            else if (_enabled)
+            else if (Enabled)
             {
                 pState[0] = enum_BP_STATE.BPS_ENABLED;
             }
-            else if (!_enabled)
+            else if (!Enabled)
             {
                 pState[0] = enum_BP_STATE.BPS_DISABLED;
             }

--- a/src/MIDebugEngine/AD7.Impl/AD7PendingBreakpoint.cs
+++ b/src/MIDebugEngine/AD7.Impl/AD7PendingBreakpoint.cs
@@ -310,15 +310,15 @@ namespace Microsoft.MIDebugEngine
                 // Bind all breakpoints that match this source and line number.
                 if (documentName != null)
                 {
-                    bindResult = await PendingBreakpoint.Bind(documentName, startPosition[0].dwLine + 1, startPosition[0].dwColumn, _engine.DebuggedProcess, condition, checksums, this);
+                    bindResult = await PendingBreakpoint.Bind(documentName, startPosition[0].dwLine + 1, startPosition[0].dwColumn, _engine.DebuggedProcess, condition, _enabled, checksums, this);
                 }
                 else if (functionName != null)
                 {
-                    bindResult = await PendingBreakpoint.Bind(functionName, _engine.DebuggedProcess, condition, this);
+                    bindResult = await PendingBreakpoint.Bind(functionName, _engine.DebuggedProcess, condition, _enabled, this);
                 }
                 else if (codeAddress != 0)
                 {
-                    bindResult = await PendingBreakpoint.Bind(codeAddress, _engine.DebuggedProcess, condition, this);
+                    bindResult = await PendingBreakpoint.Bind(codeAddress, _engine.DebuggedProcess, condition, _enabled, this);
                 }
                 else
                 {

--- a/src/MIDebugEngine/AD7.Impl/AD7PendingBreakpoint.cs
+++ b/src/MIDebugEngine/AD7.Impl/AD7PendingBreakpoint.cs
@@ -439,7 +439,12 @@ namespace Microsoft.MIDebugEngine
                 PendingBreakpoint bp = _bp;
                 if (bp != null)
                 {
-                    bp.Enable(_enabled, _engine.DebuggedProcess);
+                    _engine.DebuggedProcess.WorkerThread.RunOperation(() =>
+                    {
+                        _engine.DebuggedProcess.AddInternalBreakAction(
+                            () => bp.EnableAsync(_enabled, _engine.DebuggedProcess)
+                        );
+                    });
                 }
             }
 
@@ -543,7 +548,7 @@ namespace Microsoft.MIDebugEngine
                 {
                     _engine.DebuggedProcess.AddInternalBreakAction(
                         () => bp.SetConditionAsync(bpCondition.bstrCondition, _engine.DebuggedProcess)
-                            );
+                    );
                 });
             }
             return Constants.S_OK;
@@ -580,7 +585,7 @@ namespace Microsoft.MIDebugEngine
 
         internal async Task EnableAfterFuncEvalAsync()
         {
-            if (_enabled && _bp != null)
+            if (!_enabled && _bp != null)
             {
                 await _bp.EnableAsync(true, _engine.DebuggedProcess);
             }

--- a/src/MIDebugEngine/Engine.Impl/Breakpoints.cs
+++ b/src/MIDebugEngine/Engine.Impl/Breakpoints.cs
@@ -84,18 +84,18 @@ namespace Microsoft.MIDebugEngine
             }
         }
 
-        internal static async Task<BindResult> Bind(string functionName, DebuggedProcess process, string condition, AD7PendingBreakpoint pbreak)
+        internal static async Task<BindResult> Bind(string functionName, DebuggedProcess process, string condition, bool enabled, AD7PendingBreakpoint pbreak)
         {
             process.VerifyNotDebuggingCoreDump();
 
-            return EvalBindResult(await process.MICommandFactory.BreakInsert(functionName, condition, ResultClass.None), pbreak);
+            return EvalBindResult(await process.MICommandFactory.BreakInsert(functionName, condition, enabled, ResultClass.None), pbreak);
         }
 
-        internal static async Task<BindResult> Bind(ulong codeAddress, DebuggedProcess process, string condition, AD7PendingBreakpoint pbreak)
+        internal static async Task<BindResult> Bind(ulong codeAddress, DebuggedProcess process, string condition, bool enabled, AD7PendingBreakpoint pbreak)
         {
             process.VerifyNotDebuggingCoreDump();
 
-            return EvalBindResult(await process.MICommandFactory.BreakInsert(codeAddress, condition, ResultClass.None), pbreak);
+            return EvalBindResult(await process.MICommandFactory.BreakInsert(codeAddress, condition, enabled, ResultClass.None), pbreak);
         }
 
         internal static async Task<BindResult> Bind(string address, uint size, DebuggedProcess process, string condition, AD7PendingBreakpoint pbreak)
@@ -105,14 +105,14 @@ namespace Microsoft.MIDebugEngine
             return EvalBindWatchResult(await process.MICommandFactory.BreakWatch(address, size, ResultClass.None), pbreak, address, size);
         }
 
-        internal static async Task<BindResult> Bind(string documentName, uint line, uint column, DebuggedProcess process, string condition, IEnumerable<Checksum> checksums, AD7PendingBreakpoint pbreak)
+        internal static async Task<BindResult> Bind(string documentName, uint line, uint column, DebuggedProcess process, string condition, bool enabled, IEnumerable<Checksum> checksums, AD7PendingBreakpoint pbreak)
         {
             process.VerifyNotDebuggingCoreDump();
 
             string basename = System.IO.Path.GetFileName(documentName);     // get basename from Windows path
             basename = process.EscapePath(basename);
 
-            BindResult bindResults = EvalBindResult(await process.MICommandFactory.BreakInsert(basename, line, condition, checksums, ResultClass.None), pbreak);
+            BindResult bindResults = EvalBindResult(await process.MICommandFactory.BreakInsert(basename, line, condition, enabled, checksums, ResultClass.None), pbreak);
 
             // On GDB, the returned line information is from the pending breakpoint instead of the bound breakpoint.
             // Check the address mapping to make sure the line info is correct.
@@ -360,6 +360,7 @@ namespace Microsoft.MIDebugEngine
         /*OPTIONAL*/
         public string FunctionName { get; private set; }
         internal uint HitCount { get; private set; }
+        internal bool Enabled { get; set; }
         internal bool IsDataBreakpoint { get { return _parent.AD7breakpoint.IsDataBreakpoint; } }
         private MITextPosition _textPosition;
 
@@ -368,14 +369,17 @@ namespace Microsoft.MIDebugEngine
             // CLRDBG TODO: Support clr addresses for breakpoints
             this.Addr = bindinfo.TryFindAddr("addr") ?? 0;
             this.FunctionName = bindinfo.TryFindString("func");
+            this.Enabled = bindinfo.TryFindString("enabled") == "n" ? false : true;
             this.HitCount = 0;
             _parent = parent;
             _textPosition = MITextPosition.TryParse(bindinfo);
         }
+
         internal BoundBreakpoint(PendingBreakpoint parent, ulong addr, /*optional*/ TupleValue frame)
         {
             Addr = addr;
             HitCount = 0;
+            Enabled = true;
             _parent = parent;
 
             if (frame != null)
@@ -388,6 +392,7 @@ namespace Microsoft.MIDebugEngine
         internal BoundBreakpoint(PendingBreakpoint parent, ulong addr, uint size)
         {
             Addr = addr;
+            Enabled = true;
             _parent = parent;
         }
 

--- a/src/MIDebugEngine/Engine.Impl/Breakpoints.cs
+++ b/src/MIDebugEngine/Engine.Impl/Breakpoints.cs
@@ -315,14 +315,6 @@ namespace Microsoft.MIDebugEngine
             }
         }
 
-        internal void Enable(bool bEnable, DebuggedProcess process)
-        {
-            process.WorkerThread.RunOperation(async () =>
-            {
-                await EnableInternal(bEnable, process);
-            });
-        }
-
         internal async Task EnableAsync(bool bEnable, DebuggedProcess process)
         {
             await EnableInternal(bEnable, process);

--- a/src/MIDebugEngine/Engine.Impl/DebugUnixChildProcess.cs
+++ b/src/MIDebugEngine/Engine.Impl/DebugUnixChildProcess.cs
@@ -130,7 +130,7 @@ namespace Microsoft.MIDebugEngine
 
         public async Task SetBreakAtMain()
         {
-            Results results = await _process.MICommandFactory.BreakInsert("main", null);
+            Results results = await _process.MICommandFactory.BreakInsert("main", condition: null, enabled: true);
             var bkpt = results.Find("bkpt");
             if (bkpt is ValueListValue)
             {


### PR DESCRIPTION
Before the fix, trying to enable a disabled breakpoint in run mode won't have affect, even after we enter break mode later it won't be enabled, the breakpoint will be "Pending" forever.
This fix won't affect VSCode scenario because VSCode only insert/delete, and the enable/disable code path isn't executed.

Fix bug https://devdiv.visualstudio.com/DevDiv/VS%20Diag%20IntelliTrace/_workItems/index?_a=edit&id=226898&triage=true