### PR TITLE
Use -- instead of -x for gnome-terminal

### DIFF
--- a/src/MICore/TerminalLauncher.cs
+++ b/src/MICore/TerminalLauncher.cs
@@ -179,7 +179,7 @@ namespace MICore
             if (File.Exists(GnomeTerminalPath))
             {
                 _terminalPath = GnomeTerminalPath;
-                _bashCommandPrefix = String.Format(CultureInfo.InvariantCulture, "--title {0} -x", _title);
+                _bashCommandPrefix = String.Format(CultureInfo.InvariantCulture, "--title {0} --", _title);
             }
             else if (File.Exists(XTermPath))
             {


### PR DESCRIPTION
The `-x` option is deprecated, so use `--` instead.

In Ubuntu 18.04, using the `-x` option results in the program being launched in a new tab in an existing terminal. This terminal is not brought to the foreground, nor is the tab activated, which makes a bunch of work for the user to find where there program is. Using the `--` option, on the other hand, results in the program opening in a new terminal and the new terminal is brought to the foreground as one might expect.