### PR TITLE
VS 2015 Glass fixes

### DIFF
--- a/src/DebugEngineHost/Host.cs
+++ b/src/DebugEngineHost/Host.cs
@@ -43,21 +43,25 @@ namespace Microsoft.DebugEngineHost
         /// </summary>
         public static void EnsureMainThreadInitialized()
         {
-            // This call is to initialize the global service provider while we are still on the main thread.
-            // Do not remove this this, even though the return value goes unused.
-            var globalProvider = Microsoft.VisualStudio.Shell.ServiceProvider.GlobalProvider;
-
-#if LAB
             try
             {
+                // This call is to initialize the global service provider while we are still on the main thread.
+                // Do not remove this this, even though the return value goes unused.
+                var globalProvider = Microsoft.VisualStudio.Shell.ServiceProvider.GlobalProvider;
+
+#if LAB
                 // Force the IVsTelemetryService to complete its lazy loading. There is a hang caused by trying to
                 // send telemetry while Visual Studio is launching the debugger if the telemetry helper also needs 
                 // to load the telemetry service on the main thread.
                 // Do not remove this this, even though the return value goes unused.
                 var telemetryService = TelemetryHelper.TelemetryService;
-            }
-            catch { }
 #endif
+
+            }
+            catch
+            {
+                // In glass, VS types will be missing. Ignore the exceptions.
+            }
         }
 
         /// <summary>

--- a/test/Android/androidtest.cmd
+++ b/test/Android/androidtest.cmd
@@ -16,7 +16,8 @@ set _DeviceId=
 set _Platform=
 set _SdkRoot=%ProgramFiles(x86)%\Android\android-sdk
 set _NdkRoot=%ProgramData%\Microsoft\AndroidNDK\android-ndk-r11c
-set _LoopCount=
+if not exist "%_NdkRoot%" for /f %%v in ('dir /b /o:n %ProgramData%\Microsoft\AndroidNDK\android-ndk-r*') do set _NdkRoot=%ProgramData%\Microsoft\AndroidNDK\%%v
+ set _LoopCount=
 set _Verbose=
 set _TestsToRun=
 
@@ -195,7 +196,10 @@ exit /b -1
     if NOT "%ERRORLEVEL%"=="0" echo ERROR: Failed to build %~1. See build.log for more information.& set FAILED_TESTS="%~1" "%FAILED_TESTS%"& goto RunSingleTestDone
     
     ::Deploy the app
-    call "%_SdkRoot%\platform-tools\adb.exe" -s %_DeviceId% install -r %_Platform%\Debug\%~1.apk > adb.log 2>&1
+    set ApkFile=%_Platform%\Debug\%~1.apk
+    if not exist "%ApkFile%" set ApkFile=%~1\%~1.Packaging\%_Platform%\Debug\%~1.apk
+    if not exist "%ApkFile%" echo ERROR: Building the app failed to create '%CD%\%ApkFile%'& set FAILED_TESTS="%~1" "%FAILED_TESTS%"& goto RunSingleTestDone
+    call "%_SdkRoot%\platform-tools\adb.exe" -s %_DeviceId% install -r %ApkFile% > adb.log 2>&1
     if NOT "%ERRORLEVEL%"=="0" echo ERROR: adb failed for one reason or another.& set FAILED_TESTS="%~1" "%FAILED_TESTS%"& goto RunSingleTestDone
     
     ::Create temp directory


### PR DESCRIPTION
- Host was mistakenly taking a hard dependency on the existance of a shell dll. This moves the dependency to be a soft dependency.
- On the machine I was running things at least, there was a different NDK, and the .apk files where dropping to a different place than when AndroidTest.cmd expected. This made AndroidTest.cmd a bit more forgiving.