### PR TITLE
Fix for hang when VS loses connection with linux

### DIFF
--- a/src/SSHDebugPS/SSH/SSHConnection.cs
+++ b/src/SSHDebugPS/SSH/SSHConnection.cs
@@ -172,7 +172,8 @@ namespace Microsoft.SSHDebugPS.SSH
 
             if (_remoteSystem != null)
             {
-                _remoteSystem.Dispose();
+                if (_remoteSystem.IsConnected)
+                    _remoteSystem.Disconnect();
                 _remoteSystem = null;
             }
         }


### PR DESCRIPTION
Calling _remoteSystem.Dispose() will hang VS until a timeout (30sec-1min) if VS has lost connection to the remote Linux machine. 