### PR TITLE
Fix install.cmd for VS 2017

### DIFF
--- a/src/MIDebugPackage/MIDebugPackage.csproj
+++ b/src/MIDebugPackage/MIDebugPackage.csproj
@@ -248,6 +248,10 @@
       <Name>IOSDebugLauncher</Name>
       <IncludeOutputGroupsInVSIX>BuiltProjectOutputGroup;BuiltProjectOutputGroupDependencies;GetCopyToOutputDirectoryItems;SatelliteDllsProjectOutputGroup;</IncludeOutputGroupsInVSIX>
     </ProjectReference>
+    <ProjectReference Include="..\JDbg\JDbg.csproj">
+      <Project>{78728205-db3e-4b7b-a7d2-5cbe38e9c607}</Project>
+      <Name>JDbg</Name>
+    </ProjectReference>
     <ProjectReference Include="..\MICore\MICore.csproj">
       <Project>{54c33afa-438d-4932-a2f0-d0f2bb2fadc9}</Project>
       <Name>MICore</Name>


### PR DESCRIPTION
In testing my last change I discovered that Install.cmd was still hard coded to only install to VS 2015, and it wasn't quite right for VS 2017 anyway. This fixes it to work with either.

I also had trouble F5'ing into the experimental instance in 2017, so this tweaks our project to make this work.