### PR TITLE
Pick up correct arch folder for NDK x64

### DIFF
--- a/src/AndroidDebugLauncher/TargetArchitectureExtensions.cs
+++ b/src/AndroidDebugLauncher/TargetArchitectureExtensions.cs
@@ -17,7 +17,7 @@ namespace AndroidDebugLauncher
                     return "x86";
 
                 case TargetArchitecture.X64:
-                    return "x64";
+                    return "x86_64";
 
                 case TargetArchitecture.ARM:
                     return "arm";


### PR DESCRIPTION
VS had some blocking changes in deploying to x64 Android devices or emulators. After clearing up those issues an issue was then hit in mi-engine where it could not find the NDK GDB directory. For android it uses x86_64 for x64bit devices and ToNDKArchitectureName was returning the wrong value for this. Tested deploying to x64, x86, ARM, and ARM64 emulators. 