### PR TITLE
Speed up parsing of gdb output strings by using indexes into the orig…

### DIFF
--- a/src/MICore/MIResults.cs
+++ b/src/MICore/MIResults.cs
@@ -740,7 +740,6 @@ namespace MICore
 
         public string ParseCString(string input)
         {
-            input = input.Trim();
             if (input == null)
             {
                 throw new ArgumentNullException("input");


### PR DESCRIPTION
…inal string rather than creating new strings at each step.

This results in a huge speedup. In the example reported (Issue #583) the time to parse when from 106 seconds to .1 second.
