### PR TITLE
Fix DebuggedProcess.HandleBreakModeEvent for deleted breakpoints

### DIFF
--- a/src/MIDebugEngine/Engine.Impl/DebuggedProcess.cs
+++ b/src/MIDebugEngine/Engine.Impl/DebuggedProcess.cs
@@ -1060,15 +1060,20 @@ namespace Microsoft.MIDebugEngine
                     _callback.OnException(thread, "Unknown", "Unknown stopping event", 0);
                 }
             }
-            if (breakRequest != BreakRequest.None)
+            if (IsExternalBreakRequest(breakRequest))
             {
                 _callback.OnStopComplete(thread);
             }
         }
 
+        private static bool IsExternalBreakRequest(BreakRequest breakRequest)
+        {
+            return breakRequest == BreakRequest.Async || breakRequest == BreakRequest.Stop;
+        }
+
         private void CmdContinueAsyncConditional(BreakRequest request)
         {
-            if (request != BreakRequest.None)
+            if (!IsExternalBreakRequest(request))
             {
                 CmdContinueAsync();
             }


### PR DESCRIPTION
The change to support async stop events had a bug that caused us to leave the debuggee in stop state but not send a stopping event to the UI if a breakpoint was deleted in run mode by the user, but the breakpoint was hit before it made it to the command line debugger.

This fixes it.