### PR TITLE
Escape quotes in expression

### DIFF
--- a/src/MICore/CommandFactories/MICommandFactory.cs
+++ b/src/MICore/CommandFactories/MICommandFactory.cs
@@ -328,7 +328,8 @@ namespace MICore
 
         public virtual async Task<Results> VarCreate(string expression, int threadId, uint frameLevel, enum_EVALFLAGS dwFlags, ResultClass resultClass = ResultClass.done)
         {
-            string command = string.Format("-var-create - * \"{0}\"", expression);
+            string quoteEscapedExpression = EscapeQuotes(expression);
+            string command = string.Format("-var-create - * \"{0}\"", quoteEscapedExpression);
             Results results = await ThreadFrameCmdAsync(command, resultClass, threadId, frameLevel);
 
             return results;
@@ -566,6 +567,10 @@ namespace MICore
             return results;
         }
 
+        internal string EscapeQuotes(string str)
+        {
+            return str.Replace("\"", "\\\"");
+        }
 
         #endregion
 

--- a/src/MICore/CommandFactories/lldb.cs
+++ b/src/MICore/CommandFactories/lldb.cs
@@ -71,7 +71,8 @@ namespace MICore
 
         public override async Task<Results> VarCreate(string expression, int threadId, uint frameLevel, enum_EVALFLAGS dwFlags, ResultClass resultClass = ResultClass.done)
         {
-            string command = string.Format("-var-create - - \"{0}\"", expression);  // use '-' to indicate that "--frame" should be used to determine the frame number
+            string quoteEscapedExpression = EscapeQuotes(expression);
+            string command = string.Format("-var-create - - \"{0}\"", quoteEscapedExpression);  // use '-' to indicate that "--frame" should be used to determine the frame number
             Results results = await ThreadFrameCmdAsync(command, resultClass, threadId, frameLevel);
 
             return results;


### PR DESCRIPTION
This is needed to evaluate expressions that contain quotes and spaces: e.g.,
`message = "hello world"`

This is needed for both GDB and LLDB, but not CLRDBG.

This was tested on Ubuntu (GDB), OS X (LLDB) and Windows (GDB from MinGW).

@pieandcakes @jacdavis 