### PR TITLE
Package the UnixPortSupplier interop assembly

### DIFF
--- a/MIEngine.UnixPortSupplier.nuspec
+++ b/MIEngine.UnixPortSupplier.nuspec
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="utf-8"?>
+<package>
+  <metadata>
+    <id>VS.Redist.Debugger.MDD.UnixPortSupplier</id>
+    <version>0.0.0.0</version>
+    <authors>VSEng</authors>
+    <owners>VSEng</owners>
+    <requireLicenseAcceptance>false</requireLicenseAcceptance>
+    <description>Package containing VS.Redist.Debugger.MDD.UnixPortSupplier artifacts</description>
+    <releaseNotes></releaseNotes>
+    <copyright>Copyright 2016</copyright>
+    <tags></tags>
+  </metadata>
+  <files>
+    <file src="drop\Release\ReferenceAssemblies\Microsoft.VisualStudio.Debugger.Interop.UnixPortSupplier.DesignTime.xml" target="ref\dotnet" />
+    <file src="drop\Release\ReferenceAssemblies\Microsoft.VisualStudio.Debugger.Interop.UnixPortSupplier.DesignTime.dll" target="ref\dotnet" />
+  </files>
+</package>

--- a/MIEngine.mdd.nuspec
+++ b/MIEngine.mdd.nuspec
@@ -14,6 +14,7 @@
   <files>
     <file src="drop\Release\ReferenceAssemblies\*.xml" target="ref\dotnet" />
     <file src="drop\Release\ReferenceAssemblies\Microsoft.DebugEngineHost.dll" target="ref\dotnet" />
+    <file src="drop\Release\ReferenceAssemblies\Microsoft.VisualStudio.Debugger.Interop.UnixPortSupplier.DesignTime.dll" target="ref\dotnet" />
     <file src="drop\Release\Microsoft.MICore.dll" target="ref\dotnet" />
     <file src="drop\Release\*" target="Release" exclude="drop\Release\Install.cmd;drop\Release\ReferenceAssemblies" />
     <file src="drop\Debug\*" target="Debug" exclude="drop\Debug\Install.cmd;drop\Debug\ReferenceAssemblies" />

--- a/MIEngine.mdd.nuspec
+++ b/MIEngine.mdd.nuspec
@@ -12,9 +12,8 @@
     <tags></tags>
   </metadata>
   <files>
-    <file src="drop\Release\ReferenceAssemblies\*.xml" target="ref\dotnet" />
+    <file src="drop\Release\ReferenceAssemblies\*.xml" target="ref\dotnet" exclude="drop\Release\ReferenceAssemblies\Microsoft.VisualStudio.Debugger.Interop.UnixPortSupplier.DesignTime.xml" />
     <file src="drop\Release\ReferenceAssemblies\Microsoft.DebugEngineHost.dll" target="ref\dotnet" />
-    <file src="drop\Release\ReferenceAssemblies\Microsoft.VisualStudio.Debugger.Interop.UnixPortSupplier.DesignTime.dll" target="ref\dotnet" />
     <file src="drop\Release\Microsoft.MICore.dll" target="ref\dotnet" />
     <file src="drop\Release\*" target="Release" exclude="drop\Release\Install.cmd;drop\Release\ReferenceAssemblies" />
     <file src="drop\Debug\*" target="Debug" exclude="drop\Debug\Install.cmd;drop\Debug\ReferenceAssemblies" />


### PR DESCRIPTION
Ensure that the MS.VS.Debugger.Interop.UnixPortSupplier.DesignTime
assembly is packaged into the MDD NuGet package so it can be referenced
from other projects.