### PR TITLE
Add FormatProvider for FXCop error CA1305. Fix failing tests and a bug

### DIFF
--- a/src/SSHDebugPS/AD7/AD7UnixAsyncCommand.cs
+++ b/src/SSHDebugPS/AD7/AD7UnixAsyncCommand.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
+using System.Globalization;
 using System.Threading;
 using Microsoft.VisualStudio.Debugger.Interop.UnixPortSupplier;
 
@@ -84,7 +85,7 @@ namespace Microsoft.SSHDebugPS
 
         protected void OnClosed(object sender, int exitCode)
         {
-            Callback.OnExit(exitCode.ToString());
+            Callback.OnExit(exitCode.ToString(CultureInfo.InvariantCulture));
             Close();
         }
 

--- a/src/SSHDebugPS/PSOutputParser.cs
+++ b/src/SSHDebugPS/PSOutputParser.cs
@@ -123,7 +123,7 @@ namespace Microsoft.SSHDebugPS
             int index = 0;
             int strLen = headerLine.Length;
 
-            // pid column is right justified so the pid column stops at the last letter index
+            // pid column is a fixed length column
             if (!SkipNonWhitespace(headerLine, ref index))
                 return false;
             _pidCol = new ColumnDef(0, index);
@@ -147,7 +147,7 @@ namespace Microsoft.SSHDebugPS
             SkipNonWhitespace(headerLine, ref index);
 
             // make sure the line is now empty, aside from whitespace
-            if (SkipWhitespace(headerLine, ref index))
+            if (SkipWhitespace(headerLine, ref index) && index < strLen)
                 return false;
 
             return true;

--- a/src/SSHDebugPS/PSOutputParser.cs
+++ b/src/SSHDebugPS/PSOutputParser.cs
@@ -147,7 +147,7 @@ namespace Microsoft.SSHDebugPS
             SkipNonWhitespace(headerLine, ref index);
 
             // make sure the line is now empty, aside from whitespace
-            if (SkipWhitespace(headerLine, ref index) && index < strLen)
+            if (SkipWhitespace(headerLine, ref index))
                 return false;
 
             return true;

--- a/src/SSHDebugPS/SSH/SSHConnection.cs
+++ b/src/SSHDebugPS/SSH/SSHConnection.cs
@@ -46,7 +46,7 @@ namespace Microsoft.SSHDebugPS.SSH
             var usernameCommand = _remoteSystem.Shell.ExecuteCommand("id -u -n");
             if (usernameCommand.ExitCode == 0)
             {
-                username = usernameCommand.Output.TrimEnd('\n'); // trim line endings because 'id' command ends with a newline
+                username = usernameCommand.Output.TrimEnd('\n', '\r'); // trim line endings because 'id' command ends with a newline
             }
 
             var command = _remoteSystem.Shell.ExecuteCommand(PSOutputParser.PSCommandLine);

--- a/src/SSHDebugPS/SSH/SSHConnection.cs
+++ b/src/SSHDebugPS/SSH/SSHConnection.cs
@@ -46,7 +46,7 @@ namespace Microsoft.SSHDebugPS.SSH
             var usernameCommand = _remoteSystem.Shell.ExecuteCommand("id -u -n");
             if (usernameCommand.ExitCode == 0)
             {
-                username = usernameCommand.Output;
+                username = usernameCommand.Output.TrimEnd('\n'); // trim line endings because 'id' command ends with a newline
             }
 
             var command = _remoteSystem.Shell.ExecuteCommand(PSOutputParser.PSCommandLine);

--- a/src/SSHDebugTests/PSOutputParserTests.cs
+++ b/src/SSHDebugTests/PSOutputParserTests.cs
@@ -17,13 +17,13 @@ namespace SSHDebugTests
             const string username = "greggm";
             // example output from ps on a real Ubuntu 14 machine (with many processes removed):
             const string input =
-                "    A B        C\n" +
-                "    1 root     /sbin/init\n" +
-                "    2 root     [kthreadd]\n" +
-                "  720 message+ dbus-daemon --system --fork\n" +
-                " 2389 greggm   -bash\n" +
-                " 2580 root     /sbin/dhclient -d -sf /usr/lib/NetworkManager/nm-dhcp-client.action -pf /run/sendsigs.omit.d/network-manager.dhclient-eth0.pid -lf /var/lib/NetworkManager/dhclient-d08a482b-ff90-4007-9b13-6500eb94b673-eth0.lease -cf /var/lib/NetworkManager/dhclient-eth0.conf eth0\n" +
-                " 2913 greggm   ps -axww -o pid=A,ruser=B,args=C\n";
+                "pppppppppp rrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrr COMMAND\n" +
+                "         1 root                             /sbin/init\n" +
+                "         2 root                             [kthreadd]\n" +
+                "       720 message+                         dbus-daemon --system --fork\n" +
+                "      2389 greggm                           -bash\n" +
+                "      2580 root                             /sbin/dhclient -d -sf /usr/lib/NetworkManager/nm-dhcp-client.action -pf /run/sendsigs.omit.d/network-manager.dhclient-eth0.pid -lf /var/lib/NetworkManager/dhclient-d08a482b-ff90-4007-9b13-6500eb94b673-eth0.lease -cf /var/lib/NetworkManager/dhclient-eth0.conf eth0\n" +
+                "      2913 greggm                           ps -axww -o pid=pppppppppp -o ruser=rrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrr -o args\n";
 
             List<Process> r = PSOutputParser.Parse(input, username);
             Assert.AreEqual(5, r.Count);
@@ -63,10 +63,10 @@ namespace SSHDebugTests
             // Made up ps output from a system where $USER wasn't a thing
             const string username = "";
             const string input =
-                "    A B        C\n" +
-                "    1 root     /sbin/init\n" +
-                "  720          dbus-daemon --system --fork\n" +
-                " 2389 greggm   -bash\n";
+                "pppppppppp rrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrr COMMAND\n" +
+                "         1 root                             /sbin/init\n" +
+                "       720                                  dbus-daemon --system --fork\n" +
+                "      2389 greggm                           -bash\n";
 
             List<Process> r = PSOutputParser.Parse(input, username);
             Assert.AreEqual(3, r.Count);


### PR DESCRIPTION
Once I fixed the format provider, the SSH PS tests were failing, which showed a bug. Updated tests with new PS format and fixed the bug.