### PR TITLE
Stop calling CheckModules for lldb/clrdbg

### DIFF
--- a/src/MIDebugEngine/Engine.Impl/DebuggedProcess.cs
+++ b/src/MIDebugEngine/Engine.Impl/DebuggedProcess.cs
@@ -1425,8 +1425,12 @@ namespace Microsoft.MIDebugEngine
 
             if (_initialBreakArgs != null)
             {
-                await CheckModules();
-                _libraryLoaded.Clear();
+                if (MICommandFactory.SupportsStopOnDynamicLibLoad())
+                {
+                    await CheckModules();
+                    _libraryLoaded.Clear();
+                }
+                
                 await HandleBreakModeEvent(_initialBreakArgs, BreakRequest.None);
                 _initialBreakArgs = null;
             }


### PR DESCRIPTION
MIEngine had a method that we use for GDB to find the list of loaded modules. This method wasn't intended to be called for lldb/clrdbg, but there was one race where it could happen - if a stopping event was received before the SDM continued program create we will call CheckModule.

This adds a guard to fix this.

This should resolve https://github.com/OmniSharp/omnisharp-vscode/issues/1035.