### PR TITLE
Quote exe arguments that also contain '(' and ')'

### DIFF
--- a/src/OpenDebugAD7/MILaunchOptions.cs
+++ b/src/OpenDebugAD7/MILaunchOptions.cs
@@ -306,10 +306,10 @@ namespace OpenDebugAD7
             {
                 if (argument.IndexOfAny(s_CHARS_TO_QUOTE) >= 0)
                 {
-                    // if argument starts with a quote, escape all quotes before quoting
+                    // if argument starts with a quote, escape start and ending quotes
                     if (argument[0] == '\"')
                     {
-                        argument = argument.Replace("\"", "\\\"");
+                        argument = "\\\"" + argument.Trim('\"') + "\\\"";
                     }
 
                     return '"' + argument + '"';

--- a/src/OpenDebugAD7/MILaunchOptions.cs
+++ b/src/OpenDebugAD7/MILaunchOptions.cs
@@ -302,11 +302,16 @@ namespace OpenDebugAD7
         private static char[] s_CHARS_TO_QUOTE = { ' ', '\t', '(', ')' };
         private static string QuoteArgument(string argument)
         {
-            // Make sure its not empty or already quoted (starts with a quote)
-            if (!string.IsNullOrWhiteSpace(argument) && argument[0] != '"')
+            if (!string.IsNullOrWhiteSpace(argument))
             {
                 if (argument.IndexOfAny(s_CHARS_TO_QUOTE) >= 0)
                 {
+                    // if argument starts with a quote, escape all quotes before quoting
+                    if (argument[0] == '\"')
+                    {
+                        argument = argument.Replace("\"", "\\\"");
+                    }
+
                     return '"' + argument + '"';
                 }
             }

--- a/src/OpenDebugAD7/MILaunchOptions.cs
+++ b/src/OpenDebugAD7/MILaunchOptions.cs
@@ -292,10 +292,25 @@ namespace OpenDebugAD7
                     if (stringBuilder.Length != 0)
                         stringBuilder.Append(' ');
 
-                    stringBuilder.Append(Terminal.Quote(arg));
+                    stringBuilder.Append(QuoteArgument(arg));
                 }
             }
             return stringBuilder.ToString();
+        }
+
+        // gdb does not like parenthesis without being quoted
+        private static char[] s_CHARS_TO_QUOTE = { ' ', '\t', '(', ')' };
+        private static string QuoteArgument(string argument)
+        {
+            // Make sure its not empty or already quoted (starts with a quote)
+            if (!string.IsNullOrWhiteSpace(argument) && argument[0] != '"')
+            {
+                if (argument.IndexOfAny(s_CHARS_TO_QUOTE) >= 0)
+                {
+                    return '"' + argument + '"';
+                }
+            }
+            return argument;
         }
 
         private static void AddBaseLaunchOptionsElements(StringBuilder xmlLaunchOptions, JsonBaseLaunchOptions jsonLaunchOptions)

--- a/src/OpenDebugAD7/MILaunchOptions.cs
+++ b/src/OpenDebugAD7/MILaunchOptions.cs
@@ -304,14 +304,10 @@ namespace OpenDebugAD7
         {
             if (!string.IsNullOrWhiteSpace(argument))
             {
+                // ensure all quotes already in the string are escaped. If use has already escaped it too, undo our escaping
+                argument = argument.Replace("\"", "\\\"").Replace("\\\\\"", "\\\"");
                 if (argument.IndexOfAny(s_CHARS_TO_QUOTE) >= 0)
                 {
-                    // if argument starts with a quote, escape start and ending quotes
-                    if (argument[0] == '\"')
-                    {
-                        argument = "\\\"" + argument.Trim('\"') + "\\\"";
-                    }
-
                     return '"' + argument + '"';
                 }
             }


### PR DESCRIPTION
gdb does not like '(' and ')' without the argument being quoted. Added
check to ensure that if the argument is already quoted we don't quote it
again.