### PR TITLE
Temporarily ignore libasan source file information

### DIFF
--- a/src/MIDebugEngine/Engine.Impl/DebuggedModule.cs
+++ b/src/MIDebugEngine/Engine.Impl/DebuggedModule.cs
@@ -118,5 +118,6 @@ namespace Microsoft.MIDebugEngine
         public uint GetLoadOrder() { return _loadOrder; }
 
         public Object Client { get; internal set; }      // really AD7Module
+        public bool IgnoreSource { get; internal set; }     // filter out source references from this module
     }
 }

--- a/src/MIDebugEngine/Engine.Impl/DebuggedProcess.cs
+++ b/src/MIDebugEngine/Engine.Impl/DebuggedProcess.cs
@@ -153,16 +153,7 @@ namespace Microsoft.MIDebugEngine
                     {
                         id = file;
                     }
-                    var module = FindModule(id);
-                    if (module == null)
-                    {
-                        module = new DebuggedModule(id, file, loadAddr, size, symsLoaded, symPath, _loadOrder++);
-                        lock (_moduleList)
-                        {
-                            _moduleList.Add(module);
-                        }
-                        _callback.OnModuleLoad(module);
-                    }
+                    AddModule(id, file, loadAddr, size, symsLoaded, symPath);
                 }
             };
 
@@ -1561,24 +1552,36 @@ namespace Microsoft.MIDebugEngine
                     }
                     line = line.Trim();
                     line = line.TrimEnd(new char[] { '"', '\n' });
-                    var module = FindModule(line);
-                    if (module == null)
-                    {
-                        module = new DebuggedModule(line, line, startAddr, endAddr - startAddr, symbolsLoaded, line, _loadOrder++);
-                        lock (_moduleList)
-                        {
-                            _moduleList.Add(module);
-                        }
-
-                        _callback.OnModuleLoad(module);
-                    }
-                    else if (!module.SymbolsLoaded && symbolsLoaded)
-                    {
-                        module.SymbolsLoaded = true;
-                        _callback.OnSymbolsLoaded(module);
-                    }
+                    AddModule(line, line, startAddr, endAddr - startAddr, symbolsLoaded, line);
                 }
             }
+        }
+
+        private DebuggedModule AddModule(string id, string name, ulong baseAddr, ulong size, bool symbolsLoaded, string symPath)
+        {
+            var module = FindModule(id);
+            if (module == null)
+            {
+                module = new DebuggedModule(id, name, baseAddr, size, symbolsLoaded, symPath, _loadOrder++);
+                lock (_moduleList)
+                {
+                    // Temporary kludge to work around VS asking user for source when __sanitizer::Die breakpoint is hit.
+                    // Will be removed when asan implementation switches to using the unhandled exception dialog.
+                    if (id.Contains("libasan.so"))
+                    {
+                        module.IgnoreSource = true;
+                    }
+                    _moduleList.Add(module);
+                }
+
+                _callback.OnModuleLoad(module);
+            }
+            else if (!module.SymbolsLoaded && symbolsLoaded)
+            {
+                module.SymbolsLoaded = true;
+                _callback.OnSymbolsLoaded(module);
+            }
+            return module;
         }
 
         // this is called on any thread, so we need to dispatch the command via
@@ -1813,6 +1816,14 @@ namespace Microsoft.MIDebugEngine
             lock (_moduleList)
             {
                 return _moduleList.Find((m) => m.Id == id);
+            }
+        }
+
+        public DebuggedModule FindModule(ulong addr)
+        {
+            lock (_moduleList)
+            {
+                return _moduleList.Find((m) => m.AddressInModule(addr));
             }
         }
 

--- a/src/MIDebugEngine/Engine.Impl/DebuggedThread.cs
+++ b/src/MIDebugEngine/Engine.Impl/DebuggedThread.cs
@@ -313,7 +313,19 @@ namespace Microsoft.MIDebugEngine
         private ThreadContext CreateContext(TupleValue frame)
         {
             ulong? pc = frame.TryFindAddr("addr");
-            MITextPosition textPosition = MITextPosition.TryParse(this._debugger, frame);
+
+            // don't report source line info for modules marked as IgnoreSource
+            DebuggedModule module = null;
+            if (pc != null)
+            {
+                module = _debugger.FindModule(pc.Value);
+                if (module != null && !module.IgnoreSource)
+                {
+                    module = null;
+                }
+            }
+            MITextPosition textPosition = module == null ? MITextPosition.TryParse(this._debugger, frame) : null;
+
             string func = frame.TryFindString("func");
             uint level = frame.FindUint("level");
             string from = frame.TryFindString("from");

--- a/src/MIDebugEngine/Engine.Impl/DebuggedThread.cs
+++ b/src/MIDebugEngine/Engine.Impl/DebuggedThread.cs
@@ -315,16 +315,16 @@ namespace Microsoft.MIDebugEngine
             ulong? pc = frame.TryFindAddr("addr");
 
             // don't report source line info for modules marked as IgnoreSource
-            DebuggedModule module = null;
+            bool ignoreSource = false;
             if (pc != null)
             {
-                module = _debugger.FindModule(pc.Value);
-                if (module != null && !module.IgnoreSource)
+                var module = _debugger.FindModule(pc.Value);
+                if (module != null && module.IgnoreSource)
                 {
-                    module = null;
+                    ignoreSource = true;
                 }
             }
-            MITextPosition textPosition = module == null ? MITextPosition.TryParse(this._debugger, frame) : null;
+            MITextPosition textPosition = !ignoreSource ? MITextPosition.TryParse(this._debugger, frame) : null;
 
             string func = frame.TryFindString("func");
             uint level = frame.FindUint("level");


### PR DESCRIPTION
This change causes the MIEngine to ignore source line information coming from libasan (AddressSanitizer). The purpose is to stop VS from popping up a source dialog when an ASAN error occurs. It is seen as a feedback blocker for the first demonstration of ASAN integrated into VS. We plan to revisit the implementation post Update1 and will remove this temporary kludge at that point. 
