### PR TITLE
Revert "Adding list-features and check for async  (#759)"

### DIFF
--- a/src/MICore/CommandFactories/MICommandFactory.cs
+++ b/src/MICore/CommandFactories/MICommandFactory.cs
@@ -669,12 +669,6 @@ namespace MICore
         /// <returns>[Required] Task to track when this is complete</returns>
         abstract public Task EnableTargetAsyncOption();
 
-        /// <summary>
-        /// Obtains a Results object containing the set of features supported by the debugger.
-        /// </summary>
-        /// <returns>[Required] Task that will contain the Results.</returns>
-        abstract public Task<Results> ListTargetFeatures();
-
         public virtual bool SupportsBreakpointChecksums()
         {
             return false;

--- a/src/MICore/CommandFactories/clrdbg.cs
+++ b/src/MICore/CommandFactories/clrdbg.cs
@@ -89,11 +89,6 @@ namespace MICore
             return Task.FromResult<List<ulong>>(null);
         }
 
-        public override Task<Results> ListTargetFeatures()
-        {
-            return Task.FromResult(new Results(ResultClass.None));
-        }
-
         public override Task EnableTargetAsyncOption()
         {
             // clrdbg is always in target-async mode

--- a/src/MICore/CommandFactories/gdb.cs
+++ b/src/MICore/CommandFactories/gdb.cs
@@ -183,12 +183,6 @@ namespace MICore
             return addresses;
         }
 
-        public override async Task<Results> ListTargetFeatures()
-        {
-            Results results = await _debugger.CmdAsync("-list-target-features", ResultClass.done);
-            return results;
-        }
-
         public override Task EnableTargetAsyncOption()
         {
             // Linux attach TODO: GDB will fail this command when attaching. This is worked around

--- a/src/MICore/CommandFactories/lldb.cs
+++ b/src/MICore/CommandFactories/lldb.cs
@@ -108,11 +108,6 @@ namespace MICore
             return Task.FromResult<List<ulong>>(null);
         }
 
-        public override Task<Results> ListTargetFeatures()
-        {
-            return Task.FromResult(new Results(ResultClass.None));
-        }
-
         public override Task EnableTargetAsyncOption()
         {
             // lldb-mi doesn't support target-async mode, and doesn't seem to need to

--- a/src/MIDebugEngine/Engine.Impl/DebuggedProcess.cs
+++ b/src/MIDebugEngine/Engine.Impl/DebuggedProcess.cs
@@ -579,11 +579,7 @@ namespace Microsoft.MIDebugEngine
 
             try
             {
-                Results res = await this.MICommandFactory.ListTargetFeatures();
-                if (res.Contains("async"))
-                {
-                    await this.MICommandFactory.EnableTargetAsyncOption();
-                }
+                await this.MICommandFactory.EnableTargetAsyncOption();
                 List<LaunchCommand> commands = GetInitializeCommands();
                 _childProcessHandler?.Enable();
 


### PR DESCRIPTION
This reverts commit b04d5618164b7efe079b3c2378f843374b13e0f5.

This is being reverted as it hangs in the VS & Android case. gdb for Android supports async but doesnt' list it as capabilities. It is noticed when trying to stop debugging while running. 