### PR TITLE
Fix for displaying char* and char** values

### DIFF
--- a/src/MICore/CommandFactories/lldb.cs
+++ b/src/MICore/CommandFactories/lldb.cs
@@ -77,6 +77,17 @@ namespace MICore
 
             return results;
         }
+        
+        public override async Task<Results> VarListChildren(string variableReference, enum_DEBUGPROP_INFO_FLAGS dwFlags, ResultClass resultClass = ResultClass.done)
+        {
+            // This override is necessary because lldb treats any object with children as not a simple object.
+            // This prevents char* and char** from returning a value when queried by -var-list-children
+            // Limit the number of children expanded to 1000 in case memory is uninitialized
+            string command = string.Format("-var-list-children --all-values \"{0}\" 0 1000", variableReference);
+            Results results = await _debugger.CmdAsync(command, resultClass);
+
+            return results;
+        }
 
         protected override async Task<Results> ThreadFrameCmdAsync(string command, ResultClass exepctedResultClass, int threadId, uint frameLevel)
         {


### PR DESCRIPTION
changing to var-list-children to use --all-values. lldb treats any object
with children as not simple, and therefore will not show values when
passing --simple-values as the parameter.