### PR TITLE
RunInTerminalResponse may not have a responseBody

### DIFF
--- a/src/OpenDebugAD7/AD7DebugSession.cs
+++ b/src/OpenDebugAD7/AD7DebugSession.cs
@@ -567,9 +567,10 @@ namespace OpenDebugAD7
 
                     Protocol.SendClientRequest(
                         request,
-                        (args, response) =>
+                        (args, responseBody) =>
                         {
-                            success(response.ProcessId);
+                            // responseBody can be null
+                            success(responseBody?.ProcessId);
                         },
                         (args, exception) =>
                         {


### PR DESCRIPTION
* Update variable name and add null check before operating on the
responseBody

Fixes: https://github.com/Microsoft/vscode-cpptools/issues/2858