### PR TITLE
InstallToVSCode: remove System.Diagnostics.StackTrace dependency

### DIFF
--- a/tools/InstallToVSCode/CLRDependencies/project.json.template
+++ b/tools/InstallToVSCode/CLRDependencies/project.json.template
@@ -9,7 +9,6 @@
     "System.Collections.Specialized":  "4.0.1",
     "System.Collections.Immutable": "1.2.0", 
     "System.Diagnostics.Process" : "4.1.0",
-    "System.Diagnostics.StackTrace":  "4.0.1",  
     "System.Dynamic.Runtime": "4.0.11",
     "Microsoft.CSharp": "4.0.1",
     "System.Threading.Tasks.Dataflow": "4.6.0",


### PR DESCRIPTION
InstallToVSCode declared a dependency on System.Diagnostics.StackTrace. As
far as I can tell, this is not needed, and having it breaks Dev15 versions
of clrdbg as it pulls down an older version of System.Reflection.Metadata.
This removes the dependency.