### PR TITLE
Fix build on Dev15

### DIFF
--- a/src/MICore/GenerateXmlSerializersAssembly.targets
+++ b/src/MICore/GenerateXmlSerializersAssembly.targets
@@ -87,7 +87,8 @@
       <SerializationSigningCompilerOptions Condition="'$(DelaySign)'=='true'">$(SerializationSigningCompilerOptions) /delaysign</SerializationSigningCompilerOptions>
 
       <CompilerPath>$(CscToolPath)$(CscToolExe)</CompilerPath>
-      <CompilerPath Condition="'$(CompilerPath)' == ''">$(MSBuildBinPath)\csc.exe</CompilerPath>
+      <CompilerPath Condition="'$(CompilerPath)' == '' and Exists('$(MSBuildBinPath)\csc.exe')">$(MSBuildBinPath)\csc.exe</CompilerPath>
+      <CompilerPath Condition="'$(CompilerPath)' == '' and Exists('$(MSBuildBinPath)\roslyn\csc.exe')">$(MSBuildBinPath)\roslyn\csc.exe</CompilerPath>
 
       <RefPath Condition="'$(IsMonoRuntime)' == 'false'">$(MSBuildFrameworkToolsPath)</RefPath>
       <RefPath Condition="'$(IsMonoRuntime)' == 'true'">$(SDK40ToolsPath)</RefPath>
@@ -95,6 +96,7 @@
 
     <Error Condition="'$(SDK40ToolsPath)'==''" Text="SDK40ToolsPath msbuild property is undefined." />
     <Error Condition="!Exists('$(SDK40ToolsPath)sgen.exe')" Text="sgen.exe does not exist in the SDK40ToolsPath ($(SDK40ToolsPath)xsd.exe)." />
+    <Error Condition="'$(CompilerPath)' == '' or !Exists('$(CompilerPath)')" Text="Unable to locate csc.exe - path '$(CompilerPath)' is not valid!" />
 
     <RemoveDir Condition="Exists('$(IntermediateOutputPath)sgen')" Directories="$(IntermediateOutputPath)sgen" />
     <MakeDir Directories="$(IntermediateOutputPath)sgen" />


### PR DESCRIPTION
Adjusts targets files to check both "$(MSBuildBinPath)\csc.exe" and "$(MSBuildBinPath)\Roslyn\csc.exe" and adds a better error message in case locating the binary fails.