### PR TITLE
Add non-shell commands to SSH port supplier

### DIFF
--- a/IL/liblinux.il
+++ b/IL/liblinux.il
@@ -15,7 +15,7 @@
 	.custom instance void [mscorlib]System.Runtime.InteropServices.ComVisibleAttribute::.ctor(bool) = { bool(false) }
 	.publickey = (00 24 00 00 04 80 00 00 94 00 00 00 06 02 00 00 00 24 00 00 52 53 41 31 00 04 00 00 01 00 01 00 07 D1 FA 57 C4 AE D9 F0 A3 2E 84 AA 0F AE FD 0D E9 E8 FD 6A EC 8F 87 FB 03 76 6C 83 4C 99 92 1E B2 3B E7 9A D9 D5 DC C1 DD 9A D2 36 13 21 02 90 0B 72 3C F9 80 95 7F C4 E1 77 10 8F C6 07 77 4F 29 E8 32 0E 92 EA 05 EC E4 E8 21 C0 A5 EF E8 F1 64 5C 4C 0C 93 C1 AB 99 28 5D 62 2C AA 65 2C 1D FA D6 3D 74 5D 6F 2D E5 F1 7E 5E AF 0F C4 96 3D 26 1C 8A 12 43 65 18 20 6D C0 93 34 4D 5A D2 93)
 	.hash algorithm 0x00008004
-	.ver 14:0:0:0
+	.ver 15:0:0:0
 }
 .namespace liblinux
 {
@@ -113,6 +113,11 @@
 	{
 		.method public hidebysig specialname 
 			instance class [mscorlib]System.Exception get_Exception()
+		{
+			ret
+		}
+		.method public hidebysig specialname 
+			instance void .ctor(class [mscorlib]System.Exception exception)
 		{
 			ret
 		}
@@ -1037,6 +1042,7 @@
 		.field static public literal valuetype liblinux.SystemId OSX = int32(0x0000001D)
 		.field static public literal valuetype liblinux.SystemId OpenBSD = int32(0x0000001F)
 		.field static public literal valuetype liblinux.SystemId OpenSUSE = int32(0x00000014)
+		.field static public literal valuetype liblinux.SystemId OracleLinux = int32(0x00000024)
 		.field static public literal valuetype liblinux.SystemId PCLinuxOS = int32(0x00000019)
 		.field static public literal valuetype liblinux.SystemId Poky = int32(0x00000022)
 		.field static public literal valuetype liblinux.SystemId Puppy = int32(0x00000009)
@@ -1344,7 +1350,15 @@
 		{
 		}
 		.method public virtual hidebysig newslot abstract 
+			instance class [mscorlib]'System.IO.FileInfo' DownloadFile(string localFileName, int32 bufferSize)
+		{
+		}
+		.method public virtual hidebysig newslot abstract 
 			instance class 'liblinux.IO.IRemoteFile' UploadFile(string localFileName)
+		{
+		}
+		.method public virtual hidebysig newslot abstract 
+			instance class 'liblinux.IO.IRemoteFile' UploadFile(string localFileName, int32 bufferSize)
 		{
 		}
 		.method public virtual hidebysig newslot abstract 
@@ -1352,11 +1366,23 @@
 		{
 		}
 		.method public virtual hidebysig newslot abstract 
+			instance class [mscorlib]'System.IO.DirectoryInfo' Download(string localPath, int32 bufferSize)
+		{
+		}
+		.method public virtual hidebysig newslot abstract 
 			instance class [mscorlib]'System.IO.DirectoryInfo' DownloadDirectory(string remotePath, string localPath)
 		{
 		}
 		.method public virtual hidebysig newslot abstract 
+			instance class [mscorlib]'System.IO.DirectoryInfo' DownloadDirectory(string remotePath, string localPath, int32 bufferSize)
+		{
+		}
+		.method public virtual hidebysig newslot abstract 
 			instance class 'liblinux.IO.IRemoteDirectory' UploadDirectory(string localPath, string remotePath)
+		{
+		}
+		.method public virtual hidebysig newslot abstract 
+			instance class 'liblinux.IO.IRemoteDirectory' UploadDirectory(string localPath, string remotePath, int32 bufferSize)
 		{
 		}
 		.method public virtual hidebysig newslot abstract 
@@ -1388,7 +1414,15 @@
 		{
 		}
 		.method public virtual hidebysig newslot abstract 
+			instance class [mscorlib]'System.IO.FileInfo' DownloadTo(string localPath, int32 bufferSize)
+		{
+		}
+		.method public virtual hidebysig newslot abstract 
 			instance class [mscorlib]'System.IO.FileInfo' Download(string localFileName)
+		{
+		}
+		.method public virtual hidebysig newslot abstract 
+			instance class [mscorlib]'System.IO.FileInfo' Download(string localFileName, int32 bufferSize)
 		{
 		}
 	}
@@ -1408,7 +1442,23 @@
 		{
 		}
 		.method public virtual hidebysig newslot abstract 
+			instance class 'liblinux.IO.IRemoteFile' UploadFile(string localFileName, string remoteFileName, int32 bufferSize)
+		{
+		}
+		.method public virtual hidebysig newslot abstract 
+			instance class [mscorlib]'System.Threading.Tasks.Task`1'<class 'liblinux.IO.IRemoteFile'> UploadFileAsync(string localFileName, string remoteFileName, int32 bufferSize)
+		{
+		}
+		.method public virtual hidebysig newslot abstract 
 			instance class [mscorlib]'System.IO.FileInfo' DownloadFile(string remoteFileName, string localFileName)
+		{
+		}
+		.method public virtual hidebysig newslot abstract 
+			instance class [mscorlib]'System.IO.FileInfo' DownloadFile(string remoteFileName, string localFileName, int32 bufferSize)
+		{
+		}
+		.method public virtual hidebysig newslot abstract 
+			instance class [mscorlib]'System.Threading.Tasks.Task`1'<class [mscorlib]'System.IO.FileInfo'> DownloadFileAsync(string remoteFileName, string localFileName, int32 bufferSize)
 		{
 		}
 		.method public virtual hidebysig newslot abstract 
@@ -1424,7 +1474,15 @@
 		{
 		}
 		.method public virtual hidebysig newslot abstract 
+			instance class 'liblinux.IO.IRemoteDirectory' UploadDirectory(string localPath, string remotePath, int32 bufferSize)
+		{
+		}
+		.method public virtual hidebysig newslot abstract 
 			instance class [mscorlib]'System.IO.DirectoryInfo' DownloadDirectory(string remotePath, string localPath)
+		{
+		}
+		.method public virtual hidebysig newslot abstract 
+			instance class [mscorlib]'System.IO.DirectoryInfo' DownloadDirectory(string remotePath, string localPath, int32 bufferSize)
 		{
 		}
 		.method public virtual hidebysig newslot abstract 
@@ -1768,7 +1826,27 @@
 			ret
 		}
 		.method public virtual hidebysig newslot 
+			instance class 'liblinux.IO.IRemoteFile' UploadFile(string localFileName, string remoteFileName, int32 bufferSize)
+		{
+			ret
+		}
+		.method public virtual hidebysig newslot 
+			instance class [mscorlib]'System.Threading.Tasks.Task`1'<class 'liblinux.IO.IRemoteFile'> UploadFileAsync(string localFileName, string remoteFileName, int32 bufferSize)
+		{
+			ret
+		}
+		.method public virtual hidebysig newslot 
 			instance class [mscorlib]'System.IO.FileInfo' DownloadFile(string remoteFileName, string localFileName)
+		{
+			ret
+		}
+		.method public virtual hidebysig newslot 
+			instance class [mscorlib]'System.IO.FileInfo' DownloadFile(string remoteFileName, string localFileName, int32 bufferSize)
+		{
+			ret
+		}
+		.method public virtual hidebysig newslot 
+			instance class [mscorlib]'System.Threading.Tasks.Task`1'<class [mscorlib]'System.IO.FileInfo'> DownloadFileAsync(string remoteFileName, string localFileName, int32 bufferSize)
 		{
 			ret
 		}
@@ -1788,7 +1866,17 @@
 			ret
 		}
 		.method public virtual hidebysig newslot 
+			instance class 'liblinux.IO.IRemoteDirectory' UploadDirectory(string localPath, string remotePath, int32 bufferSize)
+		{
+			ret
+		}
+		.method public virtual hidebysig newslot 
 			instance class [mscorlib]'System.IO.DirectoryInfo' DownloadDirectory(string remotePath, string localPath)
+		{
+			ret
+		}
+		.method public virtual hidebysig newslot 
+			instance class [mscorlib]'System.IO.DirectoryInfo' DownloadDirectory(string remotePath, string localPath, int32 bufferSize)
 		{
 			ret
 		}
@@ -1928,7 +2016,23 @@
 		{
 		}
 		.method public virtual hidebysig newslot abstract 
+			instance class 'liblinux.IO.IRemoteFile' UploadFile(string localFileName, string remoteFileName, int32 bufferSize)
+		{
+		}
+		.method public virtual hidebysig newslot abstract 
+			instance class [mscorlib]'System.Threading.Tasks.Task`1'<class 'liblinux.IO.IRemoteFile'> UploadFileAsync(string localFileName, string remoteFileName, int32 bufferSize)
+		{
+		}
+		.method public virtual hidebysig newslot abstract 
 			instance class [mscorlib]'System.IO.FileInfo' DownloadFile(string remoteFileName, string localFileName)
+		{
+		}
+		.method public virtual hidebysig newslot abstract 
+			instance class [mscorlib]'System.IO.FileInfo' DownloadFile(string remoteFileName, string localFileName, int32 bufferSize)
+		{
+		}
+		.method public virtual hidebysig newslot abstract 
+			instance class [mscorlib]'System.Threading.Tasks.Task`1'<class [mscorlib]'System.IO.FileInfo'> DownloadFileAsync(string remoteFileName, string localFileName, int32 bufferSize)
 		{
 		}
 		.method public virtual hidebysig newslot abstract 
@@ -1944,7 +2048,15 @@
 		{
 		}
 		.method public virtual hidebysig newslot abstract 
+			instance class 'liblinux.IO.IRemoteDirectory' UploadDirectory(string localPath, string remotePath, int32 bufferSize)
+		{
+		}
+		.method public virtual hidebysig newslot abstract 
 			instance class [mscorlib]'System.IO.DirectoryInfo' DownloadDirectory(string remotePath, string localPath)
+		{
+		}
+		.method public virtual hidebysig newslot abstract 
+			instance class [mscorlib]'System.IO.DirectoryInfo' DownloadDirectory(string remotePath, string localPath, int32 bufferSize)
 		{
 		}
 		.method public virtual hidebysig newslot abstract 
@@ -2228,12 +2340,62 @@
 			ret
 		}
 		.method public hidebysig 
+			instance bool TryGetById(int32 id, valuetype liblinux.Persistence.RetrieveMode mode, [out] class liblinux.ConnectionInfo& connectionInfo)
+		{
+			ret
+		}
+		.method public hidebysig 
 			instance bool TryGetById(int32 id, [out] class liblinux.Persistence.StoredConnectionInfo& storedConnectionInfo)
 		{
 			ret
 		}
 		.method public hidebysig 
+			instance bool TryGetById(int32 id, valuetype liblinux.Persistence.RetrieveMode mode, [out] class liblinux.Persistence.StoredConnectionInfo& storedConnectionInfo)
+		{
+			ret
+		}
+		.method public hidebysig 
 			instance bool TryGet(class liblinux.ConnectionInfo connectionInfo, [out] class liblinux.Persistence.StoredConnectionInfo& storedConnectionInfo)
+		{
+			ret
+		}
+		.method public hidebysig 
+			instance bool TryGetByName(string name, [out] class liblinux.ConnectionInfo& connectionInfo)
+		{
+			ret
+		}
+		.method public hidebysig 
+			instance bool TryGetByName(string name, valuetype liblinux.Persistence.RetrieveMode mode, [out] class liblinux.ConnectionInfo& connectionInfo)
+		{
+			ret
+		}
+		.method public hidebysig 
+			instance bool TryGetByName(string name, valuetype [mscorlib]System.StringComparison comparisonType, [out] class liblinux.ConnectionInfo& connectionInfo)
+		{
+			ret
+		}
+		.method public hidebysig 
+			instance bool TryGetByName(string name, valuetype [mscorlib]System.StringComparison comparisonType, valuetype liblinux.Persistence.RetrieveMode mode, [out] class liblinux.ConnectionInfo& connectionInfo)
+		{
+			ret
+		}
+		.method public hidebysig 
+			instance bool TryGetByName(string name, [out] class liblinux.Persistence.StoredConnectionInfo& storedConnectionInfo)
+		{
+			ret
+		}
+		.method public hidebysig 
+			instance bool TryGetByName(string name, valuetype liblinux.Persistence.RetrieveMode mode, [out] class liblinux.Persistence.StoredConnectionInfo& storedConnectionInfo)
+		{
+			ret
+		}
+		.method public hidebysig 
+			instance bool TryGetByName(string name, valuetype [mscorlib]System.StringComparison comparisonType, [out] class liblinux.Persistence.StoredConnectionInfo& storedConnectionInfo)
+		{
+			ret
+		}
+		.method public hidebysig 
+			instance bool TryGetByName(string name, valuetype [mscorlib]System.StringComparison comparisonType, valuetype liblinux.Persistence.RetrieveMode mode, [out] class liblinux.Persistence.StoredConnectionInfo& storedConnectionInfo)
 		{
 			ret
 		}
@@ -2244,6 +2406,16 @@
 		}
 		.method public hidebysig 
 			instance bool Contains(int32 connectionId)
+		{
+			ret
+		}
+		.method public hidebysig 
+			instance bool Contains(string name)
+		{
+			ret
+		}
+		.method public hidebysig 
+			instance bool Contains(string name, valuetype [mscorlib]System.StringComparison comparisonType)
 		{
 			ret
 		}
@@ -2305,6 +2477,13 @@
 		.field public rtspecialname specialname int32 value__
 		.field static public literal valuetype liblinux.Persistence.PersistenceMode Disk = int32(0x00000001)
 		.field static public literal valuetype liblinux.Persistence.PersistenceMode Memory = int32(0x00000000)
+	}
+	.class public sealed RetrieveMode
+		extends [mscorlib]System.Enum
+	{
+		.field public rtspecialname specialname int32 value__
+		.field static public literal valuetype liblinux.Persistence.RetrieveMode All = int32(0x00000000)
+		.field static public literal valuetype liblinux.Persistence.RetrieveMode PropertiesOnly = int32(0x00000001)
 	}
 	.class public StoredConnectionInfo
 		extends [mscorlib]System.Object
@@ -3019,6 +3198,18 @@
 		{
 			ret
 		}
+		.method public final virtual hidebysig newslot specialname 
+			instance void add_Finished(class [mscorlib]System.EventHandler 'value')
+		{
+			.custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = { }
+			ret
+		}
+		.method public final virtual hidebysig newslot specialname 
+			instance void remove_Finished(class [mscorlib]System.EventHandler 'value')
+		{
+			.custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = { }
+			ret
+		}
 		.method public virtual hidebysig newslot specialname 
 			instance bool get_Running()
 		{
@@ -3107,6 +3298,10 @@
 		{
 			.custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = { }
 			ret
+		}
+		.method public virtual hidebysig newslot abstract 
+			instance void Write(string text)
+		{
 		}
 		.method public virtual hidebysig newslot specialname 
 			instance bool get_Queue()
@@ -3254,6 +3449,11 @@
 			ret
 		}
 		.method family hidebysig 
+			instance void NotifyCommandFinished(object sender)
+		{
+			ret
+		}
+		.method family hidebysig 
 			instance void EnsureCommandNotRunning()
 		{
 			ret
@@ -3262,6 +3462,11 @@
 		{
 			.addon instance void liblinux.Shell.CommonCommandBase::add_ErrorOutputReceived(class [mscorlib]'System.EventHandler`1'<class liblinux.Shell.OutputReceivedEventArgs>)
 			.removeon instance void liblinux.Shell.CommonCommandBase::remove_ErrorOutputReceived(class [mscorlib]'System.EventHandler`1'<class liblinux.Shell.OutputReceivedEventArgs>)
+		}
+		.event [mscorlib]System.EventHandler Finished
+		{
+			.addon instance void liblinux.Shell.CommonCommandBase::add_Finished(class [mscorlib]System.EventHandler)
+			.removeon instance void liblinux.Shell.CommonCommandBase::remove_Finished(class [mscorlib]System.EventHandler)
 		}
 		.event class [mscorlib]'System.EventHandler`1'<class liblinux.Shell.OutputReceivedEventArgs> OutputReceived
 		{
@@ -3356,6 +3561,16 @@
 		implements liblinux.Shell.ICommand, [mscorlib]System.IDisposable
 	{
 		.method public virtual hidebysig newslot abstract specialname 
+			instance void add_Finished(class [mscorlib]System.EventHandler 'value')
+		{
+			.custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = { }
+		}
+		.method public virtual hidebysig newslot abstract specialname 
+			instance void remove_Finished(class [mscorlib]System.EventHandler 'value')
+		{
+			.custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = { }
+		}
+		.method public virtual hidebysig newslot abstract specialname 
 			instance bool get_Running()
 		{
 		}
@@ -3394,6 +3609,11 @@
 		.method public virtual hidebysig newslot abstract 
 			instance void Cancel()
 		{
+		}
+		.event [mscorlib]System.EventHandler Finished
+		{
+			.addon instance void liblinux.Shell.IAsyncronousCommand::add_Finished(class [mscorlib]System.EventHandler)
+			.removeon instance void liblinux.Shell.IAsyncronousCommand::remove_Finished(class [mscorlib]System.EventHandler)
 		}
 		.property instance bool Cancelled()
 		{
@@ -3779,6 +3999,14 @@
 		{
 			.custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = { }
 		}
+		.method public virtual hidebysig newslot abstract 
+			instance void Write(string text)
+		{
+		}
+		.method public virtual hidebysig newslot abstract specialname 
+			instance bool get_Completed()
+		{
+		}
 		.method public virtual hidebysig newslot abstract specialname 
 			instance bool get_DelayOutputReceiveEvents()
 		{
@@ -3849,6 +4077,10 @@
 		{
 			.get instance bool liblinux.Shell.IStreamableCommand::get_AccumulateOutput()
 			.set instance void liblinux.Shell.IStreamableCommand::set_AccumulateOutput(bool)
+		}
+		.property instance bool Completed()
+		{
+			.get instance bool liblinux.Shell.IStreamableCommand::get_Completed()
 		}
 		.property instance bool DelayOutputReceiveEvents()
 		{
@@ -4060,6 +4292,11 @@
 			ret
 		}
 		.method public virtual hidebysig 
+			instance void Write(string text)
+		{
+			ret
+		}
+		.method public virtual hidebysig 
 			instance void BeginOutputRead()
 		{
 			ret
@@ -4109,6 +4346,11 @@
 	{
 		.method public hidebysig specialname 
 			instance string get_Output()
+		{
+			ret
+		}
+		.method public hidebysig specialname 
+			instance void .ctor(string output)
 		{
 			ret
 		}

--- a/src/MICore/Transports/UnixShellPortTransport.cs
+++ b/src/MICore/Transports/UnixShellPortTransport.cs
@@ -58,7 +58,7 @@ namespace MICore
             }
 
             _callback.AppendToInitializationLog(string.Format(CultureInfo.CurrentUICulture, MICoreResources.Info_StartingUnixCommand, _startRemoteDebuggerCommand));
-            _launchOptions.UnixPort.BeginExecuteAsyncCommand(_startRemoteDebuggerCommand, this, out _asyncCommand);
+            _launchOptions.UnixPort.BeginExecuteAsyncCommand(_startRemoteDebuggerCommand, true, this, out _asyncCommand);
         }
 
         /// <summary>

--- a/src/Microsoft.VisualStudio.Debugger.Interop.UnixPortSupplier/Microsoft.VisualStudio.Debugger.Interop.UnixPortSupplier.cs
+++ b/src/Microsoft.VisualStudio.Debugger.Interop.UnixPortSupplier/Microsoft.VisualStudio.Debugger.Interop.UnixPortSupplier.cs
@@ -36,10 +36,11 @@ namespace Microsoft.VisualStudio.Debugger.Interop.UnixPortSupplier
         /// it.
         /// </summary>
         /// <param name="commandText">Text of the command to execut</param>
+        /// <param name="runInShell">True if a PTY should be allocated and a shell started before executing the command.</param>
         /// <param name="callback">Callback which will receive the output and events 
         /// from the command</param>
         /// <param name="asyncCommand">Returned command object</param>
-        void BeginExecuteAsyncCommand(string commandText, IDebugUnixShellCommandCallback callback, out IDebugUnixShellAsyncCommand asyncCommand);
+        void BeginExecuteAsyncCommand(string commandText, bool runInShell, IDebugUnixShellCommandCallback callback, out IDebugUnixShellAsyncCommand asyncCommand);
 
         /// <summary>
         /// Copy a single file from the local machine to the remote machine.
@@ -70,7 +71,7 @@ namespace Microsoft.VisualStudio.Debugger.Interop.UnixPortSupplier
 
     /// <summary>
     /// Interface representing an executing asynchronous command. This is returned from 
-    /// <see cref="IDebugUnixShellPort.BeginExecuteAsyncCommand(string, IDebugUnixShellCommandCallback, out IDebugUnixShellAsyncCommand)"/>.
+    /// <see cref="IDebugUnixShellPort.BeginExecuteAsyncCommand(string, bool, IDebugUnixShellCommandCallback, out IDebugUnixShellAsyncCommand)"/>.
     /// </summary>
     [ComImport()]
     [ComVisible(true)]
@@ -79,7 +80,13 @@ namespace Microsoft.VisualStudio.Debugger.Interop.UnixPortSupplier
     public interface IDebugUnixShellAsyncCommand
     {
         /// <summary>
-        /// Writes to the standard input steam of the executing command
+        /// Writes to the standard input stream of the executing command
+        /// </summary>
+        /// <param name="text">Text to send to the command</param>
+        void Write(string text);
+
+        /// <summary>
+        /// Writes to the standard input steam of the executing command, appending a newline
         /// </summary>
         /// <param name="text">Text to send to the command</param>
         void WriteLine(string text);
@@ -92,7 +99,7 @@ namespace Microsoft.VisualStudio.Debugger.Interop.UnixPortSupplier
 
     /// <summary>
     /// Interface to receive events from an executing async command. This is passed to 
-    /// <see cref="IDebugUnixShellPort.BeginExecuteAsyncCommand(string, IDebugUnixShellCommandCallback, out IDebugUnixShellAsyncCommand)"/>.
+    /// <see cref="IDebugUnixShellPort.BeginExecuteAsyncCommand(string, bool, IDebugUnixShellCommandCallback, out IDebugUnixShellAsyncCommand)"/>.
     /// </summary>
     [ComImport()]
     [ComVisible(true)]

--- a/src/Microsoft.VisualStudio.Debugger.Interop.UnixPortSupplier/Microsoft.VisualStudio.Debugger.Interop.UnixPortSupplier.cs
+++ b/src/Microsoft.VisualStudio.Debugger.Interop.UnixPortSupplier/Microsoft.VisualStudio.Debugger.Interop.UnixPortSupplier.cs
@@ -15,7 +15,7 @@ namespace Microsoft.VisualStudio.Debugger.Interop.UnixPortSupplier
     [ComImport()]
     [ComVisible(true)]
     [InterfaceType(ComInterfaceType.InterfaceIsIUnknown)]
-    [Guid("808CC6CA-45B1-47D5-9779-62BAA597BA50")]
+    [Guid("5FE438B2-46BA-4637-88B3-E7B908D17331")]
     public interface IDebugUnixShellPort
     {
         /// <summary>

--- a/src/SSHDebugPS/AD7Port.cs
+++ b/src/SSHDebugPS/AD7Port.cs
@@ -129,9 +129,9 @@ namespace Microsoft.SSHDebugPS
             commandOutput = output;
         }
 
-        void IDebugUnixShellPort.BeginExecuteAsyncCommand(string commandText, IDebugUnixShellCommandCallback callback, out IDebugUnixShellAsyncCommand asyncCommand)
+        void IDebugUnixShellPort.BeginExecuteAsyncCommand(string commandText, bool runInShell, IDebugUnixShellCommandCallback callback, out IDebugUnixShellAsyncCommand asyncCommand)
         {
-            GetConnection(ConnectionReason.Deferred).BeginExecuteAsyncCommand(commandText, callback, out asyncCommand);
+            GetConnection(ConnectionReason.Deferred).BeginExecuteAsyncCommand(commandText, runInShell, callback, out asyncCommand);
         }
 
         void IConnectionPointContainer.EnumConnectionPoints(out IEnumConnectionPoints ppEnum)

--- a/src/SSHDebugPS/AD7UnixAsyncCommand.cs
+++ b/src/SSHDebugPS/AD7UnixAsyncCommand.cs
@@ -53,7 +53,7 @@ namespace Microsoft.SSHDebugPS
             {
                 if (_command != null)
                 {
-                    _command.Write(text + "\r");
+                    _command.Write(text + "\n");
                 }
             }
         }

--- a/src/SSHDebugPS/AD7UnixAsyncCommand.cs
+++ b/src/SSHDebugPS/AD7UnixAsyncCommand.cs
@@ -8,60 +8,52 @@ using System.Text;
 using System.Collections.Generic;
 using System.Threading;
 using System.Diagnostics;
+using liblinux;
 
 namespace Microsoft.SSHDebugPS
 {
     internal class AD7UnixAsyncCommand : IDebugUnixShellAsyncCommand
     {
         private readonly object _lock = new object();
-        private readonly string _beginMessage;
-        private readonly string _exitMessagePrefix;
-        private IStreamingShell _streamingShell;
         private readonly IDebugUnixShellCommandCallback _callback;
-        private readonly LineBuffer _lineBuffer = new LineBuffer();
-        private int _firedOnExit;
-        private int _bClosed = 0;
-        private bool _beginReceived;
-        private string _startCommand;
 
-        public AD7UnixAsyncCommand(IStreamingShell streamingShell, IDebugUnixShellCommandCallback callback)
+        private IRemoteSystem _remoteSystem;
+        private NonHostedCommand _command;
+
+        public AD7UnixAsyncCommand(IRemoteSystem remoteSystem, IDebugUnixShellCommandCallback callback)
         {
-            _streamingShell = streamingShell;
+            _remoteSystem = remoteSystem;
             _callback = callback;
-            Guid id = Guid.NewGuid();
-            _beginMessage = string.Format("Begin:{0}", id);
-            _exitMessagePrefix = string.Format("Exit:{0}-", id);
-            _streamingShell.OutputReceived += OnOutputReceived;
-            _streamingShell.Closed += OnClosedOrDisconnected;
-            _streamingShell.Disconnected += OnClosedOrDisconnected;
-            _streamingShell.ErrorOccured += OnError;
         }
 
         internal void Start(string commandText)
         {
-            // The scripts and commands which gets executed are based on bash and may not work with other shells. 
-            // Invoking bash as the first command to make sure of that.
-            _streamingShell.WriteLine("/bin/bash");
+            _command = _remoteSystem.Shell.ExecuteCommandAsynchronously(commandText, Timeout.Infinite);
+            _command.Finished += (sender, e) => _callback.OnExit(_command.ExitCode.ToString());
+            _command.OutputReceived += (sender, e) => _callback.OnOutputLine(e.Output);
 
-            _startCommand = string.Format("echo \"{0}\"; {1}; echo \"{2}$?\"", _beginMessage, commandText, _exitMessagePrefix);
-            _streamingShell.WriteLine(_startCommand);
-            _streamingShell.Flush();
-            _streamingShell.BeginOutputRead();
+            _command.RedirectErrorOutputToOutput = true;
+            _command.BeginOutputRead();
+        }
+
+        void IDebugUnixShellAsyncCommand.Write(string text)
+        {
+            lock (_lock)
+            {
+                if (_command != null)
+                {
+                    _command.Write(text);
+                }
+            }
         }
 
         void IDebugUnixShellAsyncCommand.WriteLine(string text)
         {
-            if (_bClosed == 1)
-            {
-                return;
-            }
-
             lock (_lock)
             {
-                if (_streamingShell != null)
+                if (_command != null)
                 {
-                    _streamingShell.WriteLine(text);
-                    _streamingShell.Flush();
+                    _command.Write(text + "\r");
                 }
             }
         }
@@ -71,117 +63,16 @@ namespace Microsoft.SSHDebugPS
             Close();
         }
 
-        private void OnOutputReceived(object sender, OutputReceivedEventArgs e)
-        {
-            IEnumerable<string> linesToSend = null;
-
-            if (string.IsNullOrEmpty(e.Output))
-                return;
-
-            _lineBuffer.ProcessText(e.Output, out linesToSend);
-
-            foreach (string line in linesToSend)
-            {
-                if (_bClosed == 1)
-                {
-                    return;
-                }
-
-                if (line.EndsWith(_startCommand, StringComparison.Ordinal))
-                {
-                    // When logged in as root, shell sends a copy of stdin to stdout.
-                    // This ignores the shell command that was used to launch the debugger.
-                    continue;
-                }
-
-                int endCommandIndex = line.IndexOf(_exitMessagePrefix);
-                if (endCommandIndex >= 0)
-                {
-                    if (Interlocked.CompareExchange(ref _firedOnExit, 1, 0) == 0)
-                    {
-                        string exitCode = SplitExitCode(line, endCommandIndex + _exitMessagePrefix.Length);
-                        _callback.OnExit(exitCode);
-                    }
-                    Close();
-                    return;
-                }
-
-                if (!_beginReceived)
-                {
-                    if (line.Contains(_beginMessage))
-                    {
-                        _beginReceived = true;
-                    }
-                    continue;
-                }
-
-                _callback.OnOutputLine(line);
-            }
-        }
-
-        private void OnError(object sender, liblinux.ErrorOccuredEventArgs e)
-        {
-            if (Interlocked.CompareExchange(ref _firedOnExit, 1, 0) == 0)
-            {
-                _callback.OnExit(null);
-            }
-
-            Close();
-        }
-
-        private void OnClosedOrDisconnected(object sender, EventArgs e)
-        {
-            if (_firedOnExit == 0 && _bClosed == 0)
-            {
-                Debug.Fail("Why was the SSH session closed?");
-                OnError(sender, null);
-            }
-        }
-
         private void Close()
         {
-            // Don't want output processing thread and the PollThread to go through this at the same time
-            // If PollThread issues Dispose and the output processing thread block on the _lock below, it will cause ThreadInterruptedException
-            // in the output processing thread
-            if (Interlocked.CompareExchange(ref _bClosed, 1, 0) == 0) 
+            lock (_lock)
             {
-                lock (_lock)
+                if (_command != null)
                 {
-                    try
-                    {
-                        _streamingShell?.Dispose();
-                    }
-                    catch (ThreadInterruptedException)
-                    {
-                        // We will run into this when we are closing as a result of getting exit message
-                        // in OnOutputReceived method in error cases. The method will be called on the thread
-                        // that StreamingShell uses for output processing. Dispose tries to interrupt the
-                        // same thread we are on leading to ThreadInterruptedException
-                    }
-
-                    _streamingShell = null;
+                    _command.Dispose();
+                    _command = null;
                 }
             }
-        }
-
-        private static string SplitExitCode(string line, int startIndex)
-        {
-            string exitCode = line.Substring(startIndex);
-
-            // If there was some extra cruft at the end of the line after the exit code, remove it
-            if ((exitCode.Length > 0 && char.IsDigit(exitCode[0])) ||
-                (exitCode.Length > 1 && exitCode[0] == '-' && char.IsDigit(exitCode[1])))
-            {
-                for (int c = 1; c < exitCode.Length; c++)
-                {
-                    if (!char.IsDigit(exitCode[c]))
-                    {
-                        return exitCode.Substring(0, c);
-                    }
-                }
-            }
-
-            return exitCode;
         }
     }
 }

--- a/src/SSHDebugPS/AD7UnixAsyncShellCommand.cs
+++ b/src/SSHDebugPS/AD7UnixAsyncShellCommand.cs
@@ -1,0 +1,204 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using liblinux.Shell;
+using Microsoft.VisualStudio.Debugger.Interop.UnixPortSupplier;
+using System.Text;
+using System.Collections.Generic;
+using System.Threading;
+using System.Diagnostics;
+
+namespace Microsoft.SSHDebugPS
+{
+    internal class AD7UnixAsyncShellCommand : IDebugUnixShellAsyncCommand
+    {
+        private readonly object _lock = new object();
+        private readonly string _beginMessage;
+        private readonly string _exitMessagePrefix;
+        private IStreamingShell _streamingShell;
+        private readonly IDebugUnixShellCommandCallback _callback;
+        private readonly LineBuffer _lineBuffer = new LineBuffer();
+        private int _firedOnExit;
+        private int _bClosed = 0;
+        private bool _beginReceived;
+        private string _startCommand;
+
+        public AD7UnixAsyncShellCommand(IStreamingShell streamingShell, IDebugUnixShellCommandCallback callback)
+        {
+            _streamingShell = streamingShell;
+            _callback = callback;
+            Guid id = Guid.NewGuid();
+            _beginMessage = string.Format("Begin:{0}", id);
+            _exitMessagePrefix = string.Format("Exit:{0}-", id);
+            _streamingShell.OutputReceived += OnOutputReceived;
+            _streamingShell.Closed += OnClosedOrDisconnected;
+            _streamingShell.Disconnected += OnClosedOrDisconnected;
+            _streamingShell.ErrorOccured += OnError;
+        }
+
+        internal void Start(string commandText)
+        {
+            // The scripts and commands which gets executed are based on bash and may not work with other shells. 
+            // Invoking bash as the first command to make sure of that.
+            _streamingShell.WriteLine("/bin/bash");
+
+            _startCommand = string.Format("echo \"{0}\"; {1}; echo \"{2}$?\"", _beginMessage, commandText, _exitMessagePrefix);
+            _streamingShell.WriteLine(_startCommand);
+            _streamingShell.Flush();
+            _streamingShell.BeginOutputRead();
+        }
+
+        void IDebugUnixShellAsyncCommand.Write(string text)
+        {
+            if (_bClosed == 1)
+            {
+                return;
+            }
+
+            lock (_lock)
+            {
+                if (_streamingShell != null)
+                {
+                    _streamingShell.Write(text);
+                    _streamingShell.Flush();
+                }
+            }
+        }
+
+        void IDebugUnixShellAsyncCommand.WriteLine(string text)
+        {
+            if (_bClosed == 1)
+            {
+                return;
+            }
+
+            lock (_lock)
+            {
+                if (_streamingShell != null)
+                {
+                    _streamingShell.WriteLine(text);
+                    _streamingShell.Flush();
+                }
+            }
+        }
+
+        void IDebugUnixShellAsyncCommand.Abort()
+        {
+            Close();
+        }
+
+        private void OnOutputReceived(object sender, OutputReceivedEventArgs e)
+        {
+            IEnumerable<string> linesToSend = null;
+
+            if (string.IsNullOrEmpty(e.Output))
+                return;
+
+            _lineBuffer.ProcessText(e.Output, out linesToSend);
+
+            foreach (string line in linesToSend)
+            {
+                if (_bClosed == 1)
+                {
+                    return;
+                }
+
+                if (line.EndsWith(_startCommand, StringComparison.Ordinal))
+                {
+                    // When logged in as root, shell sends a copy of stdin to stdout.
+                    // This ignores the shell command that was used to launch the debugger.
+                    continue;
+                }
+
+                int endCommandIndex = line.IndexOf(_exitMessagePrefix);
+                if (endCommandIndex >= 0)
+                {
+                    if (Interlocked.CompareExchange(ref _firedOnExit, 1, 0) == 0)
+                    {
+                        string exitCode = SplitExitCode(line, endCommandIndex + _exitMessagePrefix.Length);
+                        _callback.OnExit(exitCode);
+                    }
+                    Close();
+                    return;
+                }
+
+                if (!_beginReceived)
+                {
+                    if (line.Contains(_beginMessage))
+                    {
+                        _beginReceived = true;
+                    }
+                    continue;
+                }
+
+                _callback.OnOutputLine(line);
+            }
+        }
+
+        private void OnError(object sender, liblinux.ErrorOccuredEventArgs e)
+        {
+            if (Interlocked.CompareExchange(ref _firedOnExit, 1, 0) == 0)
+            {
+                _callback.OnExit(null);
+            }
+
+            Close();
+        }
+
+        private void OnClosedOrDisconnected(object sender, EventArgs e)
+        {
+            if (_firedOnExit == 0 && _bClosed == 0)
+            {
+                Debug.Fail("Why was the SSH session closed?");
+                OnError(sender, null);
+            }
+        }
+
+        private void Close()
+        {
+            // Don't want output processing thread and the PollThread to go through this at the same time
+            // If PollThread issues Dispose and the output processing thread block on the _lock below, it will cause ThreadInterruptedException
+            // in the output processing thread
+            if (Interlocked.CompareExchange(ref _bClosed, 1, 0) == 0) 
+            {
+                lock (_lock)
+                {
+                    try
+                    {
+                        _streamingShell?.Dispose();
+                    }
+                    catch (ThreadInterruptedException)
+                    {
+                        // We will run into this when we are closing as a result of getting exit message
+                        // in OnOutputReceived method in error cases. The method will be called on the thread
+                        // that StreamingShell uses for output processing. Dispose tries to interrupt the
+                        // same thread we are on leading to ThreadInterruptedException
+                    }
+
+                    _streamingShell = null;
+                }
+            }
+        }
+
+        private static string SplitExitCode(string line, int startIndex)
+        {
+            string exitCode = line.Substring(startIndex);
+
+            // If there was some extra cruft at the end of the line after the exit code, remove it
+            if ((exitCode.Length > 0 && char.IsDigit(exitCode[0])) ||
+                (exitCode.Length > 1 && exitCode[0] == '-' && char.IsDigit(exitCode[1])))
+            {
+                for (int c = 1; c < exitCode.Length; c++)
+                {
+                    if (!char.IsDigit(exitCode[c]))
+                    {
+                        return exitCode.Substring(0, c);
+                    }
+                }
+            }
+
+            return exitCode;
+        }
+    }
+}

--- a/src/SSHDebugPS/SSHDebugPS.csproj
+++ b/src/SSHDebugPS/SSHDebugPS.csproj
@@ -91,6 +91,7 @@
     <Compile Include="AD7ConnectCanceledException.cs" />
     <Compile Include="AD7Process.cs" />
     <Compile Include="AD7Program.cs" />
+    <Compile Include="AD7UnixAsyncCommand.cs" />
     <Compile Include="MIEngineLauncher.cs" />
     <Compile Include="CommandFailedException.cs" />
     <Compile Include="ConnectionReason.cs" />
@@ -108,7 +109,7 @@
       <DesignTime>True</DesignTime>
       <DependentUpon>StringResources.resx</DependentUpon>
     </Compile>
-    <Compile Include="AD7UnixAsyncCommand.cs" />
+    <Compile Include="AD7UnixAsyncShellCommand.cs" />
     <Compile Include="VSOperationWaiter.cs" />
   </ItemGroup>
   <ItemGroup>


### PR DESCRIPTION
Extends the SSH port supplier to allow commands to be run without starting
a shell and allocating a PTY on the remote host.