### PR TITLE
Load any new modules before creating frame object.

### DIFF
--- a/src/MIDebugEngine/Engine.Impl/DebuggedProcess.cs
+++ b/src/MIDebugEngine/Engine.Impl/DebuggedProcess.cs
@@ -1086,6 +1086,7 @@ namespace Microsoft.MIDebugEngine
                 }
             }
 
+            await this.EnsureModulesLoaded();
             await ThreadCache.StackFrames(thread);  // prepopulate the break thread in the thread cache
             ThreadContext cxt = await ThreadCache.GetThreadContext(thread);
 


### PR DESCRIPTION
Can't find correct module for frame if modules are not processed first. Was causing trouble with ASAN tests runs.