### PR TITLE
Updated Json parsing with custom enum converter

### DIFF
--- a/src/MICore/JsonLaunchOptions.cs
+++ b/src/MICore/JsonLaunchOptions.cs
@@ -3,11 +3,10 @@
 
 using System;
 using System.Collections.Generic;
-using System.Runtime.Serialization;
-using Newtonsoft.Json;
-using Newtonsoft.Json.Converters;
-using Newtonsoft.Json.Linq;
+using System.Diagnostics;
 using System.Globalization;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
 
 namespace MICore.Json.LaunchOptions
 {
@@ -185,17 +184,14 @@ namespace MICore.Json.LaunchOptions
         /// <summary>
         /// The command to execute after the debugger is fully setup in order to cause the target process to run. Allowed values are "exec-run", "exec-continue", "None". The default value is "exec-run".
         /// </summary>
-        [JsonProperty("launchCompleteCommand", DefaultValueHandling = DefaultValueHandling.Ignore)]
+        [JsonProperty("launchCompleteCommand", DefaultValueHandling = DefaultValueHandling.Ignore),
+        JsonConverter(typeof(LaunchCompleteCommandConverter))]
         public LaunchCompleteCommandValue? LaunchCompleteCommand { get; set; }
-
-        [JsonConverter(typeof(StringEnumConverter))]
+        
         public enum LaunchCompleteCommandValue
         {
-            [EnumMember(Value = "exec-run")]
             Exec_run,
-            [EnumMember(Value = "exec-continue")]
             Exec_continue,
-            [EnumMember(Value = "None")]
             None,
         }
 
@@ -328,6 +324,49 @@ namespace MICore.Json.LaunchOptions
             this.PipeTransport = pipeTransport;
         }
 
+        #endregion
+
+        #region Private class
+        /// <summary>
+        /// Custom converter to avoid dependency on System.Runtime.Serialization.Primitives.dll
+        /// </summary>
+        private class LaunchCompleteCommandConverter : JsonConverter
+        {
+            public override object ReadJson(JsonReader reader, Type objectType, object existingValue, JsonSerializer serializer)
+            {
+                if (objectType == typeof(LaunchCompleteCommandValue?) && reader.Value is String)
+                {
+                    String value = (String)reader.Value;
+                    if (value.Equals("exec-continue", StringComparison.Ordinal))
+                    {
+                        return LaunchCompleteCommandValue.Exec_continue;
+                    }
+                    if (value.Equals("exec-run", StringComparison.Ordinal))
+                    {
+                        return LaunchCompleteCommandValue.Exec_run;
+                    }
+                    if (value.Equals("None", StringComparison.Ordinal))
+                    {
+                        return LaunchCompleteCommandValue.None;
+                    }
+
+                    throw new InvalidLaunchOptionsException(String.Format(CultureInfo.CurrentCulture, MICoreResources.Error_InvalidLaunchCompleteCommandValue, reader.Value));
+                }
+
+                Debug.Fail(String.Format("Unexpected objectType '{0}' passed for launchCompleteCommand serialization.", objectType.ToString()));
+                return null;
+            }
+
+            public override bool CanConvert(Type objectType)
+            {
+                return objectType == typeof(LaunchCompleteCommandValue?);
+            }
+
+            public override void WriteJson(JsonWriter writer, object value, JsonSerializer serializer)
+            {
+                throw new NotImplementedException();
+            }
+        }
         #endregion
     }
 

--- a/src/MICore/JsonLaunchOptions.cs
+++ b/src/MICore/JsonLaunchOptions.cs
@@ -186,15 +186,8 @@ namespace MICore.Json.LaunchOptions
         /// </summary>
         [JsonProperty("launchCompleteCommand", DefaultValueHandling = DefaultValueHandling.Ignore),
         JsonConverter(typeof(LaunchCompleteCommandConverter))]
-        public LaunchCompleteCommandValue? LaunchCompleteCommand { get; set; }
+        public LaunchCompleteCommand? LaunchCompleteCommand { get; set; }
         
-        public enum LaunchCompleteCommandValue
-        {
-            Exec_run,
-            Exec_continue,
-            None,
-        }
-
         /// <summary>
         /// Environment variables to add to the environment for the program. Example: [ { "name": "squid", "value": "clam" } ].
         /// </summary>
@@ -276,7 +269,7 @@ namespace MICore.Json.LaunchOptions
             string cwd = null,
             List<SetupCommand> setupCommands = null,
             List<SetupCommand> customLaunchSetupCommands = null,
-            LaunchCompleteCommandValue? launchCompleteCommand = null,
+            LaunchCompleteCommand? launchCompleteCommand = null,
             string visualizerFile = null,
             bool? showDisplayString = null,
             List<Environment> environment = null,
@@ -334,20 +327,20 @@ namespace MICore.Json.LaunchOptions
         {
             public override object ReadJson(JsonReader reader, Type objectType, object existingValue, JsonSerializer serializer)
             {
-                if (objectType == typeof(LaunchCompleteCommandValue?) && reader.Value is String)
+                if (objectType == typeof(LaunchCompleteCommand?) && reader.TokenType == JsonToken.String)
                 {
-                    String value = (String)reader.Value;
+                    String value = reader.Value.ToString();
                     if (value.Equals("exec-continue", StringComparison.Ordinal))
                     {
-                        return LaunchCompleteCommandValue.Exec_continue;
+                        return MICore.LaunchCompleteCommand.ExecContinue;
                     }
                     if (value.Equals("exec-run", StringComparison.Ordinal))
                     {
-                        return LaunchCompleteCommandValue.Exec_run;
+                        return MICore.LaunchCompleteCommand.ExecRun;
                     }
                     if (value.Equals("None", StringComparison.Ordinal))
                     {
-                        return LaunchCompleteCommandValue.None;
+                        return MICore.LaunchCompleteCommand.None;
                     }
 
                     throw new InvalidLaunchOptionsException(String.Format(CultureInfo.CurrentUICulture, MICoreResources.Error_InvalidLaunchCompleteCommandValue, reader.Value));
@@ -359,7 +352,7 @@ namespace MICore.Json.LaunchOptions
 
             public override bool CanConvert(Type objectType)
             {
-                return objectType == typeof(LaunchCompleteCommandValue?);
+                return objectType == typeof(LaunchCompleteCommand?);
             }
 
             public override void WriteJson(JsonWriter writer, object value, JsonSerializer serializer)
@@ -510,7 +503,7 @@ namespace MICore.Json.LaunchOptions
     {
         public static BaseOptions GetLaunchOrAttachOptions(JObject parsedJObject)
         {
-            BaseOptions baseOptions;
+            BaseOptions baseOptions = null;
             string requestType = parsedJObject["request"]?.Value<string>();
             if (String.IsNullOrWhiteSpace(requestType))
             {

--- a/src/MICore/JsonLaunchOptions.cs
+++ b/src/MICore/JsonLaunchOptions.cs
@@ -350,10 +350,10 @@ namespace MICore.Json.LaunchOptions
                         return LaunchCompleteCommandValue.None;
                     }
 
-                    throw new InvalidLaunchOptionsException(String.Format(CultureInfo.CurrentCulture, MICoreResources.Error_InvalidLaunchCompleteCommandValue, reader.Value));
+                    throw new InvalidLaunchOptionsException(String.Format(CultureInfo.CurrentUICulture, MICoreResources.Error_InvalidLaunchCompleteCommandValue, reader.Value));
                 }
 
-                Debug.Fail(String.Format("Unexpected objectType '{0}' passed for launchCompleteCommand serialization.", objectType.ToString()));
+                Debug.Fail(String.Format(CultureInfo.CurrentUICulture, "Unexpected objectType '{0}' passed for launchCompleteCommand serialization.", objectType.ToString()));
                 return null;
             }
 

--- a/src/MICore/LaunchOptions.cs
+++ b/src/MICore/LaunchOptions.cs
@@ -455,7 +455,7 @@ namespace MICore
 
             if (launchOptions == null)
             {
-                throw new InvalidLaunchOptionsException(MICoreResources.Error_LaunchOptionsNull);
+                throw new InvalidLaunchOptionsException(MICoreResources.Error_UnknownLaunchOptions);
             }
 
             MIMode mi = ConvertMIModeString(RequireAttribute(launchOptions.MIMode, nameof(launchOptions.MIMode)));
@@ -1697,18 +1697,7 @@ namespace MICore
 
             if (launch.LaunchCompleteCommand.HasValue)
             {
-                switch (launch.LaunchCompleteCommand.Value)
-                {
-                    case Json.LaunchOptions.LaunchOptions.LaunchCompleteCommandValue.Exec_continue:
-                        this.LaunchCompleteCommand = LaunchCompleteCommand.ExecContinue;
-                        break;
-                    case Json.LaunchOptions.LaunchOptions.LaunchCompleteCommandValue.Exec_run:
-                        this.LaunchCompleteCommand = LaunchCompleteCommand.ExecRun;
-                        break;
-                    case Json.LaunchOptions.LaunchOptions.LaunchCompleteCommandValue.None:
-                        this.LaunchCompleteCommand = LaunchCompleteCommand.None;
-                        break;
-                }
+                this.LaunchCompleteCommand = launch.LaunchCompleteCommand.Value;
             }
         }
 

--- a/src/MICore/LaunchOptions.cs
+++ b/src/MICore/LaunchOptions.cs
@@ -357,9 +357,7 @@ namespace MICore
                 }                
                 else
                 {
-                    throw new InvalidLaunchOptionsException(
-                        String.Format(CultureInfo.CurrentUICulture, MICoreResources.Error_InvalidLaunchOptions, 
-                            String.Format(CultureInfo.CurrentUICulture, MICoreResources.Error_SourceFileMapFormat, item.Key)));
+                    throw new InvalidLaunchOptionsException(String.Format(CultureInfo.CurrentUICulture, MICoreResources.Error_SourceFileMapFormat, item.Key));
                 }
             }
             return new ReadOnlyCollection<SourceMapEntry>(sourceMaps);
@@ -457,7 +455,7 @@ namespace MICore
 
             if (launchOptions == null)
             {
-                throw new InvalidLaunchOptionsException(MICoreResources.Error_InvalidLaunchOptions);
+                throw new InvalidLaunchOptionsException(MICoreResources.Error_LaunchOptionsNull);
             }
 
             MIMode mi = ConvertMIModeString(RequireAttribute(launchOptions.MIMode, nameof(launchOptions.MIMode)));

--- a/src/MICore/MICoreResources.Designer.cs
+++ b/src/MICore/MICoreResources.Designer.cs
@@ -259,15 +259,6 @@ namespace MICore {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Launch options are null..
-        /// </summary>
-        public static string Error_LaunchOptionsNull {
-            get {
-                return ResourceManager.GetString("Error_LaunchOptionsNull", resourceCulture);
-            }
-        }
-        
-        /// <summary>
         ///   Looks up a localized string similar to Failed to initialize debugger terminal..
         /// </summary>
         public static string Error_LocalUnixTerminalDebuggerInitializationFailed {

--- a/src/MICore/MICoreResources.Designer.cs
+++ b/src/MICore/MICoreResources.Designer.cs
@@ -187,6 +187,15 @@ namespace MICore {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Unknown launchCompleteCommand value &apos;{0}&apos;. Expected values are &apos;exec-run&apos;, &apos;exec-continue&apos; and &apos;None&apos;..
+        /// </summary>
+        public static string Error_InvalidLaunchCompleteCommandValue {
+            get {
+                return ResourceManager.GetString("Error_InvalidLaunchCompleteCommandValue", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Launch options string provided by the project system is invalid. {0}.
         /// </summary>
         public static string Error_InvalidLaunchOptions {
@@ -246,6 +255,15 @@ namespace MICore {
         public static string Error_LauncherSerializerNotFound {
             get {
                 return ResourceManager.GetString("Error_LauncherSerializerNotFound", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Launch options are null..
+        /// </summary>
+        public static string Error_LaunchOptionsNull {
+            get {
+                return ResourceManager.GetString("Error_LaunchOptionsNull", resourceCulture);
             }
         }
         

--- a/src/MICore/MICoreResources.resx
+++ b/src/MICore/MICoreResources.resx
@@ -284,4 +284,11 @@ Error: {1}</value>
     <value>The format of source file map entry '{0}' is incorrect.  </value>
     <comment>{0} source file map entry</comment>
   </data>
+  <data name="Error_InvalidLaunchCompleteCommandValue" xml:space="preserve">
+    <value>Unknown launchCompleteCommand value '{0}'. Expected values are 'exec-run', 'exec-continue' and 'None'.</value>
+    <comment>{0} value</comment>
+  </data>
+  <data name="Error_LaunchOptionsNull" xml:space="preserve">
+    <value>Launch options are null.</value>
+  </data>
 </root>

--- a/src/MICore/MICoreResources.resx
+++ b/src/MICore/MICoreResources.resx
@@ -288,7 +288,4 @@ Error: {1}</value>
     <value>Unknown launchCompleteCommand value '{0}'. Expected values are 'exec-run', 'exec-continue' and 'None'.</value>
     <comment>{0} value</comment>
   </data>
-  <data name="Error_LaunchOptionsNull" xml:space="preserve">
-    <value>Launch options are null.</value>
-  </data>
 </root>

--- a/src/MICore/project.json
+++ b/src/MICore/project.json
@@ -24,7 +24,6 @@
         "System.Runtime.Extensions": "4.1.0",
         "System.Runtime.InteropServices": "4.1.0",
         "System.Runtime.InteropServices.RuntimeInformation": "4.0.0",
-        "System.Runtime.Serialization.Primitives": "4.1.1",
         "System.Security.Cryptography.X509Certificates": "4.1.0",
         "System.Text.Encoding": "4.0.11",
         "System.Text.Encoding.Extensions": "4.0.11",

--- a/src/MIDebugEngine/Engine.Impl/EngineUtils.cs
+++ b/src/MIDebugEngine/Engine.Impl/EngineUtils.cs
@@ -84,7 +84,7 @@ namespace Microsoft.MIDebugEngine
 
         public static int UnexpectedException(Exception e)
         {
-            Debug.Fail("Unexpected exception during Attach");
+            Debug.Fail("Unexpected exception.");
             return Constants.RPC_E_SERVERFAULT;
         }
 


### PR DESCRIPTION
* Remove reliance on System.runtime.serialization.primitives.dll
* fixed error message strings. There were some instances where Error_InvalidLaunchOptions string showed up twice because InvalidLaunchOptionsException already prepends the message.

This is to fix a missing assembly issue in VS2017 where System.Runtime.Serialization.Primitives version 4.1.1 was not installed