### PR TITLE
Improve handling of debugger aborts

### DIFF
--- a/src/MICore/CommandLock.cs
+++ b/src/MICore/CommandLock.cs
@@ -107,7 +107,7 @@ namespace MICore
         {
         }
 
-        internal void Close(string closeMessage)
+        public void Close(string closeMessage)
         {
             lock (this.LockObject)
             {

--- a/src/MICore/CommandLock.cs
+++ b/src/MICore/CommandLock.cs
@@ -83,7 +83,7 @@ namespace MICore
         }
     }
 
-    sealed public class CommandLock : IDisposable
+    sealed public class CommandLock
     {
         /// <summary>
         /// 0 if lock is free
@@ -101,24 +101,26 @@ namespace MICore
         private int _pendingSharedLockRequests;
         private TaskCompletionSource<int> _waitingSharedLockSource;
         private readonly Queue<TaskCompletionSource<ExclusiveLockToken>> _waitingExclusiveLockRequests = new Queue<TaskCompletionSource<ExclusiveLockToken>>();
+        private string _closeMessage;
 
         public CommandLock()
         {
         }
 
-        public void Close()
+        internal void Close(string closeMessage)
         {
             lock (this.LockObject)
             {
+                _closeMessage = closeMessage;
                 _lockStatus = StatusClosed;
                 if (_waitingSharedLockSource != null)
                 {
-                    _waitingSharedLockSource.SetException(new DebuggerDisposedException());
+                    _waitingSharedLockSource.SetException(new DebuggerDisposedException(_closeMessage));
                     _waitingSharedLockSource = null;
                 }
                 foreach (TaskCompletionSource<ExclusiveLockToken> completionSource in _waitingExclusiveLockRequests)
                 {
-                    completionSource.SetException(new DebuggerDisposedException());
+                    completionSource.SetException(new DebuggerDisposedException(_closeMessage));
                 }
                 _waitingExclusiveLockRequests.Clear();
             }
@@ -134,7 +136,7 @@ namespace MICore
             {
                 if (_lockStatus == StatusClosed)
                 {
-                    throw new DebuggerDisposedException();
+                    throw new DebuggerDisposedException(_closeMessage);
                 }
 
                 if (_lockStatus == StatusFree)
@@ -160,7 +162,7 @@ namespace MICore
             {
                 if (_lockStatus == StatusClosed)
                 {
-                    throw new DebuggerDisposedException();
+                    throw new DebuggerDisposedException(_closeMessage);
                 }
 
                 if (_lockStatus >= 0)
@@ -318,10 +320,5 @@ namespace MICore
         }
 
         private object LockObject { get { return _waitingExclusiveLockRequests; } }
-
-        public void Dispose()
-        {
-            Close();
-        }
     }
 }

--- a/src/MICore/Debugger.cs
+++ b/src/MICore/Debugger.cs
@@ -28,7 +28,7 @@ namespace MICore
         public event EventHandler RunModeEvent;
         public event EventHandler ProcessExitEvent;
         public event EventHandler DebuggerExitEvent;
-        public event EventHandler<string> DebuggerAbortedEvent;
+        public event EventHandler<DebuggerAbortedEventArgs> DebuggerAbortedEvent;
         public event EventHandler<string> OutputStringEvent;
         public event EventHandler EvaluationEvent;
         public event EventHandler ErrorEvent;
@@ -57,7 +57,7 @@ namespace MICore
         {
             get
             {
-                return _isClosed;
+                return _closeMessage != null;
             }
         }
 
@@ -79,7 +79,13 @@ namespace MICore
         private int _localDebuggerPid = -1;
 
         protected bool _connected;
-        protected bool _terminating;
+        private bool _terminating;
+        private bool _detaching;
+
+        public bool IsStopDebuggingInProgress
+        {
+            get { return _terminating || _detaching || this.ProcessState == MICore.ProcessState.Exited; }
+        }
 
         public class ResultEventArgs : EventArgs
         {
@@ -117,7 +123,12 @@ namespace MICore
         /// </summary>
         private string _lastCommandText;
         private uint _lastCommandId;
-        private bool _isClosed;
+
+        /// <summary>
+        /// Message used in any DebuggerDisposedExceptions once the debugger is closed. Setting
+        /// this to non-null indicates that the debugger is now closed. It is only set once.
+        /// </summary>
+        private string _closeMessage;
 
         /// <summary>
         /// [Optional] If a console command is being executed, list where we append the output
@@ -377,9 +388,9 @@ namespace MICore
             bool processContinued = false;
             if (source != null)
             {
-                if (_isClosed)
+                if (this.IsClosed)
                 {
-                    source.SetException(new DebuggerDisposedException());
+                    source.SetException(new DebuggerDisposedException(_closeMessage));
                 }
                 else
                 {
@@ -473,19 +484,32 @@ namespace MICore
         {
             if (Interlocked.CompareExchange(ref _exiting, 1, 0) == 0)
             {
-                Close();
+                string closeMessage;
+                if (this.ProcessState == ProcessState.Exited && !_terminating && !_detaching)
+                {
+                    closeMessage = MICoreResources.Error_TargetProcessExited;
+                }
+                else
+                {
+                    closeMessage = MICoreResources.Error_DebuggerClosed;
+                }
+
+                Close(closeMessage);
             }
         }
 
-        private void Close()
+        private void Close(string closeMessage)
         {
-            _isClosed = true;
+            Debug.Assert(closeMessage != null, "Invalid close message. Very bad.");
+            Debug.Assert(_closeMessage == null, "Why was Close called more than once? Should be impossible.");
+
+            _closeMessage = closeMessage;
             _transport.Close();
             lock (_waitingOperations)
             {
                 foreach (var value in _waitingOperations.Values)
                 {
-                    value.Abort();
+                    value.Abort(_closeMessage);
                 }
                 _waitingOperations.Clear();
             }
@@ -493,7 +517,7 @@ namespace MICore
             {
                 if (_internalBreakActionCompletionSource != null)
                 {
-                    _internalBreakActionCompletionSource.SetException(new DebuggerDisposedException());
+                    _internalBreakActionCompletionSource.SetException(new DebuggerDisposedException(_closeMessage));
                 }
                 _internalBreakActions.Clear();
             }
@@ -590,12 +614,13 @@ namespace MICore
 
         public async Task<Results> CmdDetach()
         {
+            _detaching = true;
             if (ProcessState == ProcessState.Running)
             {
                 await CmdBreak(BreakRequest.Async);
             }
-            await CmdAsync("-target-detach", ResultClass.done);
 
+            await CmdAsync("-target-detach", ResultClass.done);
             return new Results(ResultClass.done);
         }
 
@@ -689,7 +714,7 @@ namespace MICore
             {
                 if (this.ProcessState == MICore.ProcessState.Exited)
                 {
-                    throw new DebuggerDisposedException();
+                    throw new DebuggerDisposedException(GetTargetProcessExitedReason());
                 }
                 else
                 {
@@ -704,7 +729,7 @@ namespace MICore
                 {
                     if (this.ProcessState == MICore.ProcessState.Exited)
                     {
-                        throw new DebuggerDisposedException();
+                        throw new DebuggerDisposedException(GetTargetProcessExitedReason());
                     }
                     else
                     {
@@ -726,6 +751,16 @@ namespace MICore
                     _consoleCommandOutput = null;
                 }
             }
+        }
+
+        private string GetTargetProcessExitedReason()
+        {
+            if (_closeMessage != null)
+            {
+                return _closeMessage;
+            }
+
+            return MICoreResources.Error_TargetProcessExited;
         }
 
         public async Task<Results> CmdAsync(string command, ResultClass expectedResultClass)
@@ -759,9 +794,9 @@ namespace MICore
 
             lock (_waitingOperations)
             {
-                if (_isClosed)
+                if (this.IsClosed)
                 {
-                    throw new DebuggerDisposedException();
+                    throw new DebuggerDisposedException(_closeMessage);
                 }
 
                 id = ++_lastCommandId;
@@ -844,12 +879,20 @@ namespace MICore
                     }
                 }
 
-                Close();
+
+                string message;
+                if (string.IsNullOrEmpty(exitCode))
+                    message = string.Format(CultureInfo.CurrentCulture, MICoreResources.Error_MIDebuggerExited_UnknownCode, this.MICommandFactory.Name);
+                else
+                    message = string.Format(CultureInfo.CurrentCulture, MICoreResources.Error_MIDebuggerExited_WithCode, this.MICommandFactory.Name, exitCode);
+
+                Close(message);
+
                 if (this.ProcessState != ProcessState.Exited)
                 {
                     if (DebuggerAbortedEvent != null)
                     {
-                        DebuggerAbortedEvent(this, exitCode);
+                        DebuggerAbortedEvent(this, new DebuggerAbortedEventArgs(message, exitCode));
                     }
                 }
                 else
@@ -968,9 +1011,9 @@ namespace MICore
 
             public Task<Results> Task { get { return _completionSource.Task; } }
 
-            internal void Abort()
+            internal void Abort(string abortMessage)
             {
-                _completionSource.SetException(new DebuggerDisposedException(Command));
+                _completionSource.SetException(new DebuggerDisposedException(abortMessage, Command));
             }
         }
 
@@ -1479,5 +1522,18 @@ namespace MICore
                 throw new InvalidCoreDumpOperationException();
         }
     }
+
+    public class DebuggerAbortedEventArgs
+    {
+        public readonly string Message;
+        public readonly string /*OPTIONAL*/ ExitCode;
+
+        public DebuggerAbortedEventArgs(string message, string exitCode)
+        {
+            Debug.Assert(message != null, "Invalid argument");
+            this.Message = message;
+            this.ExitCode = exitCode;
+        }
+    };
 }
 

--- a/src/MICore/DebuggerDisposedException.cs
+++ b/src/MICore/DebuggerDisposedException.cs
@@ -15,17 +15,6 @@ namespace MICore
         /// </summary>
         public string AbortedCommand { get; private set; }
 
-        private const string Debugger = "Debugger";
-
-        /// <summary>
-        /// Constructor for the DebuggerDisposedException which takes the aborted command.
-        /// </summary>
-        /// <param name="abortedCommand">MI Command</param>
-        public DebuggerDisposedException(string abortedCommand = null) : base(Debugger)
-        {
-            AbortedCommand = abortedCommand;
-        }
-
         /// <summary>
         /// Constructor for the DebuggerDisposedException which takes message, innerException and aborted command.
         /// </summary>
@@ -37,9 +26,8 @@ namespace MICore
         /// <summary>
         /// Constructor for the DebuggerDisposedException which takes message and aborted command.
         /// </summary>
-        public DebuggerDisposedException(string message, string abortedCommand = null) : base(Debugger, message)
+        public DebuggerDisposedException(string message, string abortedCommand = null) : this(message, null, abortedCommand)
         {
-            AbortedCommand = abortedCommand;
         }
     }
 }

--- a/src/MICore/MICoreResources.Designer.cs
+++ b/src/MICore/MICoreResources.Designer.cs
@@ -91,6 +91,15 @@ namespace MICore {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to The debugger is no longer debugging the specified process..
+        /// </summary>
+        public static string Error_DebuggerClosed {
+            get {
+                return ResourceManager.GetString("Error_DebuggerClosed", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Unable to establish a connection to {0}. Debug output may contain more information..
         /// </summary>
         public static string Error_DebuggerInitializeFailed_NoStdErr {
@@ -250,7 +259,7 @@ namespace MICore {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to {0} exited unexpectedly. Debugging will now abort..
+        ///   Looks up a localized string similar to {0} exited unexpectedly..
         /// </summary>
         public static string Error_MIDebuggerExited_UnknownCode {
             get {
@@ -259,7 +268,7 @@ namespace MICore {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to {0} exited unexpectedly with exit code {1}. Debugging will now abort..
+        ///   Looks up a localized string similar to {0} exited unexpectedly with exit code {1}..
         /// </summary>
         public static string Error_MIDebuggerExited_WithCode {
             get {
@@ -336,6 +345,15 @@ namespace MICore {
         public static string Error_StringIsNullOrEmpty {
             get {
                 return ResourceManager.GetString("Error_StringIsNullOrEmpty", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to The target process has exited..
+        /// </summary>
+        public static string Error_TargetProcessExited {
+            get {
+                return ResourceManager.GetString("Error_TargetProcessExited", resourceCulture);
             }
         }
         

--- a/src/MICore/MICoreResources.resx
+++ b/src/MICore/MICoreResources.resx
@@ -162,11 +162,11 @@ Error: {1}</value>
     <value>Device App Launcher {0} could not be found.</value>
   </data>
   <data name="Error_MIDebuggerExited_UnknownCode" xml:space="preserve">
-    <value>{0} exited unexpectedly. Debugging will now abort.</value>
+    <value>{0} exited unexpectedly.</value>
     <comment>{0} is the name of the debugger</comment>
   </data>
   <data name="Error_MIDebuggerExited_WithCode" xml:space="preserve">
-    <value>{0} exited unexpectedly with exit code {1}. Debugging will now abort.</value>
+    <value>{0} exited unexpectedly with exit code {1}.</value>
     <comment>{0} is the name of the debugger</comment>
   </data>
   <data name="Error_MissingAttribute" xml:space="preserve">
@@ -261,5 +261,11 @@ Error: {1}</value>
   </data>
   <data name="Error_LauncherSerializerNotFound" xml:space="preserve">
     <value>Device App Launcher Serializer {0} could not be found.</value>
+  </data>
+  <data name="Error_DebuggerClosed" xml:space="preserve">
+    <value>The debugger is no longer debugging the specified process.</value>
+  </data>
+  <data name="Error_TargetProcessExited" xml:space="preserve">
+    <value>The target process has exited.</value>
   </data>
 </root>

--- a/src/MIDebugEngine.sln
+++ b/src/MIDebugEngine.sln
@@ -223,8 +223,8 @@ Global
 		{95C0421F-D4C1-46E8-9177-6DAA4D71D0F2}.Release|Any CPU.Build.0 = Release|Any CPU
 		{7654CFBB-30DB-4C20-BDE3-A960CBA2036C}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{7654CFBB-30DB-4C20-BDE3-A960CBA2036C}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{7654CFBB-30DB-4C20-BDE3-A960CBA2036C}.Debug-PortablePDB|Any CPU.ActiveCfg = Debug-PortablePDB|Any CPU
-		{7654CFBB-30DB-4C20-BDE3-A960CBA2036C}.Debug-PortablePDB|Any CPU.Build.0 = Debug-PortablePDB|Any CPU
+		{7654CFBB-30DB-4C20-BDE3-A960CBA2036C}.Debug-PortablePDB|Any CPU.ActiveCfg = Debug|Any CPU
+		{7654CFBB-30DB-4C20-BDE3-A960CBA2036C}.Debug-PortablePDB|Any CPU.Build.0 = Debug|Any CPU
 		{7654CFBB-30DB-4C20-BDE3-A960CBA2036C}.Desktop.Debug|Any CPU.ActiveCfg = Desktop.Debug|Any CPU
 		{7654CFBB-30DB-4C20-BDE3-A960CBA2036C}.Desktop.Debug|Any CPU.Build.0 = Desktop.Debug|Any CPU
 		{7654CFBB-30DB-4C20-BDE3-A960CBA2036C}.Desktop.Release|Any CPU.ActiveCfg = Desktop.Release|Any CPU

--- a/src/MIDebugEngine/ResourceStrings.Designer.cs
+++ b/src/MIDebugEngine/ResourceStrings.Designer.cs
@@ -80,6 +80,15 @@ namespace Microsoft.MIDebugEngine {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Debugging will now abort..
+        /// </summary>
+        internal static string DebuggingWillAbort {
+            get {
+                return ResourceManager.GetString("DebuggingWillAbort", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Sample Engine.
         /// </summary>
         internal static string EngineName {

--- a/src/MIDebugEngine/ResourceStrings.resx
+++ b/src/MIDebugEngine/ResourceStrings.resx
@@ -248,4 +248,7 @@ See https://aka.ms/miengine-gdb-troubleshooting for details.</value>
   <data name="Error_UnsupportedPlatform" xml:space="preserve">
     <value>Unsupported platform.</value>
   </data>
+  <data name="DebuggingWillAbort" xml:space="preserve">
+    <value>Debugging will now abort.</value>
+  </data>
 </root>


### PR DESCRIPTION
This checkin improves the error message that we show when GDB exits or we otherwise loose the connection to the target process.

This also fixes a hang that could happen if we lost our connection after DebuggedProcess.Initialize, but before DebuggedProcess.ResumeFromLaunch. The issue was that nothing would send the program destroy event.