### PR TITLE
Remove MacOS from using IntegratedTerminal

### DIFF
--- a/src/MIDebugEngine/Engine.Impl/DebuggedProcess.cs
+++ b/src/MIDebugEngine/Engine.Impl/DebuggedProcess.cs
@@ -194,7 +194,8 @@ namespace Microsoft.MIDebugEngine
                 if (HostRunInTerminal.IsRunInTerminalAvailable()
                     && string.IsNullOrWhiteSpace(localLaunchOptions.MIDebuggerServerAddress)
                     && IsCoreDump == false
-                    && (PlatformUtilities.IsWindows() ? !localLaunchOptions.UseExternalConsole : true))
+                    && (PlatformUtilities.IsWindows() ? !localLaunchOptions.UseExternalConsole : true)
+                    && !PlatformUtilities.IsOSX())
                 {
                     localTransport = new RunInTerminalTransport();
 
@@ -800,7 +801,7 @@ namespace Microsoft.MIDebugEngine
                     // TODO: The last clause for LLDB may need to be changed when we support LLDB on Linux as LLDB's tty redirection doesn't work.
                     if (localLaunchOptions != null &&
                         ((PlatformUtilities.IsWindows() && localLaunchOptions.UseExternalConsole)
-                        || (PlatformUtilities.IsOSX() && this.MICommandFactory.Mode == MIMode.Lldb)))
+                        || (PlatformUtilities.IsOSX() && this.MICommandFactory.Mode == MIMode.Lldb && localLaunchOptions.UseExternalConsole)))
                     {
                         commands.Add(new LaunchCommand("-gdb-set new-console on", ignoreFailures: true));
                     }

--- a/src/MIDebugEngine/Engine.Impl/DebuggedProcess.cs
+++ b/src/MIDebugEngine/Engine.Impl/DebuggedProcess.cs
@@ -800,8 +800,9 @@ namespace Microsoft.MIDebugEngine
 
                     // TODO: The last clause for LLDB may need to be changed when we support LLDB on Linux as LLDB's tty redirection doesn't work.
                     if (localLaunchOptions != null &&
-                        ((PlatformUtilities.IsWindows() && localLaunchOptions.UseExternalConsole)
-                        || (PlatformUtilities.IsOSX() && this.MICommandFactory.Mode == MIMode.Lldb && localLaunchOptions.UseExternalConsole)))
+                        localLaunchOptions.UseExternalConsole &&
+                        (PlatformUtilities.IsWindows() ||
+                            (PlatformUtilities.IsOSX() && this.MICommandFactory.Mode == MIMode.Lldb)))
                     {
                         commands.Add(new LaunchCommand("-gdb-set new-console on", ignoreFailures: true));
                     }


### PR DESCRIPTION
This is because the capability in lldb-mi doesn't exist yet. Falling
back to LocalTransport

This is to fix: https://github.com/Microsoft/vscode-cpptools/issues/2646 