### PR TITLE
Implement IDebugDocumentContext150

### DIFF
--- a/src/MIDebugEngine/AD7.Definitions/IDebugDocumentContext150.cs
+++ b/src/MIDebugEngine/AD7.Definitions/IDebugDocumentContext150.cs
@@ -1,0 +1,24 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Runtime.InteropServices;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Microsoft.VisualStudio.Debugger.Interop
+{
+
+    /// <summary>
+    /// This interface was originally defined in Microsoft.VisualStudio.Debugger.Interop.15.0.dll
+    /// We redefine it here because the deubgger interop assemblies are not portable,
+    /// and we need this to be available in dev14 (when we do not have Interop.15.0.dll available)
+    /// </summary>
+    [Guid("3cfd5762-425b-4a0b-a962-3a6cacbcaef5")]
+    [ComVisible(true)]
+    [InterfaceType(ComInterfaceType.InterfaceIsIUnknown)]
+    public interface IDebugDocumentContext150
+    {
+        [PreserveSig]
+        Int32 UseDefaultSourceSearchDirectories(out Int32 pfUseDefaultSearchDirectories);
+    }
+}

--- a/src/MIDebugEngine/AD7.Impl/AD7DocumentContext.cs
+++ b/src/MIDebugEngine/AD7.Impl/AD7DocumentContext.cs
@@ -11,7 +11,7 @@ using MICore;
 namespace Microsoft.MIDebugEngine
 {
     // This class represents a document context to the debugger. A document context represents a location within a source file. 
-    internal class AD7DocumentContext : IDebugDocumentContext2
+    internal class AD7DocumentContext : IDebugDocumentContext2, IDebugDocumentContext150
     {
         private readonly MITextPosition _textPosition;
         private AD7MemoryAddress _codeContext;
@@ -25,7 +25,7 @@ namespace Microsoft.MIDebugEngine
             _debuggedProcess = debuggedProcess;
         }
 
-        #region IDebugDocumentContext2 Members
+#region IDebugDocumentContext2 Members
 
         // Compares this document context to a given array of document contexts.
         int IDebugDocumentContext2.Compare(enum_DOCCONTEXT_COMPARE Compare, IDebugDocumentContext2[] rgpDocContextSet, uint dwDocContextSetLen, out uint pdwDocContext)
@@ -156,9 +156,20 @@ namespace Microsoft.MIDebugEngine
         int IDebugDocumentContext2.Seek(int nCount, out IDebugDocumentContext2 ppDocContext)
         {
             ppDocContext = null;
+
             return Constants.E_NOTIMPL;
         }
 
-        #endregion
+#endregion
+
+#region IDebugDocumentContext150 Members
+        public int UseDefaultSourceSearchDirectories(out int pfUseDefaultSourceSearchDirectories)
+        {
+            pfUseDefaultSourceSearchDirectories = 0;
+            return Constants.S_OK;
+        }
+
+#endregion
+
     }
 }

--- a/src/MIDebugEngine/MIDebugEngine.csproj
+++ b/src/MIDebugEngine/MIDebugEngine.csproj
@@ -112,6 +112,7 @@
   <ItemGroup>
     <Compile Include="AD7.Definitions\AD7Guids.cs" />
     <Compile Include="AD7.Definitions\AD7Hresult.cs" />
+    <Compile Include="AD7.Definitions\IDebugDocumentContext150.cs" />
     <Compile Include="AD7.Impl\AD7BoundBreakpoint.cs" />
     <Compile Include="AD7.Impl\AD7BreakpointResolution.cs" />
     <Compile Include="AD7.Impl\AD7Disassembly.cs" />


### PR DESCRIPTION
This allows the MIEngine to opt out of Visual Studio's default source
search directories. We were seeing an issue where linux's crt source
files names might match source files in Microsoft's crt, which is on the
Default Source Search Path. This was causing VS to show incorrect source
files.

This change required us to create our own definition of
IDebugDocumentContext150, which was previously defined in
Microsoft.VisualStudio.Debugger.Interop.15.0.dll. Unfortunately we
cannot take a dependency on this dll because:
1. It is compatible with portable clr code, so this would not work for
x-plat scenarios
2. We need MIEngine to continue to run in dev14, where
Debugger.Interop.15.0.dll is not available.