### PR TITLE
Change to calling step commands with frame id.

### DIFF
--- a/src/MICore/CommandFactories/MICommandFactory.cs
+++ b/src/MICore/CommandFactories/MICommandFactory.cs
@@ -217,31 +217,31 @@ namespace MICore
         public async Task ExecStep(int threadId, ResultClass resultClass = ResultClass.running)
         {
             string command = "-exec-step";
-            await ThreadCmdAsync(command, resultClass, threadId);
+            await ThreadFrameCmdAsync(command, resultClass, threadId, 0);
         }
 
         public async Task ExecNext(int threadId, ResultClass resultClass = ResultClass.running)
         {
             string command = "-exec-next";
-            await ThreadCmdAsync(command, resultClass, threadId);
+            await ThreadFrameCmdAsync(command, resultClass, threadId, 0);
         }
 
         public async Task ExecFinish(int threadId, ResultClass resultClass = ResultClass.running)
         {
             string command = "-exec-finish";
-            await ThreadCmdAsync(command, resultClass, threadId);
+            await ThreadFrameCmdAsync(command, resultClass, threadId, 0);
         }
 
         public async Task ExecStepInstruction(int threadId, ResultClass resultClass = ResultClass.running)
         {
             string command = "-exec-step-instruction";
-            await ThreadCmdAsync(command, resultClass, threadId);
+            await ThreadFrameCmdAsync(command, resultClass, threadId, 0);
         }
 
         public async Task ExecNextInstruction(int threadId, ResultClass resultClass = ResultClass.running)
         {
             string command = "-exec-next-instruction";
-            await ThreadCmdAsync(command, resultClass, threadId);
+            await ThreadFrameCmdAsync(command, resultClass, threadId, 0);
         }
 
         /// <summary>
@@ -331,6 +331,7 @@ namespace MICore
 
         #region Variable Objects
 
+        // Calls to VarCreate will change the current debugger thread and frame selection to what is passed in. This is because it needs to be queried in the context of a thread/frame id.
         public virtual async Task<Results> VarCreate(string expression, int threadId, uint frameLevel, enum_EVALFLAGS dwFlags, ResultClass resultClass = ResultClass.done)
         {
             string quoteEscapedExpression = EscapeQuotes(expression);

--- a/src/MIDebugEngine/Engine.Impl/DebuggedProcess.cs
+++ b/src/MIDebugEngine/Engine.Impl/DebuggedProcess.cs
@@ -1792,7 +1792,7 @@ namespace Microsoft.MIDebugEngine
                             {
                                 args.Add(new SimpleVariableInformation(n, /*isParam*/ true, null, null));
                             }
-                        }
+                        }                        
                     }
                 }
                 parameters.Add(new ArgumentList(level, args));


### PR DESCRIPTION
Test failure caused by var-create changing frames, which revealed a bug where step commands would operate based on selected Frame on the thread instead of the top frame. Changed to call with frame. 