### PR TITLE
Update InstallToVSCode scripts to support 'novsdbg'

### DIFF
--- a/tools/InstallToVSCode/InstallToVSCode.cmd
+++ b/tools/InstallToVSCode/InstallToVSCode.cmd
@@ -47,7 +47,9 @@ if not exist "%MIEngineBinDir%Microsoft.MIDebugEngine.dll" echo ERROR: Microsoft
 if NOT "%~5"=="-d" echo ERROR: Bad command line argument. Expected '-d ^<vsdbg-dir^>'. & exit /b -1
 if "%~6" == "" echo ERROR: VsDbg binaries directory not set &exit /b -1
 set VSDBGBITSDIR=%~6
+if "%VSDBGBITSDIR%"=="novsdbg" goto SkipVSDBGCheck
 if not exist "%VSDBGBITSDIR%\vsdbg.dll" echo ERROR: %VSDBGBITSDIR%\vsdbg.dll does not exist. & exit /b -1
+:SkipVSDBGCheck
 
 set DESTDIR=%USERPROFILE%\.MIEngine-VSCode-Debug
 if exist "%DESTDIR%" rmdir /s /q "%DESTDIR%"
@@ -97,6 +99,8 @@ for %%f in (xunit.console.netcore.exe) do call :InstallFile "%OpenDebugAD7BinDir
 for %%f in (%OpenDebugAD7BinDir%\*.dll) do call :InstallFile "%%f"
 
 echo.
+
+if "%VSDBGBITSDIR%"=="novsdbg" goto AfterVSDBGCopy
 echo Installing vsdbg bits from %VSDBGBITSDIR%...
 
 REM NOTE: We ignore files that already exist. This is because we have already
@@ -118,6 +122,7 @@ pushd %destdir%
 ren vsdbg.exe clrdbg.exe
 if not "%errorlevel%"=="0" echo error: unable to rename vsdbg.exe???& exit /b -1
 popd
+:AfterVSDBGCopy
 
 for %%f in (coreclr\coreclr.ad7Engine.json) do call :InstallFile "%~dp0%%f"
 for %%f in (Microsoft.MICore.dll Microsoft.MIDebugEngine.dll) do call :InstallFile "%MIEngineBinDir%%%f"
@@ -172,7 +177,7 @@ if NOT "%ERRORLEVEL%"=="0" echo ERROR: mklink failed. Ensure this script is runn
 goto eof
 
 :Help
-echo InstallToVSCode ^<link^|copy^> ^<portable^|debug^> ^<oss-dev^|alpha^|insiders^|stable^> ^<open-debug-ad7-dir^> -d ^<vsdbg-binaries^>
+echo InstallToVSCode ^<link^|copy^> ^<portable^|debug^> ^<oss-dev^|alpha^|insiders^|stable^> ^<open-debug-ad7-dir^> -d ^<vsdbg-binaries^|novsdbg^>
 echo.
 echo This script is used to copy files needed to enable MIEngine based debugging 
 echo into VS Code.
@@ -190,7 +195,7 @@ echo   insiders: Install to VSCode insiders
 echo   stable: Install to VSCode stable
 echo.
 echo  open-debug-ad7-dir : Root of the OpenDebugAD7 repo
-echo  vsdbg-binaries: Directory which contains vsdbg binaries
+echo  vsdbg-binaries: Directory which contains vsdbg binaries or 'novsdbg' to not copy vsdbg binaries
 echo.
 echo Example: 
 echo .\InstallToVSCode.cmd link portable alpha c:\dd\OpenDebugAD7 -d c:\dd\vs1\out\binaries\amd64chk\Debugger\x-plat\vsdbg

--- a/tools/InstallToVSCode/InstallToVSCode.sh
+++ b/tools/InstallToVSCode/InstallToVSCode.sh
@@ -3,7 +3,7 @@ script_dir=`dirname $0`
 
 print_help()
 {
-    echo 'InstallToVSCode.sh <link|copy> <oss-dev|alpha|insiders|stable> <open-debug-ad7-dir> -d <vsdbg-binaries>'
+    echo 'InstallToVSCode.sh <link|copy> <oss-dev|alpha|insiders|stable> <open-debug-ad7-dir> -d <vsdbg-binaries|novsdbg>'
     echo ''
     echo 'This script is used to copy files needed to enable MIEngine based debugging'
     echo 'into VS Code.'
@@ -171,9 +171,11 @@ pushd $DropDir >/dev/null
 DropDir=$(pwd)
 popd >/dev/null
 
-[ ! "$4" == "-d" ] && echo "ERROR: Bad command line argument. Expected '-d <vsdbg-dir>'." && exit 1
+[ ! "$4" == "-d" ] && echo "ERROR: Bad command line argument. Expected '-d <vsdbg-dir|novsdbg>'." && exit 1
 VSDBGBITSDIR=${5:?"ERROR: VsDbg binaries directory must be specified with -d option. See -h for usage."}
-[ ! -f "$VSDBGBITSDIR/vsdbg" ] && echo "ERROR: $VSDBGBITSDIR/vsdbg does not exist." && exit 1
+if [ "$VSDBGBITSDIR" != "novsdbg" ]; then
+    [ ! -f "$VSDBGBITSDIR/vsdbg" ] && echo "ERROR: $VSDBGBITSDIR/vsdbg does not exist." && exit 1
+fi
 DESTDIR=$HOME/.MIEngine-VSCode-Debug
 
 VSCodeExtensionsRoot=$HOME/$VSCodeDirName/extensions
@@ -196,6 +198,19 @@ mkdir -p "$DESTDIR"
 
 hash dotnet 2>/dev/null
 [ $? -ne 0 ] && echo "ERROR: The .NET CLI is not installed. see: http://dotnet.github.io/getting-started/" && exit 1
+
+OSName=$(uname -s)
+if [ "$OSName" == "Linux" ]; then
+    DotnetSDKRoot=/usr/share/dotnet/sdk
+else
+    DotnetSDKRoot=/usr/local/share/dotnet/sdk
+fi
+
+DotnetDll="$DotnetSDKRoot/1.0.0-preview2-1-003177/dotnet.dll"
+if [ ! -f $DotnetDll ]; then
+    echo "ERROR: $DotnetDll not found. Ensure that the preview 2 .NET SDK is installed."
+    exit 1
+fi
 
 SetupSymLink "$CSharpExtensionRoot/.debugger" "$DESTDIR"
 [ $? -ne 0 ] && echo "ERROR: Unable to link $CSharpExtensionRoot/.debugger to $DESTDIR" && exit 1
@@ -220,10 +235,10 @@ runtime_id=`dotnet --info | grep RID: | tr -d ' ' | cut -f2 -d:`
 sed s/@current-OS@/\ \ \ \ \"${runtime_id}\":{}/ project.json.template>project.json
 [ $? -ne 0 ] && echo "ERROR: sed failed." && exit 1
 
-dotnet restore
+dotnet $DotnetDll restore
 [ $? -ne 0 ] && echo "ERROR: dotnet restore failed." && exit 1
 
-dotnet publish -o "$DESTDIR"
+dotnet $DotnetDll publish -o "$DESTDIR"
 [ $? -ne 0 ] && echo "ERROR: dotnet publish failed." && exit 1
 
 popd >/dev/null
@@ -242,33 +257,35 @@ for dll in $(ls $OpenDebugAD7BinDir/*.dll); do
     install_module "$dll" "" ignoreMissingPdbs
 done
 
-echo ''
-echo "Installing vsdbg bits from $VSDBGBITSDIR"
+if [ "$VSDBGBITSDIR" != "novsdbg" ]; then
+    echo ''
+    echo "Installing vsdbg bits from $VSDBGBITSDIR"
 
-for vsdbgFile in $(ls $VSDBGBITSDIR/*); do
-    if [ -f "$vsdbgFile" ]; then
-        # NOTE: We ignore files that already exist. This is because we have already
-        # cleaned the directory originally, and published CoreCLR files. Replacing existing
-        # files will replace some of those CoreCLR files with new copies that will not work.
-        install_new_file "$vsdbgFile"
-    fi
-done
-
-for directory in $(ls -d $VSDBGBITSDIR/*/); do
-    directory_name=$(basename $directory)
-
-    if [ ! -d "$DESTDIR/$directory_name" ]; then
-        mkdir "$DESTDIR/$directory_name"
-    fi
-
-    for dll in $(ls $directory/*.dll); do
-        install_file "$dll" "$directory_name/"
+    for vsdbgFile in $(ls $VSDBGBITSDIR/*); do
+        if [ -f "$vsdbgFile" ]; then
+            # NOTE: We ignore files that already exist. This is because we have already
+            # cleaned the directory originally, and published CoreCLR files. Replacing existing
+            # files will replace some of those CoreCLR files with new copies that will not work.
+            install_new_file "$vsdbgFile"
+        fi
     done
-done
 
-# Rename vsdbg back to clrdbg
-mv "$DESTDIR/vsdbg" "$DESTDIR/clrdbg"
-[ $? -ne 0 ] && echo "ERROR: Unable to move vsdbg executable." && exit 1
+    for directory in $(ls -d $VSDBGBITSDIR/*/); do
+        directory_name=$(basename $directory)
+
+        if [ ! -d "$DESTDIR/$directory_name" ]; then
+            mkdir "$DESTDIR/$directory_name"
+        fi
+
+        for dll in $(ls $directory/*.dll); do
+            install_file "$dll" "$directory_name/"
+        done
+    done
+
+    # Rename vsdbg back to clrdbg
+    mv "$DESTDIR/vsdbg" "$DESTDIR/clrdbg"
+    [ $? -ne 0 ] && echo "ERROR: Unable to move vsdbg executable." && exit 1
+fi
 
 install_file "$script_dir/coreclr/coreclr.ad7Engine.json"
 install_file "$DropDir/osxlaunchhelper.scpt"


### PR DESCRIPTION
In order to run the legacy tests we only need the drop of MIEngine and OpenDebugAD7 and it is easier to just avoid copying vsdbg from a legacy drop. 