### PR TITLE
Fix for hang with VS on gdb error message (#616)

### DIFF
--- a/src/MICore/Debugger.cs
+++ b/src/MICore/Debugger.cs
@@ -49,6 +49,8 @@ namespace MICore
 
         public bool IsCygwin { get; protected set; }
 
+        public bool IsLocalGdbOnWindows { get; protected set; }
+
         public virtual void FlushBreakStateData()
         {
         }

--- a/src/MICore/Debugger.cs
+++ b/src/MICore/Debugger.cs
@@ -49,7 +49,7 @@ namespace MICore
 
         public bool IsCygwin { get; protected set; }
 
-        public bool IsLocalGdbOnWindows { get; protected set; }
+        public bool SendNewLineAfterCmd { get; protected set; }
 
         public virtual void FlushBreakStateData()
         {
@@ -421,6 +421,10 @@ namespace MICore
             _lastCommandId = 1000;
             _transport = transport;
             FlushBreakStateData();
+
+            this.SendNewLineAfterCmd = (options is LocalLaunchOptions &&
+                PlatformUtilities.IsWindows() &&
+                this.MICommandFactory.Mode == MIMode.Gdb);
 
             _transport.Init(this, options, Logger, waitLoop);
         }
@@ -1447,6 +1451,14 @@ namespace MICore
         private void SendToTransport(string cmd)
         {
             _transport.Send(cmd);
+
+            // https://github.com/Microsoft/MIEngine/issues/616 :
+            // If it is local gdb (MinGW/Cygwin) on Windows, we need to send an extra line after commands 
+            // so that if it errors, the error will come through. 
+            if (this.SendNewLineAfterCmd)
+            {
+                _transport.Send(String.Empty);
+            }
         }
 
         public static ulong ParseAddr(string addr, bool throwOnError = false)

--- a/src/MICore/Transports/StreamTransport.cs
+++ b/src/MICore/Transports/StreamTransport.cs
@@ -142,17 +142,15 @@ namespace MICore
         }
         protected void Echo(string cmd)
         {
-            Logger?.WriteLine("<-" + cmd);
-            Logger?.Flush();
+            if (!String.IsNullOrWhiteSpace(cmd))
+            {
+                Logger?.WriteLine("<-" + cmd);
+                Logger?.Flush();
+            }
+
             lock (_locker)
             {
                 _writer?.WriteLine(cmd);
-                // https://github.com/Microsoft/MIEngine/issues/616 : If it is local gdb (MinGW/Cygwin) on Windows, we need to send an extra line after commands 
-                // so that if it errors, the error will come through. 
-                if((_callback is Debugger) && ((Debugger)_callback).IsLocalGdbOnWindows)
-                {
-                    _writer?.WriteLine();
-                }
                 _writer?.Flush();
             }
         }

--- a/src/MICore/Transports/StreamTransport.cs
+++ b/src/MICore/Transports/StreamTransport.cs
@@ -147,6 +147,12 @@ namespace MICore
             lock (_locker)
             {
                 _writer?.WriteLine(cmd);
+                // https://github.com/Microsoft/MIEngine/issues/616 : If it is local gdb (MinGW/Cygwin) on Windows, we need to send an extra line after commands 
+                // so that if it errors, the error will come through. 
+                if((_callback is Debugger) && ((Debugger)_callback).IsLocalGdbOnWindows)
+                {
+                    _writer?.WriteLine();
+                }
                 _writer?.Flush();
             }
         }

--- a/src/MIDebugEngine/AD7.Impl/AD7Engine.cs
+++ b/src/MIDebugEngine/AD7.Impl/AD7Engine.cs
@@ -13,7 +13,6 @@ using System.Threading.Tasks;
 using MICore;
 using System.Globalization;
 using Microsoft.DebugEngineHost;
-
 using Logger = MICore.Logger;
 
 namespace Microsoft.MIDebugEngine
@@ -761,6 +760,11 @@ namespace Microsoft.MIDebugEngine
             {
                 return AD7_HRESULT.E_CRASHDUMP_UNSUPPORTED;
             }
+            catch (Exception e)
+            {
+                _engineCallback.OnError(EngineUtils.GetExceptionDescription(e));
+                return Constants.E_ABORT;
+            }
 
             return Constants.S_OK;
         }
@@ -948,6 +952,11 @@ namespace Microsoft.MIDebugEngine
             catch (InvalidCoreDumpOperationException)
             {
                 return AD7_HRESULT.E_CRASHDUMP_UNSUPPORTED;
+            }
+            catch (Exception e)
+            {
+                _engineCallback.OnError(EngineUtils.GetExceptionDescription(e));
+                return Constants.E_ABORT;
             }
 
             return Constants.S_OK;

--- a/src/MIDebugEngine/Engine.Impl/DebuggedProcess.cs
+++ b/src/MIDebugEngine/Engine.Impl/DebuggedProcess.cs
@@ -753,7 +753,6 @@ namespace Microsoft.MIDebugEngine
             // If running locally on windows, determine if gdb is running from cygwin
             if (localLaunchOptions != null && PlatformUtilities.IsWindows() && this.MICommandFactory.Mode == MIMode.Gdb)
             {
-                this.IsLocalGdbOnWindows = true;
                 // mingw will not implement this command, but to be safe, also check if the results contains the string cygwin.
                 LaunchCommand lc = new LaunchCommand("show configuration", null, true, null, (string resStr) =>
                 {

--- a/src/MIDebugEngine/Engine.Impl/DebuggedProcess.cs
+++ b/src/MIDebugEngine/Engine.Impl/DebuggedProcess.cs
@@ -753,6 +753,7 @@ namespace Microsoft.MIDebugEngine
             // If running locally on windows, determine if gdb is running from cygwin
             if (localLaunchOptions != null && PlatformUtilities.IsWindows() && this.MICommandFactory.Mode == MIMode.Gdb)
             {
+                this.IsLocalGdbOnWindows = true;
                 // mingw will not implement this command, but to be safe, also check if the results contains the string cygwin.
                 LaunchCommand lc = new LaunchCommand("show configuration", null, true, null, (string resStr) =>
                 {


### PR DESCRIPTION
Fix for Issue #616 
* Hang was because gdb on MinGW/Cygwin would send ^error but not flush.
Fix is to send additional newline at the end of every command if we are
running local launch on gdb on windows

* Fix for error messages during continue or step showing useless message
in VS. Fix is to catch the exceptions instead of letting it go through,
return the actual exception's message and send E_ABORT