### PR TITLE
Fix for racecondition on startup with target architecture fix.

### DIFF
--- a/src/MICore/CommandFactories/MICommandFactory.cs
+++ b/src/MICore/CommandFactories/MICommandFactory.cs
@@ -551,10 +551,8 @@ namespace MICore
 
         #region Helpers
 
-        public virtual Task<TargetArchitecture> GetTargetArchitecture()
-        {
-            return Task.FromResult(TargetArchitecture.Unknown);
-        }
+        public abstract string GetTargetArchitectureCommand();
+        public abstract TargetArchitecture ParseTargetArchitectureResult(string result);
 
         public virtual async Task<Results> SetOption(string variable, string value, ResultClass resultClass = ResultClass.done)
         {

--- a/src/MICore/CommandFactories/clrdbg.cs
+++ b/src/MICore/CommandFactories/clrdbg.cs
@@ -230,10 +230,15 @@ namespace MICore
             throw new NotImplementedException("clrdbg catch command");
         }
 
-        public override Task<TargetArchitecture> GetTargetArchitecture()
+        public override string GetTargetArchitectureCommand()
         {
+            return null;
+        }
+
+        public override TargetArchitecture ParseTargetArchitectureResult(string result)
+        { 
             // CLRDBG only support x64 now.
-            return Task.FromResult(TargetArchitecture.X64);
+            return TargetArchitecture.X64;
         }
     }
 }

--- a/src/MICore/CommandFactories/gdb.cs
+++ b/src/MICore/CommandFactories/gdb.cs
@@ -230,10 +230,13 @@ namespace MICore
 
         public override bool SupportsDataBreakpoints { get { return true; } }
 
-        public override async Task<TargetArchitecture> GetTargetArchitecture()
+        public override string GetTargetArchitectureCommand()
         {
-            string cmd = "show architecture";
-            var result = await _debugger.ConsoleCmdAsync(cmd);
+            return "show architecture";
+        }
+
+        public override TargetArchitecture ParseTargetArchitectureResult(string result)
+        { 
             using (StringReader stringReader = new StringReader(result))
             {
                 while (true)

--- a/src/MICore/CommandFactories/lldb.cs
+++ b/src/MICore/CommandFactories/lldb.cs
@@ -98,10 +98,13 @@ namespace MICore
             return Task.FromResult((object)null);
         }
 
-        public override async Task<TargetArchitecture> GetTargetArchitecture()
+        public override string GetTargetArchitectureCommand()
         {
-            string cmd = "platform status";
-            var result = await _debugger.ConsoleCmdAsync(cmd);
+            return "platform status";
+        }
+
+        public override TargetArchitecture ParseTargetArchitectureResult(string result)
+        { 
             using (StringReader stringReader = new StringReader(result))
             {
                 while (true)

--- a/src/MICore/Debugger.cs
+++ b/src/MICore/Debugger.cs
@@ -661,7 +661,7 @@ namespace MICore
             PostCommand("-gdb-exit");
         }
 
-        private string Escape(string str)
+        protected string Escape(string str)
         {
             StringBuilder outStr = new StringBuilder();
             for (int i = 0; i < str.Length; ++i)

--- a/src/MICore/Debugger.cs
+++ b/src/MICore/Debugger.cs
@@ -661,7 +661,7 @@ namespace MICore
             PostCommand("-gdb-exit");
         }
 
-        protected string Escape(string str)
+        private string Escape(string str)
         {
             StringBuilder outStr = new StringBuilder();
             for (int i = 0; i < str.Length; ++i)

--- a/src/MIDebugEngine/Engine.Impl/DebuggedProcess.cs
+++ b/src/MIDebugEngine/Engine.Impl/DebuggedProcess.cs
@@ -516,21 +516,6 @@ namespace Microsoft.MIDebugEngine
                     }
                 }
 
-                var arch = await MICommandFactory.GetTargetArchitecture();
-                if (arch == TargetArchitecture.Unknown)
-                {
-                    if (LaunchOptions.TargetArchitecture != TargetArchitecture.Unknown)
-                    {
-                        arch = LaunchOptions.TargetArchitecture;
-                    }
-                    else
-                    {
-                        WriteOutput(ResourceStrings.Warning_UsingDefaultArchitecture);
-                        arch = TargetArchitecture.X64;  // use as default
-                    }
-                }
-                SetTargetArch(arch);
-
                 success = true;
             }
             finally
@@ -610,6 +595,9 @@ namespace Microsoft.MIDebugEngine
                     // Add executable information
                     this.AddExecutablePathCommand(commands);
 
+                    // Important: this must occur after file-exec-and-symbols but before anything else.
+                    this.AddGetTargetArchitectureCommand(commands);
+
                     // Add core dump information (linux/mac does not support quotes around this path but spaces in the path do work)
                     string coreDump = _launchOptions.UseUnixSymbolPaths ? _launchOptions.CoreDumpPath : EscapePath(_launchOptions.CoreDumpPath);
                     string coreDumpCommand = _launchOptions.DebuggerMIMode == MIMode.Lldb ? String.Concat("target create --core ", coreDump) : String.Concat("-target-select core ", coreDump);
@@ -622,12 +610,17 @@ namespace Microsoft.MIDebugEngine
 
                     CheckCygwin(commands, localLaunchOptions);
 
+                    this.AddExecutablePathCommand(commands);
+
                     // check for remote
                     string destination = localLaunchOptions?.MIDebuggerServerAddress;
                     if (!string.IsNullOrEmpty(destination))
                     {
                         commands.Add(new LaunchCommand("-target-select remote " + destination, string.Format(CultureInfo.CurrentUICulture, ResourceStrings.ConnectingMessage, destination)));
                     }
+
+                    // Important: this must occur after file-exec-and-symbols but before anything else.
+                    this.AddGetTargetArchitectureCommand(commands);
 
                     int pid = localLaunchOptions.ProcessId;
                     commands.Add(new LaunchCommand(String.Format(CultureInfo.CurrentUICulture, "-target-attach {0}", pid), ignoreFailures: false));
@@ -676,6 +669,9 @@ namespace Microsoft.MIDebugEngine
                     }
 
                     this.AddExecutablePathCommand(commands);
+
+                    // Important: this must occur after file-exec-and-symbols but before anything else.
+                    this.AddGetTargetArchitectureCommand(commands);
 
                     // LLDB requires -exec-arguments after -file-exec-and-symbols has been run, or else it errors
                     if (!string.IsNullOrWhiteSpace(_launchOptions.ExeArguments))
@@ -728,6 +724,7 @@ namespace Microsoft.MIDebugEngine
         {
             string exe = EscapePath(_launchOptions.ExePath);
             string description = string.Format(CultureInfo.CurrentUICulture, ResourceStrings.LoadingSymbolMessage, _launchOptions.ExePath);
+
             Action<string> failureHandler = (string miError) =>
             {
                 string message = string.Format(CultureInfo.CurrentUICulture, ResourceStrings.Error_ExePathInvalid, _launchOptions.ExePath, MICommandFactory.Name, miError);
@@ -735,6 +732,44 @@ namespace Microsoft.MIDebugEngine
             };
 
             commands.Add(new LaunchCommand("-file-exec-and-symbols " + exe, description, ignoreFailures: false, failureHandler: failureHandler));
+        }
+
+        private void AddGetTargetArchitectureCommand(IList<LaunchCommand> commands)
+        {
+            Action<string> failureHandler = (string miError) =>
+            {
+                // TODO: new failure message
+                string message = string.Format(CultureInfo.CurrentUICulture, ResourceStrings.Error_ExePathInvalid, _launchOptions.ExePath, MICommandFactory.Name, miError);
+                throw new LaunchErrorException(message);
+            };
+
+            Action<string> successHandler = (string resultsStr) =>
+            {
+                TargetArchitecture arch = MICommandFactory.ParseTargetArchitectureResult(resultsStr);
+
+                if (LaunchOptions.TargetArchitecture != TargetArchitecture.Unknown)
+                {
+                    arch = LaunchOptions.TargetArchitecture;
+                }
+                else
+                {
+                    WriteOutput(ResourceStrings.Warning_UsingDefaultArchitecture);
+                    arch = TargetArchitecture.X64;  // use as default
+                }
+
+                SetTargetArch(arch);
+            };
+
+            string cmd = MICommandFactory.GetTargetArchitectureCommand();
+
+            if (cmd != null)
+            {
+                commands.Add(new LaunchCommand(cmd, ignoreFailures: false, successHandler: successHandler, failureHandler: failureHandler));
+            }
+            else
+            {
+                SetTargetArch(MICommandFactory.ParseTargetArchitectureResult(null));
+            }
         }
 
         public override void FlushBreakStateData()

--- a/src/MIDebugEngine/ResourceStrings.Designer.cs
+++ b/src/MIDebugEngine/ResourceStrings.Designer.cs
@@ -10,7 +10,6 @@
 
 namespace Microsoft.MIDebugEngine {
     using System;
-    using System.Reflection;
     
     
     /// <summary>
@@ -40,7 +39,7 @@ namespace Microsoft.MIDebugEngine {
         internal static global::System.Resources.ResourceManager ResourceManager {
             get {
                 if (object.ReferenceEquals(resourceMan, null)) {
-                    global::System.Resources.ResourceManager temp = new global::System.Resources.ResourceManager("Microsoft.MIDebugEngine.ResourceStrings", typeof(ResourceStrings).GetTypeInfo().Assembly);
+                    global::System.Resources.ResourceManager temp = new global::System.Resources.ResourceManager("Microsoft.MIDebugEngine.ResourceStrings", typeof(ResourceStrings).Assembly);
                     resourceMan = temp;
                 }
                 return resourceMan;
@@ -96,6 +95,15 @@ namespace Microsoft.MIDebugEngine {
         internal static string Error_ExePathInvalid {
             get {
                 return ResourceManager.GetString("Error_ExePathInvalid", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Failed to obtain target architecture..
+        /// </summary>
+        internal static string Error_FailedToGetTargetArchitecture {
+            get {
+                return ResourceManager.GetString("Error_FailedToGetTargetArchitecture", resourceCulture);
             }
         }
         

--- a/src/MIDebugEngine/ResourceStrings.resx
+++ b/src/MIDebugEngine/ResourceStrings.resx
@@ -229,4 +229,7 @@
     <value>Debugger executable '{0}' is not signed. As a result, debugging may not work properly.</value>
     <comment>0 = debugger path</comment>
   </data>
+  <data name="Error_FailedToGetTargetArchitecture" xml:space="preserve">
+    <value>Failed to obtain target architecture.</value>
+  </data>
 </root>


### PR DESCRIPTION
The target architecture fix introduced a race condition between
the -exec-run or -target-attach and the module loads finishing.
This was causing many debuggees to fail during attach or startup
due to the process state not being able to send the console command
to obtain the architecture. This moves the acquisition of that state
to between the -file-exec-and-symbols and the actual running.

NOTE: needed to set the binary on attach so that the debuggers
know the architecture. Apparently, the miengine wasn't doing that
before.