### PR TITLE
LLDB also doesn't send thread-group-exited when -target-detach is issued

### DIFF
--- a/src/MIDebugEngine/Engine.Impl/DebuggedProcess.cs
+++ b/src/MIDebugEngine/Engine.Impl/DebuggedProcess.cs
@@ -1381,10 +1381,10 @@ namespace Microsoft.MIDebugEngine
 
         public void Detach()
         {
-            // Special casing sending the fake stopped event for clrdbg. 
+            // Special casing sending the fake stopped event for clrdbg and lldb. 
             // GDB prints out thread group exit events on mi command "-target-detach" which is handed by method HandleThreadGroupExited
             // GDB or the debuggee can terminate and those are handled by Terminate and TerminateProcess methods.
-            if (MICommandFactory.Mode == MIMode.Clrdbg)
+            if (MICommandFactory.Mode == MIMode.Clrdbg || MICommandFactory.Mode == MIMode.Lldb)
             {
                 ScheduleStdOutProcessing(@"*stopped,reason=""disconnected""");
             }


### PR DESCRIPTION
This seems to be the same as clrdbg. Adding the same fix.
@edumunoz @rajkumar42 @chuckries 