### PR TITLE
Users/jacdavis

### DIFF
--- a/src/MICore/Transports/LocalTransport.cs
+++ b/src/MICore/Transports/LocalTransport.cs
@@ -27,7 +27,10 @@ namespace MICore
             Process proc = new Process();
             proc.StartInfo.FileName = localOptions.MIDebuggerPath;
             proc.StartInfo.Arguments = "--interpreter=mi";
-            proc.StartInfo.WorkingDirectory = miDebuggerDir;
+
+            // LLDB has the -environment-cd mi command that is used to set the working dir for gdb/clrdbg, but it doesn't work.
+            // So, set lldb's working dir to the user's requested folder before launch.
+            proc.StartInfo.WorkingDirectory = options.DebuggerMIMode == MIMode.Lldb ? options.WorkingDirectory : miDebuggerDir;
 
             // On Windows, GDB locally requires that the directory be on the PATH, being the working directory isn't good enough
             if (PlatformUtilities.IsWindows() &&


### PR DESCRIPTION
Fix working directory for lldb launch.

    Normally, we set the working dir using the -environment-cd
    mi command. lldb does support this command, but sadly, it doesn't
    work, at least on mac. Instead, I'm setting the working dir
    of lldb at launch which will carry over to the debuggee.