### PR TITLE
Fixes for thread-created and terminate/detach

### DIFF
--- a/src/MICore/CommandFactories/MICommandFactory.cs
+++ b/src/MICore/CommandFactories/MICommandFactory.cs
@@ -97,9 +97,14 @@ namespace MICore
         {
         }
 
-        public virtual async Task<Results> ThreadInfo()
+        public virtual async Task<Results> ThreadInfo(uint? threadid = null)
         {
-            Results threadsinfo = await _debugger.CmdAsync("-thread-info", ResultClass.None);
+            string command = "-thread-info";
+            if (threadid.HasValue)
+            {
+                command = String.Concat(command, " ", threadid.Value);
+            }
+            Results threadsinfo = await _debugger.CmdAsync(command, ResultClass.None);
             return threadsinfo;
         }
 

--- a/src/MICore/CommandFactories/gdb.cs
+++ b/src/MICore/CommandFactories/gdb.cs
@@ -155,9 +155,9 @@ namespace MICore
                 _currentFrameLevel = frameLevel;
             }
         }
-        public override async Task<Results> ThreadInfo()
+        public override async Task<Results> ThreadInfo(uint? threadId = null)
         {
-            Results results = await base.ThreadInfo();
+            Results results = await base.ThreadInfo(threadId);
             if (results.ResultClass == ResultClass.done && results.Contains("current-thread-id"))
             {
                 _currentThreadId = results.FindInt("current-thread-id");

--- a/src/MICore/Debugger.cs
+++ b/src/MICore/Debugger.cs
@@ -394,7 +394,7 @@ namespace MICore
                 }
                 else
                 {
-                    if (_requestingRealAsyncBreak == BreakRequest.Internal && fIsAsyncBreak)
+                    if (_requestingRealAsyncBreak == BreakRequest.Internal && fIsAsyncBreak && (!_terminating && !_detaching))
                     {
                         CmdContinueAsync();
                         processContinued = true;
@@ -561,8 +561,7 @@ namespace MICore
             }
             return CmdBreakInternal();
         }
-
-
+        
         internal bool IsLocalGdb()
         {
             if (this.MICommandFactory.Mode == MIMode.Gdb &&
@@ -1540,4 +1539,3 @@ namespace MICore
         }
     };
 }
-

--- a/src/MIDebugEngine/Engine.Impl/DebuggedProcess.cs
+++ b/src/MIDebugEngine/Engine.Impl/DebuggedProcess.cs
@@ -384,9 +384,15 @@ namespace Microsoft.MIDebugEngine
             ErrorEvent += delegate (object o, EventArgs args)
             {
                 // NOTE: Exceptions leaked from this method may cause VS to crash, be careful
-
                 ResultEventArgs result = (ResultEventArgs)args;
-                _callback.OnError(result.Results.FindString("msg"));
+                // In lldb, the format is ^error,message=""
+                // In gdb/vsdbg it is ^error,msg=""
+                string message = result.Results.TryFindString("msg");
+                if(String.IsNullOrWhiteSpace(message))
+                {
+                    message = result.Results.TryFindString("message");
+                }
+                _callback.OnError(message);
             };
 
             ThreadCreatedEvent += delegate (object o, EventArgs args)


### PR DESCRIPTION
1. Fix for Pause on OS X with lldb. LLDB does not break on attach so
threads were not being sent to the UI. Fix was to send back messages when
threads are created directly

2. fix for detach/terminate. With the change to do an internal break, it
was sending -exec-interrupt, -exec-abort and then -exec-continue which was
causing errors. added check in DoInternalBreakActions to only continue if
we are not terminating or detaching.

3. Fix for ErrorEvent. on LLDB, the message format is ^error,message=""
but in gdb it is ^error,msg="". Added a special case for it.

@gregg-miskelly @paulmaybee @rajkumar42 