### PR TITLE
Send kill command rather than -exec-interrupt when remote attached.

### DIFF
--- a/src/MICore/Debugger.cs
+++ b/src/MICore/Debugger.cs
@@ -589,7 +589,7 @@ namespace MICore
         private bool IsRemoteGdb()
         {
             return this.MICommandFactory.Mode == MIMode.Gdb &&
-               (this._launchOptions is PipeLaunchOptions ||
+               (this._launchOptions is PipeLaunchOptions || this._launchOptions is UnixShellPortLaunchOptions ||
                (this._launchOptions is LocalLaunchOptions
                     && !String.IsNullOrEmpty(((LocalLaunchOptions)this._launchOptions).MIDebuggerServerAddress)));
         }
@@ -733,6 +733,14 @@ namespace MICore
             {
                 int pid = PidByInferior("i1");
                 if (pid != 0 && ((PipeTransport)_transport).Interrupt(pid))
+                {
+                    return Task.FromResult<Results>(new Results(ResultClass.done));
+                }
+            }
+            else if (IsRemoteGdb() && _transport is UnixShellPortTransport)
+            {
+                int pid = PidByInferior("i1");
+                if (pid != 0 && ((UnixShellPortTransport)_transport).Interrupt(pid))
                 {
                     return Task.FromResult<Results>(new Results(ResultClass.done));
                 }

--- a/src/MICore/Transports/UnixShellPortTransport.cs
+++ b/src/MICore/Transports/UnixShellPortTransport.cs
@@ -196,5 +196,29 @@ namespace MICore
         {
             return true;
         }
+
+        public bool Interrupt(int pid)
+        {
+            int exitCode = -1;
+            string output = null;
+            string error = null;
+            string killCmd = string.Format(CultureInfo.InvariantCulture, "kill -2 {0}", pid);
+
+            try
+            {
+                exitCode = ExecuteSyncCommand(MICoreResources.Info_KillingPipeProcess, killCmd, System.Threading.Timeout.Infinite, out output, out error);
+
+                if (exitCode != 0)
+                {
+                    this._callback.OnStdErrorLine(string.Format(CultureInfo.InvariantCulture, MICoreResources.Warn_ProcessExit, killCmd, exitCode));
+                }
+            }
+            catch (Exception e)
+            {
+                this._callback.OnStdErrorLine(string.Format(CultureInfo.InvariantCulture, MICoreResources.Warn_ProcessException, killCmd, e.Message));
+            }
+
+            return exitCode == 0;
+        }
     }
 }


### PR DESCRIPTION
Fixes Issue #667 

