### PR TITLE
Add deploy directory to the MEF probe path

### DIFF
--- a/src/MIDebugPackage/MIDebugPackagePackage.cs
+++ b/src/MIDebugPackage/MIDebugPackagePackage.cs
@@ -37,6 +37,7 @@ namespace Microsoft.MIDebugPackage
     // This attribute is needed to let the shell know that this package exposes some menus.
     [ProvideMenuResource("Menus.ctmenu", 1)]
     [Guid(GuidList.guidMIDebugPackagePkgString)]
+    [ProvideBindingPath]
     public sealed class MIDebugPackagePackage : Package, IOleCommandTarget
     {
         private IOleCommandTarget _packageCommandTarget;

--- a/src/MIDebugPackage/MIDebugPackagePackage.cs
+++ b/src/MIDebugPackage/MIDebugPackagePackage.cs
@@ -37,7 +37,10 @@ namespace Microsoft.MIDebugPackage
     // This attribute is needed to let the shell know that this package exposes some menus.
     [ProvideMenuResource("Menus.ctmenu", 1)]
     [Guid(GuidList.guidMIDebugPackagePkgString)]
+#if LAB
+    // Adding this dll location to VS probe path. Custom launcher types are referenced by Linux/Azure Sphere workloads. 
     [ProvideBindingPath]
+#endif
     public sealed class MIDebugPackagePackage : Package, IOleCommandTarget
     {
         private IOleCommandTarget _packageCommandTarget;


### PR DESCRIPTION
Running into MEF cache building errors after some new reference to the Linux workload were added.