### PR TITLE
Fix CA1305 errors when building in VS

### DIFF
--- a/src/MICore/Debugger.cs
+++ b/src/MICore/Debugger.cs
@@ -1212,7 +1212,7 @@ namespace MICore
                         if (waitingOperation != null)
                         {
                             Results results = _miResults.ParseCommandOutput(noprefix);
-                            Logger.WriteLine(id + ": elapsed time " + (int)(DateTime.Now - waitingOperation.StartTime).TotalMilliseconds);
+                            Logger.WriteLine(id.ToString(CultureInfo.InvariantCulture) + ": elapsed time " + ((int)(DateTime.Now - waitingOperation.StartTime).TotalMilliseconds).ToString(CultureInfo.InvariantCulture));
                             waitingOperation.OnComplete(results, this.MICommandFactory);
                             return;
                         }

--- a/src/MICore/Logger.cs
+++ b/src/MICore/Logger.cs
@@ -51,7 +51,7 @@ namespace MICore
                 s_initTime = DateTime.Now;
 
                 LoadMIDebugLogger(configStore);
-                res.WriteLine("Initialized log at: " + s_initTime);
+                res.WriteLine("Initialized log at: " + s_initTime.ToString(CultureInfo.InvariantCulture));
             }
 
 #if DEBUG

--- a/src/MIDebugEngine/Engine.Impl/DebuggedProcess.cs
+++ b/src/MIDebugEngine/Engine.Impl/DebuggedProcess.cs
@@ -765,7 +765,7 @@ namespace Microsoft.MIDebugEngine
                             }
                         };
 
-                        commands.Add(new LaunchCommand("-target-attach " + _launchOptions.ProcessId.Value, ignoreFailures: false, failureHandler: failureHandler));
+                        commands.Add(new LaunchCommand("-target-attach " + _launchOptions.ProcessId.Value.ToString(CultureInfo.InvariantCulture), ignoreFailures: false, failureHandler: failureHandler));
                     }
 
                     if (this.MICommandFactory.Mode == MIMode.Lldb)

--- a/src/MIDebugEngine/Natvis.Impl/Natvis.cs
+++ b/src/MIDebugEngine/Natvis.Impl/Natvis.cs
@@ -136,7 +136,7 @@ namespace Microsoft.MIDebugEngine.Natvis
                 ScopedNames = new Dictionary<string, string>();
                 for (int i = 0; i < name.Args.Count; ++i)
                 {
-                    ScopedNames["$T" + (i + 1)] = name.Args[i].FullyQualifiedName;
+                    ScopedNames["$T" + (i + 1).ToString(CultureInfo.InvariantCulture)] = name.Args[i].FullyQualifiedName;
                 }
             }
         }
@@ -786,7 +786,7 @@ namespace Microsoft.MIDebugEngine.Natvis
                         IVariableInformation value = getValue(nodes.Peek().Content);
                         if (value != null)
                         {
-                            content.Add(new SimpleWrapper("[" + i + "]", _process.Engine, value));
+                            content.Add(new SimpleWrapper("[" + i.ToString(CultureInfo.InvariantCulture) + "]", _process.Engine, value));
                             i++;
                         }
                         break;
@@ -819,7 +819,7 @@ namespace Microsoft.MIDebugEngine.Natvis
                     IVariableInformation value = getValue(node);
                     if (value != null)
                     {
-                        content.Add(new SimpleWrapper("[" + i + "]", _process.Engine, value));
+                        content.Add(new SimpleWrapper("[" + i.ToString(CultureInfo.InvariantCulture) + "]", _process.Engine, value));
                         i++;
                     }
                 }
@@ -897,7 +897,7 @@ namespace Microsoft.MIDebugEngine.Natvis
                     {
                         for (int j = 0; j < name.Qualifiers[i].Args.Count; ++j)
                         {
-                            scopedNames["$T" + t] = name.Qualifiers[i].Args[j].FullyQualifiedName;
+                            scopedNames["$T" + t.ToString(CultureInfo.InvariantCulture)] = name.Qualifiers[i].Args[j].FullyQualifiedName;
                             t++;
                         }
                     }


### PR DESCRIPTION
Fixing all the CA1305 errors. These errors come after updating VS 2019 versions.