### PR TITLE
always do clean up on process exit

### DIFF
--- a/src/MICore/Transports/PipeTransport.cs
+++ b/src/MICore/Transports/PipeTransport.cs
@@ -287,30 +287,27 @@ namespace MICore
             // our pipe.
             _allReadersDone.WaitOne(100);
 
-            if (!this.IsClosed)
+            // We are sometimes seeing m_process throw InvalidOperationExceptions by the time we get here. 
+            // Attempt to get the real exit code, if we can't, still log the message with unknown exit code.
+            string exitCode = null;
+            try
             {
-                // We are sometimes seeing m_process throw InvalidOperationExceptions by the time we get here. 
-                // Attempt to get the real exit code, if we can't, still log the message with unknown exit code.
-                string exitCode = null;
-                try
-                {
-                    exitCode = string.Format(CultureInfo.InvariantCulture, "{0} (0x{0:X})", _process.ExitCode);
-                }
-                catch (InvalidOperationException)
-                {
-                }
-                this.Callback.AppendToInitializationLog(string.Format(CultureInfo.InvariantCulture, "\"{0}\" exited with code {1}.", _process.StartInfo.FileName, exitCode ?? "???"));
+                exitCode = string.Format(CultureInfo.InvariantCulture, "{0} (0x{0:X})", _process.ExitCode);
+            }
+            catch (InvalidOperationException)
+            {
+            }
 
+            this.Callback.AppendToInitializationLog(string.Format(CultureInfo.InvariantCulture, "\"{0}\" exited with code {1}.", _process.StartInfo.FileName, exitCode ?? "???"));
 
-                try
-                {
-                    this.Callback.OnDebuggerProcessExit(exitCode);
-                }
-                catch
-                {
-                    // We have no exception back stop here, and we are trying to report failures. But if something goes wrong,
-                    // lets not crash VS
-                }
+            try
+            {
+                this.Callback.OnDebuggerProcessExit(exitCode);
+            }
+            catch
+            {
+                // We have no exception back stop here, and we are trying to report failures. But if something goes wrong,
+                // lets not crash VS
             }
         }
 


### PR DESCRIPTION
Fix bug https://devdiv.visualstudio.com/DevDiv/VS%20Diag%20IntelliTrace/_workItems/index?_a=edit&id=287836&triage=true

Debugger depends on this process exit event to clean up the waiting operations.
Before the change, if a readline failed first the StreamTransport._bQuit will
be set to true and the process exit event won't be sent. Some waiting operations
won't be cleaned up and cause UI hang.