### PR TITLE
Correctly generate full names for C# arrays

### DIFF
--- a/src/MIDebugEngine/Engine.Impl/Variables.cs
+++ b/src/MIDebugEngine/Engine.Impl/Variables.cs
@@ -258,6 +258,10 @@ namespace Microsoft.MIDebugEngine
                 Name = '[' + this.Name + ']';
                 VariableNodeType = NodeType.ArrayElement;
             }
+            else if (this.Name.Length > 2 && this.Name[0] == '[' && this.Name[this.Name.Length-1] == ']')
+            {
+                VariableNodeType = NodeType.ArrayElement;
+            }
             else
             {
                 _strippedName = Name;


### PR DESCRIPTION
This is a partial fix for full names with clrdbg. A full fix with come later with the new architecture so that that clrdbg will directly report full names. With this checkin, the MIEngine will generate a full name of '(myArray)[0]' instead of '(myArray).[0]'.