### PR TITLE
Fixing crash bug when attaching through SSH.

### DIFF
--- a/src/MICore/LaunchCommand.cs
+++ b/src/MICore/LaunchCommand.cs
@@ -22,9 +22,9 @@ namespace MICore
         public readonly bool IgnoreFailures;
         public readonly bool IsMICommand;
         public /*OPTIONAL*/ Action<string> FailureHandler { get; private set; }
-        public /*OPTIONAL*/ Action<string> SuccessHandler { get; private set; }
+        public /*OPTIONAL*/ Func<string, Task> SuccessHandler { get; private set; }
 
-        public LaunchCommand(string commandText, string description = null, bool ignoreFailures = false, Action<string> failureHandler = null, Action<string> successHandler = null)
+        public LaunchCommand(string commandText, string description = null, bool ignoreFailures = false, Action<string> failureHandler = null, Func<string, Task> successHandler = null)
         {
             if (commandText == null)
                 throw new ArgumentNullException("commandText");

--- a/src/MIDebugEngine/ResourceStrings.Designer.cs
+++ b/src/MIDebugEngine/ResourceStrings.Designer.cs
@@ -102,7 +102,7 @@ namespace Microsoft.MIDebugEngine {
         ///
         ///{1} failed with message: {2}
         ///
-        ///Updates can cause binaries replaced on disk and resulting in this failure. Try re-launching the application or restarting the machine..
+        ///This may occur if the process&apos;s executable was changed after the process was started, such as when installing an update. Try re-launching the application or restarting the machine..
         /// </summary>
         internal static string Error_ExePathInvalid {
             get {

--- a/src/MIDebugEngine/ResourceStrings.Designer.cs
+++ b/src/MIDebugEngine/ResourceStrings.Designer.cs
@@ -100,7 +100,9 @@ namespace Microsoft.MIDebugEngine {
         /// <summary>
         ///   Looks up a localized string similar to Program path &apos;{0}&apos; is missing or invalid.
         ///
-        ///{1} failed with message: {2}.
+        ///{1} failed with message: {2}
+        ///
+        ///Updates can cause binaries replaced on disk and resulting in this failure. Try re-launching the application or restarting the machine..
         /// </summary>
         internal static string Error_ExePathInvalid {
             get {

--- a/src/MIDebugEngine/ResourceStrings.resx
+++ b/src/MIDebugEngine/ResourceStrings.resx
@@ -215,7 +215,7 @@
 
 {1} failed with message: {2}
 
-Updates can cause binaries replaced on disk and resulting in this failure. Try re-launching the application or restarting the machine.</value>
+This may occur if the process's executable was changed after the process was started, such as when installing an update. Try re-launching the application or restarting the machine.</value>
     <comment>0: exe path passed in
 1: Name of the debugger (ex: 'GDB')
 2: Message from GDB</comment>

--- a/src/MIDebugEngine/ResourceStrings.resx
+++ b/src/MIDebugEngine/ResourceStrings.resx
@@ -213,7 +213,9 @@
   <data name="Error_ExePathInvalid" xml:space="preserve">
     <value>Program path '{0}' is missing or invalid.
 
-{1} failed with message: {2}</value>
+{1} failed with message: {2}
+
+Updates can cause binaries replaced on disk and resulting in this failure. Try re-launching the application or restarting the machine.</value>
     <comment>0: exe path passed in
 1: Name of the debugger (ex: 'GDB')
 2: Message from GDB</comment>


### PR DESCRIPTION
Exceptions were not caught because it was a void async method, which crashed the application. Fixed it to return a Task.
Added actionable error message for the user in situations when this can happen.