### PR TITLE
Fix for gdb follow-fork-mode child

### DIFF
--- a/src/MIDebugEngine/Engine.Impl/DebuggedProcess.cs
+++ b/src/MIDebugEngine/Engine.Impl/DebuggedProcess.cs
@@ -2249,6 +2249,8 @@ namespace Microsoft.MIDebugEngine
             return ConsoleCmdAsync(@"shell echo -e \\033c 1>&2");
         }
 
+        public bool IsChildProcessDebugging => _childProcessHandler != null;
+
         public bool MapCurrentSrcToCompileTimeSrc(string currentSrc, out string compilerSrc)
         {
             if (_launchOptions.SourceMap != null)

--- a/src/MIDebugEngine/Engine.Impl/DebuggedThread.cs
+++ b/src/MIDebugEngine/Engine.Impl/DebuggedThread.cs
@@ -499,7 +499,8 @@ namespace Microsoft.MIDebugEngine
                     }
                     foreach (var newt in newThreads)
                     {
-                        if (!newt.ChildThread)
+                        // If we are child process debugging, check and see if its a child thread
+                        if (!(_debugger.IsChildProcessDebugging && newt.ChildThread))
                         {
                             _callback.OnThreadStart(newt);
                         }
@@ -509,7 +510,8 @@ namespace Microsoft.MIDebugEngine
                 {
                     foreach (var dead in deadThreads)
                     {
-                        if (!dead.ChildThread)
+                        // If we are child process debugging, check and see if its a child thread
+                        if (!(_debugger.IsChildProcessDebugging && dead.ChildThread))
                         {
                             // Send the destroy event outside the lock
                             _callback.OnThreadExit(dead, 0);


### PR DESCRIPTION
Fix for a bug where following the child process would cause VS Code to
hang in debugging

Fix for: https://github.com/microsoft/vscode-cpptools/issues/2738 