### PR TITLE
Fixing dotnet restore error issues

### DIFF
--- a/scripts/GetClrDbg.sh
+++ b/scripts/GetClrDbg.sh
@@ -392,6 +392,7 @@ else
     dotnet restore > dotnet_restore.log 2>&1
     if [ $? -ne 0 ]; then
         echo "Error: dotnet restore failed"
+        cat dotnet_restore.log >&2
         exit 1
     fi
 

--- a/src/MICore/MICoreResources.Designer.cs
+++ b/src/MICore/MICoreResources.Designer.cs
@@ -104,7 +104,7 @@ namespace MICore {
         ///
         ///{1}
         ///
-        ///See output window for details..
+        ///See Output Window for details..
         /// </summary>
         public static string Error_DebuggerInitializeFailed_StdErr {
             get {

--- a/src/MICore/MICoreResources.Designer.cs
+++ b/src/MICore/MICoreResources.Designer.cs
@@ -102,7 +102,9 @@ namespace MICore {
         /// <summary>
         ///   Looks up a localized string similar to Unable to establish a connection to {0}. The following message was written to stderr:
         ///
-        ///{1}.
+        ///{1}
+        ///
+        ///See output window for details..
         /// </summary>
         public static string Error_DebuggerInitializeFailed_StdErr {
             get {

--- a/src/MICore/MICoreResources.resx
+++ b/src/MICore/MICoreResources.resx
@@ -131,7 +131,9 @@
   <data name="Error_DebuggerInitializeFailed_StdErr" xml:space="preserve">
     <value>Unable to establish a connection to {0}. The following message was written to stderr:
 
-{1}</value>
+{1}
+
+See output window for details.</value>
   </data>
   <data name="Error_DebugServerInitializationFailed" xml:space="preserve">
     <value>Debug server process failed to initialize.</value>

--- a/src/MICore/MICoreResources.resx
+++ b/src/MICore/MICoreResources.resx
@@ -133,7 +133,7 @@
 
 {1}
 
-See output window for details.</value>
+See Output Window for details.</value>
   </data>
   <data name="Error_DebugServerInitializationFailed" xml:space="preserve">
     <value>Debug server process failed to initialize.</value>

--- a/src/MIDebugEngine/ResourceStrings.Designer.cs
+++ b/src/MIDebugEngine/ResourceStrings.Designer.cs
@@ -120,7 +120,7 @@ namespace Microsoft.MIDebugEngine {
         /// <summary>
         ///   Looks up a localized string similar to Attaching to process {0} with {1} failed because of insufficient privileges with error message &apos;{2}&apos;.
         ///
-        ///To attach to application on Linux, login as super user or set ptrace_scope to 0.
+        ///To attach to an application on Linux, login as super user or set ptrace_scope to 0.
         ///See https://aka.ms/miengine-gdb-troubleshooting for details..
         /// </summary>
         internal static string Error_PTraceFailure {

--- a/src/MIDebugEngine/ResourceStrings.resx
+++ b/src/MIDebugEngine/ResourceStrings.resx
@@ -239,7 +239,7 @@
   <data name="Error_PTraceFailure" xml:space="preserve">
     <value>Attaching to process {0} with {1} failed because of insufficient privileges with error message '{2}'.
 
-To attach to application on Linux, login as super user or set ptrace_scope to 0.
+To attach to an application on Linux, login as super user or set ptrace_scope to 0.
 See https://aka.ms/miengine-gdb-troubleshooting for details.</value>
     <comment>{0} process pid
 {1} Debugger

--- a/src/SSHDebugPS/AD7UnixAsyncCommand.cs
+++ b/src/SSHDebugPS/AD7UnixAsyncCommand.cs
@@ -151,16 +151,16 @@ namespace Microsoft.SSHDebugPS
                         _streamingShell.Close();
                     }
 
-                    if (_streamingShell != null)
-                    {
-                        _streamingShell.Dispose();
-                        _streamingShell = null;
-                    }
+                    _streamingShell?.Dispose();
                 }
                 catch (ThreadInterruptedException)
                 {
                     // This can happen if the command failed on a timeout. Say dotnet restore failed because of insufficient permissions etc.
+                    // Calling dispose on StreamingShell throws ThreadInterruptedException as well. For this case, any operation on StreamingShell
+                    // will likely cause this exception to be thrown, setting it to null to allow cleanup.
                 }
+
+                _streamingShell = null;
             }
         }
 

--- a/src/SSHDebugPS/AD7UnixAsyncCommand.cs
+++ b/src/SSHDebugPS/AD7UnixAsyncCommand.cs
@@ -16,7 +16,7 @@ namespace Microsoft.SSHDebugPS
         private readonly object _lock = new object();
         private readonly string _beginMessage;
         private readonly string _exitMessagePrefix;
-        private readonly IStreamingShell _streamingShell;
+        private IStreamingShell _streamingShell;
         private readonly IDebugUnixShellCommandCallback _callback;
         private readonly LineBuffer _lineBuffer = new LineBuffer();
         private int _firedOnExit;
@@ -143,9 +143,25 @@ namespace Microsoft.SSHDebugPS
                     return;
 
                 _isClosed = true;
-            }
 
-            _streamingShell.Close();
+                try
+                {
+                    if (_streamingShell != null && _streamingShell.IsOpen)
+                    {
+                        _streamingShell.Close();
+                    }
+
+                    if (_streamingShell != null)
+                    {
+                        _streamingShell.Dispose();
+                        _streamingShell = null;
+                    }
+                }
+                catch (ThreadInterruptedException)
+                {
+                    // This can happen if the command failed on a timeout. Say dotnet restore failed because of insufficient permissions etc.
+                }
+            }
         }
 
         private static string SplitExitCode(string line, int startIndex)


### PR DESCRIPTION
printing dotnet_restore.log to console
catching exception when the command times out