### PR TITLE
Add noDebug flag for clrdbg

### DIFF
--- a/src/MICore/CommandFactories/MICommandFactory.cs
+++ b/src/MICore/CommandFactories/MICommandFactory.cs
@@ -242,7 +242,7 @@ namespace MICore
         /// <summary>
         /// Tells GDB to spawn a target process previous setup with -file-exec-and-symbols or similar
         /// </summary>
-        public async Task ExecRun()
+        public virtual async Task ExecRun()
         {
             string command = "-exec-run";
             await _debugger.CmdAsync(command, ResultClass.running);

--- a/src/MICore/CommandFactories/clrdbg.cs
+++ b/src/MICore/CommandFactories/clrdbg.cs
@@ -199,6 +199,13 @@ namespace MICore
             }
         }
 
+        public override async Task ExecRun()
+        {
+            string command = (_debugger.LaunchOptions.NoDebug) ? "-exec-run --noDebug" : "-exec-run";
+            _debugger.VerifyNotDebuggingCoreDump();
+            await _debugger.CmdAsync(command, ResultClass.running);
+        }
+
         override public async Task Terminate()
         {
             string command = "-exec-abort";

--- a/src/MICore/LaunchOptions.cs
+++ b/src/MICore/LaunchOptions.cs
@@ -414,6 +414,8 @@ namespace MICore
 
         public MIMode DebuggerMIMode { get; set; }
 
+        public bool NoDebug { get; private set; } = false;
+
         private Xml.LaunchOptions.BaseLaunchOptions _baseOptions;
         /// <summary>
         /// Hold on to options in serializable form to support child process debugging
@@ -707,10 +709,10 @@ namespace MICore
         // Kofe debugger depends on this method to generate LaunchOptions
         public static LaunchOptions GetInstance(HostConfigurationStore configStore, string exePath, string args, string dir, string options, IDeviceAppLauncherEventCallback eventCallback, TargetEngine targetEngine)
         {
-            return GetInstance(configStore, exePath, args, dir, options, eventCallback, targetEngine, null);
+            return GetInstance(configStore, exePath, args, dir, options, false, eventCallback, targetEngine, null);
         }
 
-        public static LaunchOptions GetInstance(HostConfigurationStore configStore, string exePath, string args, string dir, string options, IDeviceAppLauncherEventCallback eventCallback, TargetEngine targetEngine, Logger logger)
+        public static LaunchOptions GetInstance(HostConfigurationStore configStore, string exePath, string args, string dir, string options, bool noDebug, IDeviceAppLauncherEventCallback eventCallback, TargetEngine targetEngine, Logger logger)
         {
             if (string.IsNullOrWhiteSpace(exePath))
                 throw new ArgumentNullException("exePath");
@@ -806,6 +808,8 @@ namespace MICore
 
             if (string.IsNullOrEmpty(launchOptions.WorkingDirectory))
                 launchOptions.WorkingDirectory = dir;
+
+            launchOptions.NoDebug = noDebug;
 
             if (launchOptions._setupCommands == null)
                 launchOptions._setupCommands = new List<LaunchCommand>(capacity: 0).AsReadOnly();

--- a/src/MICoreUnitTests/BasicLaunchOptionsTests.cs
+++ b/src/MICoreUnitTests/BasicLaunchOptionsTests.cs
@@ -311,7 +311,7 @@ namespace MICoreUnitTests
 
         private LaunchOptions GetLaunchOptions(string content)
         {
-            return LaunchOptions.GetInstance(null, "bogus-exe-path", null, null, content, null, TargetEngine.Native, null);
+            return LaunchOptions.GetInstance(null, "bogus-exe-path", null, null, content, false, null, TargetEngine.Native, null);
         }
     }
 }

--- a/src/MIDebugEngine/AD7.Impl/AD7Engine.cs
+++ b/src/MIDebugEngine/AD7.Impl/AD7Engine.cs
@@ -439,8 +439,10 @@ namespace Microsoft.MIDebugEngine
 
             try
             {
+                bool noDebug = launchFlags.HasFlag(enum_LAUNCH_FLAGS.LAUNCH_NODEBUG);
+
                 // Note: LaunchOptions.GetInstance can be an expensive operation and may push a wait message loop
-                LaunchOptions launchOptions = LaunchOptions.GetInstance(_configStore, exe, args, dir, options, _engineCallback, TargetEngine.Native, Logger);
+                LaunchOptions launchOptions = LaunchOptions.GetInstance(_configStore, exe, args, dir, options, noDebug, _engineCallback, TargetEngine.Native, Logger);
 
                 // We are being asked to debug a process when we currently aren't debugging anything
                 _pollThread = new WorkerThread(Logger);


### PR DESCRIPTION
Add `--noDebug` flag to clrdbg's `-exec-run` command to enable Ctrl-F5 support for VS Code.