### PR TITLE
Invalid condition in RetryBreak timer guard clause

### DIFF
--- a/src/MICore/Debugger.cs
+++ b/src/MICore/Debugger.cs
@@ -223,7 +223,7 @@ namespace MICore
                         // When using signals to stop the proces, do not kick off another break attempt. The debug break injection and
                         // signal based models are reliable so no retries are needed. Cygwin can't currently async-break reliably, so
                         // use retries there.
-                        if (!IsLocalGdb() && !this.IsCygwin)
+                        if (!IsLocalGdb() && this.IsCygwin)
                         {
                             _breakTimer = new Timer(RetryBreak, null, BREAK_DELTA, BREAK_DELTA);
                         }


### PR DESCRIPTION
As it is stated in comment - SIGINT delivery is reliable, so no need to re-send it, but Cygwin can't currently async-break reliably, so use retries there. However, the actual condition "!IsCygwin" in the guard clause seems to be wrong and should be inverted.
