### PR TITLE
Fix NullRef in SSH port supplier

### DIFF
--- a/src/SSHDebugPS/AD7UnixAsyncCommand.cs
+++ b/src/SSHDebugPS/AD7UnixAsyncCommand.cs
@@ -29,7 +29,7 @@ namespace Microsoft.SSHDebugPS
         internal void Start(string commandText)
         {
             _command = _remoteSystem.Shell.ExecuteCommandAsynchronously(commandText, Timeout.Infinite);
-            _command.Finished += (sender, e) => _callback.OnExit(_command.ExitCode.ToString());
+            _command.Finished += (sender, e) => _callback.OnExit(((NonHostedCommand)sender).ExitCode.ToString());
             _command.OutputReceived += (sender, e) => _callback.OnOutputLine(e.Output);
 
             _command.RedirectErrorOutputToOutput = true;


### PR DESCRIPTION
There's a race condition between a SSH command completing normally and
being disposed - the member for the command is set to null when the
command is disposed, but handler for the command's "Finished" event
still references the member.  The fix is to have the "Finished" event
handler access the command via the "sender" instead.