### PR TITLE
Copy localized SSH provider assemblies to drop folder.

### DIFF
--- a/build/miengine.csharp.localization.targets
+++ b/build/miengine.csharp.localization.targets
@@ -1,0 +1,39 @@
+<Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+
+    <!-- Localize the output assembly if requested -->
+  <ItemGroup Condition=" '$(LocalizeOutputAssembly)'=='true' ">
+    <FilesToLocalize Include="$(TargetPath)">
+      <TranslationFile>$(RepositoryRoot)loc\lcl\{Lang}\$(TargetFileName).lcl</TranslationFile>
+      <LciCommentFile>$(RepositoryRoot)loc\lci\$(TargetFileName).lci</LciCommentFile>
+    </FilesToLocalize>
+    <!-- Ensure new localized assemblies are signed -->
+    <SignFilesDependsOn Include="GatherLocalizedOutputsForSigning" />
+  </ItemGroup>
+
+  <!-- Custom target that will be invoked before signing (and after localization).
+       This target is conditioned to only run if localization is currently turned on. -->
+  <Target Name="GatherLocalizedOutputsForSigning" Condition="'$(LocalizationEnabled)' == 'true'">
+    <ItemGroup>
+      <FilesToSign Include="$(OutDir)\localize\**\$(TargetName).resources.dll" >
+        <Authenticode>Microsoft</Authenticode>
+        <StrongName>StrongName</StrongName>
+      </FilesToSign>
+    </ItemGroup>
+  </Target>
+
+  <!-- Custom target that will be invoked after signing and loc to copy signed satellite assemblies
+       to the drop location.
+       This target is conditioned to only run if localization is currently turned on. -->
+  <Target Name="CopySatellitesToDrop" AfterTargets="SignFiles" Condition="'$(LocalizationEnabled)'=='true'">
+    <PropertyGroup>
+      <SatellitesBinDir>$(OutDir)localize\</SatellitesBinDir>
+      <SatellitesDropDir>$(DropRootDir)\loc\</SatellitesDropDir>
+    </PropertyGroup>
+    <ItemGroup>
+      <LocFilesToDrop Include="$(SatellitesBinDir)**\$(TargetName).resources.dll" />
+      <LocFilesToDrop Include="$(SatellitesBinDir)**\$(TargetName).dll.lcg" />
+    </ItemGroup>
+    <Copy DestinationFiles="@(LocFilesToDrop->'$(SatellitesDropDir)%(RecursiveDir)%(Filename)%(Extension)')"
+          SourceFiles="@(LocFilesToDrop)" />
+  </Target>
+</Project>

--- a/build/miengine.targets
+++ b/build/miengine.targets
@@ -26,43 +26,6 @@
     </Task>
   </UsingTask>
 
-    <!-- Localize the output assembly if requested -->
-  <ItemGroup Condition=" '$(LocalizeOutputAssembly)'=='true' ">
-    <FilesToLocalize Include="$(TargetPath)">
-      <TranslationFile>$(RepositoryRoot)loc\lcl\{Lang}\$(TargetFileName).lcl</TranslationFile>
-      <LciCommentFile>$(RepositoryRoot)loc\lci\$(TargetFileName).lci</LciCommentFile>
-    </FilesToLocalize>
-    <!-- Ensure new localized assemblies are signed -->
-    <SignFilesDependsOn Include="GatherLocalizedOutputsForSigning" />
-  </ItemGroup>
-
-  <!-- Custom target that will be invoked before signing (and after localization).
-       This target is conditioned to only run if localization is currently turned on. -->
-  <Target Name="GatherLocalizedOutputsForSigning" Condition="'$(LocalizationEnabled)' == 'true'">
-    <ItemGroup>
-      <FilesToSign Include="$(OutDir)\localize\**\$(TargetName).resources.dll" >
-        <Authenticode>Microsoft</Authenticode>
-        <StrongName>StrongName</StrongName>
-      </FilesToSign>
-    </ItemGroup>
-  </Target>
-
-  <!-- Custom target that will be invoked after signing and loc to copy signed satellite assemblies
-       to the drop location.
-       This target is conditioned to only run if localization is currently turned on. -->
-  <Target Name="CopySatellitesToDrop" AfterTargets="SignFiles" Condition="'$(LocalizationEnabled)'=='true'">
-    <PropertyGroup>
-      <SatellitesBinDir>$(OutDir)localize\</SatellitesBinDir>
-      <SatellitesDropDir>$(DropRootDir)\loc\</SatellitesDropDir>
-    </PropertyGroup>
-    <ItemGroup>
-      <LocFilesToDrop Include="$(SatellitesBinDir)**\$(TargetName).resources.dll" />
-      <LocFilesToDrop Include="$(SatellitesBinDir)**\$(TargetName).dll.lcg" />
-    </ItemGroup>
-    <Copy DestinationFiles="@(LocFilesToDrop->'$(SatellitesDropDir)%(RecursiveDir)%(Filename)%(Extension)')"
-          SourceFiles="@(LocFilesToDrop)" />
-  </Target>
-
   <Target Name="DetermineCompilerBinary">
     <GetRuntime>
       <Output PropertyName="IsMonoRuntime" TaskParameter="IsMonoRuntime" />

--- a/build/miengine.targets
+++ b/build/miengine.targets
@@ -47,6 +47,22 @@
     </ItemGroup>
   </Target>
 
+  <!-- Custom target that will be invoked after signing and loc to copy signed satellite assemblies
+       to the drop location.
+       This target is conditioned to only run if localization is currently turned on. -->
+  <Target Name="CopySatellitesToDrop" AfterTargets="SignFiles" Condition="'$(LocalizationEnabled)'=='true'">
+    <PropertyGroup>
+      <SatellitesBinDir>$(OutDir)localize\</SatellitesBinDir>
+      <SatellitesDropDir>$(DropRootDir)\loc\</SatellitesDropDir>
+    </PropertyGroup>
+    <ItemGroup>
+      <LocFilesToDrop Include="$(SatellitesBinDir)**\$(TargetName).resources.dll" />
+      <LocFilesToDrop Include="$(SatellitesBinDir)**\$(TargetName).dll.lcg" />
+    </ItemGroup>
+    <Copy DestinationFiles="@(LocFilesToDrop->'$(SatellitesDropDir)%(RecursiveDir)%(Filename)%(Extension)')"
+          SourceFiles="@(LocFilesToDrop)" />
+  </Target>
+
   <Target Name="DetermineCompilerBinary">
     <GetRuntime>
       <Output PropertyName="IsMonoRuntime" TaskParameter="IsMonoRuntime" />

--- a/src/SSHDebugPS/SSHDebugPS.csproj
+++ b/src/SSHDebugPS/SSHDebugPS.csproj
@@ -146,6 +146,7 @@
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Import Project="..\..\build\miengine.targets" />
+  <Import Project="..\..\build\miengine.csharp.localization.targets" />
   <Import Project="$(NuGetPackagesDirectory)\MicroBuild.Core.0.2.0\build\MicroBuild.Core.targets" Condition="Exists('$(NuGetPackagesDirectory)\MicroBuild.Core.0.2.0\build\MicroBuild.Core.targets')" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.


### PR DESCRIPTION
This copies satellite assemblies into the drop folder using the same subfolder name from the bin folder.

@pieandcakes @gregg-miskelly @jacdavis @chuckries @paulmaybee