### PR TITLE
Remove Breakpoint that we set at main after entrypoint is hit

### DIFF
--- a/src/MIDebugEngine/Engine.Impl/DebuggedProcess.cs
+++ b/src/MIDebugEngine/Engine.Impl/DebuggedProcess.cs
@@ -401,7 +401,7 @@ namespace Microsoft.MIDebugEngine
                     await ThreadCache.ThreadCreatedEvent(result.Results.FindInt("id"), result.Results.TryFindString("group-id"));
                     _childProcessHandler?.ThreadCreatedEvent(result.Results);
                 }
-                catch(Exception)
+                catch (Exception)
                 {
                     // Avoid crashing VS
                 }
@@ -1059,6 +1059,9 @@ namespace Microsoft.MIDebugEngine
                         // LLDB requires this command to be issued after the process has started.
                         await ConsoleCmdAsync("process handle --pass true --stop false --notify false SIGHUP", true);
                     }
+
+                    // Delete the entry point breakpoint
+                    await MICommandFactory.BreakDelete(bkptno);
 
                     _callback.OnEntryPoint(thread);
                 }


### PR DESCRIPTION
Looks like we never remove the breakpoint we set at main and if the first line of code is in the while loop, then it keeps getting hit because it isn't being removed which comes back as an exception in VS.
@gregg-miskelly @chuckries 

fix for Bug
https://devdiv.visualstudio.com/web/wi.aspx?pcguid=011b8bdf-6d56-4f87-be0d-0092136884d9&id=451217