### PR TITLE
Move try/catch to fix error handling in Eval case

### DIFF
--- a/src/MIDebugEngine/Engine.Impl/Variables.cs
+++ b/src/MIDebugEngine/Engine.Impl/Variables.cs
@@ -428,106 +428,107 @@ namespace Microsoft.MIDebugEngine
             await _engine.UpdateRadixAsync(_engine.CurrentRadix());    // ensure the radix value is up-to-date
 
             string execCommandString = "-exec ";
-            if (_strippedName.StartsWith(execCommandString))
-            {
-                // special case for executing raw mi commands. 
-                string consoleCommand = _strippedName.Substring(execCommandString.Length);
-                string consoleResults = null;
 
-                try
+            try
+            {
+                if (_strippedName.StartsWith(execCommandString))
                 {
+                    // special case for executing raw mi commands. 
+                    string consoleCommand = _strippedName.Substring(execCommandString.Length);
+                    string consoleResults = null;
+
                     consoleResults = await MIDebugCommandDispatcher.ExecuteCommand(consoleCommand, _debuggedProcess, ignoreFailures: true);
                     Value = String.Empty;
                     this.TypeName = null;
-                }
-                catch (Exception e)
-                {
-                    if (e.InnerException != null)
-                        e = e.InnerException;
 
-                    UnexpectedMIResultException miException = e as UnexpectedMIResultException;
-                    string message;
-                    if (miException != null && miException.MIError != null)
-                        message = miException.MIError;
-                    else
-                        message = e.Message;
-
-                    SetAsError(string.Format(ResourceStrings.Failed_ExecCommandError, message));
-                }
-
-                if (!String.IsNullOrEmpty(consoleResults))
-                {
-                    _debuggedProcess.WriteOutput(consoleResults);
-                }
-            }
-            else
-            {
-                int threadId = Client.GetDebuggedThread().Id;
-                uint frameLevel = _ctx.Level;
-                Results results = await _engine.DebuggedProcess.MICommandFactory.VarCreate(_strippedName, threadId, frameLevel, dwFlags, ResultClass.None);
-
-                if (results.ResultClass == ResultClass.done)
-                {
-                    _internalName = results.FindString("name");
-                    TypeName = results.TryFindString("type");
-                    if (results.Contains("dynamic"))
+                    if (!String.IsNullOrEmpty(consoleResults))
                     {
-                        IsPreformatted = true;
+                        _debuggedProcess.WriteOutput(consoleResults);
                     }
-                    if (results.Contains("dynamic") && results.Contains("has_more"))
-                    {
-                        CountChildren = results.FindUint("has_more");
-                    }
-                    else
-                    {
-                        CountChildren = results.FindUint("numchild");
-                    }
-                    if (results.Contains("displayhint"))
-                    {
-                        DisplayHint = results.FindString("displayhint");
-                    }
-                    if (results.Contains("attributes"))
-                    {
-                        if (results.FindString("attributes") == "noneditable")
-                        {
-                            _isReadonly = true;
-                        }
-                        _attribsFetched = true;
-                    }
-                    Value = results.TryFindString("value");
-                    if ((Value == String.Empty || _format != null) && !string.IsNullOrEmpty(_internalName))
-                    {
-                        if (_format != null)
-                        {
-                            await Format();
-                        }
-                        else
-                        {
-                            results = await _engine.DebuggedProcess.MICommandFactory.VarEvaluateExpression(_internalName, ResultClass.None);
-
-                            if (results.ResultClass == ResultClass.done)
-                            {
-                                Value = results.FindString("value");
-                            }
-                            else if (results.ResultClass == ResultClass.error)
-                            {
-                                SetAsError(results.FindString("msg"));
-                            }
-                            else
-                            {
-                                Debug.Fail("Weird msg from -var-evaluate-expression");
-                            }
-                        }
-                    }
-                }
-                else if (results.ResultClass == ResultClass.error)
-                {
-                    SetAsError(results.FindString("msg"));
                 }
                 else
                 {
-                    Debug.Fail("Weird msg from -var-create");
+                    int threadId = Client.GetDebuggedThread().Id;
+                    uint frameLevel = _ctx.Level;
+                    Results results = await _engine.DebuggedProcess.MICommandFactory.VarCreate(_strippedName, threadId, frameLevel, dwFlags, ResultClass.None);
+
+                    if (results.ResultClass == ResultClass.done)
+                    {
+                        _internalName = results.FindString("name");
+                        TypeName = results.TryFindString("type");
+                        if (results.Contains("dynamic"))
+                        {
+                            IsPreformatted = true;
+                        }
+                        if (results.Contains("dynamic") && results.Contains("has_more"))
+                        {
+                            CountChildren = results.FindUint("has_more");
+                        }
+                        else
+                        {
+                            CountChildren = results.FindUint("numchild");
+                        }
+                        if (results.Contains("displayhint"))
+                        {
+                            DisplayHint = results.FindString("displayhint");
+                        }
+                        if (results.Contains("attributes"))
+                        {
+                            if (results.FindString("attributes") == "noneditable")
+                            {
+                                _isReadonly = true;
+                            }
+                            _attribsFetched = true;
+                        }
+                        Value = results.TryFindString("value");
+                        if ((Value == String.Empty || _format != null) && !string.IsNullOrEmpty(_internalName))
+                        {
+                            if (_format != null)
+                            {
+                                await Format();
+                            }
+                            else
+                            {
+                                results = await _engine.DebuggedProcess.MICommandFactory.VarEvaluateExpression(_internalName, ResultClass.None);
+
+                                if (results.ResultClass == ResultClass.done)
+                                {
+                                    Value = results.FindString("value");
+                                }
+                                else if (results.ResultClass == ResultClass.error)
+                                {
+                                    SetAsError(results.FindString("msg"));
+                                }
+                                else
+                                {
+                                    Debug.Fail("Weird msg from -var-evaluate-expression");
+                                }
+                            }
+                        }
+                    }
+                    else if (results.ResultClass == ResultClass.error)
+                    {
+                        SetAsError(results.FindString("msg"));
+                    }
+                    else
+                    {
+                        Debug.Fail("Weird msg from -var-create");
+                    }
                 }
+            }
+            catch (Exception e)
+            {
+                if (e.InnerException != null)
+                    e = e.InnerException;
+
+                UnexpectedMIResultException miException = e as UnexpectedMIResultException;
+                string message;
+                if (miException != null && miException.MIError != null)
+                    message = miException.MIError;
+                else
+                    message = e.Message;
+
+                SetAsError(string.Format(ResourceStrings.Failed_ExecCommandError, message));
             }
         }
 


### PR DESCRIPTION
This prevents an AggregateException with a useless error message, such
as the error generated in issue https://github.com/microsoft/vscode-cpptools/issues/3082