### PR TITLE
Fix addition of extra breakpoints.

### DIFF
--- a/src/MIDebugEngine/AD7.Impl/AD7PendingBreakpoint.cs
+++ b/src/MIDebugEngine/AD7.Impl/AD7PendingBreakpoint.cs
@@ -351,7 +351,7 @@ namespace Microsoft.MIDebugEngine
         {
             lock (_boundBreakpoints)
             {
-                if (!IsDataBreakpoint && _boundBreakpoints.Find((b) => b.Addr == bp.Addr) != null)
+                if (bp.Addr == 0 || (!IsDataBreakpoint && _boundBreakpoints.Find((b) => b.Addr == bp.Addr) != null))
                 {
                     return null;   // already bound to this breakpoint
                 }


### PR DESCRIPTION
Enabling/disabling breakpoint in VS breakpoint pane adds lots of unnecessary subordinate breakpoints to pending one. This patch fix this.
![before](https://cloud.githubusercontent.com/assets/17641326/20179184/518d32f0-a76e-11e6-984b-cc5196010711.png)
![after](https://cloud.githubusercontent.com/assets/17641326/20179201/5f8bf936-a76e-11e6-993e-1be62986618c.png)

