### PR TITLE
Support breakpoints in sourcefiles with same base name.

### DIFF
--- a/src/DebugEngineHost.Stub/DebugEngineHost.ref.cs
+++ b/src/DebugEngineHost.Stub/DebugEngineHost.ref.cs
@@ -383,6 +383,14 @@ public sealed class HostLogger
         {
             throw new NotImplementedException();
         }
+
+        /// <summary>
+        /// Return the solution's root directory, null if no solution
+        /// </summary>
+        public static string FindSolutionRoot()
+        {
+            throw new NotImplementedException();
+        }
     }
 
     /// <summary>

--- a/src/DebugEngineHost/HostNatvisProject.cs
+++ b/src/DebugEngineHost/HostNatvisProject.cs
@@ -37,6 +37,19 @@ namespace Microsoft.DebugEngineHost
             paths.ForEach((s) => loader(s));
         }
 
+        public static string FindSolutionRoot()
+        {
+            string path = null;
+            try
+            {
+                ThreadHelper.Generic.Invoke(() => { path = Internal.FindSolutionRootImpl(); });
+            }
+            catch (Exception)
+            {
+            }
+            return path;
+        }
+
         private static class Internal
         {
             // from vsshell.idl
@@ -87,6 +100,20 @@ namespace Microsoft.DebugEngineHost
                 {
                     LoadNatvisFromProject(proj[0], paths, solutionLevel: true);
                 }
+            }
+
+            public static string FindSolutionRootImpl()
+            {
+                string root = null;
+                string slnFile;
+                string slnUserFile;
+                var solution = (IVsSolution)Package.GetGlobalService(typeof(SVsSolution));
+                if (solution == null)
+                {
+                    return null; // failed to find a solution
+                }
+                solution.GetSolutionInfo(out root, out slnFile, out slnUserFile);
+                return root;
             }
 
             private static void LoadNatvisFromProject(IVsHierarchy hier, List<string> paths, bool solutionLevel)

--- a/src/MICore/CommandFactories/MICommandFactory.cs
+++ b/src/MICore/CommandFactories/MICommandFactory.cs
@@ -436,9 +436,11 @@ namespace MICore
                 cmd.Append(" ");
             }
 
+            cmd.Append("\"");
             cmd.Append(filename);
             cmd.Append(":");
             cmd.Append(line.ToString());
+            cmd.Append("\"");
 
             return await _debugger.CmdAsync(cmd.ToString(), resultClass);
         }

--- a/src/MICore/CommandFactories/MICommandFactory.cs
+++ b/src/MICore/CommandFactories/MICommandFactory.cs
@@ -426,7 +426,24 @@ namespace MICore
             return cmd;
         }
 
-        public virtual async Task<Results> BreakInsert(string filename, uint line, string condition, bool enabled, IEnumerable<Checksum> checksums = null, ResultClass resultClass = ResultClass.done)
+        internal bool PreparePath(string path, bool useUnixFormat, out string pathMI)
+        {
+            bool requiresQuotes = false;
+            path = path.Trim();
+            if (useUnixFormat)  // convert directory separators
+            {
+                path = path.Replace('\\', '/');
+            }
+            if (path.IndexOf(' ') != -1)    // path contains spaces. Convert to c-string format
+            {
+                path = path.Replace(@"\", @"\\");   // escape any backslashes in the path
+                requiresQuotes = true;              // parameter containing the name will need to be quoted
+            }
+            pathMI = path;
+            return requiresQuotes;
+        }
+
+        public virtual async Task<Results> BreakInsert(string filename, bool useUnixFormat, uint line, string condition, bool enabled, IEnumerable<Checksum> checksums = null, ResultClass resultClass = ResultClass.done)
         {
             StringBuilder cmd = BuildBreakInsert(condition, enabled);
 
@@ -436,11 +453,19 @@ namespace MICore
                 cmd.Append(" ");
             }
 
-            cmd.Append("\"");
-            cmd.Append(filename);
+            string filenameMI;
+            bool quotes = PreparePath(filename, useUnixFormat, out filenameMI);
+            if (quotes)
+            {
+                cmd.Append("\"");
+            }
+            cmd.Append(filenameMI);
             cmd.Append(":");
             cmd.Append(line.ToString());
-            cmd.Append("\"");
+            if (quotes)
+            {
+                cmd.Append("\"");
+            }
 
             return await _debugger.CmdAsync(cmd.ToString(), resultClass);
         }

--- a/src/MICore/LaunchOptions.cs
+++ b/src/MICore/LaunchOptions.cs
@@ -1137,7 +1137,10 @@ namespace MICore
             List<PathMapEntry> map = new List<PathMapEntry>(SourceMap);
             if (suppOptions.SourceMap != null)
             {
-                Array.ForEach(suppOptions.SourceMap, (e) => map.Add(new PathMapEntry(e)));
+                foreach (var e in suppOptions.SourceMap)
+                {
+                    map.Add(new PathMapEntry(e));
+                }
             }
             SourceMap = new ReadOnlyCollection<PathMapEntry>(map);
         }

--- a/src/MICore/LaunchOptions.cs
+++ b/src/MICore/LaunchOptions.cs
@@ -194,7 +194,7 @@ namespace MICore
             }
             set
             {
-                if (value == null)
+                if (string.IsNullOrEmpty(value))
                 {
                     throw new ArgumentNullException("EditorPath");
                 }

--- a/src/MICore/LaunchOptions.xsd
+++ b/src/MICore/LaunchOptions.xsd
@@ -365,7 +365,7 @@
     </xs:annotation>
     <xs:complexType>
       <xs:sequence>
-      <xs:element name="SourceMap" type="PathMapList" minOccurs="0" maxOccurs="1">
+      <xs:element name="SourceMap" type="SourceMapList" minOccurs="0" maxOccurs="1">
       </xs:element>
       </xs:sequence>
     </xs:complexType>
@@ -412,7 +412,7 @@
           </xs:restriction>
         </xs:simpleType>
       </xs:element>
-      <xs:element name="SourceMap" minOccurs="0" maxOccurs="1" type="PathMapList">
+      <xs:element name="SourceMap" minOccurs="0" maxOccurs="1" type="SourceMapList">
         <xs:annotation>
           <xs:documentation>
             If provided this list is used to map source file names found in the subtrees pointed to by these entries.
@@ -495,23 +495,23 @@
       <xs:element name="Command" minOccurs="0" maxOccurs="unbounded" type="Command"/>
     </xs:sequence>
   </xs:complexType>
-  <xs:complexType name="PathMapEntry">
+  <xs:complexType name="SourceMapEntry">
     <xs:annotation>
-      <xs:documentation>Current and compile-time paths to the same source trees. Files found under the EditorPath are mapped to the CompilerPath path for breakpoint matching and mapped from CompilerPath to EditorPath when displaying stacktrace locations.</xs:documentation>
+      <xs:documentation>Current and compile-time paths to the same source trees. Files found under the EditorPath are mapped to the CompileTimePath path for breakpoint matching and mapped from CompileTimePath to EditorPath when displaying stacktrace locations.</xs:documentation>
     </xs:annotation>
     <xs:simpleContent>
       <xs:extension base="xs:string">
         <xs:attribute name="EditorPath" type="xs:string">
           <xs:annotation>
-            <xs:documentation>The current path to the source tree.</xs:documentation>
+            <xs:documentation>The path to the source tree the editor will use.</xs:documentation>
           </xs:annotation>
         </xs:attribute>
-        <xs:attribute name="CompilerPath" type="xs:string">
+        <xs:attribute name="CompileTimePath" type="xs:string">
           <xs:annotation>
             <xs:documentation>The path to the source tree at compile time.</xs:documentation>
           </xs:annotation>
         </xs:attribute>
-        <xs:attribute name="UseForBreakpoints" type="xs:boolean">
+        <xs:attribute name="UseForBreakpoints" type="xs:boolean" default="false">
           <xs:annotation>
             <xs:documentation>False if entry is only used for stack frame location mapping. True if this entry should also be used when specifying breakpoint locations.</xs:documentation>
           </xs:annotation>
@@ -519,9 +519,9 @@
       </xs:extension>
     </xs:simpleContent>
   </xs:complexType>
-  <xs:complexType name="PathMapList">
+  <xs:complexType name="SourceMapList">
     <xs:sequence>
-      <xs:element name="PathMapEntry" minOccurs="0" maxOccurs="unbounded" type="PathMapEntry"/>
+      <xs:element name="SourceMapEntry" minOccurs="0" maxOccurs="unbounded" type="SourceMapEntry"/>
     </xs:sequence>
   </xs:complexType>
 </xs:schema>

--- a/src/MICore/LaunchOptions.xsd
+++ b/src/MICore/LaunchOptions.xsd
@@ -359,7 +359,19 @@
     </xs:complexType>
   </xs:element>
 
-<!--base type for LocalLaunchOptions, PipeLaunchOptions, and TcpLaunchOptions -->
+  <xs:element name="SupplementalLaunchOptions">
+    <xs:annotation>
+      <xs:documentation>Option values that supplement the xml that arrives via the launch command.</xs:documentation>
+    </xs:annotation>
+    <xs:complexType>
+      <xs:sequence>
+      <xs:element name="SourceMap" type="PathMapList" minOccurs="0" maxOccurs="1">
+      </xs:element>
+      </xs:sequence>
+    </xs:complexType>
+  </xs:element>
+
+  <!--base type for LocalLaunchOptions, PipeLaunchOptions, and TcpLaunchOptions -->
   <xs:complexType name="BaseLaunchOptions">
     <xs:sequence>
       <xs:element name="SetupCommands" minOccurs="0" maxOccurs="1" type="CommandList">
@@ -399,6 +411,13 @@
             </xs:enumeration>
           </xs:restriction>
         </xs:simpleType>
+      </xs:element>
+      <xs:element name="SourceMap" minOccurs="0" maxOccurs="1" type="PathMapList">
+        <xs:annotation>
+          <xs:documentation>
+            If provided this list is used to map source file names found in the subtrees pointed to by these entries.
+          </xs:documentation>
+        </xs:annotation>
       </xs:element>
     </xs:sequence>
     <xs:attribute name="ExePath" type="xs:string" use="optional">
@@ -474,6 +493,35 @@
   <xs:complexType name="CommandList">
     <xs:sequence>
       <xs:element name="Command" minOccurs="0" maxOccurs="unbounded" type="Command"/>
+    </xs:sequence>
+  </xs:complexType>
+  <xs:complexType name="PathMapEntry">
+    <xs:annotation>
+      <xs:documentation>Current and compile-time paths to the same source trees. Files found under the EditorPath are mapped to the CompilerPath path for breakpoint matching and mapped from CompilerPath to EditorPath when displaying stacktrace locations.</xs:documentation>
+    </xs:annotation>
+    <xs:simpleContent>
+      <xs:extension base="xs:string">
+        <xs:attribute name="EditorPath" type="xs:string">
+          <xs:annotation>
+            <xs:documentation>The current path to the source tree.</xs:documentation>
+          </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="CompilerPath" type="xs:string">
+          <xs:annotation>
+            <xs:documentation>The path to the source tree at compile time.</xs:documentation>
+          </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="UseForBreakpoints" type="xs:boolean">
+          <xs:annotation>
+            <xs:documentation>False if entry is only used for stack frame location mapping. True if this entry should also be used when specifying breakpoint locations.</xs:documentation>
+          </xs:annotation>
+        </xs:attribute>
+      </xs:extension>
+    </xs:simpleContent>
+  </xs:complexType>
+  <xs:complexType name="PathMapList">
+    <xs:sequence>
+      <xs:element name="PathMapEntry" minOccurs="0" maxOccurs="unbounded" type="PathMapEntry"/>
     </xs:sequence>
   </xs:complexType>
 </xs:schema>

--- a/src/MICore/LaunchOptions.xsd.types.designer.cs
+++ b/src/MICore/LaunchOptions.xsd.types.designer.cs
@@ -194,6 +194,34 @@ namespace MICore.Xml.LaunchOptions {
     [System.CodeDom.Compiler.GeneratedCodeAttribute("xsd", "4.6.81.0")]
     [System.Diagnostics.DebuggerStepThroughAttribute()]
     [System.Xml.Serialization.XmlTypeAttribute(Namespace="http://schemas.microsoft.com/vstudio/MDDDebuggerOptions/2014")]
+    public partial class SourceMapEntry {
+        
+        /// <remarks/>
+        [System.Xml.Serialization.XmlAttributeAttribute()]
+        public string EditorPath;
+        
+        /// <remarks/>
+        [System.Xml.Serialization.XmlAttributeAttribute()]
+        public string CompileTimePath;
+        
+        /// <remarks/>
+        [System.Xml.Serialization.XmlAttributeAttribute()]
+        [System.ComponentModel.DefaultValueAttribute(false)]
+        public bool UseForBreakpoints;
+        
+        /// <remarks/>
+        [System.Xml.Serialization.XmlTextAttribute()]
+        public string Value;
+        
+        public SourceMapEntry() {
+            this.UseForBreakpoints = false;
+        }
+    }
+    
+    /// <remarks/>
+    [System.CodeDom.Compiler.GeneratedCodeAttribute("xsd", "4.6.81.0")]
+    [System.Diagnostics.DebuggerStepThroughAttribute()]
+    [System.Xml.Serialization.XmlTypeAttribute(Namespace="http://schemas.microsoft.com/vstudio/MDDDebuggerOptions/2014")]
     public partial class Command {
         
         /// <remarks/>
@@ -233,6 +261,10 @@ namespace MICore.Xml.LaunchOptions {
         /// <remarks/>
         [System.Xml.Serialization.XmlIgnoreAttribute()]
         public bool LaunchCompleteCommandSpecified;
+        
+        /// <remarks/>
+        [System.Xml.Serialization.XmlArrayItemAttribute(IsNullable=false)]
+        public SourceMapEntry[] SourceMap;
         
         /// <remarks/>
         [System.Xml.Serialization.XmlAttributeAttribute()]
@@ -548,5 +580,17 @@ namespace MICore.Xml.LaunchOptions {
         /// <remarks/>
         [System.Xml.Serialization.XmlAttributeAttribute()]
         public string StartRemoteDebuggerCommand;
+    }
+    
+    /// <remarks/>
+    [System.CodeDom.Compiler.GeneratedCodeAttribute("xsd", "4.6.81.0")]
+    [System.Diagnostics.DebuggerStepThroughAttribute()]
+    [System.Xml.Serialization.XmlTypeAttribute(AnonymousType=true, Namespace="http://schemas.microsoft.com/vstudio/MDDDebuggerOptions/2014")]
+    [System.Xml.Serialization.XmlRootAttribute(Namespace="http://schemas.microsoft.com/vstudio/MDDDebuggerOptions/2014", IsNullable=false)]
+    public partial class SupplementalLaunchOptions {
+        
+        /// <remarks/>
+        [System.Xml.Serialization.XmlArrayItemAttribute(IsNullable=false)]
+        public SourceMapEntry[] SourceMap;
     }
 }

--- a/src/MICore/LaunchOptions.xsd.types.designer.desktop.cs
+++ b/src/MICore/LaunchOptions.xsd.types.designer.desktop.cs
@@ -391,17 +391,19 @@ namespace MICore.Xml.LaunchOptions {
     [System.Diagnostics.DebuggerStepThroughAttribute()]
     [System.ComponentModel.DesignerCategoryAttribute("code")]
     [System.Xml.Serialization.XmlTypeAttribute(Namespace="http://schemas.microsoft.com/vstudio/MDDDebuggerOptions/2014")]
-    public partial class PathMapEntry {
+    public partial class SourceMapEntry {
         
         private string editorPathField;
         
-        private string compilerPathField;
+        private string compileTimePathField;
         
         private bool useForBreakpointsField;
         
-        private bool useForBreakpointsFieldSpecified;
-        
         private string valueField;
+        
+        public SourceMapEntry() {
+            this.useForBreakpointsField = false;
+        }
         
         /// <remarks/>
         [System.Xml.Serialization.XmlAttributeAttribute()]
@@ -416,34 +418,24 @@ namespace MICore.Xml.LaunchOptions {
         
         /// <remarks/>
         [System.Xml.Serialization.XmlAttributeAttribute()]
-        public string CompilerPath {
+        public string CompileTimePath {
             get {
-                return this.compilerPathField;
+                return this.compileTimePathField;
             }
             set {
-                this.compilerPathField = value;
+                this.compileTimePathField = value;
             }
         }
         
         /// <remarks/>
         [System.Xml.Serialization.XmlAttributeAttribute()]
+        [System.ComponentModel.DefaultValueAttribute(false)]
         public bool UseForBreakpoints {
             get {
                 return this.useForBreakpointsField;
             }
             set {
                 this.useForBreakpointsField = value;
-            }
-        }
-        
-        /// <remarks/>
-        [System.Xml.Serialization.XmlIgnoreAttribute()]
-        public bool UseForBreakpointsSpecified {
-            get {
-                return this.useForBreakpointsFieldSpecified;
-            }
-            set {
-                this.useForBreakpointsFieldSpecified = value;
             }
         }
         
@@ -536,7 +528,7 @@ namespace MICore.Xml.LaunchOptions {
         
         private bool launchCompleteCommandFieldSpecified;
         
-        private PathMapEntry[] sourceMapField;
+        private SourceMapEntry[] sourceMapField;
         
         private string exePathField;
         
@@ -623,7 +615,7 @@ namespace MICore.Xml.LaunchOptions {
         
         /// <remarks/>
         [System.Xml.Serialization.XmlArrayItemAttribute(IsNullable=false)]
-        public PathMapEntry[] SourceMap {
+        public SourceMapEntry[] SourceMap {
             get {
                 return this.sourceMapField;
             }
@@ -1434,11 +1426,11 @@ namespace MICore.Xml.LaunchOptions {
     [System.Xml.Serialization.XmlRootAttribute(Namespace="http://schemas.microsoft.com/vstudio/MDDDebuggerOptions/2014", IsNullable=false)]
     public partial class SupplementalLaunchOptions {
         
-        private PathMapEntry[] sourceMapField;
+        private SourceMapEntry[] sourceMapField;
         
         /// <remarks/>
         [System.Xml.Serialization.XmlArrayItemAttribute(IsNullable=false)]
-        public PathMapEntry[] SourceMap {
+        public SourceMapEntry[] SourceMap {
             get {
                 return this.sourceMapField;
             }

--- a/src/MICore/LaunchOptions.xsd.types.designer.desktop.cs
+++ b/src/MICore/LaunchOptions.xsd.types.designer.desktop.cs
@@ -391,6 +391,80 @@ namespace MICore.Xml.LaunchOptions {
     [System.Diagnostics.DebuggerStepThroughAttribute()]
     [System.ComponentModel.DesignerCategoryAttribute("code")]
     [System.Xml.Serialization.XmlTypeAttribute(Namespace="http://schemas.microsoft.com/vstudio/MDDDebuggerOptions/2014")]
+    public partial class PathMapEntry {
+        
+        private string editorPathField;
+        
+        private string compilerPathField;
+        
+        private bool useForBreakpointsField;
+        
+        private bool useForBreakpointsFieldSpecified;
+        
+        private string valueField;
+        
+        /// <remarks/>
+        [System.Xml.Serialization.XmlAttributeAttribute()]
+        public string EditorPath {
+            get {
+                return this.editorPathField;
+            }
+            set {
+                this.editorPathField = value;
+            }
+        }
+        
+        /// <remarks/>
+        [System.Xml.Serialization.XmlAttributeAttribute()]
+        public string CompilerPath {
+            get {
+                return this.compilerPathField;
+            }
+            set {
+                this.compilerPathField = value;
+            }
+        }
+        
+        /// <remarks/>
+        [System.Xml.Serialization.XmlAttributeAttribute()]
+        public bool UseForBreakpoints {
+            get {
+                return this.useForBreakpointsField;
+            }
+            set {
+                this.useForBreakpointsField = value;
+            }
+        }
+        
+        /// <remarks/>
+        [System.Xml.Serialization.XmlIgnoreAttribute()]
+        public bool UseForBreakpointsSpecified {
+            get {
+                return this.useForBreakpointsFieldSpecified;
+            }
+            set {
+                this.useForBreakpointsFieldSpecified = value;
+            }
+        }
+        
+        /// <remarks/>
+        [System.Xml.Serialization.XmlTextAttribute()]
+        public string Value {
+            get {
+                return this.valueField;
+            }
+            set {
+                this.valueField = value;
+            }
+        }
+    }
+    
+    /// <remarks/>
+    [System.CodeDom.Compiler.GeneratedCodeAttribute("xsd", "4.6.81.0")]
+    [System.SerializableAttribute()]
+    [System.Diagnostics.DebuggerStepThroughAttribute()]
+    [System.ComponentModel.DesignerCategoryAttribute("code")]
+    [System.Xml.Serialization.XmlTypeAttribute(Namespace="http://schemas.microsoft.com/vstudio/MDDDebuggerOptions/2014")]
     public partial class Command {
         
         private bool ignoreFailuresField;
@@ -461,6 +535,8 @@ namespace MICore.Xml.LaunchOptions {
         private BaseLaunchOptionsLaunchCompleteCommand launchCompleteCommandField;
         
         private bool launchCompleteCommandFieldSpecified;
+        
+        private PathMapEntry[] sourceMapField;
         
         private string exePathField;
         
@@ -542,6 +618,17 @@ namespace MICore.Xml.LaunchOptions {
             }
             set {
                 this.launchCompleteCommandFieldSpecified = value;
+            }
+        }
+        
+        /// <remarks/>
+        [System.Xml.Serialization.XmlArrayItemAttribute(IsNullable=false)]
+        public PathMapEntry[] SourceMap {
+            get {
+                return this.sourceMapField;
+            }
+            set {
+                this.sourceMapField = value;
             }
         }
         
@@ -1334,6 +1421,29 @@ namespace MICore.Xml.LaunchOptions {
             }
             set {
                 this.startRemoteDebuggerCommandField = value;
+            }
+        }
+    }
+    
+    /// <remarks/>
+    [System.CodeDom.Compiler.GeneratedCodeAttribute("xsd", "4.6.81.0")]
+    [System.SerializableAttribute()]
+    [System.Diagnostics.DebuggerStepThroughAttribute()]
+    [System.ComponentModel.DesignerCategoryAttribute("code")]
+    [System.Xml.Serialization.XmlTypeAttribute(AnonymousType=true, Namespace="http://schemas.microsoft.com/vstudio/MDDDebuggerOptions/2014")]
+    [System.Xml.Serialization.XmlRootAttribute(Namespace="http://schemas.microsoft.com/vstudio/MDDDebuggerOptions/2014", IsNullable=false)]
+    public partial class SupplementalLaunchOptions {
+        
+        private PathMapEntry[] sourceMapField;
+        
+        /// <remarks/>
+        [System.Xml.Serialization.XmlArrayItemAttribute(IsNullable=false)]
+        public PathMapEntry[] SourceMap {
+            get {
+                return this.sourceMapField;
+            }
+            set {
+                this.sourceMapField = value;
             }
         }
     }

--- a/src/MICore/MICoreResources.Designer.cs
+++ b/src/MICore/MICoreResources.Designer.cs
@@ -313,6 +313,15 @@ namespace MICore {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Error while processing {0}: {1}.
+        /// </summary>
+        public static string Error_ProcessingFile {
+            get {
+                return ResourceManager.GetString("Error_ProcessingFile", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Commands are only accepted when the process is stopped..
         /// </summary>
         public static string Error_ProcessMustBeStopped {

--- a/src/MICore/MICoreResources.resx
+++ b/src/MICore/MICoreResources.resx
@@ -268,4 +268,7 @@ Error: {1}</value>
   <data name="Error_TargetProcessExited" xml:space="preserve">
     <value>The target process has exited.</value>
   </data>
+  <data name="Error_ProcessingFile" xml:space="preserve">
+    <value>Error while processing {0}: {1}</value>
+  </data>
 </root>

--- a/src/MIDebugEngine/AD7.Impl/AD7PendingBreakpoint.cs
+++ b/src/MIDebugEngine/AD7.Impl/AD7PendingBreakpoint.cs
@@ -34,6 +34,8 @@ namespace Microsoft.MIDebugEngine
         private bool _deleted;
         private bool _pendingDelete;
 
+        public DebuggedProcess DebuggedProcess {  get { return _engine.DebuggedProcess;  } }
+
         internal string BreakpointId
         {
             get { return _bp == null ? string.Empty : _bp.Number; }

--- a/src/MIDebugEngine/Engine.Impl/Breakpoints.cs
+++ b/src/MIDebugEngine/Engine.Impl/Breakpoints.cs
@@ -112,12 +112,11 @@ namespace Microsoft.MIDebugEngine
             process.VerifyNotDebuggingCoreDump();
 
             string compilerSrcName;
-            if (!process.MapCurrentSrcToCompilerSrc(documentName, out compilerSrcName))
+            if (!process.MapCurrentSrcToCompileTimeSrc(documentName, out compilerSrcName))
             {
                 compilerSrcName = Path.GetFileName(documentName);   
             }
-            string file = process.EscapePath(compilerSrcName, ignoreSpaces:true);
-            BindResult bindResults = EvalBindResult(await process.MICommandFactory.BreakInsert(file, line, condition, enabled, checksums, ResultClass.None), pbreak);
+            BindResult bindResults = EvalBindResult(await process.MICommandFactory.BreakInsert(compilerSrcName, process.UseUnixSymbolPaths, line, condition, enabled, checksums, ResultClass.None), pbreak);
 
             // On GDB, the returned line information is from the pending breakpoint instead of the bound breakpoint.
             // Check the address mapping to make sure the line info is correct.
@@ -126,7 +125,7 @@ namespace Microsoft.MIDebugEngine
             {
                 foreach (var boundBreakpoint in bindResults.BoundBreakpoints)
                 {
-                    string matchFile = file;
+                    string matchFile = compilerSrcName;
                     if (!string.IsNullOrEmpty(boundBreakpoint.CompiledFileName))
                     {
                         matchFile = boundBreakpoint.CompiledFileName;   // get the file name as it appears in the symbolic info

--- a/src/MIDebugEngine/Engine.Impl/DebuggedThread.cs
+++ b/src/MIDebugEngine/Engine.Impl/DebuggedThread.cs
@@ -224,7 +224,7 @@ namespace Microsoft.MIDebugEngine
         private ThreadContext CreateContext(TupleValue frame)
         {
             ulong? pc = frame.TryFindAddr("addr");
-            MITextPosition textPosition = MITextPosition.TryParse(frame);
+            MITextPosition textPosition = MITextPosition.TryParse(this._debugger, frame);
             string func = frame.TryFindString("func");
             uint level = frame.FindUint("level");
             string from = frame.TryFindString("from");

--- a/src/MIDebugEngine/Engine.Impl/Disassembly.cs
+++ b/src/MIDebugEngine/Engine.Impl/Disassembly.cs
@@ -223,7 +223,7 @@ namespace Microsoft.MIDebugEngine
                 return null;
             }
 
-            return DecodeSourceAnnotatedDisassemblyInstructions(results.Find<ResultListValue>("asm_insns").FindAll<TupleValue>("src_and_asm_line"));
+            return DecodeSourceAnnotatedDisassemblyInstructions(process, results.Find<ResultListValue>("asm_insns").FindAll<TupleValue>("src_and_asm_line"));
         }
 
         private static DisasmInstruction[] DecodeDisassemblyInstructions(TupleValue[] items)
@@ -243,12 +243,12 @@ namespace Microsoft.MIDebugEngine
             }
             return instructions;
         }
-        private static IEnumerable<DisasmInstruction> DecodeSourceAnnotatedDisassemblyInstructions(TupleValue[] items)
+        private static IEnumerable<DisasmInstruction> DecodeSourceAnnotatedDisassemblyInstructions(DebuggedProcess process, TupleValue[] items)
         {
             foreach (var item in items)
             {
                 uint line = item.FindUint("line");
-                string file = item.FindString("file");
+                string file = process.GetMappedFileFromTuple(item);
                 ValueListValue asm_items = item.Find<ValueListValue>("line_asm_insn");
                 uint lineOffset = 0;
                 foreach (var asm_item in asm_items.Content)

--- a/src/MIDebugEngine/Engine.Impl/MITextPosition.cs
+++ b/src/MIDebugEngine/Engine.Impl/MITextPosition.cs
@@ -32,13 +32,9 @@ namespace Microsoft.MIDebugEngine
             this.EndPosition = this.BeginPosition;
         }
 
-        public static MITextPosition TryParse(TupleValue miTuple)
+        public static MITextPosition TryParse(DebuggedProcess process, TupleValue miTuple)
         {
-            string filename = miTuple.TryFindString("fullname");
-            if (string.IsNullOrEmpty(filename))
-            {
-                filename = miTuple.TryFindString("file");
-            }
+            string filename = process.GetMappedFileFromTuple(miTuple);
             if (!string.IsNullOrEmpty(filename))
             {
                 filename = DebuggedProcess.UnixPathToWindowsPath(filename);


### PR DESCRIPTION
 - projects can send in source file mapping data
 - users can supply solution-specific additional source map file
@gregg-miskelly @pieandcakes 