### PR TITLE
Two natvis fixes in order to support gnu stl:

### DIFF
--- a/src/MIDebugEngine/Natvis.Impl/Natvis.cs
+++ b/src/MIDebugEngine/Natvis.Impl/Natvis.cs
@@ -544,6 +544,10 @@ namespace Microsoft.MIDebugEngine.Natvis
                         {
                             getValue = (v) => v.FindChildByName(item.ValueNode.Value);
                         }
+                        else if (GetExpression(item.ValueNode.Value, headVal, visualizer.ScopedNames) != null)
+                        {
+                            getValue = (v) => GetExpression(item.ValueNode.Value, v, visualizer.ScopedNames);
+                        }
                         if (goLeft == null || goRight == null || getValue == null)
                         {
                             continue;

--- a/src/MIDebugEngine/Natvis.Impl/NatvisNames.cs
+++ b/src/MIDebugEngine/Natvis.Impl/NatvisNames.cs
@@ -40,7 +40,7 @@ namespace Microsoft.MIDebugEngine.Natvis
         static TypeName()
         {
             s_identifier = new Regex("^[a-zA-Z$_][a-zA-Z$_0-9]*");
-            s_numeric = new Regex("^[0-9]+");        // only decimal constants
+            s_numeric = new Regex("^[0-9]+(u|l|ul)*");        // only decimal constants
             s_simpleType = new Regex(
                     @"^(signed\s+char|unsigned\s+char|char16_t|char32_t|wchar_t|char|"
                     + @"signed\s+short\s+int|signed\s+short|unsigned\s+short\s+int|unsigned\s+short|short\s+int|short|"


### PR DESCRIPTION
1. allow decimal constants to have trailing 'u' and 'l'
2. The TreeItems ValueNode element only accepted a simple field name, now allows any natvis expression value