### PR TITLE
Remove clear on Linux

### DIFF
--- a/src/MICore/Transports/RunInTerminalTransport.cs
+++ b/src/MICore/Transports/RunInTerminalTransport.cs
@@ -157,12 +157,6 @@ namespace MICore
                     cmdArgs.Add(dbgCmdScript);
                 }
 
-#if !DEBUG
-                // Make sure to clear the console
-                cmdArgs.Add(";");
-                cmdArgs.Add("clear");
-#endif
-
                 _outputStream = new StreamReader(stdOutStream, encNoBom, false, UnixUtilities.StreamBufferSize);
                 _commandStream = new StreamWriter(stdInStream, encNoBom);
             }


### PR DESCRIPTION
Remove extra clear per user request. The reason is that they would like
to see the output from their application after debugging has terminated.

Fixes: https://github.com/Microsoft/vscode-cpptools/issues/2688