### PR TITLE
Fix newtonsoft.json version and hintpath

### DIFF
--- a/src/MICore/MICore.csproj
+++ b/src/MICore/MICore.csproj
@@ -109,7 +109,7 @@
       <HintPath>$(NuGetPackagesDirectory)/Microsoft.VisualStudio.Debugger.Interop.Portable.1.0.1/lib/portable-net45+net46+dnxcore50/Microsoft.VisualStudio.Debugger.InteropA.dll</HintPath>
     </Reference>
     <Reference Include="Newtonsoft.Json, Version=6.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
-      <HintPath>$(NuGetPackagesDirectory)/Newtonsoft.Json/6.0.8/lib/portable-net45+wp80+win8+wpa81+aspnetcore50/Newtonsoft.Json.dll</HintPath>
+      <HintPath>$(NuGetPackagesDirectory)/Newtonsoft.Json.6.0.8/lib/portable-net45+wp80+win8+wpa81+aspnetcore50/Newtonsoft.Json.dll</HintPath>
     </Reference>
   </ItemGroup>
   <ItemGroup>

--- a/src/MICore/packages.config
+++ b/src/MICore/packages.config
@@ -2,5 +2,5 @@
 <packages>
   <package id="Microsoft.VisualStudio.Debugger.Interop.Portable" version="1.0.1" targetFramework="net45" />
   <package id="Mono.Unofficial.pdb2mdb" version="4.2.3.4" />
-  <package id="Newtonsoft.Json" version="6.0.4" targetFramework="net45" />
+  <package id="Newtonsoft.Json" version="6.0.8" targetFramework="net45" />
 </packages>


### PR DESCRIPTION
Updated newtonsoft.json in packages.config to the wrong version.
Updated version and corrected Hint path.