### PR TITLE
Allow lldb-mi's conditional breakpoint -break-insert to work with -f

### DIFF
--- a/src/MICore/CommandFactories/MICommandFactory.cs
+++ b/src/MICore/CommandFactories/MICommandFactory.cs
@@ -409,7 +409,7 @@ namespace MICore
 
         #region Breakpoints
 
-        private StringBuilder BuildBreakInsert(string condition)
+        protected virtual StringBuilder BuildBreakInsert(string condition)
         {
             StringBuilder cmd = new StringBuilder("-break-insert -f ");
             if (condition != null)

--- a/src/MICore/CommandFactories/lldb.cs
+++ b/src/MICore/CommandFactories/lldb.cs
@@ -46,6 +46,25 @@ namespace MICore
             }
         }
 
+        protected override StringBuilder BuildBreakInsert(string condition)
+        {
+            // LLDB's use of the pending flag requires an optional parameter or else it fails.
+            // We will use "on" for now. 
+            // TODO: Fix this on LLDB-MI's side
+            string pendingFlag = "-f on ";
+
+            StringBuilder cmd = new StringBuilder("-break-insert ");
+            cmd.Append(pendingFlag);
+
+            if (condition != null)
+            {
+                cmd.Append("-c \"");
+                cmd.Append(condition);
+                cmd.Append("\" ");
+            }
+            return cmd;
+        }
+
         public override async Task<Results> VarCreate(string expression, int threadId, uint frameLevel, enum_EVALFLAGS dwFlags, ResultClass resultClass = ResultClass.done)
         {
             string command = string.Format("-var-create - - \"{0}\"", expression);  // use '-' to indicate that "--frame" should be used to determine the frame number
@@ -67,6 +86,7 @@ namespace MICore
 
             return await _debugger.CmdAsync(threadCommand, expectedResultClass);
         }
+
         public override Task<List<ulong>> StartAddressesForLine(string file, uint line)
         {
             return Task.FromResult<List<ulong>>(null);


### PR DESCRIPTION
-break-insert's -f on lldb-mi requires a parameter.

@faxue-msft @chuckries 