### PR TITLE
Wait for process to stop before terminating or detaching. Also fixes …

### DIFF
--- a/src/MICore/Debugger.cs
+++ b/src/MICore/Debugger.cs
@@ -603,10 +603,13 @@ namespace MICore
                 _terminating = true;
                 if (ProcessState == ProcessState.Running && this.MICommandFactory.Mode != MIMode.Clrdbg)
                 {
+                    await AddInternalBreakAction(() => MICommandFactory.Terminate());
                     await CmdBreak(BreakRequest.Async);
                 }
-
-                await MICommandFactory.Terminate();
+                else
+                {
+                    await MICommandFactory.Terminate();
+                }
             }
 
             return new Results(ResultClass.done);
@@ -617,10 +620,13 @@ namespace MICore
             _detaching = true;
             if (ProcessState == ProcessState.Running)
             {
+                await AddInternalBreakAction(() => CmdAsync("-target-detach", ResultClass.done));
                 await CmdBreak(BreakRequest.Async);
             }
-
-            await CmdAsync("-target-detach", ResultClass.done);
+            else
+            {
+                await CmdAsync("-target-detach", ResultClass.done);
+            }
             return new Results(ResultClass.done);
         }
 
@@ -888,7 +894,7 @@ namespace MICore
 
                 Close(message);
 
-                if (this.ProcessState != ProcessState.Exited)
+                if (this.ProcessState != ProcessState.Exited && !_terminating && !_detaching)
                 {
                     if (DebuggerAbortedEvent != null)
                     {

--- a/src/MICore/Debugger.cs
+++ b/src/MICore/Debugger.cs
@@ -604,7 +604,6 @@ namespace MICore
                 if (ProcessState == ProcessState.Running && this.MICommandFactory.Mode != MIMode.Clrdbg)
                 {
                     await AddInternalBreakAction(() => MICommandFactory.Terminate());
-                    await CmdBreak(BreakRequest.Async);
                 }
                 else
                 {
@@ -618,10 +617,9 @@ namespace MICore
         public async Task<Results> CmdDetach()
         {
             _detaching = true;
-            if (ProcessState == ProcessState.Running)
+            if (ProcessState == ProcessState.Running && this.MICommandFactory.Mode != MIMode.Clrdbg)
             {
                 await AddInternalBreakAction(() => CmdAsync("-target-detach", ResultClass.done));
-                await CmdBreak(BreakRequest.Async);
             }
             else
             {

--- a/src/MIDebugEngine/AD7.Impl/AD7Engine.cs
+++ b/src/MIDebugEngine/AD7.Impl/AD7Engine.cs
@@ -774,13 +774,13 @@ namespace Microsoft.MIDebugEngine
             try
             {
                 _pollThread.RunOperation(() => _debuggedProcess.CmdDetach());
+                _debuggedProcess.Detach();
             }
-            catch (DebuggerDisposedException e) when (e.AbortedCommand == "-target-detach")
+            catch (DebuggerDisposedException) 
             {
                 // Detach command could cause DebuggerDisposedException and we ignore that.
             }
 
-            _debuggedProcess.Detach();
             return Constants.S_OK;
         }
 

--- a/src/MIDebugEngine/MIDebugCommandDispatcher.cs
+++ b/src/MIDebugEngine/MIDebugCommandDispatcher.cs
@@ -60,11 +60,17 @@ namespace Microsoft.MIDebugEngine
         internal static void AddProcess(DebuggedProcess process)
         {
             process.DebuggerExitEvent += process_DebuggerExitEvent;
+            process.DebuggerAbortedEvent += process_DebuggerAbortedEvent;
 
             lock (s_processes)
             {
                 s_processes.Add(process);
             }
+        }
+
+        private static void process_DebuggerAbortedEvent(object sender, DebuggerAbortedEventArgs args)
+        {
+            process_DebuggerExitEvent(sender, null);
         }
 
         private static void process_DebuggerExitEvent(object sender, EventArgs e)
@@ -73,6 +79,7 @@ namespace Microsoft.MIDebugEngine
             if (debuggedProcess != null)
             {
                 debuggedProcess.DebuggerExitEvent -= process_DebuggerExitEvent;
+                debuggedProcess.DebuggerAbortedEvent -= process_DebuggerAbortedEvent;
                 lock (s_processes)
                 {
                     s_processes.Remove(debuggedProcess);


### PR DESCRIPTION
…process reference cleanup on abort event.
Issue #520  
@gregg-miskelly @jacdavis @faxue-msft 