### PR TITLE
Enabling SSH Transport to work with GDB

### DIFF
--- a/src/MICore/CommandLock.cs
+++ b/src/MICore/CommandLock.cs
@@ -113,12 +113,12 @@ namespace MICore
                 _lockStatus = StatusClosed;
                 if (_waitingSharedLockSource != null)
                 {
-                    _waitingSharedLockSource.SetException(new ObjectDisposedException("Debugger"));
+                    _waitingSharedLockSource.SetException(new DebuggerDisposedException());
                     _waitingSharedLockSource = null;
                 }
                 foreach (TaskCompletionSource<ExclusiveLockToken> completionSource in _waitingExclusiveLockRequests)
                 {
-                    completionSource.SetException(new ObjectDisposedException("Debugger"));
+                    completionSource.SetException(new DebuggerDisposedException());
                 }
                 _waitingExclusiveLockRequests.Clear();
             }
@@ -134,7 +134,7 @@ namespace MICore
             {
                 if (_lockStatus == StatusClosed)
                 {
-                    throw new ObjectDisposedException("Debugger");
+                    throw new DebuggerDisposedException();
                 }
 
                 if (_lockStatus == StatusFree)
@@ -160,7 +160,7 @@ namespace MICore
             {
                 if (_lockStatus == StatusClosed)
                 {
-                    throw new ObjectDisposedException("Debugger");
+                    throw new DebuggerDisposedException();
                 }
 
                 if (_lockStatus >= 0)

--- a/src/MICore/Debugger.cs
+++ b/src/MICore/Debugger.cs
@@ -982,7 +982,7 @@ namespace MICore
         /// </summary>
         /// <param name="prompt">The prompt from the debugger</param>
         /// <returns>True if (gdb) prompt, false otherwise</returns>
-        /// <remarks>For SSH transport connecting to gdb, the (gdb) prompt string as a following space following it.</remarks>
+        /// <remarks>For SSH transport connecting to gdb, it has a trailing space following the prompt like "(gdb) ".</remarks>
         private static bool IsGdbPrompt(string prompt)
         {
             const string gdbPrompt = "(gdb)";

--- a/src/MICore/DebuggerDisposedException.cs
+++ b/src/MICore/DebuggerDisposedException.cs
@@ -1,0 +1,42 @@
+﻿using System;
+
+namespace MICore
+{
+    /// <summary>
+    /// Exception thrown to specify the debugger is disposed.
+    /// </summary>
+    public class DebuggerDisposedException : ObjectDisposedException
+    {
+        /// <summary>
+        /// Command where the abort happened.
+        /// </summary>
+        public string AbortedCommand { get; private set; }
+
+        private const string Debugger = "Debugger";
+
+        /// <summary>
+        /// Constructor for the DebuggerDisposedException which takes the aborted command.
+        /// </summary>
+        /// <param name="abortedCommand">MI Command</param>
+        public DebuggerDisposedException(string abortedCommand = null) : base(Debugger)
+        {
+            AbortedCommand = abortedCommand;
+        }
+
+        /// <summary>
+        /// Constructor for the DebuggerDisposedException which takes message, innerException and aborted command.
+        /// </summary>
+        public DebuggerDisposedException(string message, Exception innerException, string abortedCommand = null) : base(message, innerException)
+        {
+            AbortedCommand = abortedCommand;
+        }
+
+        /// <summary>
+        /// Constructor for the DebuggerDisposedException which takes message and aborted command.
+        /// </summary>
+        public DebuggerDisposedException(string message, string abortedCommand = null) : base(Debugger, message)
+        {
+            AbortedCommand = abortedCommand;
+        }
+    }
+}

--- a/src/MICore/MICore.csproj
+++ b/src/MICore/MICore.csproj
@@ -145,6 +145,7 @@
     <Compile Include="CommandFactories\MICommandFactory.cs" />
     <Compile Include="CommandLock.cs" />
     <Compile Include="Debugger.cs" />
+    <Compile Include="DebuggerDisposedException.cs" />
     <Compile Include="ExceptionHelper.cs" />
     <Compile Include="InvalidCoreDumpOperationException.cs" />
     <Compile Include="InvalidLaunchOptionsException.cs" />

--- a/src/MICore/Transports/UnixShellPortTransport.cs
+++ b/src/MICore/Transports/UnixShellPortTransport.cs
@@ -76,20 +76,27 @@ namespace MICore
         {
             if (!_debuggerLaunched)
             {
-                if (line != null && line.StartsWith(ErrorPrefix, System.StringComparison.OrdinalIgnoreCase))
+                if (_launchOptions.DebuggerMIMode != MIMode.Clrdbg)
                 {
-                    _callback.OnStdErrorLine(line.Substring(ErrorPrefix.Length).Trim());
+                    _debuggerLaunched = true;
                 }
                 else
                 {
-                    _callback.OnStdOutLine(line);
-                }
+                    if (line != null && line.StartsWith(ErrorPrefix, System.StringComparison.OrdinalIgnoreCase))
+                    {
+                        _callback.OnStdErrorLine(line.Substring(ErrorPrefix.Length).Trim());
+                    }
+                    else
+                    {
+                        _callback.OnStdOutLine(line);
+                    }
 
-                if (line.Equals("Info: Launching clrdbg"))
-                {
-                    _debuggerLaunched = true;
-                    UnixShellPortLaunchOptions.SetSuccessfulLaunch(_launchOptions);
-                    return;
+                    if (line.Equals("Info: Launching clrdbg"))
+                    {
+                        _debuggerLaunched = true;
+                        UnixShellPortLaunchOptions.SetSuccessfulLaunch(_launchOptions);
+                        return;
+                    }
                 }
             }
 

--- a/src/MIDebugEngine/AD7.Impl/AD7Engine.cs
+++ b/src/MIDebugEngine/AD7.Impl/AD7Engine.cs
@@ -771,7 +771,19 @@ namespace Microsoft.MIDebugEngine
         {
             _breakpointManager.ClearBoundBreakpoints();
 
-            _pollThread.RunOperation(() => _debuggedProcess.CmdDetach());
+            try
+            {
+                _pollThread.RunOperation(() => _debuggedProcess.CmdDetach());
+            }
+            catch (DebuggerDisposedException e)
+            {
+                // Detach command could cause DebuggerDisposedException and we ignore that.
+                if (e.AbortedCommand != "-target-detach")
+                {
+                    throw;
+                }
+            }
+            
             _debuggedProcess.Detach();
             return Constants.S_OK;
         }

--- a/src/MIDebugEngine/AD7.Impl/AD7Engine.cs
+++ b/src/MIDebugEngine/AD7.Impl/AD7Engine.cs
@@ -775,13 +775,10 @@ namespace Microsoft.MIDebugEngine
             {
                 _pollThread.RunOperation(() => _debuggedProcess.CmdDetach());
             }
-            catch (DebuggerDisposedException e)
+            catch (DebuggerDisposedException e) when (e.AbortedCommand != "-target-detach")
             {
                 // Detach command could cause DebuggerDisposedException and we ignore that.
-                if (e.AbortedCommand != "-target-detach")
-                {
-                    throw;
-                }
+                throw;
             }
             
             _debuggedProcess.Detach();

--- a/src/MIDebugEngine/Engine.Impl/DebuggedProcess.cs
+++ b/src/MIDebugEngine/Engine.Impl/DebuggedProcess.cs
@@ -621,6 +621,8 @@ namespace Microsoft.MIDebugEngine
                     {
                         if (_launchOptions is UnixShellPortLaunchOptions)
                         {
+                            // This code path is probably applicable when the ExePath is not specified and can be used to determine the full executable path.
+                            // For now it is limited to Linux and debugger running on remote machine.
                             Debug.Assert(_launchOptions.ExePath == null);
 
                             DetermineAndAddExecutablePathCommand(commands);
@@ -755,6 +757,10 @@ namespace Microsoft.MIDebugEngine
 
         private void DetermineAndAddExecutablePathCommand(IList<LaunchCommand> commands)
         {
+            // TODO: rajkumar42, make it robust, either use the liblinux api or fallback shell commands available in other distros.
+            // TODO: rajkumar42, -target-attach can fail with gdb if ptrace>=1, elevate permission with liblinux and retry, display error on second failure.
+            // TODO: rajkumar42, connecting to OSX via SSH doesn't work yet.
+
             // Runs a shell command to get the full path of the exe.
             string absoluteExePath = string.Format(CultureInfo.InvariantCulture, @"shell readlink -f /proc/{0}/exe", _launchOptions.ProcessId);
 

--- a/src/MIDebugEngine/ResourceStrings.Designer.cs
+++ b/src/MIDebugEngine/ResourceStrings.Designer.cs
@@ -10,7 +10,7 @@
 
 namespace Microsoft.MIDebugEngine {
     using System;
-	using System.Reflection;
+    using System.Reflection;
     
     
     /// <summary>
@@ -96,6 +96,15 @@ namespace Microsoft.MIDebugEngine {
         internal static string Error_ExePathInvalid {
             get {
                 return ResourceManager.GetString("Error_ExePathInvalid", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Failed to get executable path with error &apos;{0}&apos;..
+        /// </summary>
+        internal static string Error_FailedToGetExePath {
+            get {
+                return ResourceManager.GetString("Error_FailedToGetExePath", resourceCulture);
             }
         }
         

--- a/src/MIDebugEngine/ResourceStrings.resx
+++ b/src/MIDebugEngine/ResourceStrings.resx
@@ -232,4 +232,8 @@
   <data name="Error_FailedToGetTargetArchitecture" xml:space="preserve">
     <value>Failed to obtain target architecture.</value>
   </data>
+  <data name="Error_FailedToGetExePath" xml:space="preserve">
+    <value>Failed to get executable path with error '{0}'.</value>
+    <comment>0 = failure message</comment>
+  </data>
 </root>


### PR DESCRIPTION
Fixing: gdb prompt sent by the gdb has a trailing space.
Setting -file-exec-and-symbols for gdb.
try/catch eat DebuggerDisposedException on detach, which is expected.