### PR TITLE
Fix interrupt with pipe program

### DIFF
--- a/src/MICore/Transports/PipeTransport.cs
+++ b/src/MICore/Transports/PipeTransport.cs
@@ -352,7 +352,7 @@ namespace MICore
 
             Process proc = new Process();
             proc.StartInfo.FileName = _pipePath;
-            proc.StartInfo.Arguments = string.Format(CultureInfo.InvariantCulture, _cmdArgs, commandText);
+            proc.StartInfo.Arguments = PipeLaunchOptions.ReplaceDebuggerCommandToken(_cmdArgs, commandText, true);
             proc.StartInfo.WorkingDirectory = System.IO.Path.GetDirectoryName(_pipePath);
             proc.EnableRaisingEvents = false;
             proc.StartInfo.RedirectStandardInput = false;

--- a/src/OpenDebugAD7/MILaunchOptions.cs
+++ b/src/OpenDebugAD7/MILaunchOptions.cs
@@ -559,6 +559,7 @@ namespace OpenDebugAD7
 
                 if (pipeArgs != null)
                 {
+                    string pipeCommandArgs = CreateArgumentList(pipeArgs);
                     IEnumerable<string> allPipeArguments = pipeArgs;
                     string debuggerPath = jsonLaunchOptions.PipeTransport.DebuggerPath ?? "";
                     if (!string.IsNullOrEmpty(debuggerPath))
@@ -576,6 +577,10 @@ namespace OpenDebugAD7
 
                     string allArguments = CreateArgumentList(allPipeArguments);
                     xmlLaunchOptions.Append(String.Concat("  PipeArguments='", MILaunchOptions.XmlSingleQuotedAttributeEncode(allArguments), "'\n"));
+                    if (!string.IsNullOrEmpty(pipeCommandArgs))
+                    {
+                        xmlLaunchOptions.Append(String.Concat(" PipeCommandArguments='", MILaunchOptions.XmlSingleQuotedAttributeEncode(pipeCommandArgs), "'\n"));
+                    }
                 }
 
                 if (pipeCwd != null)


### PR DESCRIPTION
This allows the kill -2 <pid> command to be set when using pipe to debug. 

Added passing of pipeArgs as pipeCommandArgs in OpenDebugAD7.