### PR TITLE
Fix accidental removal of output numbers

### DIFF
--- a/src/MICore/Debugger.cs
+++ b/src/MICore/Debugger.cs
@@ -1166,6 +1166,7 @@ namespace MICore
 
         public void ProcessStdOutLine(string line)
         {
+            string originalLine = line;
             if (line.Length == 0)
             {
                 return;
@@ -1248,7 +1249,8 @@ namespace MICore
                         OnNotificationOutput(noprefix);
                         break;
                     default:
-                        OnDebuggeeOutput(line + '\n');
+                        // Token is not prepended, use original line.
+                        OnDebuggeeOutput(originalLine + '\n');
                         break;
                 }
             }


### PR DESCRIPTION
During ProcessStdOutLine, we try to parse the number before the token
and return the content after the token. However, if there is no token,
we should return the whole line.

Fixes https://github.com/Microsoft/vscode-cpptools/issues/3200