### PR TITLE
Fixed improper encapsulation of 'pwd' 

### DIFF
--- a/scripts/GetClrDbg.sh
+++ b/scripts/GetClrDbg.sh
@@ -267,7 +267,7 @@ prepare_install_location()
 convert_install_path_to_absolute()
 {
     if [ -z $__InstallLocation ]; then
-        __InstallLocation=$pwd
+        __InstallLocation=$(pwd)
     else
         if [ ! -d $__InstallLocation ]; then
             prepare_install_location            


### PR DESCRIPTION
When no installation path was provided, the string was set by an empty one due to incorrect encapsulation of the pwd command.