### PR TITLE
Fix for Issue #629.

### DIFF
--- a/src/MICore/LaunchOptions.cs
+++ b/src/MICore/LaunchOptions.cs
@@ -341,20 +341,24 @@ namespace MICore
             {
                 if (item.Value is String)
                 {
-                    sourceMaps.Add(new SourceMapEntry() {
+                    sourceMaps.Add(new SourceMapEntry()
+                    {
                         CompileTimePath = item.Key,
                         EditorPath = (String)item.Value,
-                        UseForBreakpoints = true });
+                        UseForBreakpoints = true
+                    });
                 }
                 else if (item.Value is JObject)
                 {
-                    Json.LaunchOptions.SourceFileMapOptions sourceMapItem = 
+                    Json.LaunchOptions.SourceFileMapOptions sourceMapItem =
                         ((JObject)item.Value).ToObject<Json.LaunchOptions.SourceFileMapOptions>();
-                    sourceMaps.Add(new SourceMapEntry() {
+                    sourceMaps.Add(new SourceMapEntry()
+                    {
                         CompileTimePath = item.Key,
                         EditorPath = sourceMapItem.EditorPath,
-                        UseForBreakpoints = sourceMapItem.UseForBreakpoints.GetValueOrDefault(true) });
-                }                
+                        UseForBreakpoints = sourceMapItem.UseForBreakpoints.GetValueOrDefault(true)
+                    });
+                }
                 else
                 {
                     throw new InvalidLaunchOptionsException(String.Format(CultureInfo.CurrentUICulture, MICoreResources.Error_SourceFileMapFormat, item.Key));
@@ -1109,9 +1113,10 @@ namespace MICore
         {
             get
             {
-                if (this is LocalLaunchOptions)
+                if (this is LocalLaunchOptions && PlatformUtilities.IsWindows())
                 {
-                    return !PlatformUtilities.IsWindows();
+                    // If MIDebuggerServerAddress is specified, then we also need to use Unix symbol paths
+                    return !String.IsNullOrWhiteSpace(((LocalLaunchOptions)this).MIDebuggerServerAddress);
                 }
                 else
                 {

--- a/src/MIDebugEngine/Engine.Impl/DebuggedProcess.cs
+++ b/src/MIDebugEngine/Engine.Impl/DebuggedProcess.cs
@@ -1248,9 +1248,10 @@ namespace Microsoft.MIDebugEngine
         {
             get { return _worker; }
         }
+
         internal string EscapePath(string path, bool ignoreSpaces = false)
         {
-            if (_launchOptions.UseUnixSymbolPaths)
+            if (this.UseUnixSymbolPaths)
             {
                 path = path.Replace('\\', '/');
             }


### PR DESCRIPTION
Unix path separators should be used when miDebuggerServerAddress is specified