### PR TITLE
Remove escapes causing malformed scripts

### DIFF
--- a/src/MICore/UnixUtilities.cs
+++ b/src/MICore/UnixUtilities.cs
@@ -76,7 +76,7 @@ namespace MICore
                 // If the system doesn't allow a non-root process to attach to another process, try to run GDB as root
                 if (localOptions.ProcessId.HasValue && !isRoot && UnixUtilities.GetRequiresRootAttach(localOptions.DebuggerMIMode))
                 {
-                    prompt = String.Format(CultureInfo.CurrentCulture, "read -n 1 -p \\\"{0}\\\" yn; if [[ ! $yn =~ ^[Yy]$ ]] ; then exit 0; fi; ", MICoreResources.Warn_AttachAsRootProcess);
+                    prompt = String.Format(CultureInfo.CurrentCulture, "read -n 1 -p \"{0}\" yn; if [[ ! $yn =~ ^[Yy]$ ]] ; then exit 0; fi; ", MICoreResources.Warn_AttachAsRootProcess);
 
                     // Prefer pkexec for a nice graphical prompt, but fall back to sudo if it's not available
                     if (File.Exists(UnixUtilities.PKExecPath))


### PR DESCRIPTION
As mentioned is [this](https://github.com/microsoft/vscode-cpptools/issues/3711) issue and others, the backslash- and doublequote-escape in this command is causing malformed scripts to be generated which will in turn fail to run. This makes it impossible to attach to processes as gdb can't elevate its permissions.

The current implementation generates this file:
```bash
echo $$ > /tmp/Microsoft-MIEngine-Pid-hp0n9b2a.oc4 ; cd /home/jenkins/code/misc/c++_node_grpc_test/server ; DbgTerm=`tty` ; set -o monitor ; trap 'rm /tmp/Microsoft-MIEngine-In-yfl0fzxv.e1q /tmp/Microsoft-MIEngine-Out-vbd9a98g.bjb /tmp/Microsoft-MIEngine-Pid-hp0n9b2a.oc4 /tmp/Microsoft-MIEngine-Cmd-2md1t9rp.9ee' EXIT ; read -n 1 -p \"Superuser access is required to attach to a process. Attaching as superuser can potentially harm your computer. Do you want to continue? [y/N]\" yn; if [[ ! $yn =~ ^[Yy]$ ]] ; then exit 0; fi; /usr/bin/pkexec /sbin/gdb --interpreter=mi --tty=$DbgTerm < /tmp/Microsoft-MIEngine-In-yfl0fzxv.e1q > /tmp/Microsoft-MIEngine-Out-vbd9a98g.bjb & clear; pid=$! ; echo $pid > /tmp/Microsoft-MIEngine-Pid-hp0n9b2a.oc4 ; wait $pid; 
```

The proposed change will generate this file, which is valid:
```bash
echo $$ > /tmp/Microsoft-MIEngine-Pid-hp0n9b2a.oc4 ; cd /home/jenkins/code/misc/c++_node_grpc_test/server ; DbgTerm=`tty` ; set -o monitor ; trap 'rm /tmp/Microsoft-MIEngine-In-yfl0fzxv.e1q /tmp/Microsoft-MIEngine-Out-vbd9a98g.bjb /tmp/Microsoft-MIEngine-Pid-hp0n9b2a.oc4 /tmp/Microsoft-MIEngine-Cmd-2md1t9rp.9ee' EXIT ; read -n 1 -p "Superuser access is required to attach to a process. Attaching as superuser can potentially harm your computer. Do you want to continue? [y/N]" yn; if [[ ! $yn =~ ^[Yy]$ ]] ; then exit 0; fi; /usr/bin/pkexec /sbin/gdb --interpreter=mi --tty=$DbgTerm < /tmp/Microsoft-MIEngine-In-yfl0fzxv.e1q > /tmp/Microsoft-MIEngine-Out-vbd9a98g.bjb & clear; pid=$! ; echo $pid > /tmp/Microsoft-MIEngine-Pid-hp0n9b2a.oc4 ; wait $pid; 
```

Disregard the file-system paths in the provided examples as they are only relevant to my file-system.