### PR TITLE
remove legacy methods required by Kofe

### DIFF
--- a/src/DebugEngineHost/HostConfigurationStore.cs
+++ b/src/DebugEngineHost/HostConfigurationStore.cs
@@ -36,12 +36,6 @@ namespace Microsoft.DebugEngineHost
             }
         }
 
-        // This is a legacy verion of this constructor which is used by Kofe
-        public HostConfigurationStore(string registryRoot, string engineId) : this(registryRoot)
-        {
-            SetEngineGuid(Guid.Parse(engineId));
-        }
-
         /// <summary>
         /// Sets the Guid of the engine being hosted. This should only be set once for each HostConfigurationStore instance.
         /// </summary>

--- a/src/MICore/LaunchOptions.cs
+++ b/src/MICore/LaunchOptions.cs
@@ -706,12 +706,6 @@ namespace MICore
             }
         }
 
-        // Kofe debugger depends on this method to generate LaunchOptions
-        public static LaunchOptions GetInstance(HostConfigurationStore configStore, string exePath, string args, string dir, string options, IDeviceAppLauncherEventCallback eventCallback, TargetEngine targetEngine)
-        {
-            return GetInstance(configStore, exePath, args, dir, options, false, eventCallback, targetEngine, null);
-        }
-
         public static LaunchOptions GetInstance(HostConfigurationStore configStore, string exePath, string args, string dir, string options, bool noDebug, IDeviceAppLauncherEventCallback eventCallback, TargetEngine targetEngine, Logger logger)
         {
             if (string.IsNullOrWhiteSpace(exePath))


### PR DESCRIPTION
I'll update the Kofe side accordingly. We need to re-ship Kofe binary for dev15 to fix the binary version.