### PR TITLE
Do not check NDK_HOME for Java debugging

### DIFF
--- a/src/AndroidDebugLauncher/InstallPaths.cs
+++ b/src/AndroidDebugLauncher/InstallPaths.cs
@@ -26,6 +26,8 @@ namespace AndroidDebugLauncher
         /// </summary>
         /// <param name="token">token to check for cancelation</param>
         /// <param name="launchOptions">[Required] launch options object</param>
+        /// <param name="logger">logger object</param>
+        /// <param name="targetEngine">target engine</param>
         /// <returns>[Required] Created InstallPaths object</returns>
         public static InstallPaths Resolve(CancellationToken token, AndroidLaunchOptions launchOptions, MICore.Logger logger, TargetEngine targetEngine)
         {
@@ -145,7 +147,7 @@ namespace AndroidDebugLauncher
         }
 
         /// <summary>
-        /// [Required] Path to GDB
+        /// [Optional] Path to GDB
         /// </summary>
         public string GDBPath
         {
@@ -154,7 +156,7 @@ namespace AndroidDebugLauncher
         }
 
         /// <summary>
-        /// [Required] Path to GDBServer
+        /// [Optional] Path to GDBServer
         /// </summary>
         public string GDBServerPath
         {

--- a/src/AndroidDebugLauncher/Launcher.cs
+++ b/src/AndroidDebugLauncher/Launcher.cs
@@ -177,7 +177,7 @@ namespace AndroidDebugLauncher
 
                 actions.Add(new NamedAction(LauncherResources.Step_ResolveInstallPaths, () =>
                 {
-                    _installPaths = InstallPaths.Resolve(token, _launchOptions, Logger);
+                    _installPaths = InstallPaths.Resolve(token, _launchOptions, Logger, _targetEngine);
                 }));
 
                 actions.Add(new NamedAction(LauncherResources.Step_ConnectToDevice, () =>


### PR DESCRIPTION
Skip the check for NDK_HOME when it's Java debugging. 