### PR TITLE
Translate octal codes to unicode chars assuming utf8

### DIFF
--- a/src/MICore/MIResults.cs
+++ b/src/MICore/MIResults.cs
@@ -980,10 +980,11 @@ namespace MICore
                         continue;
                     }
                 }
+                Debug.Assert(v < 255, "Value too large");
                 bytes[cChars++] = (byte)v;
                 i += 4;
             }
-            if (error)
+            if (error || cChars == 0)
             {
                 i = s;
                 return false;


### PR DESCRIPTION
When octal literals are found embedded in a string literal decode them assuming a utf8 encoding.


This replaces the buggy octal literal translation from last PR.
