### PR TITLE
android 26 changes to ps tool

### DIFF
--- a/src/AndroidDebugLauncher/Launcher.cs
+++ b/src/AndroidDebugLauncher/Launcher.cs
@@ -541,7 +541,16 @@ namespace AndroidDebugLauncher
         {
             Debug.Assert(_shell != null, "GetProcessIds called before m_shell is set");
 
-            ExecCommandNoLog("ps");
+            int sdkVersion = VerifySdkVersion();
+            if (sdkVersion >= 26)
+            {
+                ExecCommandNoLog("ps -A");
+            }
+            else
+            {
+                ExecCommandNoLog("ps");
+            }
+            
             var processList = new ProcessListParser(_shell.Out);
 
             return processList.FindProcesses(processName);
@@ -657,7 +666,15 @@ namespace AndroidDebugLauncher
         {
             Debug.Assert(_shell != null, "KillOldInstances called before m_shell is set");
 
-            ExecCommand("ps");
+            int sdkVersion = VerifySdkVersion();
+            if (sdkVersion >= 26)
+            {
+                ExecCommand("ps -A");
+            }
+            else
+            {
+                ExecCommand("ps");
+            }
             var processList = new ProcessListParser(_shell.Out);
 
             if (!_launchOptions.IsAttach)


### PR DESCRIPTION
With the release of Android Oreo there were a number of changes to the inputs and outputs from the Android command line shell tools (they moved from their own implementation to toybox implementation). The particular issue here is that while ps used to return all processes it now requires ps -A to return all processes. 