### PR TITLE
Remove old check for core only in Local options.

### DIFF
--- a/src/MICore/Debugger.cs
+++ b/src/MICore/Debugger.cs
@@ -598,11 +598,7 @@ namespace MICore
         {
             get
             {
-                LocalLaunchOptions localOptions = this._launchOptions as LocalLaunchOptions;
-                if (null == localOptions)
-                    return false;
-
-                return localOptions.IsCoreDump;
+                return this._launchOptions.IsCoreDump;
             }
         }
 


### PR DESCRIPTION
Core dump path  property was long ago moved to base launch options, but this check still remains, blocking remote core debugging.