### PR TITLE
Ensure logger in enabled when originally initialized via command.

### DIFF
--- a/src/MICore/Logger.cs
+++ b/src/MICore/Logger.cs
@@ -90,8 +90,12 @@ namespace MICore
                 logger = HostLogger.GetLoggerFromCmd(CmdLogInfo.logFile, CmdLogInfo.logToOutput);
                 logger = Interlocked.Exchange(ref s_logger, logger);
                 logger?.Close();
+                if (s_logger != null)
+                {
+                    s_isEnabled = true;
+                }
             }
-         }
+        }
 
         /// <summary>
         /// If logging is enabled, writes a line of text to the log


### PR DESCRIPTION
Engine logger was only being enabled if the registry was previously updated to enable logging. If MIEngineLog command was called on a clean registry the log would never become enabled. This fixes the problem by enabling the log under the command initialization case too.