### PR TITLE
Add detection for unsupported GDB versions

### DIFF
--- a/src/MICore/MICoreResources.Designer.cs
+++ b/src/MICore/MICoreResources.Designer.cs
@@ -457,6 +457,17 @@ namespace MICore {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to GDB version {0} is not supported on Windows. Consider upgrading.
+        ///
+        ///{1}.
+        /// </summary>
+        public static string Error_UnsupportedWindowsGdb {
+            get {
+                return ResourceManager.GetString("Error_UnsupportedWindowsGdb", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Installing debugger on the remote machine..
         /// </summary>
         public static string Info_InstallingDebuggerOnRemote {

--- a/src/MICore/MICoreResources.resx
+++ b/src/MICore/MICoreResources.resx
@@ -288,4 +288,10 @@ Error: {1}</value>
     <value>Unknown launchCompleteCommand value '{0}'. Expected values are 'exec-run', 'exec-continue' and 'None'.</value>
     <comment>{0} value</comment>
   </data>
+  <data name="Error_UnsupportedWindowsGdb" xml:space="preserve">
+    <value>GDB version {0} is not supported on Windows. Consider upgrading.
+
+{1}</value>
+    <comment>GDB is an acronym and should not be localized. {0} represents a dotted decimal version number. {1} represents a more detailed error message.</comment>
+  </data>
 </root>

--- a/src/MICore/MIException.cs
+++ b/src/MICore/MIException.cs
@@ -134,4 +134,23 @@ namespace MICore
             }
         }
     }
+
+    public class MIDebuggerInitializeFailedUnsupportedGdbException : MIDebuggerInitializeFailedException
+    {
+        private readonly string _gdbVersion;
+
+        public MIDebuggerInitializeFailedUnsupportedGdbException(string debuggerName, IReadOnlyList<string> errorLines, IReadOnlyList<string> outputLines, string gdbVersion)
+            : base(debuggerName, errorLines, outputLines)
+        {
+            _gdbVersion = gdbVersion;
+        }
+
+        public override string Message
+        {
+            get
+            {
+                return string.Format(CultureInfo.InvariantCulture, MICoreResources.Error_UnsupportedWindowsGdb, _gdbVersion, base.Message);
+            }
+        }
+    }
 }


### PR DESCRIPTION
I'm trying to improve the error messaging in Visual Studio when GDB versions 7.12-1, 7.12-2, 7.12-3, and 7.12.1-1 are used for debugging. These specific versions of GDB have a bug that causes them to terminate early in MinGW when invoked with the `--interpreter=mi` flag. The current Visual Studio error message in this case is somewhat cryptic, and this PR adds more detail. The new parts are in bold.

> Unable to start debugging. **GDB version 7.12.1 is not supported. Consider upgrading.**
> 
> Unable to establish a connection to GDB. The following message was written to stderr:
> 
> This application has requested the Runtime to terminate it in an unusual way.
> Please contact the application's support team for more information.
> 
> See Output Window for details.