### PR TITLE
Fix for Stack Frame parameters on LLDB

### DIFF
--- a/src/MICore/CommandFactories/lldb.cs
+++ b/src/MICore/CommandFactories/lldb.cs
@@ -36,6 +36,16 @@ namespace MICore
             return false;
         }
 
+        public override bool SupportsFrameFormatting
+        {
+            get
+            {
+                // LLDB already adds the parameter list to the function name when a -stack-list-frame or -stack-info-frame
+                // call is made so setting this to true so we don't append the parameters on stack frames.
+                return true;
+            }
+        }
+
         public override async Task<Results> VarCreate(string expression, int threadId, uint frameLevel, enum_EVALFLAGS dwFlags, ResultClass resultClass = ResultClass.done)
         {
             string command = string.Format("-var-create - - \"{0}\"", expression);  // use '-' to indicate that "--frame" should be used to determine the frame number

--- a/src/MIDebugEngine/Engine.Impl/DebuggedProcess.cs
+++ b/src/MIDebugEngine/Engine.Impl/DebuggedProcess.cs
@@ -1445,7 +1445,7 @@ namespace Microsoft.MIDebugEngine
             return variables;
         }
 
-        //This method gets the value/type info for the method parameters without creating an MI debugger varialbe for them. For use in the callstack window
+        //This method gets the value/type info for the method parameters without creating an MI debugger variable for them. For use in the callstack window
         //NOTE: eval is not called
         public async Task<List<SimpleVariableInformation>> GetParameterInfoOnly(AD7Thread thread, ThreadContext ctx)
         {
@@ -1461,7 +1461,7 @@ namespace Microsoft.MIDebugEngine
             return parameters;
         }
 
-        //This method gets the value/type info for the method parameters of all frames without creating an mi debugger varialbe for them. For use in the callstack window
+        //This method gets the value/type info for the method parameters of all frames without creating an mi debugger variable for them. For use in the callstack window
         //NOTE: eval is not called
         public async Task<List<ArgumentList>> GetParameterInfoOnly(AD7Thread thread, bool values, bool types, uint low, uint high)
         {


### PR DESCRIPTION
LLDB already appends parameter types to function names in its MI stack
info calls.

Also fixed some spelling errors.

@wiktork @gregg-miskelly @chuckries 