### PR TITLE
Redirect terminal output and error

### DIFF
--- a/src/MICore/TerminalLauncher.cs
+++ b/src/MICore/TerminalLauncher.cs
@@ -51,7 +51,7 @@ namespace MICore
             _isRoot = UnixNativeMethods.GetEUid() == 0;
         }
 
-        public void Launch(string workingDirectory)
+        public void Launch(string workingDirectory, Logger logger)
         {
             _terminalProcess = new Process
             {
@@ -61,12 +61,26 @@ namespace MICore
                     UseShellExecute = false,
                     WorkingDirectory = workingDirectory,
                     FileName = GetProcessExecutable(),
-                    Arguments = GetProcessArgs()
+                    Arguments = GetProcessArgs(),
+                    RedirectStandardError = true,
+                    RedirectStandardOutput = true
                 }
+            };
+
+            _terminalProcess.OutputDataReceived += (sender, e) =>
+            {
+                logger?.WriteLine("term-stdout: " + e.Data);
+            };
+
+            _terminalProcess.ErrorDataReceived += (sender, e) =>
+            {
+                logger?.WriteLine("term-stderr: " + e.Data);
             };
 
             SetNewProcessEnvironment(_terminalProcess.StartInfo);
             _terminalProcess.Start();
+            _terminalProcess.BeginOutputReadLine();
+            _terminalProcess.BeginErrorReadLine();
         }
     }
 

--- a/src/MICore/Transports/LocalUnixTerminalTransport.cs
+++ b/src/MICore/Transports/LocalUnixTerminalTransport.cs
@@ -66,7 +66,7 @@ namespace MICore
                 new ReadOnlyCollection<EnvironmentEntry>(new EnvironmentEntry[] { }); ;
 
             TerminalLauncher terminal = TerminalLauncher.MakeTerminal("DebuggerTerminal", launchDebuggerCommand, localOptions.Environment);
-            terminal.Launch(debuggeeDir);
+            terminal.Launch(debuggeeDir, Logger);
 
             int shellPid = -1;
 


### PR DESCRIPTION
Unread stdout and stderr messages would be returned to VsCode then VsCode
would try to JSON parse the message and fail with an unexpected token.

This fix will redirect the error and output it to the logger if enabled.