### PR TITLE
Fix bug where BPs were showing up multiple times in VS

### DIFF
--- a/src/MIDebugEngine/AD7.Impl/AD7BoundBreakpoint.cs
+++ b/src/MIDebugEngine/AD7.Impl/AD7BoundBreakpoint.cs
@@ -35,11 +35,8 @@ namespace Microsoft.MIDebugEngine
         }
 
         internal bool Deleted { get { return _deleted; } }
-        internal ulong Addr
-        {
-            get
-            { return _bp.Addr; }
-        }
+        internal ulong Addr { get { return _bp.Addr; } }
+        internal string Number { get { return _bp.Number; } }
         internal AD7PendingBreakpoint PendingBreakpoint { get { return _pendingBreakpoint; } }
         internal bool IsDataBreakpoint { get { return PendingBreakpoint.IsDataBreakpoint; } }
 

--- a/src/MIDebugEngine/AD7.Impl/AD7PendingBreakpoint.cs
+++ b/src/MIDebugEngine/AD7.Impl/AD7PendingBreakpoint.cs
@@ -263,7 +263,7 @@ namespace Microsoft.MIDebugEngine
                         bindTask = _engine.DebuggedProcess.AddInternalBreakAction(this.BindAsync);
                     });
 
-                    bindTask.Wait(_engine.GetBPLongBindTimeout()); 
+                    bindTask.Wait(_engine.GetBPLongBindTimeout());
                     if (!bindTask.IsCompleted)
                     {
                         //send a low severity warning bp. This will allow the UI to respond quickly, and if the mi debugger doesn't end up binding, this warning will get 
@@ -362,7 +362,7 @@ namespace Microsoft.MIDebugEngine
                 //check can bind one last time. If the pending breakpoint was deleted before now, we need to clean up gdb side
                 if (CanBind())
                 {
-                    foreach( var boundBp in _boundBreakpoints.Where((b) => b.PendingBreakpoint.BreakpointId == boundBreakpoint.PendingBreakpoint.BreakpointId).ToList())
+                    foreach (var boundBp in _boundBreakpoints.Where((b) => b.Number.Equals(boundBreakpoint.Number, StringComparison.Ordinal)).ToList())
                     {
                         _engine.Callback.OnBreakpointUnbound(boundBp, enum_BP_UNBOUND_REASON.BPUR_BREAKPOINT_REBIND);
                         _boundBreakpoints.Remove(boundBp);

--- a/src/MIDebugEngine/AD7.Impl/AD7PendingBreakpoint.cs
+++ b/src/MIDebugEngine/AD7.Impl/AD7PendingBreakpoint.cs
@@ -362,6 +362,12 @@ namespace Microsoft.MIDebugEngine
                 //check can bind one last time. If the pending breakpoint was deleted before now, we need to clean up gdb side
                 if (CanBind())
                 {
+                    foreach( var boundBp in _boundBreakpoints.Where((b) => b.PendingBreakpoint.BreakpointId == boundBreakpoint.PendingBreakpoint.BreakpointId).ToList())
+                    {
+                        _engine.Callback.OnBreakpointUnbound(boundBp, enum_BP_UNBOUND_REASON.BPUR_BREAKPOINT_REBIND);
+                        _boundBreakpoints.Remove(boundBp);
+                    }
+
                     _boundBreakpoints.Add(boundBreakpoint);
                     PendingBreakpoint.AddedBoundBreakpoint();
                     _engine.Callback.OnBreakpointBound(boundBreakpoint);

--- a/src/MIDebugEngine/Engine.Impl/BreakpointManager.cs
+++ b/src/MIDebugEngine/Engine.Impl/BreakpointManager.cs
@@ -51,7 +51,7 @@ namespace Microsoft.MIDebugEngine
         /// </summary>
         /// <param name="sender"></param>
         /// <param name="args"></param>
-        public void BreakpointModified(object sender, EventArgs args)
+        public async Task BreakpointModified(object sender, EventArgs args)
         {
             MICore.Debugger.ResultEventArgs res = args as MICore.Debugger.ResultEventArgs;
             MICore.ResultValue bkpt = res.Results.Find("bkpt");
@@ -85,7 +85,7 @@ namespace Microsoft.MIDebugEngine
             }
             else
             {
-                var bindList = pending.PendingBreakpoint.BindAddresses(bkpt);
+                var bindList = await pending.PendingBreakpoint.BindAddresses(bkpt);
                 RebindAddresses(pending, bindList);
             }
         }

--- a/src/MIDebugEngine/Engine.Impl/BreakpointManager.cs
+++ b/src/MIDebugEngine/Engine.Impl/BreakpointManager.cs
@@ -166,7 +166,7 @@ namespace Microsoft.MIDebugEngine
                 }
                 else
                 {
-                    bbp = pending.AddBoundBreakpoint(new BoundBreakpoint(pending.PendingBreakpoint, addr, frame));
+                    bbp = pending.AddBoundBreakpoint(new BoundBreakpoint(pending.PendingBreakpoint, addr, frame, bkptno));
                 }
             }
             return pending;

--- a/src/MIDebugEngine/Engine.Impl/Breakpoints.cs
+++ b/src/MIDebugEngine/Engine.Impl/Breakpoints.cs
@@ -231,7 +231,7 @@ namespace Microsoft.MIDebugEngine
             string number = bkpt.FindString("number");
 
             PendingBreakpoint bp = new PendingBreakpoint(pbreak, number, MIBreakpointState.Single);
-            BoundBreakpoint bbp = new BoundBreakpoint(bp, MICore.Debugger.ParseAddr(address), size);
+            BoundBreakpoint bbp = new BoundBreakpoint(bp, MICore.Debugger.ParseAddr(address), size, number);
             return new BindResult(bp, bbp);
         }
 
@@ -355,7 +355,7 @@ namespace Microsoft.MIDebugEngine
     internal class BoundBreakpoint
     {
         private PendingBreakpoint _parent;
-
+        internal readonly string Number;
         internal ulong Addr { get; set; }
         /*OPTIONAL*/
         public string FunctionName { get; private set; }
@@ -373,15 +373,17 @@ namespace Microsoft.MIDebugEngine
             this.Enabled = bindinfo.TryFindString("enabled") == "n" ? false : true;
             this.HitCount = 0;
             this.CompiledFileName = bindinfo.Contains("fullname") ? bindinfo.FindString("fullname") : bindinfo.TryFindString("file");
+            this.Number = bindinfo.Contains("number") ? bindinfo.FindString("number") : parent.Number;
             _parent = parent;
             _textPosition = MITextPosition.TryParse(parent.DebuggedProcess, bindinfo);
         }
 
-        internal BoundBreakpoint(PendingBreakpoint parent, ulong addr, /*optional*/ TupleValue frame)
+        internal BoundBreakpoint(PendingBreakpoint parent, ulong addr, /*optional*/ TupleValue frame, string bkptno)
         {
             Addr = addr;
             HitCount = 0;
             Enabled = true;
+            this.Number = bkptno;
             _parent = parent;
 
             if (frame != null)
@@ -391,10 +393,11 @@ namespace Microsoft.MIDebugEngine
             }
         }
 
-        internal BoundBreakpoint(PendingBreakpoint parent, ulong addr, uint size)
+        internal BoundBreakpoint(PendingBreakpoint parent, ulong addr, uint size, string bkptno)
         {
             Addr = addr;
             Enabled = true;
+            this.Number = bkptno;
             _parent = parent;
         }
 

--- a/src/MIDebugEngine/Engine.Impl/SourceLine.cs
+++ b/src/MIDebugEngine/Engine.Impl/SourceLine.cs
@@ -55,7 +55,10 @@ namespace Microsoft.MIDebugEngine
 
         public void Clear()
         {
-            this._mapFileToLinenums.Clear();
+            lock (_mapFileToLinenums)
+            {
+                this._mapFileToLinenums.Clear();
+            }
         }
 
         internal async Task<SourceLineMap> GetLinesForFile(string file)

--- a/src/MIDebugEngine/Engine.Impl/SourceLine.cs
+++ b/src/MIDebugEngine/Engine.Impl/SourceLine.cs
@@ -52,6 +52,12 @@ namespace Microsoft.MIDebugEngine
             _process = process;
             _mapFileToLinenums = new Dictionary<string, SourceLineMap>();
         }
+
+        public void Clear()
+        {
+            this._mapFileToLinenums.Clear();
+        }
+
         internal async Task<SourceLineMap> GetLinesForFile(string file)
         {
             string fileKey = file;


### PR DESCRIPTION
This bug is because gdb may bind the bp in a different location in the
symbol file and the address of where that is loaded in memory changes
before and after the program is launched, causing us to send multiple
breakpoint binds without an unbind for the same breakpoint id.

Fixed so we will:
A) Clear the SourceLineCache right before we start debuggee launch in a
launch scenario
B) Requery gdb for the source line to address mappings
C) use that updated SourceLineCache to determine the correct line number
for the breakpoint
D) Send a BreakpointUnbound() message with the status of Rebind for the
old breakpoint to VS to update the UI.