### PR TITLE
When debugging through SSH as root, stdin is printed in stdout stream.

### DIFF
--- a/src/SSHDebugPS/AD7UnixAsyncCommand.cs
+++ b/src/SSHDebugPS/AD7UnixAsyncCommand.cs
@@ -23,7 +23,7 @@ namespace Microsoft.SSHDebugPS
         private bool _beginReceived;
         private bool _isClosed;
 
-        private string startCommand;
+        private string _startCommand;
 
         public AD7UnixAsyncCommand(IShellStream shellStream, IDebugUnixShellCommandCallback callback)
         {
@@ -39,8 +39,8 @@ namespace Microsoft.SSHDebugPS
 
         internal void Start(string commandText)
         {
-            startCommand = string.Format("echo \"{0}\"; {1}; echo \"{2}$?\"", _beginMessage, commandText, _exitMessagePrefix);
-            _shellStream.WriteLine(startCommand);
+            _startCommand = string.Format("echo \"{0}\"; {1}; echo \"{2}$?\"", _beginMessage, commandText, _exitMessagePrefix);
+            _shellStream.WriteLine(_startCommand);
             _shellStream.Flush();
         }
 
@@ -83,7 +83,7 @@ namespace Microsoft.SSHDebugPS
                     return;
                 }
 
-                if (line.Equals(startCommand, StringComparison.Ordinal))
+                if (line.Equals(_startCommand, StringComparison.Ordinal))
                 {
                     // When logged in as root, shell sends a copy of stdin to stdout.
                     // This ignores the shell command that was used to launch the debugger.

--- a/src/SSHDebugPS/AD7UnixAsyncCommand.cs
+++ b/src/SSHDebugPS/AD7UnixAsyncCommand.cs
@@ -65,8 +65,6 @@ namespace Microsoft.SSHDebugPS
             //
             // Suggested fix: Add a ReadLine async method to the shell and remove the output received event
 
-            // TODO: rajkumar42, this breaks when logging in as root. 
-
             IEnumerable<string> linesToSend = null;
 
             lock (_lock)


### PR DESCRIPTION
Fix: ignoring the input string, if we see it when processing the stdout.