### PR TITLE
Adding ? for BaseStream

### DIFF
--- a/src/MICore/Transports/StreamTransport.cs
+++ b/src/MICore/Transports/StreamTransport.cs
@@ -231,7 +231,7 @@ namespace MICore
         {
             try
             {
-                reader?.BaseStream.WriteByte(0);
+                reader?.BaseStream?.WriteByte(0);
             }
             catch
             {


### PR DESCRIPTION
In certain scenarios the reader is valid but the BaseStream has timed
out. This causes the BaseStream to be null and causes a NPE.