### PR TITLE
Update package references

### DIFF
--- a/src/DebugEngineHost.Stub/project.json
+++ b/src/DebugEngineHost.Stub/project.json
@@ -1,17 +1,20 @@
 ﻿{
-  "supports": {
-    "net46.app": {},
-    "dnxcore50.app": {}
-  },
   "dependencies": {
-    "MicroBuild.Core": "0.2.0",
-    "Microsoft.NETCore": "5.0.0",
-    "Microsoft.NETCore.Portable.Compatibility": "1.0.0",
-    "Microsoft.VisualStudio.Debugger.Interop.Portable": "1.0.1"
+    "Microsoft.VisualStudio.Debugger.Interop.Portable": "1.0.1",
+
+    // .NET Core 1.0 RTM packages
+    "System.Collections": "4.0.11",
+    "System.Diagnostics.Debug": "4.0.11",
+    "System.Diagnostics.Tools": "4.0.1",
+    "System.Resources.ResourceManager": "4.0.1",
+    "System.Runtime": "4.1.0",
+    "System.Runtime.Extensions": "4.1.0",
+    "System.Runtime.InteropServices": "4.1.0",
+    "System.Threading.Tasks": "4.0.11"
   },
   "frameworks": {
-    "dotnet": {
-      "imports": "portable-net452"
+    "netstandard1.3": {
+      "imports": "portable-net45+net46+dnxcore50"
     }
   }
 }

--- a/src/IOSDebugLauncher/IOSDebugLauncher.csproj
+++ b/src/IOSDebugLauncher/IOSDebugLauncher.csproj
@@ -82,26 +82,6 @@
     <Reference Include="System.Core" />
     <Reference Include="System.Net.Http" />
     <Reference Include="System.Net.Http.WebRequest" />
-    <Reference Include="System.Net.Security, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>$(NuGetPackagesDirectory)\System.Net.Security.4.0.0-beta-23225\lib\net46\System.Net.Security.dll</HintPath>
-      <Private>True</Private>
-    </Reference>
-    <Reference Include="System.Security.Cryptography.Algorithms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>$(NuGetPackagesDirectory)\System.Security.Cryptography.Algorithms.4.0.0-beta-23225\lib\net46\System.Security.Cryptography.Algorithms.dll</HintPath>
-      <Private>False</Private>
-    </Reference>
-    <Reference Include="System.Security.Cryptography.Encoding, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>$(NuGetPackagesDirectory)\System.Security.Cryptography.Encoding.4.0.0-beta-23225\lib\net46\System.Security.Cryptography.Encoding.dll</HintPath>
-      <Private>False</Private>
-    </Reference>
-    <Reference Include="System.Security.Cryptography.Primitives, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>$(NuGetPackagesDirectory)\System.Security.Cryptography.Primitives.4.0.0-beta-23225\lib\net46\System.Security.Cryptography.Primitives.dll</HintPath>
-      <Private>False</Private>
-    </Reference>
-    <Reference Include="System.Security.Cryptography.X509Certificates, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>$(NuGetPackagesDirectory)\System.Security.Cryptography.X509Certificates.4.0.0-beta-23225\lib\net46\System.Security.Cryptography.X509Certificates.dll</HintPath>
-      <Private>False</Private>
-    </Reference>
     <Reference Include="System.Xml.Linq" />
     <Reference Include="System.Data.DataSetExtensions" />
     <Reference Include="Microsoft.CSharp" />

--- a/src/IOSDebugLauncher/Launcher.cs
+++ b/src/IOSDebugLauncher/Launcher.cs
@@ -91,7 +91,15 @@ namespace IOSDebugLauncher
             }
 
             debuggerLaunchOptions = new TcpLaunchOptions(_launchOptions.RemoteMachineName, _remotePorts.DebugListenerPort, _launchOptions.Secure);
-            (debuggerLaunchOptions as TcpLaunchOptions).ServerCertificateValidationCallback = _client.ServerCertificateValidationCallback;
+
+            if (_client.ServerCertificateValidationCallback != null)
+            {
+                (debuggerLaunchOptions as TcpLaunchOptions).ServerCertificateValidationCallback = (object sender, object/*X509Certificate*/ certificate, object/*X509Chain*/ chain, SslPolicyErrors sslPolicyErrors) =>
+                {
+                    return _client.ServerCertificateValidationCallback(sender, (X509Certificate)certificate, (X509Chain)chain, sslPolicyErrors);
+                };
+            }
+            
             debuggerLaunchOptions.TargetArchitecture = _launchOptions.TargetArchitecture;
             debuggerLaunchOptions.AdditionalSOLibSearchPath = _launchOptions.AdditionalSOLibSearchPath;
             debuggerLaunchOptions.DebuggerMIMode = MIMode.Lldb;

--- a/src/IOSDebugLauncher/packages.config
+++ b/src/IOSDebugLauncher/packages.config
@@ -1,14 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="Newtonsoft.Json" version="6.0.4" targetFramework="net45" userInstalled="true" />
-  <package id="System.IO" version="4.0.0" targetFramework="net46" />
-  <package id="System.Net.Primitives" version="4.0.10" targetFramework="net46" />
-  <package id="System.Net.Security" version="4.0.0-beta-23225" targetFramework="net46" />
-  <package id="System.Runtime" version="4.0.0" targetFramework="net46" />
-  <package id="System.Runtime.Handles" version="4.0.0" targetFramework="net46" />
-  <package id="System.Security.Cryptography.Algorithms" version="4.0.0-beta-23225" targetFramework="net46" />
-  <package id="System.Security.Cryptography.Encoding" version="4.0.0-beta-23225" targetFramework="net46" />
-  <package id="System.Security.Cryptography.Primitives" version="4.0.0-beta-23225" targetFramework="net46" />
-  <package id="System.Security.Cryptography.X509Certificates" version="4.0.0-beta-23225" targetFramework="net46" />
-  <package id="System.Threading.Tasks" version="4.0.0" targetFramework="net46" />
 </packages>

--- a/src/MICore/LaunchOptions.cs
+++ b/src/MICore/LaunchOptions.cs
@@ -148,7 +148,18 @@ namespace MICore
         public string Hostname { get; private set; }
         public int Port { get; private set; }
         public bool Secure { get; private set; }
-        public RemoteCertificateValidationCallback ServerCertificateValidationCallback { get; set; }
+
+        /// <summary>
+        /// MIEngine definition of RemoteCertificateValidationCallback
+        /// </summary>
+        /// <param name="sender">An object that contains state information for this validation.</param>
+        /// <param name="certificate">X509Certificate object for the certificate used to authenticate the remote party.</param>
+        /// <param name="chain">X509Chain object for the chain of certificate authorities associated with the remote certificate.</param>
+        /// <param name="sslPolicyErrors">One or more errors associated with the remote certificate.</param>
+        /// <returns>true if the specified certificate is accepted</returns>
+        public delegate bool MIServerCertificateValidationCallback(object sender, object/*X509Certificate*/ certificate, object/*X509Chain*/ chain, SslPolicyErrors sslPolicyErrors);
+
+        public MIServerCertificateValidationCallback ServerCertificateValidationCallback { get; set; }
     }
 
     public sealed class EnvironmentEntry

--- a/src/MICore/PlatformUtilities.cs
+++ b/src/MICore/PlatformUtilities.cs
@@ -3,7 +3,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.Collections.Specialized;
 using System.Diagnostics;
 using System.Runtime.InteropServices;
 

--- a/src/MICore/Transports/ClientServerTransport.cs
+++ b/src/MICore/Transports/ClientServerTransport.cs
@@ -7,7 +7,6 @@ using System.Text;
 using System.Threading;
 using System.Diagnostics;
 using System.IO;
-using System.Collections.Specialized;
 using System.Collections;
 using System.Text.RegularExpressions;
 using Microsoft.DebugEngineHost;

--- a/src/MICore/Transports/LocalTransport.cs
+++ b/src/MICore/Transports/LocalTransport.cs
@@ -7,7 +7,6 @@ using System.Text;
 using System.Threading;
 using System.Diagnostics;
 using System.IO;
-using System.Collections.Specialized;
 using System.Collections;
 using System.Runtime.InteropServices;
 

--- a/src/MICore/Transports/PipeTransport.cs
+++ b/src/MICore/Transports/PipeTransport.cs
@@ -7,7 +7,6 @@ using System.Text;
 using System.Threading;
 using System.Diagnostics;
 using System.IO;
-using System.Collections.Specialized;
 using System.Collections;
 using System.Threading.Tasks;
 using System.Globalization;

--- a/src/MICore/Transports/ServerTransport.cs
+++ b/src/MICore/Transports/ServerTransport.cs
@@ -7,7 +7,6 @@ using System.Text;
 using System.Threading;
 using System.Diagnostics;
 using System.IO;
-using System.Collections.Specialized;
 using System.Collections;
 using System.Text.RegularExpressions;
 using System.Globalization;

--- a/src/MICore/Transports/TcpTransport.cs
+++ b/src/MICore/Transports/TcpTransport.cs
@@ -31,7 +31,7 @@ namespace MICore
             TcpLaunchOptions tcpOptions = (TcpLaunchOptions)options;
 
             _client = new TcpClient();
-            _client.Connect(tcpOptions.Hostname, tcpOptions.Port);
+            _client.ConnectAsync(tcpOptions.Hostname, tcpOptions.Port).Wait();
 
             if (tcpOptions.Secure)
             {
@@ -48,7 +48,7 @@ namespace MICore
                 else
                 {
                     //else use the callback specified
-                    callback = tcpOptions.ServerCertificateValidationCallback;
+                    callback = (object sender, X509Certificate certificate, X509Chain chain, SslPolicyErrors sslPolicyErrors) => tcpOptions.ServerCertificateValidationCallback(sender, certificate, chain, sslPolicyErrors);
                 }
 
                 var certStore = new X509Store(StoreName.My, StoreLocation.CurrentUser);
@@ -61,7 +61,7 @@ namespace MICore
                     null /*UserCertificateSelectionCallback */
                     );
 
-                sslStream.AuthenticateAsClient(tcpOptions.Hostname, certStore.Certificates, System.Security.Authentication.SslProtocols.Tls, false /* checkCertificateRevocation */);
+                sslStream.AuthenticateAsClientAsync(tcpOptions.Hostname, certStore.Certificates, System.Security.Authentication.SslProtocols.Tls, false /* checkCertificateRevocation */).Wait();
                 reader = new StreamReader(sslStream);
                 writer = new StreamWriter(sslStream);
             }

--- a/src/MICore/packages.config
+++ b/src/MICore/packages.config
@@ -1,12 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="Microsoft.VisualStudio.Debugger.Interop.Portable" version="1.0.1" targetFramework="net45" />
-  <package id="System.IO.FileSystem" version="4.0.0" targetFramework="net46" />
-  <package id="System.IO.FileSystem.Primitives" version="4.0.0" targetFramework="net46" />
-  <package id="System.Reflection.TypeExtensions" version="4.0.0" targetFramework="net46" />
-  <package id="System.Threading.Thread" version="4.0.0-beta-23225" targetFramework="net46" />
-  <package id="System.Diagnostics.Process" version="4.0.0-beta-23225" targetFramework="net46" />
-  <package id="System.Net.Sockets" version="4.1.0-beta-23225" targetFramework="net46" />
-  <package id="System.Runtime.InteropServices.RuntimeInformation" version="4.0.0-beta-23225" targetFramework="net46" />
   <package id="Mono.Unofficial.pdb2mdb" version="4.2.3.4" />
 </packages>

--- a/src/MICore/project.json
+++ b/src/MICore/project.json
@@ -1,25 +1,42 @@
 {
-  "supports": {
-    "net46.app": {},
-    "dnxcore50.app": {}
-  },
   "dependencies": {
-    "MicroBuild.Core": "0.2.0",
-    "Microsoft.NETCore": "5.0.0",
-    "Microsoft.NETCore.Portable.Compatibility": "1.0.0",
-    "System.Diagnostics.Process": "4.0.0-beta-23225",
-    "System.Net.Security": "4.0.0-beta-23225",
-    "System.Net.Sockets": "4.1.0-beta-23225",
-    "System.Reflection.TypeExtensions": "4.0.0",
-    "System.Security.Cryptography.X509Certificates": "4.0.0-beta-23225",
-    "System.Threading.Thread": "4.0.0-beta-23225",
-    "System.Xml.XmlSerializer": "4.0.11-beta-23225",
-    "System.Runtime.InteropServices.RuntimeInformation": "4.0.0-beta-23225",
-    "System.IO.FileSystem.Watcher": "4.0.0-beta-23225"
+    "Microsoft.VisualStudio.Debugger.Interop.Portable": "1.0.1",
+
+    // .NET Core 1.0 RTM packages
+    "System.Collections": "4.0.11",
+    "System.Diagnostics.Debug": "4.0.11",
+    "System.Diagnostics.Process": "4.1.0",
+    "System.Diagnostics.Tools": "4.0.1",
+    "System.Globalization": "4.0.11",
+    "System.IO": "4.1.0",
+    "System.IO.FileSystem": "4.0.1",
+    "System.IO.FileSystem.Primitives": "4.0.1",
+    "System.Linq": "4.1.0",
+    "System.Net.Http": "4.1.0",
+    "System.Net.Primitives": "4.0.11",
+    "System.Net.Security": "4.0.0",
+    "System.Net.Sockets": "4.1.0",
+    "System.Reflection": "4.1.0",
+    "System.Reflection.TypeExtensions": "4.1.0",
+    "System.Resources.ResourceManager": "4.0.1",
+    "System.Runtime": "4.1.0",
+    "System.Runtime.Extensions": "4.1.0",
+    "System.Runtime.InteropServices": "4.1.0",
+    "System.Runtime.InteropServices.RuntimeInformation": "4.0.0",
+    "System.Security.Cryptography.X509Certificates": "4.1.0",
+    "System.Text.Encoding": "4.0.11",
+    "System.Text.Encoding.Extensions": "4.0.11",
+    "System.Text.RegularExpressions": "4.1.0",
+    "System.Threading": "4.0.11",
+    "System.Threading.Tasks": "4.0.11",
+    "System.Threading.Thread": "4.0.0",
+    "System.Threading.Timer": "4.0.1",
+    "System.Xml.ReaderWriter": "4.0.11",
+    "System.Xml.XmlSerializer": "4.0.11"
   },
   "frameworks": {
-    "dotnet": {
-      "imports": "portable-net452"
+    "netstandard1.3": {
+      "imports": "portable-net45+net46+dnxcore50"
     }
   }
 }

--- a/src/MIDebugEngine/Engine.Impl/DebuggedProcess.cs
+++ b/src/MIDebugEngine/Engine.Impl/DebuggedProcess.cs
@@ -709,15 +709,6 @@ namespace Microsoft.MIDebugEngine
                     // Send client version to clrdbg to set the capabilities appropriately
                     if (this.MICommandFactory.Mode == MIMode.Clrdbg)
                     {
-                        string version = string.Empty;
-                        var attribute = this.GetType().GetTypeInfo().Assembly.GetCustomAttribute(typeof(System.Reflection.AssemblyFileVersionAttribute)) as AssemblyFileVersionAttribute;
-
-                        if (attribute != null)
-                        {
-                            version = attribute.Version;
-                        }
-
-                        commands.Add(new LaunchCommand("-gdb-set client-version \"" + version + "\""));
                         commands.Add(new LaunchCommand("-gdb-set client-ui \"" + Host.GetHostUIIdentifier().ToString() + "\""));
                     }
 

--- a/src/MIDebugEngine/Engine.Impl/ExceptionManager.cs
+++ b/src/MIDebugEngine/Engine.Impl/ExceptionManager.cs
@@ -11,7 +11,6 @@ using Microsoft.VisualStudio.Debugger.Interop;
 using System.Diagnostics;
 using System.Globalization;
 using System.Collections.ObjectModel;
-using System.Collections.Concurrent;
 using System.Threading;
 using Microsoft.DebugEngineHost;
 

--- a/src/MIDebugEngine/project.json
+++ b/src/MIDebugEngine/project.json
@@ -1,17 +1,42 @@
 ﻿{
-  "supports": {
-    "net46.app": {},
-    "dnxcore50.app": {}
-  },
   "dependencies": {
-    "MicroBuild.Core": "0.2.0",
-    "Microsoft.NETCore": "5.0.0",
-    "Microsoft.NETCore.Portable.Compatibility": "1.0.0",
-    "Microsoft.VisualStudio.Debugger.Interop.Portable": "1.0.1"
+    "Microsoft.VisualStudio.Debugger.Interop.Portable": "1.0.1",
+
+    // .NET Core 1.0 RTM packages
+    "System.Collections": "4.0.11",
+    "System.Diagnostics.Debug": "4.0.11",
+    "System.Diagnostics.Process": "4.1.0",
+    "System.Diagnostics.Tools": "4.0.1",
+    "System.Globalization": "4.0.11",
+    "System.IO": "4.1.0",
+    "System.IO.FileSystem": "4.0.1",
+    "System.IO.FileSystem.Primitives": "4.0.1",
+    "System.Linq": "4.1.0",
+    "System.ObjectModel": "4.0.12",
+    "System.Net.Primitives": "4.0.11",
+    "System.Net.Security": "4.0.0",
+    "System.Net.Sockets": "4.1.0",
+    "System.Reflection": "4.1.0",
+    "System.Reflection.TypeExtensions": "4.1.0",
+    "System.Resources.ResourceManager": "4.0.1",
+    "System.Runtime": "4.1.0",
+    "System.Runtime.Extensions": "4.1.0",
+    "System.Runtime.InteropServices": "4.1.0",
+    "System.Runtime.InteropServices.RuntimeInformation": "4.0.0",
+    "System.Security.Cryptography.X509Certificates": "4.1.0",
+    "System.Text.Encoding": "4.0.11",
+    "System.Text.Encoding.Extensions": "4.0.11",
+    "System.Text.RegularExpressions": "4.1.0",
+    "System.Threading": "4.0.11",
+    "System.Threading.Tasks": "4.0.11",
+    "System.Threading.Thread": "4.0.0",
+    "System.Threading.Timer": "4.0.1",
+    "System.Xml.ReaderWriter": "4.0.11",
+    "System.Xml.XmlSerializer": "4.0.11"
   },
   "frameworks": {
-    "dotnet": {
-      "imports": "portable-net452"
+    "netstandard1.3": {
+      "imports": "portable-net45+net46+dnxcore50"
     }
   }
 }

--- a/src/Microsoft.VisualStudio.Debugger.Interop.UnixPortSupplier/project.json
+++ b/src/Microsoft.VisualStudio.Debugger.Interop.UnixPortSupplier/project.json
@@ -1,16 +1,20 @@
 ﻿{
-  "supports": {
-    "net46.app": {},
-    "dnxcore50.app": {}
-  },
   "dependencies": {
-    "Microsoft.NETCore": "5.0.0",
-    "Microsoft.NETCore.Portable.Compatibility": "1.0.0",
-    "Microsoft.VisualStudio.Debugger.Interop.Portable": "1.0.1"
+    "Microsoft.VisualStudio.Debugger.Interop.Portable": "1.0.1",
+
+    // .NET Core 1.0 RTM packages
+    "System.Collections": "4.0.11",
+    "System.Diagnostics.Debug": "4.0.11",
+    "System.Diagnostics.Tools": "4.0.1",
+    "System.Resources.ResourceManager": "4.0.1",
+    "System.Runtime": "4.1.0",
+    "System.Runtime.Extensions": "4.1.0",
+    "System.Runtime.InteropServices": "4.1.0",
+    "System.Threading.Tasks": "4.0.11"
   },
   "frameworks": {
-    "dotnet": {
-      "imports": "portable-net452"
+    "netstandard1.3": {
+      "imports": "portable-net45+net46+dnxcore50"
     }
   }
 }

--- a/src/RequiredNetFX46FacadeAssemblies.targets
+++ b/src/RequiredNetFX46FacadeAssemblies.targets
@@ -1,23 +1,17 @@
 <Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   
-  <PropertyGroup>
-    <!-- Dependencies from project.json go in folders like "Dependency\Version", but package.json uses "Dependency.Version" -->
-    <VersionSeparator Condition="'$(IsCoreClr)' == 'true'">\</VersionSeparator>
-    <VersionSeparator Condition="'$(IsCoreClr)' == 'false'">.</VersionSeparator>
-  </PropertyGroup>
-  
   <!--This is a list of additional facade assemblies which didn't ship with .NET 4.6, and we use, and therefore need
   to be included in our setup in some way.
   -->
-  <ItemGroup>
-    <RequiredNetFX46FacadeAssemblies Include="$(NuGetPackagesDirectory)\System.IO.FileSystem$(VersionSeparator)4.0.0\lib\net46\System.IO.FileSystem.dll"/>
-    <RequiredNetFX46FacadeAssemblies Include="$(NuGetPackagesDirectory)\System.IO.FileSystem.Primitives$(VersionSeparator)4.0.0\lib\net46\System.IO.FileSystem.Primitives.dll"/>
-    <RequiredNetFX46FacadeAssemblies Include="$(NuGetPackagesDirectory)\System.Reflection.TypeExtensions$(VersionSeparator)4.0.0\lib\net46\System.Reflection.TypeExtensions.dll"/>
-    <RequiredNetFX46FacadeAssemblies Include="$(NuGetPackagesDirectory)\System.Threading.Thread$(VersionSeparator)4.0.0-beta-23225\lib\net46\System.Threading.Thread.dll"/>
-    <RequiredNetFX46FacadeAssemblies Include="$(NuGetPackagesDirectory)\System.Diagnostics.Process$(VersionSeparator)4.0.0-beta-23225\ref\net46\System.Diagnostics.Process.dll"/>
-    <RequiredNetFX46FacadeAssemblies Include="$(NuGetPackagesDirectory)\System.Net.Security$(VersionSeparator)4.0.0-beta-23225\lib\net46\System.Net.Security.dll"/>
-    <RequiredNetFX46FacadeAssemblies Include="$(NuGetPackagesDirectory)\System.Net.Sockets$(VersionSeparator)4.1.0-beta-23225\lib\net46\System.Net.Sockets.dll"/>
-    <RequiredNetFX46FacadeAssemblies Include="$(NuGetPackagesDirectory)\System.Security.Cryptography.X509Certificates$(VersionSeparator)4.0.0-beta-23225\lib\net46\System.Security.Cryptography.X509Certificates.dll"/>
-    <RequiredNetFX46FacadeAssemblies Include="$(NuGetPackagesDirectory)\System.Runtime.InteropServices.RuntimeInformation$(VersionSeparator)4.0.0-beta-23225\lib\dotnet\System.Runtime.InteropServices.RuntimeInformation.dll"/>
+  <ItemGroup Condition="'$(IsCoreClr)' == 'true'">
+    <RequiredNetFX46FacadeAssemblies Include="$(NuGetPackagesDirectory)\System.IO.FileSystem\4.0.1\lib\net46\System.IO.FileSystem.dll"/>
+    <RequiredNetFX46FacadeAssemblies Include="$(NuGetPackagesDirectory)\System.IO.FileSystem.Primitives\4.0.1\lib\net46\System.IO.FileSystem.Primitives.dll"/>
+    <RequiredNetFX46FacadeAssemblies Include="$(NuGetPackagesDirectory)\System.Reflection.TypeExtensions\4.1.0\lib\net46\System.Reflection.TypeExtensions.dll"/>
+    <RequiredNetFX46FacadeAssemblies Include="$(NuGetPackagesDirectory)\System.Threading.Thread\4.0.0\lib\net46\System.Threading.Thread.dll"/>
+    <RequiredNetFX46FacadeAssemblies Include="$(NuGetPackagesDirectory)\System.Diagnostics.Process\4.1.0\ref\net46\System.Diagnostics.Process.dll"/>
+    <RequiredNetFX46FacadeAssemblies Include="$(NuGetPackagesDirectory)\System.Net.Security\4.0.0\lib\net46\System.Net.Security.dll"/>
+    <RequiredNetFX46FacadeAssemblies Include="$(NuGetPackagesDirectory)\System.Net.Sockets\4.1.0\lib\net46\System.Net.Sockets.dll"/>
+    <RequiredNetFX46FacadeAssemblies Include="$(NuGetPackagesDirectory)\System.Security.Cryptography.X509Certificates\4.1.0\lib\net46\System.Security.Cryptography.X509Certificates.dll"/>
+    <RequiredNetFX46FacadeAssemblies Include="$(NuGetPackagesDirectory)\System.Runtime.InteropServices.RuntimeInformation\4.0.0\lib\net45\System.Runtime.InteropServices.RuntimeInformation.dll"/>
   </ItemGroup>
 </Project>


### PR DESCRIPTION
The MIEngine was still compiling against incredibly ancient packages. This switches it over to something recent - the packages that came out at the same time as .NET Core 1.0 RTW.

The primary IL level difference of this change is to increment the reference assembly version of the following in the non-'Desktop' configurations.

    System.Xml.XmlSerializer
    System.IO.FileSystem
    System.Net.Http
    System.IO.FileSystem.Primitives

**Additional changes**:
* Fixes the 'Desktop' configurations to stop dropping a bunch of facade assemblies that shouldn't really be needed.
* Stops having the IOS launcher need to partially depend on facade assemblies. To do this I added an MIEngine definition of RemoteCertificateValidationCallback.

**Testing**: Verified Android debugging in VS 2015 and VS 2017. Both F5'ing the debug configuration in the experimental instance and installing the lab configuration over top our shipping bits.