### PR TITLE
Fix Go To Module / EnumModules

### DIFF
--- a/src/MIDebugEngine/AD7.Impl/AD7Engine.cs
+++ b/src/MIDebugEngine/AD7.Impl/AD7Engine.cs
@@ -10,6 +10,7 @@ using Microsoft.VisualStudio.Debugger.Interop.UnixPortSupplier;
 using System.Diagnostics;
 using System.Threading;
 using System.Threading.Tasks;
+using System.Linq;
 using MICore;
 using System.Globalization;
 using Microsoft.DebugEngineHost;
@@ -843,12 +844,9 @@ namespace Microsoft.MIDebugEngine
         {
             DebuggedModule[] modules = _debuggedProcess.GetModules();
 
-            AD7Module[] moduleObjects = new AD7Module[modules.Length];
-            for (int i = 0; i < modules.Length; i++)
-            {
-                moduleObjects[i] = new AD7Module(modules[i], _debuggedProcess);
-            }
-
+            AD7Module[] moduleObjects = modules.Select(backendModule => backendModule.Client as AD7Module)
+                .Where(ad7Module => ad7Module != null) // Ignore any modules that we haven't quite sent the module load event for
+                .ToArray();
             ppEnum = new Microsoft.MIDebugEngine.AD7ModuleEnum(moduleObjects);
 
             return Constants.S_OK;

--- a/src/MIDebugEngine/AD7.Impl/AD7Events.cs
+++ b/src/MIDebugEngine/AD7.Impl/AD7Events.cs
@@ -483,36 +483,6 @@ namespace Microsoft.MIDebugEngine
         #endregion
     }
 
-    // This interface is sent by the debug engine (DE) to indicate the results of searching for symbols for a module in the debuggee
-    internal sealed class AD7SymbolSearchEvent : AD7AsynchronousEvent, IDebugSymbolSearchEvent2
-    {
-        public const string IID = "638F7C54-C160-4c7b-B2D0-E0337BC61F8C";
-
-        private AD7Module _module;
-        private string _searchInfo;
-        private enum_MODULE_INFO_FLAGS _symbolFlags;
-
-        public AD7SymbolSearchEvent(AD7Module module, string searchInfo, enum_MODULE_INFO_FLAGS symbolFlags)
-        {
-            _module = module;
-            _searchInfo = searchInfo;
-            _symbolFlags = symbolFlags;
-        }
-
-        #region IDebugSymbolSearchEvent2 Members
-
-        int IDebugSymbolSearchEvent2.GetSymbolSearchInfo(out IDebugModule3 pModule, ref string pbstrDebugMessage, enum_MODULE_INFO_FLAGS[] pdwModuleInfoFlags)
-        {
-            pModule = _module;
-            pbstrDebugMessage = _searchInfo;
-            pdwModuleInfoFlags[0] = _symbolFlags;
-
-            return Constants.S_OK;
-        }
-
-        #endregion
-    }
-
     // This interface is sent when a pending breakpoint has been bound in the debuggee.
     internal sealed class AD7BreakpointBoundEvent : AD7AsynchronousEvent, IDebugBreakpointBoundEvent2
     {

--- a/src/MIDebugEngine/AD7.Impl/AD7Module.cs
+++ b/src/MIDebugEngine/AD7.Impl/AD7Module.cs
@@ -20,8 +20,8 @@ namespace Microsoft.MIDebugEngine
 
         public AD7Module(DebuggedModule debuggedModule, DebuggedProcess process)
         {
-            Debug.Assert(debuggedModule.Client == null, "Why is the client of the module already set?");
             Debug.Assert(debuggedModule != null, "No module provided?");
+            Debug.Assert(debuggedModule.Client == null, "Why is the client of the module already set?");
             Debug.Assert(process != null, "No process provided?");
 
             this.DebuggedModule = debuggedModule;

--- a/src/MIDebugEngine/AD7.Impl/AD7Module.cs
+++ b/src/MIDebugEngine/AD7.Impl/AD7Module.cs
@@ -20,6 +20,7 @@ namespace Microsoft.MIDebugEngine
 
         public AD7Module(DebuggedModule debuggedModule, DebuggedProcess process)
         {
+            Debug.Assert(debuggedModule.Client == null, "Why is the client of the module already set?");
             Debug.Assert(debuggedModule != null, "No module provided?");
             Debug.Assert(process != null, "No process provided?");
 

--- a/src/MIDebugEngine/Engine.Impl/DebuggedModule.cs
+++ b/src/MIDebugEngine/Engine.Impl/DebuggedModule.cs
@@ -117,6 +117,6 @@ namespace Microsoft.MIDebugEngine
 
         public uint GetLoadOrder() { return _loadOrder; }
 
-        public Object Client { get; set; }      // really AD7Module
+        public Object Client { get; internal set; }      // really AD7Module
     }
 }

--- a/src/MIDebugEngine/Engine.Impl/EngineCallback.cs
+++ b/src/MIDebugEngine/Engine.Impl/EngineCallback.cs
@@ -246,19 +246,6 @@ namespace Microsoft.MIDebugEngine
             Send(eventObject, AD7ProgramDestroyEvent.IID, null);
         }
 
-        // Engines notify the debugger about the results of a symbol serach by sending an instance
-        // of IDebugSymbolSearchEvent2
-        public void OnSymbolSearch(DebuggedModule module, string status, uint dwStatusFlags)
-        {
-            enum_MODULE_INFO_FLAGS statusFlags = (enum_MODULE_INFO_FLAGS)dwStatusFlags;
-
-            string statusString = ((statusFlags & enum_MODULE_INFO_FLAGS.MIF_SYMBOLS_LOADED) != 0 ? "Symbols Loaded - " : "No symbols loaded") + status;
-
-            AD7Module ad7Module = new AD7Module(module, _engine.DebuggedProcess);
-            AD7SymbolSearchEvent eventObject = new AD7SymbolSearchEvent(ad7Module, statusString, statusFlags);
-            Send(eventObject, AD7SymbolSearchEvent.IID, null);
-        }
-
         // Engines notify the debugger that a breakpoint has bound through the breakpoint bound event.
         public void OnBreakpointBound(object objBoundBreakpoint)
         {

--- a/src/MIDebugEngine/Engine.Impl/Structures.cs
+++ b/src/MIDebugEngine/Engine.Impl/Structures.cs
@@ -99,7 +99,6 @@ namespace Microsoft.MIDebugEngine
         void OnAsyncBreakComplete(DebuggedThread thread);
         void OnLoadComplete(DebuggedThread thread);
         //void OnProgramDestroy(uint exitCode);
-        void OnSymbolSearch(DebuggedModule module, string status, uint dwStatsFlags);
         void OnBreakpointBound(Object objPendingBreakpoint);
         void OnEntryPoint(DebuggedThread thread);
         void OnStopComplete(DebuggedThread thread);


### PR DESCRIPTION
The MIEngine had a faulty implementation of EnumModules where it would create new module objects instead of returning the same module objects that it used for stack frames / module events. This fixes it.

This also removes some dead code the MIEngine had for sending IDebugSymbolSearchEvent2's. This code also incorrectly created new modules, but that didn't matter since the code was never called anyway.