### PR TITLE
Dev/paulmay/disassembly fix

### DIFF
--- a/src/MIDebugEngine/AD7.Impl/AD7Disassembly.cs
+++ b/src/MIDebugEngine/AD7.Impl/AD7Disassembly.cs
@@ -63,6 +63,35 @@ namespace Microsoft.MIDebugEngine
             return Constants.S_OK;
         }
 
+        private DisassemblyData FetchBadInstruction(enum_DISASSEMBLY_STREAM_FIELDS dwFields)
+        {
+            DisassemblyData dis = new DisassemblyData();
+            if ((dwFields & enum_DISASSEMBLY_STREAM_FIELDS.DSF_ADDRESS) != 0)
+            {
+                dis.dwFields |= enum_DISASSEMBLY_STREAM_FIELDS.DSF_ADDRESS;
+                dis.bstrAddress = EngineUtils.AsAddr(_addr, _engine.DebuggedProcess.Is64BitArch);
+            }
+
+            if ((dwFields & enum_DISASSEMBLY_STREAM_FIELDS.DSF_CODELOCATIONID) != 0)
+            {
+                dis.dwFields |= enum_DISASSEMBLY_STREAM_FIELDS.DSF_CODELOCATIONID;
+                dis.uCodeLocationId = _addr;
+            }
+
+            if ((dwFields & enum_DISASSEMBLY_STREAM_FIELDS.DSF_SYMBOL) != 0)
+            {
+                dis.dwFields |= enum_DISASSEMBLY_STREAM_FIELDS.DSF_SYMBOL;
+                dis.bstrSymbol = string.Empty;
+            }
+
+            if ((dwFields & enum_DISASSEMBLY_STREAM_FIELDS.DSF_OPCODE) != 0)
+            {
+                dis.dwFields |= enum_DISASSEMBLY_STREAM_FIELDS.DSF_OPCODE;
+                dis.bstrOpcode = "??";
+            }
+            return dis;
+        }
+
         public int Read(uint dwInstructions, enum_DISASSEMBLY_STREAM_FIELDS dwFields, out uint pdwInstructionsRead, DisassemblyData[] prgDisassembly)
         {
             uint iOp = 0;
@@ -72,51 +101,108 @@ namespace Microsoft.MIDebugEngine
             {
                 instructions = await _engine.DebuggedProcess.Disassembly.FetchInstructions(_addr, (int)dwInstructions);
             });
-
-            if (instructions != null)
+            if (instructions == null || (instructions.First().Addr - _addr > dwInstructions))
             {
-                foreach (DisasmInstruction instruction in instructions)
+                // bad address range, return '??'
+                for (iOp = 0; iOp < dwInstructions; _addr++, ++iOp)
                 {
-                    if (iOp >= dwInstructions)
-                    {
-                        break;
-                    }
-                    _addr = instruction.Addr;
-
-                    if ((dwFields & enum_DISASSEMBLY_STREAM_FIELDS.DSF_ADDRESS) != 0)
-                    {
-                        prgDisassembly[iOp].dwFields |= enum_DISASSEMBLY_STREAM_FIELDS.DSF_ADDRESS;
-                        prgDisassembly[iOp].bstrAddress = instruction.AddressString;
-                    }
-
-                    if ((dwFields & enum_DISASSEMBLY_STREAM_FIELDS.DSF_CODELOCATIONID) != 0)
-                    {
-                        prgDisassembly[iOp].dwFields |= enum_DISASSEMBLY_STREAM_FIELDS.DSF_CODELOCATIONID;
-                        prgDisassembly[iOp].uCodeLocationId = instruction.Addr;
-                    }
-
-                    if ((dwFields & enum_DISASSEMBLY_STREAM_FIELDS.DSF_SYMBOL) != 0)
-                    {
-                        if (instruction.Offset == 0)
-                        {
-                            prgDisassembly[iOp].dwFields |= enum_DISASSEMBLY_STREAM_FIELDS.DSF_SYMBOL;
-                            prgDisassembly[iOp].bstrSymbol = instruction.Symbol ?? string.Empty;
-                        }
-                    }
-
-                    if ((dwFields & enum_DISASSEMBLY_STREAM_FIELDS.DSF_OPCODE) != 0)
-                    {
-                        prgDisassembly[iOp].dwFields |= enum_DISASSEMBLY_STREAM_FIELDS.DSF_OPCODE;
-                        prgDisassembly[iOp].bstrOpcode = instruction.Opcode;
-                    }
-
-                    iOp++;
-                };
+                    prgDisassembly[iOp] = FetchBadInstruction(dwFields);
+                }
+                pdwInstructionsRead = iOp;
+                return Constants.S_OK;
             }
 
+            // return '??' for bad addresses at start of range
+            for (iOp = 0; _addr < instructions.First().Addr; _addr++, iOp++)
+            {
+                prgDisassembly[iOp] = FetchBadInstruction(dwFields);
+            }
+            foreach (DisasmInstruction instruction in instructions)
+            {
+                if (iOp >= dwInstructions)
+                {
+                    break;
+                }
+                _addr = instruction.Addr;
+
+                if ((dwFields & enum_DISASSEMBLY_STREAM_FIELDS.DSF_ADDRESS) != 0)
+                {
+                    prgDisassembly[iOp].dwFields |= enum_DISASSEMBLY_STREAM_FIELDS.DSF_ADDRESS;
+                    prgDisassembly[iOp].bstrAddress = instruction.AddressString;
+                }
+
+                if ((dwFields & enum_DISASSEMBLY_STREAM_FIELDS.DSF_CODELOCATIONID) != 0)
+                {
+                    prgDisassembly[iOp].dwFields |= enum_DISASSEMBLY_STREAM_FIELDS.DSF_CODELOCATIONID;
+                    prgDisassembly[iOp].uCodeLocationId = instruction.Addr;
+                }
+
+                if ((dwFields & enum_DISASSEMBLY_STREAM_FIELDS.DSF_SYMBOL) != 0)
+                {
+                    if (instruction.Offset == 0)
+                    {
+                        prgDisassembly[iOp].dwFields |= enum_DISASSEMBLY_STREAM_FIELDS.DSF_SYMBOL;
+                        prgDisassembly[iOp].bstrSymbol = instruction.Symbol ?? string.Empty;
+                    }
+                }
+
+                if ((dwFields & enum_DISASSEMBLY_STREAM_FIELDS.DSF_OPCODE) != 0)
+                {
+                    prgDisassembly[iOp].dwFields |= enum_DISASSEMBLY_STREAM_FIELDS.DSF_OPCODE;
+                    prgDisassembly[iOp].bstrOpcode = instruction.Opcode;
+                }
+
+                iOp++;
+            };
+
+            if (iOp < dwInstructions)
+            {
+                // Didn't get enough instructions. Must have run out of valid memory address range.
+                Tuple<ulong, ulong> range = new Tuple<ulong, ulong>(0,0);
+                _engine.DebuggedProcess.WorkerThread.RunOperation(async () =>
+                {
+                    range = await _engine.DebuggedProcess.FindValidMemoryRange(_addr, 10, 0);
+                });
+                // return '??' for bad addresses at end of range
+                for (_addr = range.Item2; iOp < dwInstructions; _addr++, iOp++)
+                {
+                    prgDisassembly[iOp] = FetchBadInstruction(dwFields);
+                }
+            }
             pdwInstructionsRead = iOp;
 
             return pdwInstructionsRead != 0 ? Constants.S_OK : Constants.S_FALSE;
+        }
+
+        private int SeekForward(long iInstructions)
+        {
+            ICollection<DisasmInstruction> instructions = null;
+            _engine.DebuggedProcess.WorkerThread.RunOperation(async () =>
+            {
+                instructions = await _engine.DebuggedProcess.Disassembly.FetchInstructions(_addr, (int)iInstructions+1);
+            });
+            if (instructions == null)
+            {
+                // bad address range, no instructions. 
+                _addr = (ulong)((long)_addr + iInstructions);  // forward iInstructions bytes
+                return Constants.S_OK;
+            }
+            _addr = instructions.Last().Addr;
+            if (instructions.Count < iInstructions)
+            {
+                // not enough instructions were fetched; forward one byte for each missing instruction
+                _addr += (ulong)(iInstructions - instructions.Count);   // TODO: length of last instruction is unknown and not accounted for
+            }
+            return Constants.S_OK;
+        }
+
+        private int SeekBack(long iInstructions)
+        {
+            _engine.DebuggedProcess.WorkerThread.RunOperation(async () =>
+            {
+                _addr = await _engine.DebuggedProcess.Disassembly.SeekBack(_addr, (int)iInstructions);
+            });
+            return Constants.S_OK;
         }
 
         public int Seek(enum_SEEK_START dwSeekStart, IDebugCodeContext2 pCodeContext, ulong uCodeLocationId, long iInstructions)
@@ -131,28 +217,15 @@ namespace Microsoft.MIDebugEngine
                 _addr = uCodeLocationId;
             }
 
-            if (iInstructions != 0)
+            if (iInstructions >= 0)
             {
-                IEnumerable<DisasmInstruction> instructions = null;
-                // When failing to read all instructions try looking for smaller and smaller numbers of instructions
-                // so that fetching disassembly works near the start and end of valid address spaces
-                while (instructions == null && (iInstructions > 1 || -iInstructions > 1)) 
-                {
-                    _engine.DebuggedProcess.WorkerThread.RunOperation(async () =>
-                    {
-                        instructions = await _engine.DebuggedProcess.Disassembly.FetchInstructions(_addr, (int)iInstructions);
-                    });
-                    iInstructions = iInstructions/2;
-                }
-                if (instructions == null)
-                {
-                    return Constants.E_FAIL;
-                }
-                _addr = instructions.ElementAt(0).Addr;
+                return SeekForward(iInstructions);
             }
-            return Constants.S_OK;
+            else
+            {
+                return SeekBack(-iInstructions);
+            }
         }
-
         #endregion
     }
 }

--- a/src/MIDebugEngine/Engine.Impl/Disassembly.cs
+++ b/src/MIDebugEngine/Engine.Impl/Disassembly.cs
@@ -54,7 +54,7 @@ namespace Microsoft.MIDebugEngine
             return 0 <= i && i <= _instructions.Length;
         }
 
-        public bool TryFetch(ulong addr, int cnt, out IEnumerable<DisasmInstruction> instructions)
+        public bool TryFetch(ulong addr, int cnt, out ICollection<DisasmInstruction> instructions)
         {
             instructions = null;
             if (!Contains(addr, cnt))
@@ -66,6 +66,19 @@ namespace Microsoft.MIDebugEngine
                 cnt = -cnt;
             }
             instructions = new ArraySegment<DisasmInstruction>(_instructions, i, cnt);
+            return true;
+        }
+
+        public bool TryFetch(ulong startAddr, ulong endAddr, out ICollection<DisasmInstruction> instructions)
+        {
+            instructions = null;
+            if (!Contains(startAddr, 1))
+                return false;
+            if (!Contains(endAddr, 1))
+                return false;
+            int i = FindIndex(startAddr);
+            int j = FindIndex(endAddr);
+            instructions = new ArraySegment<DisasmInstruction>(_instructions, i, j-i);
             return true;
         }
 
@@ -100,46 +113,10 @@ namespace Microsoft.MIDebugEngine
             _disassemlyCache = new SortedList<ulong, DisassemblyBlock>();
         }
 
-        // 
-        /// <summary>
-        /// Fetch disassembly for a range of instructions. May return more instructions than asked for.
-        /// </summary>
-        /// <param name="address">Beginning address of an instruction to use as a starting point for disassembly.</param>
-        /// <param name="nInstructions">Number of instructions to disassemble. Negative values indicate disassembly backwards from "address".</param>
-        /// <returns></returns>
-        public async Task<IEnumerable<DisasmInstruction>> FetchInstructions(ulong address, int nInstructions)
+        private ICollection<DisasmInstruction> UpdateCache(ulong address, int nInstructions, DisasmInstruction[] instructions)
         {
-            IEnumerable<DisasmInstruction> ret = null;
-
-            lock (_disassemlyCache)
-            {
-                // check the cache
-                var kv = _disassemlyCache.FirstOrDefault((p) => p.Value.TryFetch(address, nInstructions, out ret));
-                if (kv.Value != null)
-                    return ret;
-            }
-
-            ulong endAddress;
-            ulong startAddress;
-            if (nInstructions >= 0)
-            {
-                startAddress = address;
-                endAddress = startAddress + (ulong)(_process.MaxInstructionSize * nInstructions);
-            }
-            else
-            {
-                endAddress = address;
-                startAddress = endAddress - (uint)(_process.MaxInstructionSize * -nInstructions);
-                endAddress++;   // make sure to fetch an instruction covering the original start address
-            }
-            DisasmInstruction[] instructions = await Disassemble(_process, startAddress, endAddress);
-
-            if (instructions != null && instructions.Length > 0 && nInstructions < 0)
-            {
-                instructions = await VerifyDisassembly(instructions, startAddress, address);
-            }
-
-            if (instructions != null && instructions.Length > 0)
+            ICollection<DisasmInstruction> ret = null;
+            if (instructions.Length > 0)
             {
                 DisassemblyBlock block = new DisassemblyBlock(instructions);
                 lock (_disassemlyCache)
@@ -166,8 +143,121 @@ namespace Microsoft.MIDebugEngine
                 }
                 var kv = block.TryFetch(address, nInstructions, out ret);
             }
-
             return ret;
+        }
+
+        /// <summary>
+        /// Seek backward n instructions from a target address
+        /// </summary>
+        /// <param name="address">target address</param>
+        /// <param name="nInstructions">number of instructions</param>
+        /// <returns> address - n on failure, else the address of an instruction n back from the target address</returns>
+        public async Task<ulong> SeekBack(ulong address, int nInstructions)
+        {
+            ICollection<DisasmInstruction> ret = null;
+            ulong defaultAddr = address >= (ulong)nInstructions ? address - (ulong)nInstructions : 0;
+
+            lock (_disassemlyCache)
+            {
+                // check the cache
+                var kv = _disassemlyCache.FirstOrDefault((p) => p.Value.TryFetch(address, -nInstructions, out ret));
+                if (kv.Value != null)
+                    return ret.First().Addr;
+            }
+            ulong endAddress;
+            ulong startAddress;
+            var range = await _process.FindValidMemoryRange(address, (uint)(_process.MaxInstructionSize * nInstructions)+1, (int)(_process.MaxInstructionSize * -nInstructions));
+            startAddress = range.Item1;
+            endAddress = range.Item2;
+            if (endAddress - startAddress == 0) // bad address range, no instructions
+            {
+                return defaultAddr;
+            }
+            lock (_disassemlyCache)
+            {
+                // check the cache with the adjusted range
+                var kv = _disassemlyCache.FirstOrDefault((p) => p.Value.TryFetch(startAddress, address < endAddress ? address : endAddress, out ret));
+            }
+            if (ret == null)
+            {
+                DisasmInstruction[] instructions = await Disassemble(_process, startAddress, endAddress);
+                if (instructions == null)
+                {
+                    return defaultAddr;    // unknown error condition
+                }
+
+                // when seeking back require that the disassembly contain an instruction at the target address (x86 has varying length instructions) 
+                if (instructions.Length > 0 && address < endAddress)
+                {
+                    instructions = await VerifyDisassembly(instructions, startAddress, address);
+                }
+                ret = UpdateCache(address, -nInstructions, instructions);
+                if (ret == null)
+                {
+                    return defaultAddr;
+                }
+            }
+
+            int nLess = ret.Count((i) => i.Addr < address);
+            if (nLess < nInstructions)
+            {
+                // not enough instructions were fetched; back up one byte for each missing instruction
+                return ret.First().Addr < (ulong)(nInstructions - nLess) ? 0 : (ulong)((long)ret.First().Addr - (nInstructions - nLess));
+            }
+            else
+            {
+                return ret.First().Addr;
+            }
+        }
+
+        // 
+        /// <summary>
+        /// Fetch disassembly for a range of instructions. 
+        /// </summary>
+        /// <param name="address">Beginning address of an instruction to use as a starting point for disassembly.</param>
+        /// <param name="nInstructions">Number of instructions to disassemble.</param>
+        /// <returns></returns>
+        public async Task<ICollection<DisasmInstruction>> FetchInstructions(ulong address, int nInstructions)
+        {
+            ICollection<DisasmInstruction> ret = null;
+
+            lock (_disassemlyCache)
+            {
+                // check the cache
+                var kv = _disassemlyCache.FirstOrDefault((p) => p.Value.TryFetch(address, nInstructions, out ret));
+                if (kv.Value != null)
+                    return ret;
+            }
+
+            ulong endAddress;
+            ulong startAddress;
+            var range = await _process.FindValidMemoryRange(address, (uint)(_process.MaxInstructionSize * nInstructions), 0);
+            startAddress = range.Item1;
+            endAddress = range.Item2;
+            int gap = (int)(startAddress - address);   // num of bytes before instructions begin
+            if (endAddress > startAddress && nInstructions > gap)
+            {
+                nInstructions -= gap;
+            }
+            else
+            {
+                nInstructions = 0;
+            }
+            if (endAddress - startAddress == 0 || nInstructions == 0)
+            {
+                return null;
+            }
+            lock (_disassemlyCache)
+            {
+                // re-check the cache with the verified memory range
+                var kv = _disassemlyCache.FirstOrDefault((p) => p.Value.TryFetch(startAddress, nInstructions, out ret));
+                if (kv.Value != null)
+                    return ret;
+            }
+
+            DisasmInstruction[] instructions = await Disassemble(_process, startAddress, endAddress);
+
+            return UpdateCache(address, nInstructions, instructions);
         }
 
         private async Task<DisasmInstruction[]> VerifyDisassembly(DisasmInstruction[] instructions, ulong startAddress, ulong targetAddress)


### PR DESCRIPTION
Disassembly behaved oddly when scrolling backwards and when encountering unmapped memory ranges.
Now return '??' for out-of-range memory. Enable scrolling forwards and backwards consistently.
