### PR TITLE
Undo 16.0 version changes and revert back to 14.0

### DIFF
--- a/build/version.settings.targets
+++ b/build/version.settings.targets
@@ -2,6 +2,7 @@
   <PropertyGroup>    
     <!--SxS: These three properties should be changed at the start of a new version, VersionZeroYear should be the year
     before the start of the project. When updating the version, also update MIEngine\metadata.json.-->
+    <!-- Note: Changing these version numbers require approval from partner teams such as C++ IOT -->
     <MajorVersion>14</MajorVersion>
     <MinorVersion>0</MinorVersion>
     <VersionZeroYear>2013</VersionZeroYear>

--- a/build/version.settings.targets
+++ b/build/version.settings.targets
@@ -2,7 +2,7 @@
   <PropertyGroup>    
     <!--SxS: These three properties should be changed at the start of a new version, VersionZeroYear should be the year
     before the start of the project. When updating the version, also update MIEngine\metadata.json.-->
-    <!-- Note: Changing these version numbers require approval from partner teams such as C++ IOT -->
+    <!-- Note: If you change the version number, make sure that you notify partner teams such as C++ IOT -->
     <MajorVersion>14</MajorVersion>
     <MinorVersion>0</MinorVersion>
     <VersionZeroYear>2013</VersionZeroYear>

--- a/build/version.settings.targets
+++ b/build/version.settings.targets
@@ -2,9 +2,9 @@
   <PropertyGroup>    
     <!--SxS: These three properties should be changed at the start of a new version, VersionZeroYear should be the year
     before the start of the project. When updating the version, also update MIEngine\metadata.json.-->
-    <MajorVersion>16</MajorVersion>
-    <MinorVersion>1</MinorVersion>
-    <VersionZeroYear>2018</VersionZeroYear>
+    <MajorVersion>14</MajorVersion>
+    <MinorVersion>0</MinorVersion>
+    <VersionZeroYear>2013</VersionZeroYear>
 
     <!--Compute the major and minor build number-->
     <!--Team build passes the build number in the BUILD_BUILDNUMBER variable. It has the format 'Master_20140922.4' where

--- a/metadata.json
+++ b/metadata.json
@@ -1,5 +1,5 @@
 {
   "correlationId": "595D6107-E618-4BD9-85A0-C323EFC400D1",
   "owner":"miengine",
-  "version": "16.0"
+  "version": "14.0"
 }


### PR DESCRIPTION
This is to unblock a dependent project in VS that relies on the version to be 14.0. We will be making this change again in the future. 