### PR TITLE
Removing file exists check for PipePath.

### DIFF
--- a/src/MICore/MICoreResources.Designer.cs
+++ b/src/MICore/MICoreResources.Designer.cs
@@ -122,6 +122,15 @@ namespace MICore {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to PipePath cannot be empty..
+        /// </summary>
+        public static string Error_EmptyPipePath {
+            get {
+                return ResourceManager.GetString("Error_EmptyPipePath", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Exception while processing MIEngine operation. {0}. If the problem continues restart debugging..
         /// </summary>
         public static string Error_ExceptionInOperation {

--- a/src/MICore/MICoreResources.resx
+++ b/src/MICore/MICoreResources.resx
@@ -256,4 +256,7 @@ Error: {1}</value>
   <data name="Error_InvalidLocalDirectoryPath" xml:space="preserve">
     <value>Invalid path to directory path '{0}'. Directory must be a valid directory name that exists.</value>
   </data>
+  <data name="Error_EmptyPipePath" xml:space="preserve">
+    <value>PipePath cannot be empty.</value>
+  </data>
 </root>

--- a/src/MICore/Transports/PipeTransport.cs
+++ b/src/MICore/Transports/PipeTransport.cs
@@ -111,9 +111,9 @@ namespace MICore
                 }
             }
 
-            if (!LocalLaunchOptions.CheckFilePath(pipeOptions.PipePath))
+            if (string.IsNullOrWhiteSpace(pipeOptions.PipePath))
             {
-                throw new ArgumentException(String.Format(CultureInfo.CurrentCulture, MICoreResources.Error_InvalidLocalExePath, pipeOptions.PipePath));
+                throw new ArgumentException(MICoreResources.Error_EmptyPipePath);
             }
 
             _cmdArgs = pipeOptions.PipeCommandArguments;


### PR DESCRIPTION
Previously added checks for existence of PipeProgram expects the absolute path. That breaks docker tools scenario where the absolute path is not provided.