### PR TITLE
Deploying ClrDbg as part of debugger initialization for SSH transport.

### DIFF
--- a/src/DebugEngineHost.Stub/DebugEngineHost.ref.cs
+++ b/src/DebugEngineHost.Stub/DebugEngineHost.ref.cs
@@ -437,6 +437,15 @@ namespace Microsoft.DebugEngineHost
         }
 
         /// <summary>
+        /// Sets the text of the dialog without changing the progress.
+        /// </summary>
+        /// <param name="text">Text to set.</param>
+        public void SetText(string text)
+        {
+            throw new NotImplementedException();
+        }
+
+        /// <summary>
         /// Wait for the specified handle to be signaled.
         /// </summary>
         /// <param name="handle">Handle to wait on.</param>

--- a/src/DebugEngineHost/HostWaitLoop.cs
+++ b/src/DebugEngineHost/HostWaitLoop.cs
@@ -29,6 +29,15 @@ namespace Microsoft.DebugEngineHost
         }
 
         /// <summary>
+        /// Sets the text of the dialog without changing the progress.
+        /// </summary>
+        /// <param name="text">Text to set.</param>
+        public void SetText(string text)
+        {
+            _vsWaitLoop.SetText(text);
+        }
+
+        /// <summary>
         /// Waits on the specified handle. This method should be called only once.
         /// </summary>
         /// <param name="launchCompleteHandle">[Required] handle to wait on</param>

--- a/src/DebugEngineHost/VSImpl/VsWaitLoop.cs
+++ b/src/DebugEngineHost/VSImpl/VsWaitLoop.cs
@@ -120,5 +120,10 @@ namespace Microsoft.DebugEngineHost.VSImpl
         {
             _messagePump.SetProgressInfo(totalSteps, currentStep, progressText);
         }
+
+        public void SetText(string text)
+        {
+            _messagePump.SetWaitText(text);
+        }
     }
 }

--- a/src/MICore/Debugger.cs
+++ b/src/MICore/Debugger.cs
@@ -10,6 +10,7 @@ using System.Threading.Tasks;
 using System.Globalization;
 using System.Linq;
 using Microsoft.Win32.SafeHandles;
+using Microsoft.DebugEngineHost;
 
 namespace MICore
 {
@@ -402,13 +403,13 @@ namespace MICore
             return processContinued;
         }
 
-        public void Init(ITransport transport, LaunchOptions options)
+        public void Init(ITransport transport, LaunchOptions options, HostWaitLoop waitLoop = null)
         {
             _lastCommandId = 1000;
             _transport = transport;
             FlushBreakStateData();
 
-            _transport.Init(this, options, Logger);
+            _transport.Init(this, options, Logger, waitLoop);
         }
 
         public void SetTargetArch(TargetArchitecture arch)

--- a/src/MICore/LaunchOptions.cs
+++ b/src/MICore/LaunchOptions.cs
@@ -405,6 +405,13 @@ namespace MICore
         public string StartRemoteDebuggerCommand { get; private set; }
         public Microsoft.VisualStudio.Debugger.Interop.UnixPortSupplier.IDebugUnixShellPort UnixPort { get; private set; }
 
+        public static bool LastDebuggerLaunchSuccessful = false;
+
+        private static string GetClrDbgUrl = "https://raw.githubusercontent.com/Microsoft/MIEngine/dev/rajkumar42/updatescript/scripts/GetClrDbg.sh";
+        private static string DebugerInstallationDirectory = "~/.vs-debugger";
+        private static string DebuggerFirstLaunchCommand = "mkdir -p {0} && wget -q {1} -O {0}/GetClrDbg.sh && chmod +x {0}/GetClrDbg.sh && {0}/GetClrDbg.sh -v latest -l {0}/latest -d -u";
+        private static string DebuggerSubsequentLaunchCommand = "{0}/GetClrDbg.sh -v latest -l {0}/latest -d";
+
         public UnixShellPortLaunchOptions(string startRemoteDebuggerCommand, Microsoft.VisualStudio.Debugger.Interop.UnixPortSupplier.IDebugUnixShellPort unixPort, MIMode miMode, BaseLaunchOptions baseLaunchOptions)
         {
             this.UnixPort = unixPort;
@@ -422,8 +429,14 @@ namespace MICore
                         startRemoteDebuggerCommand = "lldb-mi --interpreter=mi";
                         break;
                     case MIMode.Clrdbg:
-                        // TODO: Replace with a set of commands for downloading clrdbg from the web if it isn't already present
-                        startRemoteDebuggerCommand = "~/clrdbg/out/Linux/bin/x64.Debug/clrdbg/clrdbg --interpreter=mi";
+                        if (!LastDebuggerLaunchSuccessful)
+                        {
+                            startRemoteDebuggerCommand = string.Format(CultureInfo.InvariantCulture, DebuggerFirstLaunchCommand, DebugerInstallationDirectory, GetClrDbgUrl);
+                        }
+                        else
+                        {
+                            startRemoteDebuggerCommand = string.Format(CultureInfo.InvariantCulture, DebuggerSubsequentLaunchCommand, DebugerInstallationDirectory);
+                        }
                         break;
 
                     default:

--- a/src/MICore/MICoreResources.Designer.cs
+++ b/src/MICore/MICoreResources.Designer.cs
@@ -374,6 +374,15 @@ namespace MICore {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Installing debugger on the remote machine..
+        /// </summary>
+        public static string Info_InstallingDebuggerOnRemote {
+            get {
+                return ResourceManager.GetString("Info_InstallingDebuggerOnRemote", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Module containing this breakpoint has not yet loaded or the breakpoint address could not be obtained..
         /// </summary>
         public static string Status_BreakpointPending {

--- a/src/MICore/MICoreResources.resx
+++ b/src/MICore/MICoreResources.resx
@@ -240,4 +240,7 @@ Error: {1}</value>
   <data name="Error_InvalidLocalDirectoryPath" xml:space="preserve">
     <value>Invalid path to directory path '{0}'. Directory must be a valid directory name that exists.</value>
   </data>
+  <data name="Info_InstallingDebuggerOnRemote" xml:space="preserve">
+    <value>Installing debugger on the remote machine.</value>
+  </data>
 </root>

--- a/src/MICore/Transports/ClientServerTransport.cs
+++ b/src/MICore/Transports/ClientServerTransport.cs
@@ -10,6 +10,7 @@ using System.IO;
 using System.Collections.Specialized;
 using System.Collections;
 using System.Text.RegularExpressions;
+using Microsoft.DebugEngineHost;
 
 namespace MICore
 {
@@ -26,14 +27,14 @@ namespace MICore
             _serverTransport = serverTransport;
         }
 
-        public void Init(ITransportCallback transportCallback, LaunchOptions options, Logger logger)
+        public void Init(ITransportCallback transportCallback, LaunchOptions options, Logger logger, HostWaitLoop waitLoop = null)
         {
             _launchTimeout = ((LocalLaunchOptions)options).ServerLaunchTimeout;
-            _serverTransport.Init(transportCallback, options, logger);
+            _serverTransport.Init(transportCallback, options, logger, waitLoop);
             WaitForStart();
             if (!_clientTransport.IsClosed)
             {
-                _clientTransport.Init(transportCallback, options, logger);
+                _clientTransport.Init(transportCallback, options, logger, waitLoop);
             }
         }
 

--- a/src/MICore/Transports/ITransport.cs
+++ b/src/MICore/Transports/ITransport.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using Microsoft.DebugEngineHost;
 using System;
 using System.Collections.Generic;
 using System.Text;
@@ -12,7 +13,7 @@ namespace MICore
 
     public interface ITransport
     {
-        void Init(ITransportCallback transportCallback, LaunchOptions options, Logger logger);
+        void Init(ITransportCallback transportCallback, LaunchOptions options, Logger logger, HostWaitLoop waitLoop = null);
         void Send(string cmd);
         void Close();
         bool IsClosed { get; }

--- a/src/MICore/Transports/MockTransport.cs
+++ b/src/MICore/Transports/MockTransport.cs
@@ -7,6 +7,7 @@ using System.Text;
 using System.Threading;
 using System.Diagnostics;
 using System.IO;
+using Microsoft.DebugEngineHost;
 
 namespace MICore
 {
@@ -33,7 +34,7 @@ namespace MICore
             _filename = logfilename;
         }
 
-        public void Init(ITransportCallback transportCallback, LaunchOptions options, Logger logger)
+        public void Init(ITransportCallback transportCallback, LaunchOptions options, Logger logger, HostWaitLoop waitLoop = null)
         {
             _bQuit = false;
             _callback = transportCallback;

--- a/src/MICore/Transports/StreamTransport.cs
+++ b/src/MICore/Transports/StreamTransport.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using Microsoft.DebugEngineHost;
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
@@ -39,7 +40,7 @@ namespace MICore
         public abstract void InitStreams(LaunchOptions options, out StreamReader reader, out StreamWriter writer);
         protected virtual string GetThreadName() { return "MI.StreamTransport"; }
 
-        public virtual void Init(ITransportCallback transportCallback, LaunchOptions options, Logger logger)
+        public virtual void Init(ITransportCallback transportCallback, LaunchOptions options, Logger logger, HostWaitLoop waitLoop = null)
         {
             Logger = logger;
             _callback = transportCallback;

--- a/src/MIDebugEngine/AD7.Impl/AD7Engine.cs
+++ b/src/MIDebugEngine/AD7.Impl/AD7Engine.cs
@@ -539,7 +539,7 @@ namespace Microsoft.MIDebugEngine
                 {
                     try
                     {
-                        _debuggedProcess = new DebuggedProcess(true, launchOptions, _engineCallback, _pollThread, _breakpointManager, this, _configStore);
+                        _debuggedProcess = new DebuggedProcess(true, launchOptions, _engineCallback, _pollThread, _breakpointManager, this, _configStore, waitLoop);
                     }
                     finally
                     {


### PR DESCRIPTION
- Downloading and invoking GetClrDbg.sh on the remote machine.
- Displaying text on the progress dialog while the clrdbg is getting installed.
- Displaying error message when the installation fails.