### PR TITLE
Set state to stopped when continue command is aborted.

### DIFF
--- a/src/MICore/CommandFactories/MICommandFactory.cs
+++ b/src/MICore/CommandFactories/MICommandFactory.cs
@@ -97,6 +97,8 @@ namespace MICore
         {
         }
 
+        public virtual int CurrentThread { get; }
+
         public virtual async Task<Results> ThreadInfo(uint? threadid = null)
         {
             string command = "-thread-info";

--- a/src/MICore/CommandFactories/gdb.cs
+++ b/src/MICore/CommandFactories/gdb.cs
@@ -30,6 +30,8 @@ namespace MICore
             _currentFrameLevel = 0;
         }
 
+        public override int CurrentThread { get { return _currentThreadId; } }
+
         public override bool SupportsStopOnDynamicLibLoad()
         {
             return true;

--- a/src/MICore/MICoreResources.Designer.cs
+++ b/src/MICore/MICoreResources.Designer.cs
@@ -513,6 +513,15 @@ namespace MICore {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Debugger was unable to set the process running..
+        /// </summary>
+        public static string Info_UnableToContinue {
+            get {
+                return ResourceManager.GetString("Info_UnableToContinue", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Module containing this breakpoint has not yet loaded or the breakpoint address could not be obtained..
         /// </summary>
         public static string Status_BreakpointPending {

--- a/src/MICore/MICoreResources.Designer.cs
+++ b/src/MICore/MICoreResources.Designer.cs
@@ -80,6 +80,15 @@ namespace MICore {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Command aborted. See the output window for additional details..
+        /// </summary>
+        public static string Error_CommandAborted {
+            get {
+                return ResourceManager.GetString("Error_CommandAborted", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Internal error in MIEngine. Exception of type &apos;{0}&apos; was thrown.
         ///
         ///{1}.

--- a/src/MICore/MICoreResources.Designer.cs
+++ b/src/MICore/MICoreResources.Designer.cs
@@ -513,7 +513,7 @@ namespace MICore {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Debugger was unable to set the process running..
+        ///   Looks up a localized string similar to Debugger was unable to continue the process..
         /// </summary>
         public static string Info_UnableToContinue {
             get {

--- a/src/MICore/MICoreResources.resx
+++ b/src/MICore/MICoreResources.resx
@@ -301,4 +301,7 @@ Error: {1}</value>
   <data name="Error_CommandAborted" xml:space="preserve">
     <value>Command aborted. See the output window for additional details.</value>
   </data>
+  <data name="Info_UnableToContinue" xml:space="preserve">
+    <value>Debugger was unable to set the process running.</value>
+  </data>
 </root>

--- a/src/MICore/MICoreResources.resx
+++ b/src/MICore/MICoreResources.resx
@@ -298,4 +298,7 @@ Error: {1}</value>
     <value>Unexpected ResultClass from MI Debugger. Expected '{0}' but received '{1}'.</value>
     <comment>{0} expected value, {1} received value</comment>
   </data>
+  <data name="Error_CommandAborted" xml:space="preserve">
+    <value>Command aborted. See the output window for additional details.</value>
+  </data>
 </root>

--- a/src/MICore/MICoreResources.resx
+++ b/src/MICore/MICoreResources.resx
@@ -302,6 +302,6 @@ Error: {1}</value>
     <value>Command aborted. See the output window for additional details.</value>
   </data>
   <data name="Info_UnableToContinue" xml:space="preserve">
-    <value>Debugger was unable to set the process running.</value>
+    <value>Debugger was unable to continue the process.</value>
   </data>
 </root>

--- a/src/MIDebugEngine/Engine.Impl/DebuggedProcess.cs
+++ b/src/MIDebugEngine/Engine.Impl/DebuggedProcess.cs
@@ -401,7 +401,12 @@ namespace Microsoft.MIDebugEngine
                     {
                         // assume that it was a continue command that got aborted and return to stopped state:
                         // this occurs when using openocd to debug embedded devices and it runs out of hardware breakpoints.
-                        ScheduleStdOutProcessing(string.Format(CultureInfo.CurrentCulture, @"*stopped,reason=""exception-received"",signal-name=""SIGINT"",thread-id=""1"",exception=""{0}""", MICoreResources.Info_UnableToContinue));
+                        int currentThread = MICommandFactory.CurrentThread;
+                        if (currentThread==0)
+                        {
+                            currentThread = 1;  // default to main thread is current doesn't have a valid value for some reason
+                        }
+                        ScheduleStdOutProcessing(string.Format(CultureInfo.CurrentCulture, @"*stopped,reason=""exception-received"",signal-name=""SIGINT"",thread-id=""{1}"",exception=""{0}""", MICoreResources.Info_UnableToContinue, currentThread));
                     }
                 }
                 _callback.OnError(message);

--- a/src/MIDebugEngine/Engine.Impl/DebuggedProcess.cs
+++ b/src/MIDebugEngine/Engine.Impl/DebuggedProcess.cs
@@ -401,7 +401,7 @@ namespace Microsoft.MIDebugEngine
                     {
                         // assume that it was a continue command that got aborted and return to stopped state:
                         // this occurs when using openocd to debug embedded devices and it runs out of hardware breakpoints.
-                        ScheduleStdOutProcessing(@"*stopped,reason=""exception-received"",signal-name=""SIGINT"",thread-id=""1"",exception=""""");
+                        ScheduleStdOutProcessing(string.Format(CultureInfo.CurrentCulture, @"*stopped,reason=""exception-received"",signal-name=""SIGINT"",thread-id=""1"",exception=""{0}""", MICoreResources.Info_UnableToContinue));
                     }
                 }
                 _callback.OnError(message);


### PR DESCRIPTION
When using openocd setting up breakpoints can fail because the number of hardware supported breakpoints has been exceeded. On continue gdb will set the process as "running" but then issue an error with "Command aborted" leaving the process stopped (see below). It never sends a "stopped" even though it had issued a "running" so the debugger still thinks the process is executing. 
This change will look for the "Command aborted" string and then issue a "stopped" so that the debugger can return to break mode. It has the side effect of causing an "unhandled exception" popup. I have placed a string into the popup saying that the debugger was unable to continue the process (see below). Ideally the user wouldn't see the popup at all since there was no event. I could modify the exception handling looking for some "magic" exception that should be eaten if you think it is important enough to do.

Relevant gdb log:
1: (83623) <-1048-exec-next-instruction
1: (83635) ->1048^running
openocd: Info : no hardware breakpoint available
1: (83636) ->*running,thread-id="all"
openocd: Error: can't add breakpoint: resource not available
1: (83636) 1048: elapsed time 13
openocd: Info : no hardware breakpoint available
openocd: Error: can't add breakpoint: resource not available
1: (83638) ->&"Warning:\n"
1: (83639) ->&"Cannot insert breakpoint 7.\n"
1: (83640) ->&"Cannot access memory at address 0xbf80b5b8\n"
1: (83641) ->&"Cannot insert breakpoint 7.\n"
1: (83643) ->&"Cannot access memory at address 0xbf869f50\n"
1: (83644) ->&"\n"
1: (83644) ->1048^error,msg="Command aborted."
1: (83646) ->(gdb)
1: (83648) ->&"\n"
1: (83649) ->^done
1: (83650) ->(gdb)

Popup:
![image](https://user-images.githubusercontent.com/12514776/37105292-96a1768a-21e3-11e8-9443-637c26e5b952.png)

