### PR TITLE
Have gdb load solib symbols when the "Load Symbols" operation from th…

### DIFF
--- a/src/MIDebugEngine/AD7.Impl/AD7Events.cs
+++ b/src/MIDebugEngine/AD7.Impl/AD7Events.cs
@@ -142,6 +142,26 @@ namespace Microsoft.MIDebugEngine
         }
     }
 
+    // This interface is sent by the debug engine (DE) to the session debug manager (SDM) when a modules symbols are loaded.
+    internal sealed class AD7SymbolLoadEvent : AD7AsynchronousEvent, IDebugSymbolSearchEvent2
+    {
+        public const string IID = "EA5B9681-2CE5-4F7A-B842-5183911CE5C6";
+
+        private readonly AD7Module _module;
+
+        public AD7SymbolLoadEvent(AD7Module module)
+        {
+            _module = module;
+        }
+
+        int IDebugSymbolSearchEvent2.GetSymbolSearchInfo(out IDebugModule3 pModule, ref string pbstrDebugMessage, enum_MODULE_INFO_FLAGS[] pdwModuleInfoFlags)
+        {
+            pModule = _module;
+            pdwModuleInfoFlags[0] = enum_MODULE_INFO_FLAGS.MIF_SYMBOLS_LOADED;
+            return Constants.S_OK;
+        }
+    }
+
     // This interface is sent by the debug engine (DE) to the session debug manager (SDM) when a program has run to completion
     // or is otherwise destroyed.
     internal sealed class AD7ProgramDestroyEvent : AD7SynchronousEvent, IDebugProgramDestroyEvent2

--- a/src/MIDebugEngine/AD7.Impl/AD7Module.cs
+++ b/src/MIDebugEngine/AD7.Impl/AD7Module.cs
@@ -9,6 +9,7 @@ using System.Diagnostics;
 using System.Threading;
 using MICore;
 using System.Globalization;
+using System.Threading.Tasks;
 
 namespace Microsoft.MIDebugEngine
 {
@@ -174,7 +175,8 @@ namespace Microsoft.MIDebugEngine
         // when the module is loaded.
         int IDebugModule3.LoadSymbols()
         {
-            throw new NotImplementedException();
+            Process.LoadSymbols(DebuggedModule);
+            return Constants.S_OK;
         }
 
         // Used to support the JustMyCode features of the debugger.

--- a/src/MIDebugEngine/Engine.Impl/DebuggedModule.cs
+++ b/src/MIDebugEngine/Engine.Impl/DebuggedModule.cs
@@ -112,7 +112,7 @@ namespace Microsoft.MIDebugEngine
         public string Name { get; private set; }
         public ulong BaseAddress { get { return TextSection.BaseAddress; } }
         public ulong Size { get { return TextSection.Size; } }
-        public bool SymbolsLoaded { get; private set; }
+        public bool SymbolsLoaded { get; set; }
         public string SymbolPath { get; private set; }
 
         public uint GetLoadOrder() { return _loadOrder; }

--- a/src/MIDebugEngine/Engine.Impl/DebuggedProcess.cs
+++ b/src/MIDebugEngine/Engine.Impl/DebuggedProcess.cs
@@ -1392,6 +1392,26 @@ namespace Microsoft.MIDebugEngine
         {
             return unixPath.Replace('/', '\\');
         }
+
+        internal void LoadSymbols(DebuggedModule module)
+        {
+            if (MICommandFactory.Mode == MIMode.Gdb)
+            {
+                if (!module.SymbolsLoaded && !string.IsNullOrWhiteSpace(module.SymbolPath))
+                {
+                    Task evalTask = Task.Run(async () =>
+                    {
+                        await ConsoleCmdAsync("sharedlibrary " + module.Name);
+                        await CheckModules();
+                    });
+                }
+            }
+            else
+            {
+                throw new NotImplementedException();
+            }
+        }
+
         private async Task CheckModules()
         {
             // NOTE: The version of GDB that comes in the Android SDK doesn't support -file-list-shared-library
@@ -1457,6 +1477,11 @@ namespace Microsoft.MIDebugEngine
                         }
 
                         _callback.OnModuleLoad(module);
+                    }
+                    else if (!module.SymbolsLoaded && symbolsLoaded)
+                    {
+                        module.SymbolsLoaded = true;
+                        _callback.OnSymbolsLoaded(module);
                     }
                 }
             }

--- a/src/MIDebugEngine/Engine.Impl/EngineCallback.cs
+++ b/src/MIDebugEngine/Engine.Impl/EngineCallback.cs
@@ -85,6 +85,12 @@ namespace Microsoft.MIDebugEngine
             Send(eventObject, AD7ModuleLoadEvent.IID, null);
         }
 
+        public void OnSymbolsLoaded(DebuggedModule module)
+        {
+            var eventObject = new AD7SymbolLoadEvent(module.Client as AD7Module);
+            Send(eventObject, AD7SymbolLoadEvent.IID, null);
+        }
+
         public void OnModuleUnload(DebuggedModule debuggedModule)
         {
             Debug.Assert(_engine.DebuggedProcess.WorkerThread.IsPollThread());

--- a/src/MIDebugEngine/Engine.Impl/Structures.cs
+++ b/src/MIDebugEngine/Engine.Impl/Structures.cs
@@ -102,6 +102,7 @@ namespace Microsoft.MIDebugEngine
         void OnBreakpointBound(Object objPendingBreakpoint);
         void OnEntryPoint(DebuggedThread thread);
         void OnStopComplete(DebuggedThread thread);
+        void OnSymbolsLoaded(DebuggedModule module);
     };
 
     public class Constants


### PR DESCRIPTION
…e modules window is invoked.

This is partial support for giving users control over symbol loading. Currently the user can turn off auto loading in setup options, but then has to resort to MIDebugExec commands in order to explicitly load specific symbols. This PR lets them use the "Load Symbols" menu item in the Module window instead. 
