### PR TITLE
Fix a crashing issue when stop debugging

### DIFF
--- a/src/MICore/Debugger.cs
+++ b/src/MICore/Debugger.cs
@@ -252,10 +252,10 @@ namespace MICore
 
             //if this is an exception reported from LLDB, it will not currently contain a frame object in the MI
             //if we don't have a frame, check if this is an exception and retrieve the frame
-            if (!results.Contains("frame") &&
+            if (!results.Contains("frame") && !_terminating &&
                 (string.Compare(reason, "exception-received", StringComparison.OrdinalIgnoreCase) == 0 ||
-                string.Compare(reason, "signal-received", StringComparison.OrdinalIgnoreCase) == 0)
-                )
+                 string.Compare(reason, "signal-received", StringComparison.OrdinalIgnoreCase) == 0)
+               )
             {
                 //get the info for the current frame
                 Results frameResult = await MICommandFactory.StackInfoFrame();
@@ -273,7 +273,7 @@ namespace MICore
             this.ProcessState = ProcessState.Stopped;
             FlushBreakStateData();
 
-            if (!results.Contains("frame"))
+            if (!results.Contains("frame") && !_terminating)
             {
                 if (ModuleLoadEvent != null)
                 {

--- a/src/MIDebugEngine/Engine.Impl/DebuggedProcess.cs
+++ b/src/MIDebugEngine/Engine.Impl/DebuggedProcess.cs
@@ -365,7 +365,7 @@ namespace Microsoft.MIDebugEngine
                 }
                 catch (Exception e) when (ExceptionHelper.BeforeCatch(e, Logger, reportOnlyCorrupting: true))
                 {
-                    if (this.ProcessState == MICore.ProcessState.Exited)
+                    if (_terminating)
                     {
                         return; // ignore exceptions after the process has exited
                     }

--- a/src/MIDebugEngine/Engine.Impl/DebuggedProcess.cs
+++ b/src/MIDebugEngine/Engine.Impl/DebuggedProcess.cs
@@ -365,7 +365,7 @@ namespace Microsoft.MIDebugEngine
                 }
                 catch (Exception e) when (ExceptionHelper.BeforeCatch(e, Logger, reportOnlyCorrupting: true))
                 {
-                    if (_terminating)
+                    if (_terminating || this.ProcessState == MICore.ProcessState.Exited)
                     {
                         return; // ignore exceptions after the process has exited
                     }


### PR DESCRIPTION
https://devdiv.visualstudio.com/DevDiv/VS%20Diag%20IntelliTrace/_workItems/index?_a=edit&id=264224&triage=true

The issue is MI try to read stack or thread information after debuggee has
been killed, and eventually cause unhandled exception and crash VS. Fix by
checking terminating status before querying debuggee information.