### PR TITLE
Restrict when debuggee redirection happens

### DIFF
--- a/src/MIDebugEngine/Engine.Impl/DebuggedProcess.cs
+++ b/src/MIDebugEngine/Engine.Impl/DebuggedProcess.cs
@@ -193,6 +193,7 @@ namespace Microsoft.MIDebugEngine
                 // Also since we use gdb-set new-console on in windows for external console, we don't need to RunInTerminal
                 if (HostRunInTerminal.IsRunInTerminalAvailable()
                     && string.IsNullOrWhiteSpace(localLaunchOptions.MIDebuggerServerAddress)
+                    && string.IsNullOrWhiteSpace(localLaunchOptions.DebugServer)
                     && IsCoreDump == false
                     && (PlatformUtilities.IsWindows() ? !localLaunchOptions.UseExternalConsole : true)
                     && !PlatformUtilities.IsOSX())

--- a/src/OpenDebugAD7/MILaunchOptions.cs
+++ b/src/OpenDebugAD7/MILaunchOptions.cs
@@ -8,6 +8,7 @@ using System.Globalization;
 using System.IO;
 using System.Linq;
 using System.Text;
+using Microsoft.DebugEngineHost;
 using Microsoft.DebugEngineHost.VSCode;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Converters;
@@ -268,6 +269,7 @@ namespace OpenDebugAD7
 
             // Check to see if we need to redirect app stdin/out/err in Windows case for IntegratedTerminalSupport.
             if (Utilities.IsWindows()
+                && HostRunInTerminal.IsRunInTerminalAvailable()
                 && jsonLaunchOptions is JsonLocalLaunchOptions
                 && String.IsNullOrWhiteSpace(jsonLaunchOptions.CoreDumpPath))
             {


### PR DESCRIPTION
Add more restrictions on when redirection happens.

This includes only when RunInTerminal is available and when debugServer
is invoked.