### PR TITLE
Fix adding disabled breakpoint for lldb-mi

### DIFF
--- a/src/MICore/CommandFactories/MICommandFactory.cs
+++ b/src/MICore/CommandFactories/MICommandFactory.cs
@@ -411,7 +411,7 @@ namespace MICore
 
         protected virtual StringBuilder BuildBreakInsert(string condition, bool enabled)
         {
-            StringBuilder cmd = new StringBuilder("-break-insert -f ");
+            StringBuilder cmd = new StringBuilder("-break-insert ");
             if (condition != null)
             {
                 cmd.Append("-c \"");
@@ -435,6 +435,7 @@ namespace MICore
                 cmd.Append(" ");
             }
 
+            cmd.Append("-f ");
             cmd.Append(filename);
             cmd.Append(":");
             cmd.Append(line.ToString());


### PR DESCRIPTION
The disabled breakpoint inserted by MI command  `-break-insert -f -d hello3.cs:8` which is wrong sequence of flags (the filename:line should follow -f flags). LLDB-MI responds with the following message:
```
^error,msg="Command 'break-insert'. Command Args. Validation failed. Args missing additional information: f"
```
This PR places -f flag just before filename:line specification.
cc @chunseoklee @seanshpark @ayuckhulk