### PR TITLE
Support launchOptions on remote attach operations

### DIFF
--- a/IL/liblinux.il
+++ b/IL/liblinux.il
@@ -2847,6 +2847,16 @@
 			ret
 		}
 		.method public hidebysig specialname 
+			instance valuetype [mscorlib]'System.Nullable`1'<uint32> get_ProcessId()
+		{
+			ret
+		}
+		.method public hidebysig specialname 
+			instance void set_ProcessId(valuetype [mscorlib]'System.Nullable`1'<uint32> 'value')
+		{
+			ret
+		}
+		.method public hidebysig specialname 
 			instance void .ctor()
 		{
 			ret
@@ -2865,6 +2875,11 @@
 		{
 			.get instance string liblinux.Services.GdbServerStartInfo::get_PreLaunchCommand()
 			.set instance void liblinux.Services.GdbServerStartInfo::set_PreLaunchCommand(string)
+		}
+		.property instance valuetype [mscorlib]'System.Nullable`1'<uint32> ProcessId()
+		{
+			.get instance valuetype [mscorlib]'System.Nullable`1'<uint32> liblinux.Services.GdbServerStartInfo::get_ProcessId()
+			.set instance void liblinux.Services.GdbServerStartInfo::set_ProcessId(valuetype [mscorlib]'System.Nullable`1'<uint32>)
 		}
 		.property instance string RemotePath()
 		{

--- a/IL/liblinux.il
+++ b/IL/liblinux.il
@@ -2847,12 +2847,12 @@
 			ret
 		}
 		.method public hidebysig specialname 
-			instance valuetype [mscorlib]'System.Nullable`1'<uint32> get_ProcessId()
+			instance valuetype [mscorlib]'System.Nullable`1'<int32> get_ProcessId()
 		{
 			ret
 		}
 		.method public hidebysig specialname 
-			instance void set_ProcessId(valuetype [mscorlib]'System.Nullable`1'<uint32> 'value')
+			instance void set_ProcessId(valuetype [mscorlib]'System.Nullable`1'<int32> 'value')
 		{
 			ret
 		}
@@ -2876,10 +2876,10 @@
 			.get instance string liblinux.Services.GdbServerStartInfo::get_PreLaunchCommand()
 			.set instance void liblinux.Services.GdbServerStartInfo::set_PreLaunchCommand(string)
 		}
-		.property instance valuetype [mscorlib]'System.Nullable`1'<uint32> ProcessId()
+		.property instance valuetype [mscorlib]'System.Nullable`1'<int32> ProcessId()
 		{
-			.get instance valuetype [mscorlib]'System.Nullable`1'<uint32> liblinux.Services.GdbServerStartInfo::get_ProcessId()
-			.set instance void liblinux.Services.GdbServerStartInfo::set_ProcessId(valuetype [mscorlib]'System.Nullable`1'<uint32>)
+			.get instance valuetype [mscorlib]'System.Nullable`1'<int32> liblinux.Services.GdbServerStartInfo::get_ProcessId()
+			.set instance void liblinux.Services.GdbServerStartInfo::set_ProcessId(valuetype [mscorlib]'System.Nullable`1'<int32>)
 		}
 		.property instance string RemotePath()
 		{

--- a/src/MICore/LaunchOptions.cs
+++ b/src/MICore/LaunchOptions.cs
@@ -1396,7 +1396,7 @@ namespace MICore
             LaunchOptions options;
             if (isServerMode)
             {
-                string addr = unixPort.AttachToProcess((uint)processId, attachOptions.ServerOptions.PreAttachCommand);
+                string addr = unixPort.AttachToProcess(processId, attachOptions.ServerOptions.PreAttachCommand);
                 options = new LocalLaunchOptions(attachOptions.ServerOptions.MIDebuggerPath, addr, null);
                 options._miMode = miMode;
                 options.ExePath = attachOptions.ServerOptions.ExePath;

--- a/src/MICore/LaunchOptions.cs
+++ b/src/MICore/LaunchOptions.cs
@@ -1389,7 +1389,7 @@ namespace MICore
             AttachOptionsForConnection attachOptions = null;
             if (suppOptions != null)
             {
-                attachOptions = suppOptions.OptionsForConnection.FirstOrDefault((o) => o.ConnectionName == connection || o.ConnectionName == "*" || o.ConnectionName == null);
+                attachOptions = suppOptions.OptionsForConnection.FirstOrDefault((o) => o.ConnectionName == connection || o.ConnectionName == "*" || string.IsNullOrWhiteSpace(o.ConnectionName));
             }
             bool isServerMode = attachOptions?.ServerOptions != null;
 

--- a/src/MICore/LaunchOptions.xsd
+++ b/src/MICore/LaunchOptions.xsd
@@ -371,6 +371,102 @@
     </xs:complexType>
   </xs:element>
 
+  <xs:complexType name="ServerOptions">
+    <xs:annotation>
+      <xs:documentation>Instructions for how to setup and run the remote debugging server.</xs:documentation>
+    </xs:annotation>
+          <xs:attribute name="PreAttachCommand" type="xs:string" use="optional">
+            <xs:annotation>
+              <xs:documentation>Command to run remotely before starting the server.</xs:documentation>
+            </xs:annotation>
+          </xs:attribute>
+          <xs:attribute name="MIDebuggerPath" type="xs:string" use="required">
+            <xs:annotation>
+              <xs:documentation>Local path to the MI Debugger executable.</xs:documentation>
+            </xs:annotation>
+          </xs:attribute>
+    <xs:attribute name="ExePath" type="xs:string" use="required">
+      <xs:annotation>
+        <xs:documentation>Path to the executable file. This is a path on the Windows machine.</xs:documentation>
+      </xs:annotation>
+    </xs:attribute>
+  </xs:complexType>
+
+  <xs:complexType name="AttachOptionsForConnection">
+      <xs:sequence>
+        <xs:element name="SetupCommands" minOccurs="0" maxOccurs="1" type="CommandList">
+          <xs:annotation>
+            <xs:documentation>One or more GDB/LLDB/CLRDBG commands to execute in order to setup the underlying debugger. These are not required.</xs:documentation>
+          </xs:annotation>
+        </xs:element>
+        <xs:element name="SourceMap" type="SourceMapList" minOccurs="0" maxOccurs="1">
+        </xs:element>
+        <xs:element name="ServerOptions" type="ServerOptions" minOccurs="0" maxOccurs="1">
+          <xs:annotation>
+            <xs:documentation>If specified then attach using client-server mode.</xs:documentation>
+          </xs:annotation>
+        </xs:element>
+      </xs:sequence>
+      <xs:attribute name="AdditionalSOLibSearchPath" type="xs:string" use="optional">
+        <xs:annotation>
+          <xs:documentation>Semicolon separated list of directories to use to search for .so files. Example: 'c:\dir1;c:\dir2'</xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="MIMode" type="MIMode" use="required"/>
+    <xs:attribute name="WorkingDirectory" type="xs:string" use="optional">
+      <xs:annotation>
+        <xs:documentation>Working directory on the remote device if remote debugging, on the local device if client-server debugging.</xs:documentation>
+      </xs:annotation>
+    </xs:attribute>
+      <xs:attribute name="DebugChildProcesses" type="xs:boolean" use="optional">
+        <xs:annotation>
+          <xs:documentation>
+            If true, automatically attach debugger to any child processes created.
+          </xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="VisualizerFile" type="xs:string" use="optional">
+        <xs:annotation>
+          <xs:documentation>.natvis file to be used when debugging this platform</xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="ShowDisplayString" type="xs:boolean" use="optional">
+        <xs:annotation>
+          <xs:documentation>
+            If true, instead of showing Natvis-DisplayString value as a child of a dummy element, it is shown immediately.
+            Should only be enabled if debugger is fast enough providing the value.
+          </xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+    <xs:attribute name="ConnectionName" type="xs:string" use="optional">
+        <xs:annotation>
+          <xs:documentation>
+            Specific connection these options apply to. If missing or specified as '*' then all connections are matched.
+            Matching is done in the order of appearance in a list.
+          </xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+    </xs:complexType> 
+
+  <xs:complexType name="AttachConnectionList">
+    <xs:sequence>
+      <xs:element name="AttachOptionsForConnection" minOccurs="0" maxOccurs="unbounded" type="AttachOptionsForConnection"/>
+    </xs:sequence>
+  </xs:complexType>
+
+  <xs:element name="SupplementalAttachOptions">
+    <xs:annotation>
+      <xs:documentation>Option values that supplement the xml that arrives via the attach command.</xs:documentation>
+    </xs:annotation>
+    <xs:complexType>
+      <xs:sequence>
+        <xs:element name="OptionsForConnection" type="AttachConnectionList" minOccurs="0" maxOccurs="1">
+        </xs:element>
+      </xs:sequence>
+    </xs:complexType>
+  </xs:element>
+
+
   <!--base type for LocalLaunchOptions, PipeLaunchOptions, and TcpLaunchOptions -->
   <xs:complexType name="BaseLaunchOptions">
     <xs:sequence>

--- a/src/MICore/LaunchOptions.xsd
+++ b/src/MICore/LaunchOptions.xsd
@@ -222,7 +222,7 @@
                 <xs:documentation>Option list of environment variables to set for launch.</xs:documentation>
               </xs:annotation>
             </xs:element>
-          </xs:sequence>  
+          </xs:sequence>
           <xs:attribute name="MIDebuggerPath" type="xs:string" use="required">
             <xs:annotation>
               <xs:documentation>Path to the MI Debugger executable. If only the executable name is provided, it will attempt to search $PATH for the location of the executable.</xs:documentation>
@@ -265,8 +265,10 @@
           </xs:attribute>
           <xs:attribute name="ExternalConsole" type="xs:boolean" use="optional">
             <xs:annotation>
-              <xs:documentation>If enabled, this tells the MIEngine that the target process should run in a new console window which
-              is external to the debugger UI.</xs:documentation>
+              <xs:documentation>
+                If enabled, this tells the MIEngine that the target process should run in a new console window which
+                is external to the debugger UI.
+              </xs:documentation>
             </xs:annotation>
           </xs:attribute>
         </xs:extension>
@@ -365,8 +367,13 @@
     </xs:annotation>
     <xs:complexType>
       <xs:sequence>
-      <xs:element name="SourceMap" type="SourceMapList" minOccurs="0" maxOccurs="1">
-      </xs:element>
+        <xs:element name="SourceMap" type="SourceMapList" minOccurs="0" maxOccurs="1">
+        </xs:element>
+        <xs:element name="AttachOptions" type="AttachConnectionList" minOccurs="0" maxOccurs="1">
+          <xs:annotation>
+            <xs:documentation>Option values that supplement the xml that arrives via the attach command.</xs:documentation>
+          </xs:annotation>
+        </xs:element>
       </xs:sequence>
     </xs:complexType>
   </xs:element>
@@ -375,16 +382,16 @@
     <xs:annotation>
       <xs:documentation>Instructions for how to setup and run the remote debugging server.</xs:documentation>
     </xs:annotation>
-          <xs:attribute name="PreAttachCommand" type="xs:string" use="optional">
-            <xs:annotation>
-              <xs:documentation>Command to run remotely before starting the server.</xs:documentation>
-            </xs:annotation>
-          </xs:attribute>
-          <xs:attribute name="MIDebuggerPath" type="xs:string" use="required">
-            <xs:annotation>
-              <xs:documentation>Local path to the MI Debugger executable.</xs:documentation>
-            </xs:annotation>
-          </xs:attribute>
+    <xs:attribute name="PreAttachCommand" type="xs:string" use="optional">
+      <xs:annotation>
+        <xs:documentation>Command to run remotely before starting the server.</xs:documentation>
+      </xs:annotation>
+    </xs:attribute>
+    <xs:attribute name="MIDebuggerPath" type="xs:string" use="required">
+      <xs:annotation>
+        <xs:documentation>Local path to the MI Debugger executable.</xs:documentation>
+      </xs:annotation>
+    </xs:attribute>
     <xs:attribute name="ExePath" type="xs:string" use="required">
       <xs:annotation>
         <xs:documentation>Path to the executable file. This is a path on the Windows machine.</xs:documentation>
@@ -393,79 +400,66 @@
   </xs:complexType>
 
   <xs:complexType name="AttachOptionsForConnection">
-      <xs:sequence>
-        <xs:element name="SetupCommands" minOccurs="0" maxOccurs="1" type="CommandList">
-          <xs:annotation>
-            <xs:documentation>One or more GDB/LLDB/CLRDBG commands to execute in order to setup the underlying debugger. These are not required.</xs:documentation>
-          </xs:annotation>
-        </xs:element>
-        <xs:element name="SourceMap" type="SourceMapList" minOccurs="0" maxOccurs="1">
-        </xs:element>
-        <xs:element name="ServerOptions" type="ServerOptions" minOccurs="0" maxOccurs="1">
-          <xs:annotation>
-            <xs:documentation>If specified then attach using client-server mode.</xs:documentation>
-          </xs:annotation>
-        </xs:element>
-      </xs:sequence>
-      <xs:attribute name="AdditionalSOLibSearchPath" type="xs:string" use="optional">
+    <xs:sequence>
+      <xs:element name="SetupCommands" minOccurs="0" maxOccurs="1" type="CommandList">
         <xs:annotation>
-          <xs:documentation>Semicolon separated list of directories to use to search for .so files. Example: 'c:\dir1;c:\dir2'</xs:documentation>
+          <xs:documentation>One or more GDB/LLDB/CLRDBG commands to execute in order to setup the underlying debugger. These are not required.</xs:documentation>
         </xs:annotation>
-      </xs:attribute>
-      <xs:attribute name="MIMode" type="MIMode" use="required"/>
+      </xs:element>
+      <xs:element name="SourceMap" type="SourceMapList" minOccurs="0" maxOccurs="1">
+      </xs:element>
+      <xs:element name="ServerOptions" type="ServerOptions" minOccurs="0" maxOccurs="1">
+        <xs:annotation>
+          <xs:documentation>If specified then attach using client-server mode.</xs:documentation>
+        </xs:annotation>
+      </xs:element>
+    </xs:sequence>
+    <xs:attribute name="AdditionalSOLibSearchPath" type="xs:string" use="optional">
+      <xs:annotation>
+        <xs:documentation>Semicolon separated list of directories to use to search for .so files. Example: 'c:\dir1;c:\dir2'</xs:documentation>
+      </xs:annotation>
+    </xs:attribute>
+    <xs:attribute name="MIMode" type="MIMode" use="required"/>
     <xs:attribute name="WorkingDirectory" type="xs:string" use="optional">
       <xs:annotation>
         <xs:documentation>Working directory on the remote device if remote debugging, on the local device if client-server debugging.</xs:documentation>
       </xs:annotation>
     </xs:attribute>
-      <xs:attribute name="DebugChildProcesses" type="xs:boolean" use="optional">
-        <xs:annotation>
-          <xs:documentation>
-            If true, automatically attach debugger to any child processes created.
-          </xs:documentation>
-        </xs:annotation>
-      </xs:attribute>
-      <xs:attribute name="VisualizerFile" type="xs:string" use="optional">
-        <xs:annotation>
-          <xs:documentation>.natvis file to be used when debugging this platform</xs:documentation>
-        </xs:annotation>
-      </xs:attribute>
-      <xs:attribute name="ShowDisplayString" type="xs:boolean" use="optional">
-        <xs:annotation>
-          <xs:documentation>
-            If true, instead of showing Natvis-DisplayString value as a child of a dummy element, it is shown immediately.
-            Should only be enabled if debugger is fast enough providing the value.
-          </xs:documentation>
-        </xs:annotation>
-      </xs:attribute>
+    <xs:attribute name="DebugChildProcesses" type="xs:boolean" use="optional">
+      <xs:annotation>
+        <xs:documentation>
+          If true, automatically attach debugger to any child processes created.
+        </xs:documentation>
+      </xs:annotation>
+    </xs:attribute>
+    <xs:attribute name="VisualizerFile" type="xs:string" use="optional">
+      <xs:annotation>
+        <xs:documentation>.natvis file to be used when debugging this platform</xs:documentation>
+      </xs:annotation>
+    </xs:attribute>
+    <xs:attribute name="ShowDisplayString" type="xs:boolean" use="optional">
+      <xs:annotation>
+        <xs:documentation>
+          If true, instead of showing Natvis-DisplayString value as a child of a dummy element, it is shown immediately.
+          Should only be enabled if debugger is fast enough providing the value.
+        </xs:documentation>
+      </xs:annotation>
+    </xs:attribute>
     <xs:attribute name="ConnectionName" type="xs:string" use="optional">
-        <xs:annotation>
-          <xs:documentation>
-            Specific connection these options apply to. If missing or specified as '*' then all connections are matched.
-            Matching is done in the order of appearance in a list.
-          </xs:documentation>
-        </xs:annotation>
-      </xs:attribute>
-    </xs:complexType> 
+      <xs:annotation>
+        <xs:documentation>
+          Specific connection these options apply to. If missing or specified as '*' then all connections are matched.
+          Matching is done in the order of appearance in a list.
+        </xs:documentation>
+      </xs:annotation>
+    </xs:attribute>
+  </xs:complexType>
 
   <xs:complexType name="AttachConnectionList">
     <xs:sequence>
       <xs:element name="AttachOptionsForConnection" minOccurs="0" maxOccurs="unbounded" type="AttachOptionsForConnection"/>
     </xs:sequence>
   </xs:complexType>
-
-  <xs:element name="SupplementalAttachOptions">
-    <xs:annotation>
-      <xs:documentation>Option values that supplement the xml that arrives via the attach command.</xs:documentation>
-    </xs:annotation>
-    <xs:complexType>
-      <xs:sequence>
-        <xs:element name="OptionsForConnection" type="AttachConnectionList" minOccurs="0" maxOccurs="1">
-        </xs:element>
-      </xs:sequence>
-    </xs:complexType>
-  </xs:element>
-
 
   <!--base type for LocalLaunchOptions, PipeLaunchOptions, and TcpLaunchOptions -->
   <xs:complexType name="BaseLaunchOptions">
@@ -477,15 +471,19 @@
       </xs:element>
       <xs:element name="CustomLaunchSetupCommands" minOccurs="0" maxOccurs="1" type="CommandList">
         <xs:annotation>
-          <xs:documentation>If provided, this replaces the default commands used to launch a target with some other commands. For example,
-          this can be '-target-attach' in order to attach to a target process. An empty command list replaces the launch commands with nothing,
-          which can be useful if the debugger is being provided launch options as command line options.</xs:documentation>
+          <xs:documentation>
+            If provided, this replaces the default commands used to launch a target with some other commands. For example,
+            this can be '-target-attach' in order to attach to a target process. An empty command list replaces the launch commands with nothing,
+            which can be useful if the debugger is being provided launch options as command line options.
+          </xs:documentation>
         </xs:annotation>
       </xs:element>
       <xs:element name="LaunchCompleteCommand" minOccurs="0" maxOccurs="1">
         <xs:annotation>
-          <xs:documentation>The command to execute after the debugger is fully setup in order to cause the target process to run. 
-          The default value is 'exec-run'.</xs:documentation>
+          <xs:documentation>
+            The command to execute after the debugger is fully setup in order to cause the target process to run.
+            The default value is 'exec-run'.
+          </xs:documentation>
         </xs:annotation>
         <xs:simpleType>
           <xs:restriction base="xs:string">
@@ -496,8 +494,10 @@
             </xs:enumeration>
             <xs:enumeration value="exec-continue">
               <xs:annotation>
-                <xs:documentation>Execute the 'exec-continue' MI command which will resume from stopped state. This is useful if
-                the result of setting up the debugger is that the debuggee is in break state.</xs:documentation>
+                <xs:documentation>
+                  Execute the 'exec-continue' MI command which will resume from stopped state. This is useful if
+                  the result of setting up the debugger is that the debuggee is in break state.
+                </xs:documentation>
               </xs:annotation>
             </xs:enumeration>
             <xs:enumeration value="None">

--- a/src/MICore/LaunchOptions.xsd.types.designer.cs
+++ b/src/MICore/LaunchOptions.xsd.types.designer.cs
@@ -175,19 +175,96 @@ namespace MICore.Xml.LaunchOptions {
     [System.CodeDom.Compiler.GeneratedCodeAttribute("xsd", "4.6.81.0")]
     [System.Diagnostics.DebuggerStepThroughAttribute()]
     [System.Xml.Serialization.XmlTypeAttribute(Namespace="http://schemas.microsoft.com/vstudio/MDDDebuggerOptions/2014")]
-    public partial class EnvironmentEntry {
+    public partial class ServerOptions {
         
         /// <remarks/>
         [System.Xml.Serialization.XmlAttributeAttribute()]
-        public string Name;
+        public string PreAttachCommand;
         
         /// <remarks/>
         [System.Xml.Serialization.XmlAttributeAttribute()]
-        public string Value;
+        public string MIDebuggerPath;
+        
+        /// <remarks/>
+        [System.Xml.Serialization.XmlAttributeAttribute()]
+        public string ExePath;
+    }
+    
+    /// <remarks/>
+    [System.CodeDom.Compiler.GeneratedCodeAttribute("xsd", "4.6.81.0")]
+    [System.Diagnostics.DebuggerStepThroughAttribute()]
+    [System.Xml.Serialization.XmlTypeAttribute(Namespace="http://schemas.microsoft.com/vstudio/MDDDebuggerOptions/2014")]
+    public partial class AttachOptionsForConnection {
+        
+        /// <remarks/>
+        [System.Xml.Serialization.XmlArrayItemAttribute(IsNullable=false)]
+        public Command[] SetupCommands;
+        
+        /// <remarks/>
+        [System.Xml.Serialization.XmlArrayItemAttribute(IsNullable=false)]
+        public SourceMapEntry[] SourceMap;
+        
+        /// <remarks/>
+        public ServerOptions ServerOptions;
+        
+        /// <remarks/>
+        [System.Xml.Serialization.XmlAttributeAttribute()]
+        public string AdditionalSOLibSearchPath;
+        
+        /// <remarks/>
+        [System.Xml.Serialization.XmlAttributeAttribute()]
+        public MIMode MIMode;
+        
+        /// <remarks/>
+        [System.Xml.Serialization.XmlAttributeAttribute()]
+        public string WorkingDirectory;
+        
+        /// <remarks/>
+        [System.Xml.Serialization.XmlAttributeAttribute()]
+        public bool DebugChildProcesses;
+        
+        /// <remarks/>
+        [System.Xml.Serialization.XmlIgnoreAttribute()]
+        public bool DebugChildProcessesSpecified;
+        
+        /// <remarks/>
+        [System.Xml.Serialization.XmlAttributeAttribute()]
+        public string VisualizerFile;
+        
+        /// <remarks/>
+        [System.Xml.Serialization.XmlAttributeAttribute()]
+        public bool ShowDisplayString;
+        
+        /// <remarks/>
+        [System.Xml.Serialization.XmlIgnoreAttribute()]
+        public bool ShowDisplayStringSpecified;
+        
+        /// <remarks/>
+        [System.Xml.Serialization.XmlAttributeAttribute()]
+        public string ConnectionName;
+    }
+    
+    /// <remarks/>
+    [System.CodeDom.Compiler.GeneratedCodeAttribute("xsd", "4.6.81.0")]
+    [System.Diagnostics.DebuggerStepThroughAttribute()]
+    [System.Xml.Serialization.XmlTypeAttribute(Namespace="http://schemas.microsoft.com/vstudio/MDDDebuggerOptions/2014")]
+    public partial class Command {
+        
+        /// <remarks/>
+        [System.Xml.Serialization.XmlAttributeAttribute()]
+        public bool IgnoreFailures;
+        
+        /// <remarks/>
+        [System.Xml.Serialization.XmlIgnoreAttribute()]
+        public bool IgnoreFailuresSpecified;
+        
+        /// <remarks/>
+        [System.Xml.Serialization.XmlAttributeAttribute()]
+        public string Description;
         
         /// <remarks/>
         [System.Xml.Serialization.XmlTextAttribute()]
-        public string Value1;
+        public string Value;
     }
     
     /// <remarks/>
@@ -222,23 +299,19 @@ namespace MICore.Xml.LaunchOptions {
     [System.CodeDom.Compiler.GeneratedCodeAttribute("xsd", "4.6.81.0")]
     [System.Diagnostics.DebuggerStepThroughAttribute()]
     [System.Xml.Serialization.XmlTypeAttribute(Namespace="http://schemas.microsoft.com/vstudio/MDDDebuggerOptions/2014")]
-    public partial class Command {
+    public partial class EnvironmentEntry {
         
         /// <remarks/>
         [System.Xml.Serialization.XmlAttributeAttribute()]
-        public bool IgnoreFailures;
-        
-        /// <remarks/>
-        [System.Xml.Serialization.XmlIgnoreAttribute()]
-        public bool IgnoreFailuresSpecified;
+        public string Name;
         
         /// <remarks/>
         [System.Xml.Serialization.XmlAttributeAttribute()]
-        public string Description;
+        public string Value;
         
         /// <remarks/>
         [System.Xml.Serialization.XmlTextAttribute()]
-        public string Value;
+        public string Value1;
     }
     
     /// <remarks/>
@@ -592,5 +665,17 @@ namespace MICore.Xml.LaunchOptions {
         /// <remarks/>
         [System.Xml.Serialization.XmlArrayItemAttribute(IsNullable=false)]
         public SourceMapEntry[] SourceMap;
+    }
+    
+    /// <remarks/>
+    [System.CodeDom.Compiler.GeneratedCodeAttribute("xsd", "4.6.81.0")]
+    [System.Diagnostics.DebuggerStepThroughAttribute()]
+    [System.Xml.Serialization.XmlTypeAttribute(AnonymousType=true, Namespace="http://schemas.microsoft.com/vstudio/MDDDebuggerOptions/2014")]
+    [System.Xml.Serialization.XmlRootAttribute(Namespace="http://schemas.microsoft.com/vstudio/MDDDebuggerOptions/2014", IsNullable=false)]
+    public partial class SupplementalAttachOptions {
+        
+        /// <remarks/>
+        [System.Xml.Serialization.XmlArrayItemAttribute(IsNullable=false)]
+        public AttachOptionsForConnection[] OptionsForConnection;
     }
 }

--- a/src/MICore/LaunchOptions.xsd.types.designer.cs
+++ b/src/MICore/LaunchOptions.xsd.types.designer.cs
@@ -665,17 +665,9 @@ namespace MICore.Xml.LaunchOptions {
         /// <remarks/>
         [System.Xml.Serialization.XmlArrayItemAttribute(IsNullable=false)]
         public SourceMapEntry[] SourceMap;
-    }
-    
-    /// <remarks/>
-    [System.CodeDom.Compiler.GeneratedCodeAttribute("xsd", "4.6.81.0")]
-    [System.Diagnostics.DebuggerStepThroughAttribute()]
-    [System.Xml.Serialization.XmlTypeAttribute(AnonymousType=true, Namespace="http://schemas.microsoft.com/vstudio/MDDDebuggerOptions/2014")]
-    [System.Xml.Serialization.XmlRootAttribute(Namespace="http://schemas.microsoft.com/vstudio/MDDDebuggerOptions/2014", IsNullable=false)]
-    public partial class SupplementalAttachOptions {
         
         /// <remarks/>
         [System.Xml.Serialization.XmlArrayItemAttribute(IsNullable=false)]
-        public AttachOptionsForConnection[] OptionsForConnection;
+        public AttachOptionsForConnection[] AttachOptions;
     }
 }

--- a/src/MICore/LaunchOptions.xsd.types.designer.desktop.cs
+++ b/src/MICore/LaunchOptions.xsd.types.designer.desktop.cs
@@ -347,15 +347,9 @@ namespace MICore.Xml.LaunchOptions {
         
         private string preAttachCommandField;
         
-        private string pathField;
-        
-        private int portField;
-        
         private string mIDebuggerPathField;
         
-        public ServerOptions() {
-            this.portField = 61234;
-        }
+        private string exePathField;
         
         /// <remarks/>
         [System.Xml.Serialization.XmlAttributeAttribute()]
@@ -370,35 +364,23 @@ namespace MICore.Xml.LaunchOptions {
         
         /// <remarks/>
         [System.Xml.Serialization.XmlAttributeAttribute()]
-        public string Path {
-            get {
-                return this.pathField;
-            }
-            set {
-                this.pathField = value;
-            }
-        }
-        
-        /// <remarks/>
-        [System.Xml.Serialization.XmlAttributeAttribute()]
-        [System.ComponentModel.DefaultValueAttribute(61234)]
-        public int Port {
-            get {
-                return this.portField;
-            }
-            set {
-                this.portField = value;
-            }
-        }
-        
-        /// <remarks/>
-        [System.Xml.Serialization.XmlAttributeAttribute()]
         public string MIDebuggerPath {
             get {
                 return this.mIDebuggerPathField;
             }
             set {
                 this.mIDebuggerPathField = value;
+            }
+        }
+        
+        /// <remarks/>
+        [System.Xml.Serialization.XmlAttributeAttribute()]
+        public string ExePath {
+            get {
+                return this.exePathField;
+            }
+            set {
+                this.exePathField = value;
             }
         }
     }
@@ -1658,6 +1640,8 @@ namespace MICore.Xml.LaunchOptions {
         
         private SourceMapEntry[] sourceMapField;
         
+        private AttachOptionsForConnection[] attachOptionsField;
+        
         /// <remarks/>
         [System.Xml.Serialization.XmlArrayItemAttribute(IsNullable=false)]
         public SourceMapEntry[] SourceMap {
@@ -1668,27 +1652,15 @@ namespace MICore.Xml.LaunchOptions {
                 this.sourceMapField = value;
             }
         }
-    }
-    
-    /// <remarks/>
-    [System.CodeDom.Compiler.GeneratedCodeAttribute("xsd", "4.6.81.0")]
-    [System.SerializableAttribute()]
-    [System.Diagnostics.DebuggerStepThroughAttribute()]
-    [System.ComponentModel.DesignerCategoryAttribute("code")]
-    [System.Xml.Serialization.XmlTypeAttribute(AnonymousType=true, Namespace="http://schemas.microsoft.com/vstudio/MDDDebuggerOptions/2014")]
-    [System.Xml.Serialization.XmlRootAttribute(Namespace="http://schemas.microsoft.com/vstudio/MDDDebuggerOptions/2014", IsNullable=false)]
-    public partial class SupplementalAttachOptions {
-        
-        private AttachOptionsForConnection[] optionsForConnectionField;
         
         /// <remarks/>
         [System.Xml.Serialization.XmlArrayItemAttribute(IsNullable=false)]
-        public AttachOptionsForConnection[] OptionsForConnection {
+        public AttachOptionsForConnection[] AttachOptions {
             get {
-                return this.optionsForConnectionField;
+                return this.attachOptionsField;
             }
             set {
-                this.optionsForConnectionField = value;
+                this.attachOptionsField = value;
             }
         }
     }

--- a/src/MICore/LaunchOptions.xsd.types.designer.desktop.cs
+++ b/src/MICore/LaunchOptions.xsd.types.designer.desktop.cs
@@ -343,44 +343,287 @@ namespace MICore.Xml.LaunchOptions {
     [System.Diagnostics.DebuggerStepThroughAttribute()]
     [System.ComponentModel.DesignerCategoryAttribute("code")]
     [System.Xml.Serialization.XmlTypeAttribute(Namespace="http://schemas.microsoft.com/vstudio/MDDDebuggerOptions/2014")]
-    public partial class EnvironmentEntry {
+    public partial class ServerOptions {
         
-        private string nameField;
+        private string preAttachCommandField;
         
-        private string valueField;
+        private string pathField;
         
-        private string value1Field;
+        private int portField;
+        
+        private string mIDebuggerPathField;
+        
+        public ServerOptions() {
+            this.portField = 61234;
+        }
         
         /// <remarks/>
         [System.Xml.Serialization.XmlAttributeAttribute()]
-        public string Name {
+        public string PreAttachCommand {
             get {
-                return this.nameField;
+                return this.preAttachCommandField;
             }
             set {
-                this.nameField = value;
+                this.preAttachCommandField = value;
             }
         }
         
         /// <remarks/>
         [System.Xml.Serialization.XmlAttributeAttribute()]
+        public string Path {
+            get {
+                return this.pathField;
+            }
+            set {
+                this.pathField = value;
+            }
+        }
+        
+        /// <remarks/>
+        [System.Xml.Serialization.XmlAttributeAttribute()]
+        [System.ComponentModel.DefaultValueAttribute(61234)]
+        public int Port {
+            get {
+                return this.portField;
+            }
+            set {
+                this.portField = value;
+            }
+        }
+        
+        /// <remarks/>
+        [System.Xml.Serialization.XmlAttributeAttribute()]
+        public string MIDebuggerPath {
+            get {
+                return this.mIDebuggerPathField;
+            }
+            set {
+                this.mIDebuggerPathField = value;
+            }
+        }
+    }
+    
+    /// <remarks/>
+    [System.CodeDom.Compiler.GeneratedCodeAttribute("xsd", "4.6.81.0")]
+    [System.SerializableAttribute()]
+    [System.Diagnostics.DebuggerStepThroughAttribute()]
+    [System.ComponentModel.DesignerCategoryAttribute("code")]
+    [System.Xml.Serialization.XmlTypeAttribute(Namespace="http://schemas.microsoft.com/vstudio/MDDDebuggerOptions/2014")]
+    public partial class AttachOptionsForConnection {
+        
+        private Command[] setupCommandsField;
+        
+        private SourceMapEntry[] sourceMapField;
+        
+        private ServerOptions serverOptionsField;
+        
+        private string additionalSOLibSearchPathField;
+        
+        private MIMode mIModeField;
+        
+        private string workingDirectoryField;
+        
+        private bool debugChildProcessesField;
+        
+        private bool debugChildProcessesFieldSpecified;
+        
+        private string visualizerFileField;
+        
+        private bool showDisplayStringField;
+        
+        private bool showDisplayStringFieldSpecified;
+        
+        private string connectionNameField;
+        
+        /// <remarks/>
+        [System.Xml.Serialization.XmlArrayItemAttribute(IsNullable=false)]
+        public Command[] SetupCommands {
+            get {
+                return this.setupCommandsField;
+            }
+            set {
+                this.setupCommandsField = value;
+            }
+        }
+        
+        /// <remarks/>
+        [System.Xml.Serialization.XmlArrayItemAttribute(IsNullable=false)]
+        public SourceMapEntry[] SourceMap {
+            get {
+                return this.sourceMapField;
+            }
+            set {
+                this.sourceMapField = value;
+            }
+        }
+        
+        /// <remarks/>
+        public ServerOptions ServerOptions {
+            get {
+                return this.serverOptionsField;
+            }
+            set {
+                this.serverOptionsField = value;
+            }
+        }
+        
+        /// <remarks/>
+        [System.Xml.Serialization.XmlAttributeAttribute()]
+        public string AdditionalSOLibSearchPath {
+            get {
+                return this.additionalSOLibSearchPathField;
+            }
+            set {
+                this.additionalSOLibSearchPathField = value;
+            }
+        }
+        
+        /// <remarks/>
+        [System.Xml.Serialization.XmlAttributeAttribute()]
+        public MIMode MIMode {
+            get {
+                return this.mIModeField;
+            }
+            set {
+                this.mIModeField = value;
+            }
+        }
+        
+        /// <remarks/>
+        [System.Xml.Serialization.XmlAttributeAttribute()]
+        public string WorkingDirectory {
+            get {
+                return this.workingDirectoryField;
+            }
+            set {
+                this.workingDirectoryField = value;
+            }
+        }
+        
+        /// <remarks/>
+        [System.Xml.Serialization.XmlAttributeAttribute()]
+        public bool DebugChildProcesses {
+            get {
+                return this.debugChildProcessesField;
+            }
+            set {
+                this.debugChildProcessesField = value;
+            }
+        }
+        
+        /// <remarks/>
+        [System.Xml.Serialization.XmlIgnoreAttribute()]
+        public bool DebugChildProcessesSpecified {
+            get {
+                return this.debugChildProcessesFieldSpecified;
+            }
+            set {
+                this.debugChildProcessesFieldSpecified = value;
+            }
+        }
+        
+        /// <remarks/>
+        [System.Xml.Serialization.XmlAttributeAttribute()]
+        public string VisualizerFile {
+            get {
+                return this.visualizerFileField;
+            }
+            set {
+                this.visualizerFileField = value;
+            }
+        }
+        
+        /// <remarks/>
+        [System.Xml.Serialization.XmlAttributeAttribute()]
+        public bool ShowDisplayString {
+            get {
+                return this.showDisplayStringField;
+            }
+            set {
+                this.showDisplayStringField = value;
+            }
+        }
+        
+        /// <remarks/>
+        [System.Xml.Serialization.XmlIgnoreAttribute()]
+        public bool ShowDisplayStringSpecified {
+            get {
+                return this.showDisplayStringFieldSpecified;
+            }
+            set {
+                this.showDisplayStringFieldSpecified = value;
+            }
+        }
+        
+        /// <remarks/>
+        [System.Xml.Serialization.XmlAttributeAttribute()]
+        public string ConnectionName {
+            get {
+                return this.connectionNameField;
+            }
+            set {
+                this.connectionNameField = value;
+            }
+        }
+    }
+    
+    /// <remarks/>
+    [System.CodeDom.Compiler.GeneratedCodeAttribute("xsd", "4.6.81.0")]
+    [System.SerializableAttribute()]
+    [System.Diagnostics.DebuggerStepThroughAttribute()]
+    [System.ComponentModel.DesignerCategoryAttribute("code")]
+    [System.Xml.Serialization.XmlTypeAttribute(Namespace="http://schemas.microsoft.com/vstudio/MDDDebuggerOptions/2014")]
+    public partial class Command {
+        
+        private bool ignoreFailuresField;
+        
+        private bool ignoreFailuresFieldSpecified;
+        
+        private string descriptionField;
+        
+        private string valueField;
+        
+        /// <remarks/>
+        [System.Xml.Serialization.XmlAttributeAttribute()]
+        public bool IgnoreFailures {
+            get {
+                return this.ignoreFailuresField;
+            }
+            set {
+                this.ignoreFailuresField = value;
+            }
+        }
+        
+        /// <remarks/>
+        [System.Xml.Serialization.XmlIgnoreAttribute()]
+        public bool IgnoreFailuresSpecified {
+            get {
+                return this.ignoreFailuresFieldSpecified;
+            }
+            set {
+                this.ignoreFailuresFieldSpecified = value;
+            }
+        }
+        
+        /// <remarks/>
+        [System.Xml.Serialization.XmlAttributeAttribute()]
+        public string Description {
+            get {
+                return this.descriptionField;
+            }
+            set {
+                this.descriptionField = value;
+            }
+        }
+        
+        /// <remarks/>
+        [System.Xml.Serialization.XmlTextAttribute()]
         public string Value {
             get {
                 return this.valueField;
             }
             set {
                 this.valueField = value;
-            }
-        }
-        
-        /// <remarks/>
-        [System.Xml.Serialization.XmlTextAttribute()]
-        public string Value1 {
-            get {
-                return this.value1Field;
-            }
-            set {
-                this.value1Field = value;
             }
         }
     }
@@ -457,57 +700,44 @@ namespace MICore.Xml.LaunchOptions {
     [System.Diagnostics.DebuggerStepThroughAttribute()]
     [System.ComponentModel.DesignerCategoryAttribute("code")]
     [System.Xml.Serialization.XmlTypeAttribute(Namespace="http://schemas.microsoft.com/vstudio/MDDDebuggerOptions/2014")]
-    public partial class Command {
+    public partial class EnvironmentEntry {
         
-        private bool ignoreFailuresField;
-        
-        private bool ignoreFailuresFieldSpecified;
-        
-        private string descriptionField;
+        private string nameField;
         
         private string valueField;
         
-        /// <remarks/>
-        [System.Xml.Serialization.XmlAttributeAttribute()]
-        public bool IgnoreFailures {
-            get {
-                return this.ignoreFailuresField;
-            }
-            set {
-                this.ignoreFailuresField = value;
-            }
-        }
+        private string value1Field;
         
         /// <remarks/>
-        [System.Xml.Serialization.XmlIgnoreAttribute()]
-        public bool IgnoreFailuresSpecified {
+        [System.Xml.Serialization.XmlAttributeAttribute()]
+        public string Name {
             get {
-                return this.ignoreFailuresFieldSpecified;
+                return this.nameField;
             }
             set {
-                this.ignoreFailuresFieldSpecified = value;
+                this.nameField = value;
             }
         }
         
         /// <remarks/>
         [System.Xml.Serialization.XmlAttributeAttribute()]
-        public string Description {
-            get {
-                return this.descriptionField;
-            }
-            set {
-                this.descriptionField = value;
-            }
-        }
-        
-        /// <remarks/>
-        [System.Xml.Serialization.XmlTextAttribute()]
         public string Value {
             get {
                 return this.valueField;
             }
             set {
                 this.valueField = value;
+            }
+        }
+        
+        /// <remarks/>
+        [System.Xml.Serialization.XmlTextAttribute()]
+        public string Value1 {
+            get {
+                return this.value1Field;
+            }
+            set {
+                this.value1Field = value;
             }
         }
     }
@@ -1436,6 +1666,29 @@ namespace MICore.Xml.LaunchOptions {
             }
             set {
                 this.sourceMapField = value;
+            }
+        }
+    }
+    
+    /// <remarks/>
+    [System.CodeDom.Compiler.GeneratedCodeAttribute("xsd", "4.6.81.0")]
+    [System.SerializableAttribute()]
+    [System.Diagnostics.DebuggerStepThroughAttribute()]
+    [System.ComponentModel.DesignerCategoryAttribute("code")]
+    [System.Xml.Serialization.XmlTypeAttribute(AnonymousType=true, Namespace="http://schemas.microsoft.com/vstudio/MDDDebuggerOptions/2014")]
+    [System.Xml.Serialization.XmlRootAttribute(Namespace="http://schemas.microsoft.com/vstudio/MDDDebuggerOptions/2014", IsNullable=false)]
+    public partial class SupplementalAttachOptions {
+        
+        private AttachOptionsForConnection[] optionsForConnectionField;
+        
+        /// <remarks/>
+        [System.Xml.Serialization.XmlArrayItemAttribute(IsNullable=false)]
+        public AttachOptionsForConnection[] OptionsForConnection {
+            get {
+                return this.optionsForConnectionField;
+            }
+            set {
+                this.optionsForConnectionField = value;
             }
         }
     }

--- a/src/MIDebugEngine/AD7.Impl/AD7Engine.cs
+++ b/src/MIDebugEngine/AD7.Impl/AD7Engine.cs
@@ -85,9 +85,9 @@ namespace Microsoft.MIDebugEngine
             {
                 _pollThread.Close();
             }
-            if (_unixPort != null)
+            if (_unixPort != null && _unixPort is IDebugPortCleanup)
             {
-                _unixPort.Clean();
+                ((IDebugPortCleanup)_unixPort).Clean();
             }
         }
 

--- a/src/MIDebugEngine/Engine.Impl/DebuggedProcess.cs
+++ b/src/MIDebugEngine/Engine.Impl/DebuggedProcess.cs
@@ -649,7 +649,7 @@ namespace Microsoft.MIDebugEngine
 
                             DetermineAndAddExecutablePathCommand(commands, _launchOptions as UnixShellPortLaunchOptions);
                         }
-                        else
+                        else if (!string.IsNullOrWhiteSpace(_launchOptions.ExePath))
                         {
                             this.AddExecutablePathCommand(commands);
                         }
@@ -679,7 +679,10 @@ namespace Microsoft.MIDebugEngine
                         }
                     };
 
-                    commands.Add(new LaunchCommand("-target-attach " + _launchOptions.ProcessId.Value, ignoreFailures: false, failureHandler: failureHandler));
+                    if (localLaunchOptions == null) // gdbserver is already attached when using LocalLaunchOptions
+                    {
+                        commands.Add(new LaunchCommand("-target-attach " + _launchOptions.ProcessId.Value, ignoreFailures: false, failureHandler: failureHandler));
+                    }
 
                     if (this.MICommandFactory.Mode == MIMode.Lldb)
                     {

--- a/src/Microsoft.VisualStudio.Debugger.Interop.UnixPortSupplier/Microsoft.VisualStudio.Debugger.Interop.UnixPortSupplier.cs
+++ b/src/Microsoft.VisualStudio.Debugger.Interop.UnixPortSupplier/Microsoft.VisualStudio.Debugger.Interop.UnixPortSupplier.cs
@@ -62,11 +62,24 @@ namespace Microsoft.VisualStudio.Debugger.Interop.UnixPortSupplier
         /// <returns>Home directory of the user.</returns>
         string GetUserHomeDirectory();
 
+        /// <summary>
+        /// Attaches gdbserver to a process.
+        /// </summary>
+        /// <param name="processId">Id of the process.</param>
+        /// <param name="preAttachCommand">Command to run before starting gdbserver.</param>
+        /// <returns>Communications addr:port</returns>
+        string AttachToProcess(uint processId, string preAttachCommand);
+
         /// <returns>True if the remote machine is OSX.</returns>
         bool IsOSX();
 
         /// <returns>True if the remote machine is Linux.</returns>
         bool IsLinux();
+
+        /// <summary>
+        /// Clean up debugging resources
+        /// </summary>
+        void Clean();
     }
 
     /// <summary>

--- a/src/Microsoft.VisualStudio.Debugger.Interop.UnixPortSupplier/Microsoft.VisualStudio.Debugger.Interop.UnixPortSupplier.cs
+++ b/src/Microsoft.VisualStudio.Debugger.Interop.UnixPortSupplier/Microsoft.VisualStudio.Debugger.Interop.UnixPortSupplier.cs
@@ -62,25 +62,45 @@ namespace Microsoft.VisualStudio.Debugger.Interop.UnixPortSupplier
         /// <returns>Home directory of the user.</returns>
         string GetUserHomeDirectory();
 
+       /// <returns>True if the remote machine is OSX.</returns>
+        bool IsOSX();
+
+        /// <returns>True if the remote machine is Linux.</returns>
+        bool IsLinux();
+    }
+
+    /// <summary>
+    /// Interface implemented by a port that supports explicit cleanup
+    /// </summary>
+    [ComImport()]
+    [ComVisible(true)]
+    [InterfaceType(ComInterfaceType.InterfaceIsIUnknown)]
+    [Guid("1ECAAA80-36DB-4DA8-88B3-B298B0221BF6")]
+    public interface IDebugPortCleanup
+    {
+        /// <summary>
+        /// Clean up debugging resources
+        /// </summary>
+        void Clean();
+    }
+
+    /// <summary>
+    /// Interface implemented by an IDebugPort2 that supports using gdbserver to attach to a remote process
+    /// </summary>
+    [ComImport()]
+    [ComVisible(true)]
+    [InterfaceType(ComInterfaceType.InterfaceIsIUnknown)]
+    [Guid("C517EE50-4852-4D95-916E-1A1C89710466")]
+    public interface IDebugGdbServerAttach
+    {
         /// <summary>
         /// Attaches gdbserver to a process.
         /// </summary>
         /// <param name="processId">Id of the process.</param>
         /// <param name="preAttachCommand">Command to run before starting gdbserver.</param>
         /// <returns>Communications addr:port</returns>
-        string AttachToProcess(int processId, string preAttachCommand);
-
-        /// <returns>True if the remote machine is OSX.</returns>
-        bool IsOSX();
-
-        /// <returns>True if the remote machine is Linux.</returns>
-        bool IsLinux();
-
-        /// <summary>
-        /// Clean up debugging resources
-        /// </summary>
-        void Clean();
-    }
+        string GdbServerAttachProcess(int processId, string preAttachCommand);
+   }
 
     /// <summary>
     /// Interface representing an executing asynchronous command. This is returned from 

--- a/src/Microsoft.VisualStudio.Debugger.Interop.UnixPortSupplier/Microsoft.VisualStudio.Debugger.Interop.UnixPortSupplier.cs
+++ b/src/Microsoft.VisualStudio.Debugger.Interop.UnixPortSupplier/Microsoft.VisualStudio.Debugger.Interop.UnixPortSupplier.cs
@@ -68,7 +68,7 @@ namespace Microsoft.VisualStudio.Debugger.Interop.UnixPortSupplier
         /// <param name="processId">Id of the process.</param>
         /// <param name="preAttachCommand">Command to run before starting gdbserver.</param>
         /// <returns>Communications addr:port</returns>
-        string AttachToProcess(uint processId, string preAttachCommand);
+        string AttachToProcess(int processId, string preAttachCommand);
 
         /// <returns>True if the remote machine is OSX.</returns>
         bool IsOSX();

--- a/src/SSHDebugPS/AD7Port.cs
+++ b/src/SSHDebugPS/AD7Port.cs
@@ -14,7 +14,7 @@ using System.Threading.Tasks;
 
 namespace Microsoft.SSHDebugPS
 {
-    internal class AD7Port : IDebugPort2, IDebugUnixShellPort, IConnectionPointContainer, IConnectionPoint
+    internal class AD7Port : IDebugPort2, IDebugUnixShellPort, IDebugPortCleanup, IDebugGdbServerAttach, IConnectionPointContainer, IConnectionPoint
     {
         private readonly object _lock = new object();
         private readonly AD7PortSupplier _portSupplier;
@@ -207,7 +207,7 @@ namespace Microsoft.SSHDebugPS
             return GetConnection(ConnectionReason.Deferred).GetUserHomeDirectory();
         }
 
-        public string AttachToProcess(int id, string preAttachCommand)
+        public string GdbServerAttachProcess(int id, string preAttachCommand)
         {
             return GetConnection(ConnectionReason.Deferred).AttachToProcess(id, preAttachCommand);
         }
@@ -224,8 +224,8 @@ namespace Microsoft.SSHDebugPS
 
         public void Clean()
         {
-            GetConnection(ConnectionReason.Deferred).Clean();
+            if (_connection != null)
+                _connection.Clean();
         }
-
     }
 }

--- a/src/SSHDebugPS/AD7Port.cs
+++ b/src/SSHDebugPS/AD7Port.cs
@@ -207,7 +207,7 @@ namespace Microsoft.SSHDebugPS
             return GetConnection(ConnectionReason.Deferred).GetUserHomeDirectory();
         }
 
-        public string AttachToProcess(uint id, string preAttachCommand)
+        public string AttachToProcess(int id, string preAttachCommand)
         {
             return GetConnection(ConnectionReason.Deferred).AttachToProcess(id, preAttachCommand);
         }

--- a/src/SSHDebugPS/AD7Port.cs
+++ b/src/SSHDebugPS/AD7Port.cs
@@ -207,6 +207,11 @@ namespace Microsoft.SSHDebugPS
             return GetConnection(ConnectionReason.Deferred).GetUserHomeDirectory();
         }
 
+        public string AttachToProcess(uint id, string preAttachCommand)
+        {
+            return GetConnection(ConnectionReason.Deferred).AttachToProcess(id, preAttachCommand);
+        }
+
         public bool IsOSX()
         {
             return GetConnection(ConnectionReason.Deferred).IsOSX();
@@ -216,5 +221,11 @@ namespace Microsoft.SSHDebugPS
         {
             return GetConnection(ConnectionReason.Deferred).IsLinux();
         }
+
+        public void Clean()
+        {
+            GetConnection(ConnectionReason.Deferred).Clean();
+        }
+
     }
 }

--- a/src/SSHDebugPS/Connection.cs
+++ b/src/SSHDebugPS/Connection.cs
@@ -16,7 +16,8 @@ namespace Microsoft.SSHDebugPS
 {
     internal class Connection
     {
-        private readonly liblinux.UnixSystem _remoteSystem;
+        private liblinux.UnixSystem _remoteSystem;
+        private liblinux.Services.GdbServer _gdbserver = null;
 
         public Connection(liblinux.UnixSystem remoteSystem)
         {
@@ -126,6 +127,19 @@ namespace Microsoft.SSHDebugPS
             return _remoteSystem.FileSystem.GetDirectory(liblinux.IO.SpecialDirectory.Home).FullPath;
         }
 
+        public string AttachToProcess(uint pid, string preAttachCommand)
+        {
+            var gdbStart = new liblinux.Services.GdbServerStartInfo();
+            gdbStart.ProcessId = pid;   // indicates an attach operation
+            gdbStart.PreLaunchCommand = preAttachCommand;
+            _gdbserver = _remoteSystem.Services.GdbServer.Start(gdbStart);
+            if (_gdbserver != null)
+            {
+                return "localhost:" + _gdbserver.StartInfo.LocalPort.ToString();
+            }
+            return null;
+        }
+
         internal bool IsOSX()
         {
             return _remoteSystem.Properties.Id == SystemId.OSX;
@@ -140,6 +154,20 @@ namespace Microsoft.SSHDebugPS
             }
 
             return command.Output.Trim().Equals("Linux");
+        }
+
+        internal void Clean()
+        {
+            if (_gdbserver != null)
+            {
+                _gdbserver.Stop();
+                _gdbserver = null;
+            }
+            if (_remoteSystem != null)
+            {
+                _remoteSystem.Dispose();
+                _remoteSystem = null;
+            }
         }
     }
 }

--- a/src/SSHDebugPS/Connection.cs
+++ b/src/SSHDebugPS/Connection.cs
@@ -132,12 +132,8 @@ namespace Microsoft.SSHDebugPS
             var gdbStart = new liblinux.Services.GdbServerStartInfo();
             gdbStart.ProcessId = pid;   // indicates an attach operation
             gdbStart.PreLaunchCommand = preAttachCommand;
-            _gdbserver = _remoteSystem.Services.GdbServer.Start(gdbStart);
-            if (_gdbserver != null)
-            {
-                return "localhost:" + _gdbserver.StartInfo.LocalPort.ToString();
-            }
-            return null;
+            _gdbserver = _remoteSystem.Services.GdbServer.Start(gdbStart); // throws on failure
+            return "localhost:" + _gdbserver.StartInfo.LocalPort.ToString();
         }
 
         internal bool IsOSX()

--- a/src/SSHDebugPS/Connection.cs
+++ b/src/SSHDebugPS/Connection.cs
@@ -127,7 +127,7 @@ namespace Microsoft.SSHDebugPS
             return _remoteSystem.FileSystem.GetDirectory(liblinux.IO.SpecialDirectory.Home).FullPath;
         }
 
-        public string AttachToProcess(uint pid, string preAttachCommand)
+        public string AttachToProcess(int pid, string preAttachCommand)
         {
             var gdbStart = new liblinux.Services.GdbServerStartInfo();
             gdbStart.ProcessId = pid;   // indicates an attach operation


### PR DESCRIPTION
During an attach operation look for the file "Microsoft.MIEngine.Attach.Options.xml" in the root of the solution/open folder. Look in the file for SupplementalAttachOptions. Use these to customize the normal attach processing. If the ServerOptions element is present then use gdbserver to perform the attach rather than gdb.

Depends upon a new field in liblinux's GdbServerStartInfo class.