### PR TITLE
Fix Compilation error on nightly run by specifying a FormatProvider

### DIFF
--- a/src/SSHDebugPS/Connection.cs
+++ b/src/SSHDebugPS/Connection.cs
@@ -133,7 +133,7 @@ namespace Microsoft.SSHDebugPS
             gdbStart.ProcessId = pid;   // indicates an attach operation
             gdbStart.PreLaunchCommand = preAttachCommand;
             _gdbserver = _remoteSystem.Services.GdbServer.Start(gdbStart); // throws on failure
-            return "localhost:" + _gdbserver.StartInfo.LocalPort.ToString();
+            return "localhost:" + _gdbserver.StartInfo.LocalPort.ToString(CultureInfo.InvariantCulture);
         }
 
         internal bool IsOSX()


### PR DESCRIPTION
Fix for: 

  src\SSHDebugPS\Connection.cs (136, 0)  
 
src\SSHDebugPS\Connection.cs(136,0): Error CA1305: Microsoft.Globalization : Because the behavior of 'int.ToString()' could vary based on the current user's locale settings, replace this call in 'Connection.AttachToProcess(int, string)' with a call to 'int.ToString(IFormatProvider)'. If the result of 'int.ToString(IFormatProvider)' will be displayed to the user, specify 'CultureInfo.CurrentCulture' as the 'IFormatProvider' parameter. Otherwise, if the result will be stored and accessed by software, such as when it is persisted to disk or to a database, specify 'CultureInfo.InvariantCulture'.