### PR TITLE
CHeck architecture of target even if the user has specified a value

### DIFF
--- a/src/MICore/CommandFactories/gdb.cs
+++ b/src/MICore/CommandFactories/gdb.cs
@@ -264,6 +264,10 @@ namespace MICore
                     {
                         return TargetArchitecture.ARM64;
                     }
+                    else if (resultLine.IndexOf("aarch64", StringComparison.OrdinalIgnoreCase) >= 0)
+                    {
+                        return TargetArchitecture.ARM64;
+                    }
                     else if (resultLine.IndexOf("arm", StringComparison.OrdinalIgnoreCase) >= 0)
                     {
                         return TargetArchitecture.ARM;

--- a/src/MIDebugEngine/Engine.Impl/DebuggedProcess.cs
+++ b/src/MIDebugEngine/Engine.Impl/DebuggedProcess.cs
@@ -909,27 +909,25 @@ namespace Microsoft.MIDebugEngine
             // 1. if the command factory can discover the target architecture then use that
             // 2. else if the user specified an architecture then use that
             // 3. otherwise default to x64
-            TargetArchitecture arch = DefaultArch();
+            SetTargetArch( DefaultArch() ); // set the default value based on user input
 
-            Task successHandler(string resultsStr)
-            {
+            Func<string, Task> successHandler = (string resultsStr) => {
                 var archFromTarget = MICommandFactory.ParseTargetArchitectureResult(resultsStr);
 
                 if (archFromTarget != TargetArchitecture.Unknown)
                 {
-                    arch = archFromTarget;
+                    SetTargetArch(archFromTarget);
                 }
 
-                SetTargetArch(arch);
-
                 return Task.FromResult(0);
-            }
+            };
 
             string cmd = MICommandFactory.GetTargetArchitectureCommand();
 
             if (cmd != null)
             {
-                commands.Add(new LaunchCommand(cmd, ignoreFailures: false, successHandler: successHandler));
+                // schedule a command to fetch the the debuggers actual target achitecture 
+                commands.Add(new LaunchCommand(cmd, ignoreFailures: true, successHandler: successHandler));
             }
         }
 


### PR DESCRIPTION
Customer is reporting a crash in the VS memory tool when they specified target ARM but the device was ARM64. Memory tool crashed trying to format a long address into a small buffer.
Change the target architecture determination to let the target arch check override the users specification.