### PR TITLE
Fix debug argument parsing

### DIFF
--- a/src/WindowsDebugLauncher/Program.cs
+++ b/src/WindowsDebugLauncher/Program.cs
@@ -120,6 +120,9 @@ namespace WindowsDebugLauncher
             HelpMessage();
         }
 
+        /// <summary>
+        /// Parse dbgargs for spaces and quoted strings
+        /// </summary>
         private static List<string> ParseDebugExeArgs(string line)
         {
             List<string> args = new List<string>();
@@ -136,19 +139,15 @@ namespace WindowsDebugLauncher
                         case 'n':
                             builder.Append("\n");
                             break;
-
                         case 'r':
                             builder.Append("\r");
                             break;
-
                         case '\\':
                             builder.Append("\\");
                             break;
-
                         case '"':
                             builder.Append("\"");
                             break;
-
                         case ' ':
                             builder.Append(" ");
                             break;

--- a/src/WindowsDebugLauncher/Program.cs
+++ b/src/WindowsDebugLauncher/Program.cs
@@ -152,6 +152,8 @@ namespace WindowsDebugLauncher
                         case ' ':
                             builder.Append(" ");
                             break;
+                        default:
+                            throw new ArgumentException(FormattableString.Invariant($"Invalid escape sequence: \\{c}"));
                     }
 
                     isEscape = false;


### PR DESCRIPTION
This is to fix multiple debugger arguments when using WindowsDebugLauncher.