### PR TITLE
Addresses two shutdown-related crashes in MICore

### DIFF
--- a/src/MICore/Debugger.cs
+++ b/src/MICore/Debugger.cs
@@ -390,7 +390,7 @@ namespace MICore
             {
                 if (this.IsClosed)
                 {
-                    source.SetException(new DebuggerDisposedException(_closeMessage));
+                    source.TrySetException(new DebuggerDisposedException(_closeMessage));
                 }
                 else
                 {
@@ -402,11 +402,11 @@ namespace MICore
 
                     if (firstException != null)
                     {
-                        source.SetException(firstException);
+                        source.TrySetException(firstException);
                     }
                     else
                     {
-                        source.SetResult(null);
+                        source.TrySetResult(null);
                     }
                 }
             }

--- a/src/MICore/Transports/StreamTransport.cs
+++ b/src/MICore/Transports/StreamTransport.cs
@@ -111,6 +111,7 @@ namespace MICore
                     try
                     {
                         _writer.Dispose();
+                        _writer = null;
                     }
                     catch
                     {
@@ -143,8 +144,11 @@ namespace MICore
         {
             Logger?.WriteLine("<-" + cmd);
             Logger?.Flush();
-            _writer.WriteLine(cmd);
-            _writer.Flush();
+            lock (_locker)
+            {
+                _writer?.WriteLine(cmd);
+                _writer?.Flush();
+            }
         }
 
         private string GetLine()


### PR DESCRIPTION
VS Bug 275468 ([Feedback] GDB remote debugging reliability problems) complains of many crashes. The two stacks that seem to be MIEngine related are below. Both seem to be related to multithreading issues when closing the debugger.

.Net Runtime Event Log entries:
EventTime:9/26/2016 3:52:41 PM
Application: devenv.exe
Framework Version: v4.0.30319
Description: The process was terminated due to an unhandled exception.
Exception Info: System.NullReferenceException
at System.IO.StreamWriter.Flush(Boolean, Boolean)
at System.IO.StreamWriter.Write(Char[], Int32, Int32)
at System.IO.TextWriter.WriteLine(System.String)
at MICore.StreamTransport.Echo(System.String)
at MICore.StreamTransport.Send(System.String)
at MICore.Debugger+d__174.MoveNext()
at System.Runtime.CompilerServices.AsyncMethodBuilderCore+<>c.b__6_1(System.Object)
at System.Threading.QueueUserWorkItemCallback.WaitCallback_Context(System.Object)
at System.Threading.ExecutionContext.RunInternal(System.Threading.ExecutionContext, System.Threading.ContextCallback, System.Object, Boolean)
at System.Threading.ExecutionContext.Run(System.Threading.ExecutionContext, System.Threading.ContextCallback, System.Object, Boolean)
at System.Threading.QueueUserWorkItemCallback.System.Threading.IThreadPoolWorkItem.ExecuteWorkItem()
at System.Threading.ThreadPoolWorkQueue.Dispatch()
at System.Threading._ThreadPoolWaitCallback.PerformWaitCallback()

EventTime:8/22/2016 2:38:37 PM
Application: devenv.exe
Framework Version: v4.0.30319
Description: The process was terminated due to an unhandled exception.
Exception Info: System.InvalidOperationException
at System.Threading.Tasks.TaskCompletionSource`1[[System.__Canon, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089]].SetException(System.Exception)
at MICore.Debugger+d__121.MoveNext()
at System.Runtime.CompilerServices.TaskAwaiter.ThrowForNonSuccess(System.Threading.Tasks.Task)
at System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification(System.Threading.Tasks.Task)
at MICore.Debugger+d__118.MoveNext()
at System.Runtime.CompilerServices.AsyncMethodBuilderCore+<>c.b__6_1(System.Object)
at System.Threading.QueueUserWorkItemCallback.WaitCallback_Context(System.Object)
at System.Threading.ExecutionContext.RunInternal(System.Threading.ExecutionContext, System.Threading.ContextCallback, System.Object, Boolean)
at System.Threading.ExecutionContext.Run(System.Threading.ExecutionContext, System.Threading.ContextCallback, System.Object, Boolean)
at System.Threading.QueueUserWorkItemCallback.System.Threading.IThreadPoolWorkItem.ExecuteWorkItem()
at System.Threading.ThreadPoolWorkQueue.Dispatch()
at System.Threading._ThreadPoolWaitCallback.PerformWaitCallback()

