### PR TITLE
Turn off pagination (Issue #574)

### DIFF
--- a/src/MIDebugEngine/Engine.Impl/DebuggedProcess.cs
+++ b/src/MIDebugEngine/Engine.Impl/DebuggedProcess.cs
@@ -553,7 +553,10 @@ namespace Microsoft.MIDebugEngine
 
             commands.AddRange(_launchOptions.SetupCommands);
 
-            commands.Add(new LaunchCommand("-interpreter-exec console \"set pagination off\""));
+            if (_launchOptions.DebuggerMIMode == MIMode.Gdb)
+            {
+                commands.Add(new LaunchCommand("-interpreter-exec console \"set pagination off\""));
+            }
 
             // If the absolute prefix so path has not been specified, then don't set it to null
             // because the debugger might already have a default.

--- a/src/MIDebugEngine/Engine.Impl/DebuggedProcess.cs
+++ b/src/MIDebugEngine/Engine.Impl/DebuggedProcess.cs
@@ -553,6 +553,8 @@ namespace Microsoft.MIDebugEngine
 
             commands.AddRange(_launchOptions.SetupCommands);
 
+            commands.Add(new LaunchCommand("-interpreter-exec console \"set pagination off\""));
+
             // If the absolute prefix so path has not been specified, then don't set it to null
             // because the debugger might already have a default.
             if (!string.IsNullOrEmpty(_launchOptions.AbsolutePrefixSOLibSearchPath))


### PR DESCRIPTION
Long output from commands (more that a screen full) causes gdb to pause waiting for user input. This change turns off that behavior. @gregg-miskelly @rajkumar42 