### PR TITLE
Implement dispose pattern on AD7Engine to cleanup unix port.

### DIFF
--- a/src/SSHDebugPS/AD7Port.cs
+++ b/src/SSHDebugPS/AD7Port.cs
@@ -224,8 +224,12 @@ namespace Microsoft.SSHDebugPS
 
         public void Clean()
         {
-            if (_connection != null)
-                _connection.Clean();
+            try
+            {
+                _connection?.Clean();
+            }
+            // Dev15 632648: Liblinux sometimes throws exceptions on shutdown - we are shutting down anyways, so ignore to not crash
+            catch (Exception) { }
         }
     }
 }


### PR DESCRIPTION
There is a Watson failure coming from the SSHPort finalizer. There was a fix put into liblinux, but this also attempts to make cleanup more reliable.

@pieandcakes @gregg-miskelly @WardenGnaw 