### PR TITLE
[gdb] Execute custom .gdbinit file if present before launching the debugger

### DIFF
--- a/src/MICore/Transports/LocalTransport.cs
+++ b/src/MICore/Transports/LocalTransport.cs
@@ -40,6 +40,15 @@ namespace MICore
                 proc.StartInfo.SetEnvironmentVariable("PATH", path);
             }
 
+            // Allow to execute custom commands before launching debugger.
+            // For ex., instructing GDB not to break for certain signals
+            if (options.DebuggerMIMode == MIMode.Gdb)
+            {
+                var gdbInitFile = Path.Combine(options.WorkingDirectory, ".gdbinit");
+                if (File.Exists(gdbInitFile))
+                    proc.StartInfo.Arguments += " -x \"" + gdbInitFile + "\"";
+            }
+
             // Only pass the environment to launch clrdbg. For other modes, there are commands that set the environment variables
             // directly for the debuggee.
             if (options.DebuggerMIMode == MIMode.Clrdbg)


### PR DESCRIPTION
This is a fix/workaround for https://github.com/Microsoft/MIEngine/issues/643.

This change makes it possible to have custom project based .gdbinit file which is executed by gdb before launching the debugger.

Example usage, let's say you want gdb to ignore SIGPWR signal for specific project, you would create .gdbinit file with following contents:
handle SIGPWR nostop noprint and place it 

and instruct VS to place it in $(OutDir)\.gdb directory, upon launching the debugger, gdb would execute .gdbinit.

Please let me know if same could be achieved in some other way. Cheers!

