### PR TITLE
Add registry key for AD7metric when running under glass for BP longbind

### DIFF
--- a/src/MIDebugEngine/AD7.Impl/AD7Engine.cs
+++ b/src/MIDebugEngine/AD7.Impl/AD7Engine.cs
@@ -370,7 +370,7 @@ namespace Microsoft.MIDebugEngine
                 object timeoutExtension = _configStore.GetEngineMetric("BpLongBindTimeoutExtension");
                 if (timeoutExtension != null && timeoutExtension is int && ((int)timeoutExtension == 1))
                 {
-                    s_bpLongBindTimeout = 2500; // if its set, make it 10x
+                    s_bpLongBindTimeout = 50000; // if its set, make it longer
                 }
             }
             return s_bpLongBindTimeout;

--- a/src/MIDebugEngine/AD7.Impl/AD7Engine.cs
+++ b/src/MIDebugEngine/AD7.Impl/AD7Engine.cs
@@ -62,6 +62,8 @@ namespace Microsoft.MIDebugEngine
 
         private static List<int> s_childProcessLaunch;
 
+        private static int s_bpLongBindTimeout = 0;
+
         static AD7Engine()
         {
             s_childProcessLaunch = new List<int>();
@@ -357,6 +359,21 @@ namespace Microsoft.MIDebugEngine
             }
 
             return Constants.S_OK;
+        }
+
+        public int GetBPLongBindTimeout()
+        {
+            if (s_bpLongBindTimeout == 0)
+            {
+                s_bpLongBindTimeout = 250; // default is to wait a quarter of a second
+
+                object timeoutExtension = _configStore.GetEngineMetric("BpLongBindTimeoutExtension");
+                if (timeoutExtension != null && timeoutExtension is int && ((int)timeoutExtension == 1))
+                {
+                    s_bpLongBindTimeout = 2500; // if its set, make it 10x
+                }
+            }
+            return s_bpLongBindTimeout;
         }
 
         // Informs a DE that the program specified has been atypically terminated and that the DE should

--- a/src/MIDebugEngine/AD7.Impl/AD7PendingBreakpoint.cs
+++ b/src/MIDebugEngine/AD7.Impl/AD7PendingBreakpoint.cs
@@ -263,8 +263,7 @@ namespace Microsoft.MIDebugEngine
                         bindTask = _engine.DebuggedProcess.AddInternalBreakAction(this.BindAsync);
                     });
 
-                    bindTask.Wait(250); //wait a quarter of a second
-
+                    bindTask.Wait(_engine.GetBPLongBindTimeout()); 
                     if (!bindTask.IsCompleted)
                     {
                         //send a low severity warning bp. This will allow the UI to respond quickly, and if the mi debugger doesn't end up binding, this warning will get 

--- a/test/MIEngine.regdef
+++ b/test/MIEngine.regdef
@@ -7,7 +7,8 @@ Windows Registry Editor Version 5.00
 ; "AddressBP"=dword:00000001
 "AlwaysLoadLocal"=dword:00000001
 "AlwaysLoadProgramProviderLocal"=dword:00000001
-"BpBindingLongBindExtension"=dword:00000001
+; BpLongBindTimeoutExtension is added for glass tests to prevent false error from failing the test.
+"BpLongBindTimeoutExtension"=dword:00000001
 ; "CallStackBP"=dword:00000001
 ; "ConditionalBP"=dword:00000001
 ; "DataBP"=dword:00000001

--- a/test/MIEngine.regdef
+++ b/test/MIEngine.regdef
@@ -7,6 +7,7 @@ Windows Registry Editor Version 5.00
 ; "AddressBP"=dword:00000001
 "AlwaysLoadLocal"=dword:00000001
 "AlwaysLoadProgramProviderLocal"=dword:00000001
+"BpBindingLongBindExtension"=dword:00000001
 ; "CallStackBP"=dword:00000001
 ; "ConditionalBP"=dword:00000001
 ; "DataBP"=dword:00000001


### PR DESCRIPTION
Tested both with glass and with VS. Fixes #651 

Run on device: 169.254.138.177:5555 KitKat
Running 'Attach'
Running 'Breakpoint'
Running 'BreakPointEnableAndDisable'
Running 'BreakPointWhenTrueCondition'
Running 'CallStack'
Running 'Eval'
Running 'EvalComplexExpression'
Running 'EvalCompoundDataTypes'
Running 'EvalErrors'
Running 'EvalPrimitiveTypes'
Running 'Exceptions'
Running 'FunctionBreakPoints'
Running 'Locals'
Running 'MultiThreadingCallStack'
Running 'Sanity'
Running 'Stepping'
Running 'SwitchFramesInCallStack'
----------------------------------------
All tests completed succesfully.