### PR TITLE
Don't apply natvis visualizations to pretty-printed ("dynamic") results

### DIFF
--- a/src/MIDebugEngine/AD7.Impl/AD7Property.cs
+++ b/src/MIDebugEngine/AD7.Impl/AD7Property.cs
@@ -75,7 +75,7 @@ namespace Microsoft.MIDebugEngine
                 // double the mi messages since var-show-attributes is a separate call.
                 if (_engine.DebuggedProcess.MICommandFactory.Mode == MICore.MIMode.Clrdbg)
                 {
-                    if (variable.IsReadOnly)
+                    if (variable.IsReadOnly())
                     {
                         propertyInfo.dwAttrib |= enum_DBG_ATTRIB_FLAGS.DBG_ATTRIB_VALUE_READONLY;
                     }

--- a/src/MIDebugEngine/Engine.Impl/Variables.cs
+++ b/src/MIDebugEngine/Engine.Impl/Variables.cs
@@ -39,6 +39,7 @@ namespace Microsoft.MIDebugEngine
         bool IsVisualized { get; }
         bool IsReadOnly { get; }
         enum_DEBUGPROP_INFO_FLAGS PropertyInfoFlags { get; set; }
+        bool IsPreformatted { get; set; }
     }
 
     internal class SimpleVariableInformation
@@ -86,6 +87,8 @@ namespace Microsoft.MIDebugEngine
         public bool IsVisualized { get { return _parent == null ? false : _parent.IsVisualized; } }
         public enum_DEBUGPROP_INFO_FLAGS PropertyInfoFlags { get; set; }
         private string DisplayHint { get; set; }
+        public bool IsPreformatted { get; set; }
+
 
         private static bool IsPointer(string typeName)
         {
@@ -225,6 +228,7 @@ namespace Microsoft.MIDebugEngine
             if (results.Contains("dynamic"))
             {
                 CountChildren = 1;
+                IsPreformatted = true;
             }
             else
             {
@@ -258,7 +262,7 @@ namespace Microsoft.MIDebugEngine
                 Name = '[' + this.Name + ']';
                 VariableNodeType = NodeType.ArrayElement;
             }
-            else if (this.Name.Length > 2 && this.Name[0] == '[' && this.Name[this.Name.Length-1] == ']')
+            else if (this.Name.Length > 2 && this.Name[0] == '[' && this.Name[this.Name.Length - 1] == ']')
             {
                 VariableNodeType = NodeType.ArrayElement;
             }
@@ -458,6 +462,10 @@ namespace Microsoft.MIDebugEngine
                 {
                     _internalName = results.FindString("name");
                     TypeName = results.TryFindString("type");
+                    if (results.Contains("dynamic"))
+                    {
+                        IsPreformatted = true;
+                    }
                     if (results.Contains("dynamic") && results.Contains("has_more"))
                     {
                         CountChildren = results.FindUint("has_more");
@@ -675,6 +683,7 @@ namespace Microsoft.MIDebugEngine
             return DisplayHint == "map";
         }
 
+        [DebuggerHidden()]
         public bool IsReadOnly
         {
             get

--- a/src/MIDebugEngine/Engine.Impl/Variables.cs
+++ b/src/MIDebugEngine/Engine.Impl/Variables.cs
@@ -37,7 +37,7 @@ namespace Microsoft.MIDebugEngine
         VariableInformation FindChildByName(string name);
         string EvalDependentExpression(string expr);
         bool IsVisualized { get; }
-        bool IsReadOnly { get; }
+        bool IsReadOnly();
         enum_DEBUGPROP_INFO_FLAGS PropertyInfoFlags { get; set; }
         bool IsPreformatted { get; set; }
     }
@@ -683,33 +683,29 @@ namespace Microsoft.MIDebugEngine
             return DisplayHint == "map";
         }
 
-        [DebuggerHidden()]
-        public bool IsReadOnly
+        public bool IsReadOnly()
         {
-            get
+            if (!_attribsFetched)
             {
-                if (!_attribsFetched)
+                if (string.IsNullOrEmpty(_internalName))
                 {
-                    if (string.IsNullOrEmpty(_internalName))
-                    {
-                        return true;
-                    }
-
-                    this.VerifyNotDisposed();
-
-                    string attribute = string.Empty;
-
-                    _engine.DebuggedProcess.WorkerThread.RunOperation(async () =>
-                    {
-                        attribute = await _engine.DebuggedProcess.MICommandFactory.VarShowAttributes(_internalName);
-                    });
-
-                    _isReadonly = (attribute == "noneditable");
-                    _attribsFetched = true;
+                    return true;
                 }
 
-                return _isReadonly;
+                this.VerifyNotDisposed();
+
+                string attribute = string.Empty;
+
+                _engine.DebuggedProcess.WorkerThread.RunOperation(async () =>
+                {
+                    attribute = await _engine.DebuggedProcess.MICommandFactory.VarShowAttributes(_internalName);
+                });
+
+                _isReadonly = (attribute == "noneditable");
+                _attribsFetched = true;
             }
+
+            return _isReadonly;
         }
 
         public void Assign(string expression)

--- a/src/MIDebugEngine/Natvis.Impl/Natvis.cs
+++ b/src/MIDebugEngine/Natvis.Impl/Natvis.cs
@@ -48,7 +48,7 @@ namespace Microsoft.MIDebugEngine.Natvis
         public ThreadContext ThreadContext { get { return Parent.ThreadContext; } }
         public virtual bool IsVisualized { get { return Parent.IsVisualized; } }
         public virtual enum_DEBUGPROP_INFO_FLAGS PropertyInfoFlags { get; set; }
-        public virtual bool IsReadOnly { get { return Parent.IsReadOnly; } }
+        public virtual bool IsReadOnly() => Parent.IsReadOnly();
 
         public VariableInformation FindChildByName(string name) => Parent.FindChildByName(name);
         public string EvalDependentExpression(string expr) => Parent.EvalDependentExpression(expr);

--- a/src/MIDebugEngine/Natvis.Impl/Natvis.cs
+++ b/src/MIDebugEngine/Natvis.Impl/Natvis.cs
@@ -64,6 +64,7 @@ namespace Microsoft.MIDebugEngine.Natvis
         public void Dispose()
         {
         }
+        public bool IsPreformatted { get { return Parent.IsPreformatted; } set { } }
     }
 
     internal class VisualizerWrapper : SimpleWrapper
@@ -339,7 +340,8 @@ namespace Microsoft.MIDebugEngine.Natvis
                 {
                     if (!(variable is VisualizerWrapper) && //no displaystring for dummy vars ([Raw View])
                         (ShowDisplayStrings == DisplayStringsState.On
-                        || (ShowDisplayStrings == DisplayStringsState.ForVisualizedItems && variable.IsVisualized)))
+                        || (ShowDisplayStrings == DisplayStringsState.ForVisualizedItems && variable.IsVisualized)) &&
+                        !variable.IsPreformatted)
                     {
                         VisualizerInfo visualizer = FindType(variable);
                         if (visualizer == null)
@@ -379,6 +381,10 @@ namespace Microsoft.MIDebugEngine.Natvis
 
         private IVariableInformation GetVisualizationWrapper(IVariableInformation variable)
         {
+            if (variable.IsPreformatted)
+            {
+                return null;
+            }
             VisualizerInfo visualizer = FindType(variable);
             if (visualizer == null || variable is VisualizerWrapper)    // don't stack wrappers
             {


### PR DESCRIPTION
When both pretty-printing and natvis are enabled (the new default for Linux projects) then the combination of features seems to give best results. In particular, there is no pretty printing for std::list, but nativs will format a list just fine. With this fix a list\<string\> will be formatted optimally, using natvis to decode the list and allowing the string to be pretty-printed.