### PR TITLE
Send LoadCompleteEvent from MIEngine. Add event logging.

### DIFF
--- a/src/MICore/Transports/PipeTransport.cs
+++ b/src/MICore/Transports/PipeTransport.cs
@@ -353,6 +353,7 @@ namespace MICore
             Process proc = new Process();
             proc.StartInfo.FileName = _pipePath;
             proc.StartInfo.Arguments = PipeLaunchOptions.ReplaceDebuggerCommandToken(_cmdArgs, commandText, true);
+            Logger.WriteLine("Running process {0} {1}", proc.StartInfo.FileName, proc.StartInfo.Arguments);
             proc.StartInfo.WorkingDirectory = System.IO.Path.GetDirectoryName(_pipePath);
             proc.EnableRaisingEvents = false;
             proc.StartInfo.RedirectStandardInput = false;

--- a/src/MIDebugEngine/AD7.Impl/AD7Engine.cs
+++ b/src/MIDebugEngine/AD7.Impl/AD7Engine.cs
@@ -335,6 +335,7 @@ namespace Microsoft.MIDebugEngine
 
                     try
                     {
+                        _engineCallback.OnLoadComplete(null);
                         // At this point breakpoints and exception settings have been sent down, so we can resume the target
                         _pollThread.RunOperation(() =>
                         {

--- a/src/MIDebugEngine/AD7.Impl/AD7Engine.cs
+++ b/src/MIDebugEngine/AD7.Impl/AD7Engine.cs
@@ -335,7 +335,7 @@ namespace Microsoft.MIDebugEngine
 
                     try
                     {
-                        _engineCallback.OnLoadComplete(null);
+                        _engineCallback.OnLoadComplete();
                         // At this point breakpoints and exception settings have been sent down, so we can resume the target
                         _pollThread.RunOperation(() =>
                         {

--- a/src/MIDebugEngine/AD7.Impl/AD7Events.cs
+++ b/src/MIDebugEngine/AD7.Impl/AD7Events.cs
@@ -352,7 +352,7 @@ namespace Microsoft.MIDebugEngine
     }
 
     // This interface is sent by the debug engine (DE) to the session debug manager (SDM) when a program is loaded, but before any code is executed.
-    internal sealed class AD7LoadCompleteEvent : AD7StoppingEvent, IDebugLoadCompleteEvent2
+    internal sealed class AD7LoadCompleteEvent : AD7AsynchronousEvent, IDebugLoadCompleteEvent2
     {
         public const string IID = "B1844850-1349-45D4-9F12-495212F5EB0B";
 

--- a/src/MIDebugEngine/Engine.Impl/EngineCallback.cs
+++ b/src/MIDebugEngine/Engine.Impl/EngineCallback.cs
@@ -29,7 +29,7 @@ namespace Microsoft.MIDebugEngine
         {
             uint attributes;
             Guid riidEvent = new Guid(iidEvent);
-
+            _engine.Logger.WriteLine("Send Event {0}", eventObject.GetType().Name);
             EngineUtils.RequireOk(eventObject.GetAttributes(out attributes));
             EngineUtils.RequireOk(_eventCallback.Event(_engine, null, program, thread, eventObject, ref riidEvent, attributes));
         }
@@ -241,7 +241,7 @@ namespace Microsoft.MIDebugEngine
 
         public void OnLoadComplete(DebuggedThread thread)
         {
-            AD7Thread ad7Thread = (AD7Thread)thread.Client;
+            AD7Thread ad7Thread = (AD7Thread)thread?.Client;
             AD7LoadCompleteEvent eventObject = new AD7LoadCompleteEvent();
             Send(eventObject, AD7LoadCompleteEvent.IID, ad7Thread);
         }

--- a/src/MIDebugEngine/Engine.Impl/EngineCallback.cs
+++ b/src/MIDebugEngine/Engine.Impl/EngineCallback.cs
@@ -239,11 +239,10 @@ namespace Microsoft.MIDebugEngine
             Send(eventObject, AD7AsyncBreakCompleteEvent.IID, ad7Thread);
         }
 
-        public void OnLoadComplete(DebuggedThread thread)
+        public void OnLoadComplete()
         {
-            AD7Thread ad7Thread = (AD7Thread)thread?.Client;
             AD7LoadCompleteEvent eventObject = new AD7LoadCompleteEvent();
-            Send(eventObject, AD7LoadCompleteEvent.IID, ad7Thread);
+            Send(eventObject, AD7LoadCompleteEvent.IID, null);
         }
 
         public void OnProgramDestroy(uint exitCode)

--- a/src/MIDebugEngine/Engine.Impl/Structures.cs
+++ b/src/MIDebugEngine/Engine.Impl/Structures.cs
@@ -97,7 +97,7 @@ namespace Microsoft.MIDebugEngine
         void OnException(DebuggedThread thread, string name, string description, uint code, Guid? exceptionCategory = null, ExceptionBreakpointState state = ExceptionBreakpointState.None);
         void OnStepComplete(DebuggedThread thread);
         void OnAsyncBreakComplete(DebuggedThread thread);
-        void OnLoadComplete(DebuggedThread thread);
+        void OnLoadComplete();
         //void OnProgramDestroy(uint exitCode);
         void OnBreakpointBound(Object objPendingBreakpoint);
         void OnEntryPoint(DebuggedThread thread);


### PR DESCRIPTION
Multi-process debugging was failing and VS was hanging because the debugger failed to Stop all processes before attempting to request data (stack info).  The stop behavior is triggered in the SDM by the LoadCompleteEvent from the debug engine. This fix sends the LoadCompleteEvent on process startup.

Also adding event logging messages to the engine log.

See https://devdiv.visualstudio.com/DefaultCollection/DevDiv/_workitems/edit/776626
