### PR TITLE
Fixing watson crash where Regex is throwing ArgumentNullException

### DIFF
--- a/src/MICore/Transports/ServerTransport.cs
+++ b/src/MICore/Transports/ServerTransport.cs
@@ -36,7 +36,7 @@ namespace MICore
             proc.StartInfo.FileName = localOptions.DebugServer;
             proc.StartInfo.Arguments = localOptions.DebugServerArgs;
             proc.StartInfo.WorkingDirectory = miDebuggerDir;
-            _startPattern = localOptions.ServerStarted;
+            _startPattern = localOptions.ServerStarted; // Can be null
             _messagePrefix = Path.GetFileNameWithoutExtension(localOptions.DebugServer);
 
             InitProcess(proc, out reader, out writer);
@@ -44,7 +44,7 @@ namespace MICore
 
         protected override string FilterLine(string line)
         {
-            if (!_started && Regex.IsMatch(line, _startPattern, RegexOptions.None, new TimeSpan(0, 0, 0, 0, 10) /* 10 ms */))
+            if (!_started && (String.IsNullOrWhiteSpace(_startPattern) || Regex.IsMatch(line, _startPattern, RegexOptions.None, new TimeSpan(0, 0, 0, 0, 10) /* 10 ms */)))
             {
                 _started = true;
                 StartedEvent.Set();


### PR DESCRIPTION
Fix for Watson crash because _startPattern can be null. 

may want to guard the overall TransportLoop better too to prevent VS from crashing. 