### PR TITLE
Fixing GetClrDbg ps1 and sh script to download latest clrdbg

### DIFF
--- a/scripts/GetClrDbg.ps1
+++ b/scripts/GetClrDbg.ps1
@@ -3,13 +3,13 @@
 Downloads the given $Version of clrdbg for the given $RuntimeID and installs it to the given $InstallPath
 
 .DESCRIPTION
-The following script will generate a project.json and NuGet.config and use dotnet restore and publish to install clrdbg, the .NET Core Debugger
+The following script will download clrdbg and install clrdbg, the .NET Core Debugger
 
 .PARAMETER Version
-Specifies the version of clrdbg to install. Can be 'latest', VS2015U2, or a specific version string i.e. 14.0.25406-preview-3044032
+Specifies the version of clrdbg to install. Can be 'latest', VS2015U2, or a specific version string i.e. 15.0.25930.0
 
 .PARAMETER RuntimeID
-Specifies the .NET Runtime ID of the clrdbg that will be downloaded. Example: ubuntu.14.04-x64. Defaults to the Runtime ID of the current machine.
+Specifies the .NET Runtime ID of the clrdbg that will be downloaded. Example: ubuntu.14.04-x64. Defaults to win7-x64.
 
 .Parameter InstallPath
 Specifies the path where clrdbg will be installed. Defaults to the directory containing this script.
@@ -51,54 +51,15 @@ Param (
     $RemoveExistingOnUpgrade
 )
 
-function GetDotNetRuntimeID() {
-    $ridLine = dotnet --info | findstr "RID"
-    
-    if ([System.String]::IsNullOrEmpty($ridLine)) {
-        throw [System.Exception] "Unable to determine runtime from dotnet --info. Make sure dotnet cli is up to date on this machine"
-    }
-
-    $rid = $ridLine.Split(":")[1].Trim();
-
-    if ([System.String]::IsNullOrEmpty($rid)) {
-        throw [System.Exception] "Unable to determine runtime from dotnet --info. Make sure dotnet cli is up to date on this machine"
-    }
-
-    return $rid
-}
-
-# Produces project.json in the current directory
-function GenerateProjectJson([string] $version, [string]$runtimeID) {
-    $projectJson = 
-"{
-    `"dependencies`": {
-       `"Microsoft.VisualStudio.clrdbg`": `"$version`"
-    },
-    `"frameworks`": {
-        `"netstandardapp1.5`": {
-          `"imports`": [ `"dnxcore50`", `"portable-net45+win8`" ]
-       }
-   },
-   `"runtimes`": {
-      `"$runtimeID`": {}
-   }
-}"
-
-    $projectJson | Out-File -Encoding utf8 project.json
-}
-
-# Produces NuGet.config in the current directory
-function GenerateNuGetConfig() {
-    $nugetConfig = 
-"<?xml version=`"1.0`" encoding=`"utf-8`"?>
-<configuration>
-  <packageSources>
-      <clear />
-      <add key=`"api.nuget.org`" value=`"https://api.nuget.org/v3/index.json`" />
-  </packageSources>
-</configuration>"
-
-    $nugetConfig | Out-File -Encoding utf8 NuGet.config
+# In a separate method to prevent locking zip files.
+function DownloadAndExtract([string]$url, [string]$targetLocation) {
+    Add-Type -assembly "System.IO.Compression.FileSystem"
+    Add-Type -assembly "System.IO.Compression"
+    $zipStream = (New-Object System.Net.WebClient).OpenRead($url)
+    $zipArchive = New-Object System.IO.Compression.ZipArchive -ArgumentList $zipStream
+    [System.IO.Compression.ZipFileExtensions]::ExtractToDirectory($zipArchive, $targetLocation)
+    $zipArchive.Dispose()
+    $zipStream.Dispose()
 }
 
 # Checks if the existing version is the latest version.
@@ -134,34 +95,22 @@ function WriteSuccessInfo([string]$installationPath, [string]$runtimeId, [string
     $version | Out-File -Encoding utf8 $SuccessVersionFile
 }
 
-# Add new version constants here
-# 'latest' version may be updated
-# all other version constants i.e. 'vs2015u2' may not be updated after they are finalized
 if ($Version -eq "latest") {
-    $VersionNumber = "14.0.25406-preview-3044032"
+    $VersionNumber = "15.0.25930.0"
 } elseif ($Version -eq "vs2015u2") {
-    $VersionNumber = "14.0.25406-preview-3044032"
+    $VersionNumber = "15.0.25930.0"
 }
 Write-Host "Info: Using clrdbg version '$VersionNumber'"
 
 if (-not $RuntimeID) {
-    $RuntimeID = GetDotNetRuntimeID
+    $RuntimeID = "win7-x64"
 }
 Write-Host "Info: Using Runtime ID '$RuntimeID'"
-
-# create the temp folder if it does not exist
-$GuidString = [System.Guid]::NewGuid()
-$TempPath = Join-Path -Path $env:TEMP -ChildPath $GuidString
-if (-not (Test-Path -Path $TempPath -PathType Container)) {
-    New-Item -ItemType Directory -Force -Path $TempPath -ErrorAction Stop | Out-Null
-}
-$TempPath = Resolve-Path -Path $TempPath -ErrorAction Stop
 
 # if we were given a relative path, assume its relative to the script directory and create an absolute path
 if (-not([System.IO.Path]::IsPathRooted($InstallPath))) {
     $InstallPath = Join-Path -Path (Split-Path -Path $MyInvocation.MyCommand.Definition) -ChildPath $InstallPath
 }
-
 
 if (IsLatest $InstallPath $RuntimeID $VersionNumber) {
     Write-Host "Info: Latest version of ClrDbg is present. Skipping downloads"
@@ -173,26 +122,16 @@ if (IsLatest $InstallPath $RuntimeID $VersionNumber) {
         }
     }
     
-    Push-Location $TempPath -ErrorAction Stop
+    $target = ("clrdbg-" + $VersionNumber).Replace('.','-') + "/clrdbg-" + $RuntimeID + ".zip"
+    $url = "https://vsdebugger.azureedge.net/" + $target
     
-    Write-Host "Info: Generating project.json"
-    GenerateProjectJson $VersionNumber $RuntimeID
-
-    Write-Host "Info: Generating NuGet.config"
-    GenerateNuGetConfig
-
-    Write-Host "Info: Executing dotnet restore"
-    dotnet restore
-
-    Write-Host "Info: Executing dotnet publish"
-    dotnet publish -r $RuntimeID -o $InstallPath
-
-    Pop-Location
-
-    Remove-Item -Path $TempPath -Recurse -Force
+    if (Test-Path $InstallPath) {
+        Remove-Item -Path $InstallPath -Force -Recurse
+    }
+    
+    DownloadAndExtract $url $InstallPath
 
     WriteSuccessInfo $InstallPath $RuntimeID $VersionNumber
     Write-Host "Info: Successfully installed clrdbg at '$InstallPath'"
 }
-
 

--- a/scripts/GetClrDbg.sh
+++ b/scripts/GetClrDbg.sh
@@ -428,7 +428,8 @@ else
         __RuntimeID=
         get_dotnet_runtime_id
         if [ -z $__RuntimeID ]; then
-            echo "Error: Unable to determine dotnet Runtime ID. Please make sure that dotnet is installed and the platform is supported. Look at https://www.microsoft.com/net/core for supported platforms."
+            echo "Error: Unable to determine dotnet Runtime ID. Please make sure that dotnet is installed and the platform is supported. Look at https://www.microsoft.com/net/core for supported platforms. Alternatively you can specify the RuntimeID with -r switch."
+            print_help
             exit 1
         fi
     fi

--- a/scripts/GetClrDbg.sh
+++ b/scripts/GetClrDbg.sh
@@ -21,6 +21,9 @@ __RemoveExistingOnUpgrade=false
 # Internal, fully specified version of the ClrDbg. Computed when the meta version is used.
 __ClrDbgVersion=
 
+# RuntimeID of dotnet
+__RuntimeID=
+
 # Gets the script directory
 get_script_directory()
 {
@@ -31,21 +34,22 @@ get_script_directory()
 
 print_help()
 {
-    echo 'GetClrDbg.sh [-usdh] -v V [-l L]'
+    echo 'GetClrDbg.sh [-usdh] -v V [-l L] [-r R]'
     echo ''
     echo 'This script downloads and configures clrdbg, the Cross Platform .NET Debugger'
     echo '-u    Deletes the existing installation directory of the debugger before installing the current version.'
     echo '-s    Skips any steps which requires downloading from the internet.'
     echo '-d    Launches debugger after the script completion.'
     echo '-h    Prints usage information.'
-    echo '-v V  Version V can be "latest" or a version number such as 14.0.25109-preview-2865786'
+    echo '-v V  Version V can be "latest" or a version number such as 15.0.25930.0'
     echo '-l L  Location L where the debugger should be installed. Can be absolute or relative'
+    echo '-r R  Debugger for the RuntimeID will be installed'
     echo ''
     echo 'Legacy commandline'
     echo '  GetClrDbg.sh <version> [<install path>]'   
     echo '  If <install path> is not specified, clrdbg will be installed to the directory'
     echo '  from which this script was executed.' 
-    echo '  <version> can be "latest" or a version number such as 14.0.25109-preview-2865786'
+    echo '  <version> can be "latest" or a version number such as 15.0.25930.0'
 }
 
 # Set the __RuntimeID by reading the contents of /etc/os-release. 
@@ -70,21 +74,31 @@ get_dotnet_runtime_id()
         ubuntu) 
             if [[ "$PlatformVersionID" == 14* ]]; then
                 __RuntimeID=ubuntu.14.04-x64
-            elif [[ "$PlatformVersionID" == 16* ]]; then
+            elif [[ "$PlatformVersionID" == 16.04 ]]; then
                 __RuntimeID=ubuntu.16.04-x64
+            elif [[ "$PlatformVersionID" == 16.10 ]]; then
+                __RuntimeID=ubuntu.16.10-x64
             fi
             ;;
         centos)
             __RuntimeID=centos.7-x64
             ;;
         fedora)
-            __RuntimeID=fedora.23-x64
+            if [[ "$PlatformVersionID" == 23 ]]; then
+                __RuntimeID=fedora.23-x64
+            elif [[ "$PlatformVersionID" == 24 ]]; then
+                __RuntimeID=fedora.24-x64
+            fi
             ;;
         opensuse)
-            __RuntimeID=opensuse.13.2-x64
+            if [[ "$PlatformVersionID" == 13.2 ]]; then
+                __RuntimeID=opensuse.13.2-x64
+            elif [[ "$PlatformVersionID" == 42.1 ]]; then
+                __RuntimeID=opensuse.42.1-x64
+            fi
             ;;
         rhel)
-            __RuntimeID=rhel.7-x64
+            __RuntimeID=rhel.7.2-x64
             ;;
         debian)
             __RuntimeID=debian.8-x64
@@ -146,7 +160,7 @@ generate_nuget_config()
 # Parses and populates the arguments
 parse_and_get_arguments()
 {
-    while getopts "v:l:suhd" opt; do
+    while getopts "v:l:r:suhd" opt; do
         case $opt in
             v)
                 __ClrDbgMetaVersion=$OPTARG;
@@ -163,7 +177,10 @@ parse_and_get_arguments()
             d)
                 __LaunchClrDbg=true
                 ;;
-            h)            
+            r)
+                __RuntimeID=$OPTARG
+                ;;
+            h)
                 print_help
                 exit 1
                 ;;    
@@ -272,10 +289,10 @@ set_clrdbg_version()
     version_string="$(echo $1 | awk '{print tolower($0)}')"
     case $version_string in
         latest)
-            __ClrDbgVersion=14.0.25520-preview-3139256
+            __ClrDbgVersion=15.0.25930.0
             ;;
         vs2015u2)
-            __ClrDbgVersion=14.0.25520-preview-3139256 #This version is now locked and should not be updated.
+            __ClrDbgVersion=15.0.25930.0
             ;;
         *)
             simpleVersionRegex="^[0-9].*"
@@ -336,6 +353,43 @@ check_latest()
     fi
 }
 
+download_and_extract()
+{
+    clrdbgZip="clrdbg-${__RuntimeID}.zip"
+    target="$(echo ${__ClrDbgVersion} | tr '.' '-')"
+    url="$(echo https://vsdebugger.azureedge.net/clrdbg-${target}/${clrdbgZip})"
+   
+    echo "Downloading ${url}"
+    if ! hash unzip 2>/dev/null; then
+        echo "unzip command not found. Install unzip for this script to work."
+        exit 1
+    fi
+   
+    if hash wget 2>/dev/null; then
+        wget -q $url -O $clrdbgZip
+    elif hash curl 2>/dev/null; then
+        curl -s $url -o $clrdbgZip
+    else
+        echo "Install curl or wget. It is needed to download clrdbg."
+        exit 1
+    fi
+    
+    if [ $? -ne  0 ]; then
+        echo "Could not download ${url}"
+        exit 1;
+    fi
+    
+    unzip -q $clrdbgZip
+    
+    if [ $? -ne  0 ]; then
+        echo "Failed to unzip clrdbg"
+        exit 1;
+    fi
+    
+    chmod +x ./clrdbg
+    rm $clrdbgZip
+}
+
 get_script_directory
 
 if [ -z "$1" ]; then
@@ -369,39 +423,18 @@ else
 
     # For the rest of this script we can assume the working directory is the install path
 
-    echo 'Info: Determining Runtime ID'
-    __RuntimeID=
-    get_dotnet_runtime_id
     if [ -z $__RuntimeID ]; then
-        echo "Error: Unable to determine dotnet Runtime ID. Please make sure that dotnet is installed and the platform is supported. Look at https://www.microsoft.com/net/core for supported platforms."
-        exit 1
+        echo 'Info: Determining Runtime ID'
+        __RuntimeID=
+        get_dotnet_runtime_id
+        if [ -z $__RuntimeID ]; then
+            echo "Error: Unable to determine dotnet Runtime ID. Please make sure that dotnet is installed and the platform is supported. Look at https://www.microsoft.com/net/core for supported platforms."
+            exit 1
+        fi
     fi
+    
     echo "Info: Using Runtime ID '$__RuntimeID'"
-
-    echo 'Info: Generating project.json'
-    generate_project_json $__RuntimeID
-
-    echo 'Info: Generating NuGet.config'
-    generate_nuget_config
-
-    # dotnet restore and publish add color to their output
-    # I have found that the extra characters to provide color can corrupt
-    # the shell output when running this as part of docker build
-    # Therefore, I redirect the output of these commands to a log
-    echo 'Info: Executing dotnet restore'
-    dotnet restore > dotnet_restore.log 2>&1
-    if [ $? -ne 0 ]; then
-        echo "Error: dotnet restore failed"
-        cat dotnet_restore.log >&2
-        exit 1
-    fi
-
-    echo 'Info: Executing dotnet publish'
-    dotnet publish -r $__RuntimeID -o . > dotnet_publish.log 2>&1
-    if [ $? -ne 0 ]; then
-        echo "Error: dotnet publish failed"
-        exit 1
-    fi
+    download_and_extract
 
     echo "$__ClrDbgVersion" > success.txt
     popd > /dev/null 2>&1


### PR DESCRIPTION
Fixing GetClrDbg ps1 and sh script to pull down the latest versions of clrdbg binaries with NI images.