### PR TITLE
Fix termination on MinGW/Cygwin by calling Windows API to terminate.

### DIFF
--- a/src/MICore/CommandFactories/gdb.cs
+++ b/src/MICore/CommandFactories/gdb.cs
@@ -207,6 +207,7 @@ namespace MICore
             // that isn't actually supported by gdb. 
             await _debugger.CmdAsync("kill", ResultClass.None);
         }
+
         private static string TypeBySize(uint size)
         {
             switch (size)

--- a/src/MICore/Debugger.cs
+++ b/src/MICore/Debugger.cs
@@ -11,6 +11,7 @@ using System.Globalization;
 using System.Linq;
 using Microsoft.Win32.SafeHandles;
 using Microsoft.DebugEngineHost;
+using System.Runtime.InteropServices;
 
 namespace MICore
 {
@@ -48,6 +49,8 @@ namespace MICore
         public bool EntrypointHit { get; protected set; }
 
         public bool IsCygwin { get; protected set; }
+
+        public bool IsMinGW { get; protected set; }
 
         public bool SendNewLineAfterCmd { get; protected set; }
 
@@ -233,7 +236,7 @@ namespace MICore
                         _retryCount = 0;
                         _waitingToStop = true;
 
-                        // When using signals to stop the proces, do not kick off another break attempt. The debug break injection and
+                        // When using signals to stop the process, do not kick off another break attempt. The debug break injection and
                         // signal based models are reliable so no retries are needed. Cygwin can't currently async-break reliably, so
                         // use retries there.
                         if (!IsLocalGdb() && !this.IsCygwin)
@@ -604,14 +607,49 @@ namespace MICore
             }
         }
 
+        [DllImport("kernel32.dll", SetLastError = true)]
+        public static extern IntPtr OpenProcess(int dwDesiredAccess, [MarshalAs(UnmanagedType.Bool)] bool bInheritHandle, int dwProcessId);
+        [DllImport("kernel32.dll", SetLastError = true)]
+        [return: MarshalAs(UnmanagedType.Bool)]
+        static extern bool TerminateProcess(IntPtr hProcess, uint uExitCode);
+
         public async Task<Results> CmdTerminate()
         {
             if (!_terminating)
             {
                 _terminating = true;
-                if (ProcessState == ProcessState.Running && this.MICommandFactory.Mode != MIMode.Clrdbg)
+                if (ProcessState == ProcessState.Running &&
+                    this.MICommandFactory.Mode != MIMode.Clrdbg)
                 {
-                    await AddInternalBreakAction(() => MICommandFactory.Terminate());
+                    // MinGW and Cygwin on Windows don't support async break. Because of this,
+                    // the normal path of sending an internal async break so we can exit doesn't work.
+                    // Therefore, we will call TerminateProcess on the debuggee with the exit code of 0
+                    // to terminate debugging. 
+                    if ((this.IsCygwin || this.IsMinGW) && _debuggeePids.Count > 0)
+                    {
+                        int debuggeePid = _debuggeePids.First().Value;
+                        IntPtr handle = IntPtr.Zero;
+                        try
+                        {
+                            // 0x1 = Terminate
+                            handle = OpenProcess(0x1, false, debuggeePid);
+                            if (handle != IntPtr.Zero && TerminateProcess(handle, 0))
+                            {
+                                // OperationThread's _runningOpCompleteEvent is doing WaitOne(). Calling MICommandFactory.Terminate() will Set() it, unblocking the UI. 
+                                await MICommandFactory.Terminate();
+                                return new Results(ResultClass.done);
+                            }
+                        }
+                        finally
+                        {
+                            if (handle != IntPtr.Zero)
+                                Marshal.FreeCoTaskMem(handle);
+                        }
+                    }
+                    else
+                    {
+                        await AddInternalBreakAction(() => MICommandFactory.Terminate());
+                    }
                 }
                 else
                 {

--- a/src/MIDebugEngine/Engine.Impl/DebuggedProcess.cs
+++ b/src/MIDebugEngine/Engine.Impl/DebuggedProcess.cs
@@ -790,6 +790,7 @@ namespace Microsoft.MIDebugEngine
                     }
                     else
                     {
+                        this.IsMinGW = true;
                         // Gdb on windows and not cygwin implies mingw
                         _engineTelemetry.SendWindowsRuntimeEnvironment(EngineTelemetry.WindowsRuntimeEnvironment.MinGW);
                     }

--- a/src/MIDebugEngine/Engine.Impl/DebuggedThread.cs
+++ b/src/MIDebugEngine/Engine.Impl/DebuggedThread.cs
@@ -217,7 +217,11 @@ namespace Microsoft.MIDebugEngine
                 Results results = await _debugger.MICommandFactory.ThreadInfo(tid);
                 if (results.ResultClass != ResultClass.done)
                 {
-                    Debug.Fail("Thread info not successful");
+                    // This can happen on some versions of gdb where thread-info is not supported while running, so only assert if we're also not running. 
+                    if (this._debugger.ProcessState != ProcessState.Running)
+                    {
+                        Debug.Fail("Thread info not successful");
+                    }
                 }
                 else
                 {


### PR DESCRIPTION
MinGW and Cygwin do not allow Async break to occur without user
intervention. The problem is with -exec-abort (stop debugging) while in
run mode requires us to do an async break so that we can abort. Since we
can't do that without additional user intervention, we will terminate
the child process instead.