### PR TITLE
Fix how the home directory is fetched when using docker

### DIFF
--- a/src/SSHDebugPS/Docker/DockerConnection.cs
+++ b/src/SSHDebugPS/Docker/DockerConnection.cs
@@ -96,6 +96,17 @@ namespace Microsoft.SSHDebugPS.Docker
             }
         }
 
+        // Base implementation was evaluating '$HOME' on the host machine and not the client machine, causing the home directory to be wrong.
+        public override string GetUserHomeDirectory()
+        {
+            string command = "eval echo '~'";
+            string commandOutput;
+            string errorMessage;
+            ExecuteCommand(command, Timeout.Infinite, throwOnFailure: true, commandOutput: out commandOutput, errorMessage: out errorMessage);
+
+            return commandOutput;
+        }
+
         // Execute a command and wait for a response. No more interaction
         public override void ExecuteSyncCommand(string commandDescription, string commandText, out string commandOutput, int timeout, out int exitCode)
         {


### PR DESCRIPTION
$HOME was being queried on the local machine when using SSH. This fixes
https://devdiv.visualstudio.com/DevDiv/_workitems/edit/962606.