### PR TITLE
Do not include metadata.json in NuGet packages

### DIFF
--- a/MIEngine.mdd.nuspec
+++ b/MIEngine.mdd.nuspec
@@ -17,6 +17,5 @@
     <file src="drop\Release\Microsoft.MICore.dll" target="ref\dotnet" />
     <file src="drop\Release\*" target="Release" exclude="drop\Release\Install.cmd;drop\Release\ReferenceAssemblies" />
     <file src="drop\Debug\*" target="Debug" exclude="drop\Debug\Install.cmd;drop\Debug\ReferenceAssemblies" />
-    <file src="MicroBuildOutputs\metadata.json" target="" />
   </files>
 </package>


### PR DESCRIPTION
Fixes build break, since Microbuild no longer produces this file