### PR TITLE
Change check for isTerminating

### DIFF
--- a/src/MICore/Debugger.cs
+++ b/src/MICore/Debugger.cs
@@ -286,18 +286,21 @@ namespace MICore
             this.ProcessState = ProcessState.Stopped;
             FlushBreakStateData();
 
-            if (!results.Contains("frame") && !_terminating)
+            if (!_terminating)
             {
-                if (ModuleLoadEvent != null)
+                if (!results.Contains("frame"))
                 {
-                    ModuleLoadEvent(this, new ResultEventArgs(results));
+                    if (ModuleLoadEvent != null)
+                    {
+                        ModuleLoadEvent(this, new ResultEventArgs(results));
+                    }
                 }
-            }
-            else if (BreakModeEvent != null)
-            {
-                BreakRequest request = _requestingRealAsyncBreak;
-                _requestingRealAsyncBreak = BreakRequest.None;
-                BreakModeEvent(this, new StoppingEventArgs(results, request));
+                else if (BreakModeEvent != null)
+                {
+                    BreakRequest request = _requestingRealAsyncBreak;
+                    _requestingRealAsyncBreak = BreakRequest.None;
+                    BreakModeEvent(this, new StoppingEventArgs(results, request));
+                }
             }
         }
 


### PR DESCRIPTION
During test runs, because it is so fast, we could be terminating and fall through to the second case. In this instance, the Android MDD Sanity test was running so fast that it _terminating was true so it was falling through to the second case. What we want to do is that if it is _terminating, to do neither block of work. 