### PR TITLE
Set environment variables through the appropriate command

### DIFF
--- a/src/MICore/CommandFactories/MICommandFactory.cs
+++ b/src/MICore/CommandFactories/MICommandFactory.cs
@@ -579,6 +579,8 @@ namespace MICore
         abstract protected Task<Results> ThreadFrameCmdAsync(string command, ResultClass expectedResultClass, int threadId, uint frameLevel);
         abstract protected Task<Results> ThreadCmdAsync(string command, ResultClass expectedResultClass, int threadId);
 
+        abstract public string GetSetEnvironmentVariableCommand(string name, string value);
+
         abstract public bool SupportsStopOnDynamicLibLoad();
 
         abstract public bool SupportsChildProcessDebugging();

--- a/src/MICore/CommandFactories/clrdbg.cs
+++ b/src/MICore/CommandFactories/clrdbg.cs
@@ -247,5 +247,13 @@ namespace MICore
             // CLRDBG only support x64 now.
             return TargetArchitecture.X64;
         }
+
+        public override string GetSetEnvironmentVariableCommand(string name, string value)
+        {
+            // clrdbg doesn't implement a command to set environment variables on the debuggee
+            // This is worked around by setting the environment variables on the actual debugger
+            // process, and getting the debuggee to inherit those.
+            throw new NotImplementedException();
+        }
     }
 }

--- a/src/MICore/CommandFactories/gdb.cs
+++ b/src/MICore/CommandFactories/gdb.cs
@@ -266,6 +266,11 @@ namespace MICore
             return TargetArchitecture.Unknown;
         }
 
+        public override string GetSetEnvironmentVariableCommand(string name, string value)
+        {
+            return string.Format(CultureInfo.InvariantCulture, "set env {0} {1}", name, value);
+        }
+
         public override async Task Signal(string sig)
         {
             string command = String.Format("-interpreter-exec console \"signal {0}\"", sig);

--- a/src/MICore/CommandFactories/lldb.cs
+++ b/src/MICore/CommandFactories/lldb.cs
@@ -143,6 +143,14 @@ namespace MICore
             return TargetArchitecture.Unknown;
         }
 
+        public override string GetSetEnvironmentVariableCommand(string name, string value)
+        {
+            // LLDB requires surrounding values with quotes if the values contain spaces.
+            // This is because LLDB allows setting multiple environment variables with one command,
+            // using a space as the delimiter between variables.
+            return string.Format(CultureInfo.InvariantCulture, "settings set target.env-vars {0}=\"{1}\"", name, EscapeQuotes(value));
+        }
+
         public override Task Signal(string sig)
         {
             throw new NotImplementedException("lldb signal command");

--- a/src/MICore/Transports/LocalTransport.cs
+++ b/src/MICore/Transports/LocalTransport.cs
@@ -41,9 +41,14 @@ namespace MICore
                 proc.StartInfo.SetEnvironmentVariable("PATH", path);
             }
 
-            foreach (EnvironmentEntry entry in localOptions.Environment)
+            // Only pass the environment to launch clrdbg. For other modes, there are commands that set the environment variables
+            // directly for the debuggee.
+            if (options.DebuggerMIMode == MIMode.Clrdbg)
             {
-                proc.StartInfo.SetEnvironmentVariable(entry.Name, entry.Value);
+                foreach (EnvironmentEntry entry in localOptions.Environment)
+                {
+                    proc.StartInfo.SetEnvironmentVariable(entry.Name, entry.Value);
+                }
             }
 
             InitProcess(proc, out reader, out writer);

--- a/src/MICore/Transports/LocalUnixTerminalTransport.cs
+++ b/src/MICore/Transports/LocalUnixTerminalTransport.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
+using System.Collections.ObjectModel;
 using System.Globalization;
 using System.IO;
 using System.Text;
@@ -57,6 +58,12 @@ namespace MICore
                 _dbgStdOutName,
                 pidFifo,
                 debuggerCmd);
+
+            // Only pass the environment to launch clrdbg. For other modes, there are commands that set the environment variables
+            // directly for the debuggee.
+            ReadOnlyCollection<EnvironmentEntry> environmentForDebugger = localOptions.DebuggerMIMode == MIMode.Clrdbg ?
+                localOptions.Environment :
+                new ReadOnlyCollection<EnvironmentEntry>(new EnvironmentEntry[] { }); ;
 
             TerminalLauncher terminal = TerminalLauncher.MakeTerminal("DebuggerTerminal", launchDebuggerCommand, localOptions.Environment);
             terminal.Launch(debuggeeDir);

--- a/src/MIDebugEngine/Engine.Impl/DebuggedProcess.cs
+++ b/src/MIDebugEngine/Engine.Impl/DebuggedProcess.cs
@@ -722,6 +722,15 @@ namespace Microsoft.MIDebugEngine
                         {
                             commands.Add(new LaunchCommand("-target-select remote " + destination, string.Format(CultureInfo.CurrentUICulture, ResourceStrings.ConnectingMessage, destination)));
                         }
+
+                        // Environment variables are set for the debuggee only with the modes that support that
+                        if (this.MICommandFactory.Mode != MIMode.Clrdbg)
+                        {
+                            foreach (EnvironmentEntry envEntry in localLaunchOptions.Environment)
+                            {
+                                commands.Add(new LaunchCommand(MICommandFactory.GetSetEnvironmentVariableCommand(envEntry.Name, envEntry.Value)));
+                            }
+                        }
                     }
                 }
             }


### PR DESCRIPTION
Previously, in order to set the desired environment variables intended for the
debuggee, MIEngine was setting them for the debugger process, given that
subprocesses (debuggee) inherit the environment. This is not the case by default
with LLDB, and is cleaner to only set the environment variables in the debuggee
directly. This is done by using GDB/LLDB commands that only affect the debuggee.
CLRDBG doesn't support these commands, so for now the old behavior is preserved.

@pieandcakes @jacdavis @gregg-miskelly 