### PR TITLE
Fix for entrypoint bp delete and watson

### DIFF
--- a/src/MICore/CommandFactories/MICommandFactory.cs
+++ b/src/MICore/CommandFactories/MICommandFactory.cs
@@ -522,9 +522,9 @@ namespace MICore
             }
         }
 
-        public virtual async Task BreakDelete(string bkptno)
+        public virtual async Task BreakDelete(string bkptno, ResultClass resultClass = ResultClass.done)
         {
-            await _debugger.CmdAsync("-break-delete " + bkptno, ResultClass.done);
+            await _debugger.CmdAsync("-break-delete " + bkptno, resultClass);
         }
 
         public virtual async Task BreakCondition(string bkptno, string expr)

--- a/src/MICore/Debugger.cs
+++ b/src/MICore/Debugger.cs
@@ -1126,7 +1126,11 @@ namespace MICore
                     {
                         miError = results.FindString("msg");
                     }
-
+                    else
+                    {
+                        miError = results.ResultClass.ToString();
+                    }
+                
                     _completionSource.SetException(new UnexpectedMIResultException(commandFactory.Name, this.Command, miError));
                 }
                 else

--- a/src/MICore/Debugger.cs
+++ b/src/MICore/Debugger.cs
@@ -1128,9 +1128,9 @@ namespace MICore
                     }
                     else
                     {
-                        miError = results.ResultClass.ToString();
+                        miError = String.Format(CultureInfo.CurrentCulture, MICoreResources.Error_UnexpectedResultClass, Enum.GetName(typeof(ResultClass), _expectedResultClass), Enum.GetName(typeof(ResultClass), results.ResultClass));
                     }
-                
+
                     _completionSource.SetException(new UnexpectedMIResultException(commandFactory.Name, this.Command, miError));
                 }
                 else

--- a/src/MICore/MICoreResources.Designer.cs
+++ b/src/MICore/MICoreResources.Designer.cs
@@ -430,6 +430,15 @@ namespace MICore {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Unexpected ResultClass from MI Debugger. Expected &apos;{0}&apos; but received &apos;{1}&apos;..
+        /// </summary>
+        public static string Error_UnexpectedResultClass {
+            get {
+                return ResourceManager.GetString("Error_UnexpectedResultClass", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Internal error: unable to serialize launch options..
         /// </summary>
         public static string Error_UnknownLaunchOptions {

--- a/src/MICore/MICoreResources.resx
+++ b/src/MICore/MICoreResources.resx
@@ -294,4 +294,8 @@ Error: {1}</value>
 {1}</value>
     <comment>GDB is an acronym and should not be localized. {0} represents a dotted decimal version number. {1} represents a more detailed error message.</comment>
   </data>
+  <data name="Error_UnexpectedResultClass" xml:space="preserve">
+    <value>Unexpected ResultClass from MI Debugger. Expected '{0}' but received '{1}'.</value>
+    <comment>{0} expected value, {1} received value</comment>
+  </data>
 </root>

--- a/src/MIDebugEngine/Engine.Impl/DebuggedProcess.cs
+++ b/src/MIDebugEngine/Engine.Impl/DebuggedProcess.cs
@@ -1056,7 +1056,7 @@ namespace Microsoft.MIDebugEngine
             else if (reason == "entry-point-hit")
             {
                 this.EntrypointHit = true;
-                this.OnEntrypointHit();
+                await this.OnEntrypointHit();
                 _callback.OnEntryPoint(thread);
             }
             else if (reason == "breakpoint-hit")
@@ -1083,7 +1083,7 @@ namespace Microsoft.MIDebugEngine
                     {
                         // Hitting a bp before the entrypoint overrules entrypoint processing.
                         this.EntrypointHit = true;
-                        this.OnEntrypointHit();
+                        await this.OnEntrypointHit();
                     }
 
                     List<object> bplist = new List<object>();
@@ -1093,7 +1093,7 @@ namespace Microsoft.MIDebugEngine
                 else if (!this.EntrypointHit)
                 {
                     this.EntrypointHit = true;
-                    this.OnEntrypointHit();
+                    await this.OnEntrypointHit();
 
                     _callback.OnEntryPoint(thread);
                 }
@@ -1223,7 +1223,7 @@ namespace Microsoft.MIDebugEngine
         /// <summary>
         /// Tasks to run when the entry point is hit.
         /// </summary>
-        private async void OnEntrypointHit()
+        private async Task OnEntrypointHit()
         {
             if (this.MICommandFactory.Mode == MIMode.Lldb)
             {
@@ -1235,7 +1235,8 @@ namespace Microsoft.MIDebugEngine
 
             if (this._deleteEntryPointBreakpoint && !String.IsNullOrWhiteSpace(this._entryPointBreakpoint))
             {
-                await MICommandFactory.BreakDelete(this._entryPointBreakpoint);
+                // Try and delete the entrypoint breakpoint. We only try this once but in some cases this won't succeed
+                await MICommandFactory.BreakDelete(this._entryPointBreakpoint, ResultClass.None);
                 this._deleteEntryPointBreakpoint = false;
             }
         }


### PR DESCRIPTION
* change 'async void' to 'async Task' and add await
* change to Expect possible failure on deleting the entrypoint bp. We
will try and delete it once now and if it fails, move on.