### PR TITLE
Allow lldb-mi to assign expressions to variables

### DIFF
--- a/src/MICore/CommandFactories/MICommandFactory.cs
+++ b/src/MICore/CommandFactories/MICommandFactory.cs
@@ -360,7 +360,7 @@ namespace MICore
             return results;
         }
 
-        public async Task<string> VarAssign(string variableName, string expression)
+        public virtual async Task<string> VarAssign(string variableName, string expression, int threadId, uint frameLevel)
         {
             string command = string.Format("-var-assign {0} \"{1}\"", variableName, expression);
             Results results = await _debugger.CmdAsync(command, ResultClass.done);

--- a/src/MICore/CommandFactories/lldb.cs
+++ b/src/MICore/CommandFactories/lldb.cs
@@ -160,5 +160,26 @@ namespace MICore
         {
             throw new NotImplementedException("lldb catch command");
         }
+
+        /// <summary>
+        /// Assigns the value of an expression to a variable.
+        /// Since LLDB only accepts assigning values to variables, the expression may need to be evaluated.
+        /// However, since the result of evaluating an expression in LLDB can return some extra information:
+        /// e.g., 'a' --> 97 'a'. We don't want to assign the value "97 'a'". Instead, we first try
+        /// assigning what the user passed, only falling back to evaluation if the first assignment fails.
+        /// </summary>
+        public async override Task<string> VarAssign(string variableName, string expression, int threadId, uint frameLevel)
+        {
+            try
+            {
+                return await base.VarAssign(variableName, expression, threadId, frameLevel);
+            }
+            catch (UnexpectedMIResultException)
+            {
+                Results results = await VarCreate(expression, threadId, frameLevel, 0, ResultClass.done);
+                string value = results.FindString("value");
+                return await base.VarAssign(variableName, value, threadId, frameLevel);
+            }
+        }
     }
 }

--- a/src/MIDebugEngine/Engine.Impl/Variables.cs
+++ b/src/MIDebugEngine/Engine.Impl/Variables.cs
@@ -705,8 +705,11 @@ namespace Microsoft.MIDebugEngine
 
             _engine.DebuggedProcess.WorkerThread.RunOperation(async () =>
             {
+                int threadId = Client.GetDebuggedThread().Id;
+                uint frameLevel = _ctx.Level;
+
                 _engine.DebuggedProcess.FlushBreakStateData();
-                Value = await _engine.DebuggedProcess.MICommandFactory.VarAssign(_internalName, expression);
+                Value = await _engine.DebuggedProcess.MICommandFactory.VarAssign(_internalName, expression, threadId, frameLevel);
             });
         }
 


### PR DESCRIPTION
lldb-mi doesn't evaluate expressions passed in -var-assign <expression>
This workaround evaluates the expression as a different step. I will create a bug in the lldb database to see if this is something they're interested in fixing.
