### PR TITLE
Change signing error message to not be shown for lldb-mi

### DIFF
--- a/src/MIDebugEngine/Engine.Impl/DebuggedProcess.cs
+++ b/src/MIDebugEngine/Engine.Impl/DebuggedProcess.cs
@@ -176,6 +176,7 @@ namespace Microsoft.MIDebugEngine
 
                 if (PlatformUtilities.IsOSX() &&
                     localLaunchOptions.DebuggerMIMode != MIMode.Clrdbg &&
+                    localLaunchOptions.DebuggerMIMode != MIMode.Lldb && 
                     !UnixUtilities.IsBinarySigned(localLaunchOptions.MIDebuggerPath))
                 {
                     string message = String.Format(CultureInfo.CurrentCulture, ResourceStrings.Warning_DarwinDebuggerUnsigned, localLaunchOptions.MIDebuggerPath);


### PR DESCRIPTION
The executable that is signed is not lldb-mi but debugserver

@edumunoz 