### PR TITLE
Unzip prompts when overwriting existing files.

### DIFF
--- a/scripts/GetClrDbg.sh
+++ b/scripts/GetClrDbg.sh
@@ -379,7 +379,7 @@ download_and_extract()
         exit 1;
     fi
     
-    unzip -q $clrdbgZip
+    unzip -o -f -q $clrdbgZip
     
     if [ $? -ne  0 ]; then
         echo "Failed to unzip clrdbg"


### PR DESCRIPTION
Fixing it by force overwriting on top of existing files.