### PR TITLE
Fix Natvis for DisplayString conditionals in C

### DIFF
--- a/src/MIDebugEngine/Natvis.Impl/Natvis.cs
+++ b/src/MIDebugEngine/Natvis.Impl/Natvis.cs
@@ -846,7 +846,11 @@ namespace Microsoft.MIDebugEngine.Natvis
             if (!String.IsNullOrWhiteSpace(condition))
             {
                 string exprValue = GetExpressionValue(condition, variable, scopedNames);
-                res = !String.IsNullOrEmpty(exprValue) && (exprValue.Equals("true", StringComparison.OrdinalIgnoreCase) || exprValue.Equals("1", StringComparison.OrdinalIgnoreCase));
+
+                bool exprBool = false;
+                int exprInt = 0;
+                res = !String.IsNullOrEmpty(exprValue) &&
+                    ((bool.TryParse(exprValue, out exprBool) && exprBool) || (int.TryParse(exprValue, out exprInt) && exprInt > 0));
             }
             return res;
         }

--- a/src/MIDebugEngine/Natvis.Impl/Natvis.cs
+++ b/src/MIDebugEngine/Natvis.Impl/Natvis.cs
@@ -846,7 +846,7 @@ namespace Microsoft.MIDebugEngine.Natvis
             if (!String.IsNullOrWhiteSpace(condition))
             {
                 string exprValue = GetExpressionValue(condition, variable, scopedNames);
-                res = !String.IsNullOrEmpty(exprValue) && (exprValue == "true");
+                res = !String.IsNullOrEmpty(exprValue) && (exprValue.Equals("true", StringComparison.OrdinalIgnoreCase) || exprValue.Equals("1", StringComparison.OrdinalIgnoreCase));
             }
             return res;
         }


### PR DESCRIPTION
Issue: gdb returns "1" and "0" instead of "true" and "false" when
debugging C and a condition is passed for evaluation.

Changed code to check for either "true" or "1"

https://github.com/Microsoft/vscode-cpptools/issues/476

@rajkumar42 @gregg-miskelly @chuckries 