### PR TITLE
Fix framelevel when break all occurs in Visual Studio

### DIFF
--- a/src/MICore/CommandFactories/gdb.cs
+++ b/src/MICore/CommandFactories/gdb.cs
@@ -26,6 +26,8 @@ namespace MICore
         public override void DefineCurrentThread(int threadId)
         {
             _currentThreadId = threadId;
+            // If current threadId is changed, reset _currentFrameLevel
+            _currentFrameLevel = 0;
         }
 
         public override bool SupportsStopOnDynamicLibLoad()


### PR DESCRIPTION
VS keeps state of framelevel when break all occurs. gdb assumes when you
break all that the framelevel of current thread is 0. reset the tracking
framelevelid in MIEngine to 0 so that we will call -stack-select-frame
every time we break all if we are expecting a non-zero framelevel.

VSTS bug 410289