### PR TITLE
Add extention point for debugger launchers

### DIFF
--- a/src/DebugEngineHost.Stub/DebugEngineHost.ref.cs
+++ b/src/DebugEngineHost.Stub/DebugEngineHost.ref.cs
@@ -187,12 +187,22 @@ namespace Microsoft.DebugEngineHost
         {
             throw new NotImplementedException();
         }
-    }
 
-    /// <summary>
-    /// The host logger returned from HostConfigurationStore.GetLogger.
-    /// </summary>
-    public sealed class HostLogger
+        /// <summary>
+        /// Lookup the clsid of the launcher that understands these options
+        /// </summary>
+        /// <param name="launchOptionsName">launch options type name</param>
+        /// <returns></returns>
+        public Guid GetCustomLauncherClsid(string launchOptionsName)
+        {
+            throw new NotImplementedException();
+    }
+}
+
+/// <summary>
+/// The host logger returned from HostConfigurationStore.GetLogger.
+/// </summary>
+public sealed class HostLogger
     {
         private HostLogger()
         {

--- a/src/DebugEngineHost.Stub/DebugEngineHost.ref.cs
+++ b/src/DebugEngineHost.Stub/DebugEngineHost.ref.cs
@@ -189,14 +189,14 @@ namespace Microsoft.DebugEngineHost
         }
 
         /// <summary>
-        /// Lookup the clsid of the launcher that understands these options
+        /// Load the launcher that understands these options
         /// </summary>
-        /// <param name="launchOptionsName">launch options type name</param>
+        /// <param name="launcherTypeName">launch options type name</param>
         /// <returns></returns>
-        public Guid GetCustomLauncherClsid(string launchOptionsName)
+        public object GetCustomLauncher(string launcherTypeName)
         {
             throw new NotImplementedException();
-    }
+        }
 }
 
 /// <summary>

--- a/src/DebugEngineHost/HostConfigurationStore.cs
+++ b/src/DebugEngineHost/HostConfigurationStore.cs
@@ -137,10 +137,15 @@ namespace Microsoft.DebugEngineHost
             return GetDebuggerConfigurationSetting(DebuggerSectionName, settingName, defaultValue);
         }
 
-        public Guid GetCustomLauncherClsid(string launcherTypeName)
+        public object GetCustomLauncher(string launcherTypeName)
         {
             string guidstr = GetDebuggerConfigurationSetting(LaunchersSectionName, launcherTypeName, Guid.Empty.ToString());
-            return new Guid(guidstr);
+            Guid clsidLauncher = new Guid(guidstr);
+            if (clsidLauncher == Guid.Empty)
+            {
+                return null;
+            }
+            return HostLoader.VsCoCreateManagedObject(this, clsidLauncher);
         }
 
         private T GetDebuggerConfigurationSetting<T>(string sectionName, string settingName, T defaultValue)

--- a/src/DebugEngineHost/HostConfigurationStore.cs
+++ b/src/DebugEngineHost/HostConfigurationStore.cs
@@ -16,6 +16,7 @@ namespace Microsoft.DebugEngineHost
     public sealed class HostConfigurationStore
     {
         private const string DebuggerSectionName = "Debugger";
+        private const string LaunchersSectionName = "MILaunchers";
 
         private string _engineId;
         private string _registryRoot;
@@ -133,7 +134,18 @@ namespace Microsoft.DebugEngineHost
 
         public T GetDebuggerConfigurationSetting<T>(string settingName, T defaultValue)
         {
-            object valueObj = GetOptionalValue(DebuggerSectionName, settingName);
+            return GetDebuggerConfigurationSetting(DebuggerSectionName, settingName, defaultValue);
+        }
+
+        public Guid GetCustomLauncherClsid(string launcherTypeName)
+        {
+            string guidstr = GetDebuggerConfigurationSetting(LaunchersSectionName, launcherTypeName, Guid.Empty.ToString());
+            return new Guid(guidstr);
+        }
+
+        private T GetDebuggerConfigurationSetting<T>(string sectionName, string settingName, T defaultValue)
+        {
+            object valueObj = GetOptionalValue(sectionName, settingName);
             if (valueObj == null)
             {
                 return defaultValue;

--- a/src/MICore/MICoreResources.Designer.cs
+++ b/src/MICore/MICoreResources.Designer.cs
@@ -232,6 +232,15 @@ namespace MICore {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Device App Launcher Serializer {0} could not be found..
+        /// </summary>
+        public static string Error_LauncherSerializerNotFound {
+            get {
+                return ResourceManager.GetString("Error_LauncherSerializerNotFound", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Failed to initialize debugger terminal..
         /// </summary>
         public static string Error_LocalUnixTerminalDebuggerInitializationFailed {

--- a/src/MICore/MICoreResources.resx
+++ b/src/MICore/MICoreResources.resx
@@ -259,4 +259,7 @@ Error: {1}</value>
   <data name="Error_EmptyPipePath" xml:space="preserve">
     <value>PipePath cannot be empty.</value>
   </data>
+  <data name="Error_LauncherSerializerNotFound" xml:space="preserve">
+    <value>Device App Launcher Serializer {0} could not be found.</value>
+  </data>
 </root>


### PR DESCRIPTION
Looks up Xml launch options name in the registry in order to discover the clsid for the correct launcher to handle the options. 
Does not touch current IOS and Android launcher code paths. They can be updated to use the same extension mechanism but I don't have the time before next release to perform the appropriate testing on those scenarios.