### PR TITLE
Bugfixes For Docker Host and remote connections

### DIFF
--- a/src/SSHDebugPS/ConnectionManager.cs
+++ b/src/SSHDebugPS/ConnectionManager.cs
@@ -20,7 +20,6 @@ namespace Microsoft.SSHDebugPS
 {
     internal class ConnectionManager
     {
-
         public static DockerConnection GetDockerConnection(string name)
         {
            if (string.IsNullOrWhiteSpace(name))

--- a/src/SSHDebugPS/Docker/DockerConnection.cs
+++ b/src/SSHDebugPS/Docker/DockerConnection.cs
@@ -73,8 +73,15 @@ namespace Microsoft.SSHDebugPS.Docker
                     }
                     else
                     {
-                        Debug.Assert(string.IsNullOrWhiteSpace(containerName), "containerName should be empty");
-                        containerName = segment;
+                        if (!string.IsNullOrWhiteSpace(containerName))
+                        {
+                            Debug.Fail("containerName should be empty");
+                            invalidString = true;
+                        }
+                        else
+                        {
+                            containerName = segment;
+                        }
                     }
                 }
             }
@@ -88,7 +95,7 @@ namespace Microsoft.SSHDebugPS.Docker
             return false;
         }
 
-#endregion
+        #endregion
 
         private string _containerName;
         private readonly DockerExecutionManager _dockerExecutionManager;

--- a/src/SSHDebugPS/Docker/DockerHelper.cs
+++ b/src/SSHDebugPS/Docker/DockerHelper.cs
@@ -34,6 +34,10 @@ namespace Microsoft.SSHDebugPS.Docker
                 ManualResetEvent resetEvent = new ManualResetEvent(false);
                 commandRunner.ErrorOccured += ((sender, args) =>
                 {
+                    if (!string.IsNullOrWhiteSpace(args.ErrorMessage))
+                    {
+                        errorSB.AppendLine(args.ErrorMessage);
+                    }
                     resetEvent.Set();
                 });
 
@@ -50,7 +54,7 @@ namespace Microsoft.SSHDebugPS.Docker
                         if (args.Trim()[0] != '{')
                         {
                             // output isn't json, command Error
-                            errorSB.AppendLine(args);
+                            errorSB.Append(args);
                         }
                         else
                         {
@@ -129,9 +133,6 @@ namespace Microsoft.SSHDebugPS.Docker
                 }
             }
 
-            VSMessageBoxHelper.PostErrorMessage(
-                StringResources.Error_ContainerUnavailableTitle,
-                StringResources.Error_ContainerUnavailableMessage.FormatCurrentCultureWithArgs(containerName));
             return false;
         }
 

--- a/src/SSHDebugPS/Docker/TransportSettings/DockerTransportSettings.cs
+++ b/src/SSHDebugPS/Docker/TransportSettings/DockerTransportSettings.cs
@@ -10,9 +10,8 @@ namespace Microsoft.SSHDebugPS.Docker
         protected abstract string SubCommand { get; }
         protected abstract string SubCommandArgs { get; }
 
-        protected string HostName { get; private set; }
-
-        protected bool HostIsUnix { get; private set; }
+        internal string HostName { get; private set; }
+        internal bool HostIsUnix { get; private set; }
 
         public DockerTransportSettingsBase(string hostname, bool hostIsUnix)
         {

--- a/src/SSHDebugPS/UI/ContainerPickerDialogWindow.xaml
+++ b/src/SSHDebugPS/UI/ContainerPickerDialogWindow.xaml
@@ -421,6 +421,7 @@
                   x:Name="ConnectionTypeComboBox"
                   Margin="0,4,0,0"
                   AutomationProperties.LabeledBy="{Binding ElementName=ConnectionTypeLabel}"
+                  ToolTip="{x:Static local:UIResources.ConnectionToolTip}"
                   ItemsSource="{Binding SupportedConnections}"
                   SelectedItem="{Binding SelectedConnection}"
                   DisplayMemberPath="DisplayName"
@@ -509,7 +510,7 @@
                                   Height="16"
                                   VerticalAlignment="Center"
                                   HorizontalAlignment="Center"
-                                  Margin="6"
+                                  Margin="4,4,0,0"
                                   Visibility="{Binding StatusIsError, Converter={StaticResource BoolToVisibilityConverter}, Mode=OneWay}"
                                   Moniker="{x:Static catalog:KnownMonikers.StatusWarning}" />
             <TextBlock DockPanel.Dock="Right"

--- a/src/SSHDebugPS/UI/ContainerPickerDialogWindow.xaml.cs
+++ b/src/SSHDebugPS/UI/ContainerPickerDialogWindow.xaml.cs
@@ -151,9 +151,7 @@ namespace Microsoft.SSHDebugPS.UI
                     remoteConnectionString = Model.SelectedConnection.Connection.Name;
                 }
 
-                string dockerString = string.IsNullOrWhiteSpace(Model.Hostname) ? containerId : "{0}::{1}".FormatInvariantWithArgs(Model.Hostname, containerId);
-
-                _selectedContainerConnectionString = string.IsNullOrWhiteSpace(remoteConnectionString) ? dockerString : "{0}/{1}".FormatInvariantWithArgs(remoteConnectionString, dockerString);
+                _selectedContainerConnectionString = DockerConnection.CreateConnectionString(containerId, remoteConnectionString, Model.Hostname);
                 return true;
             }
 

--- a/src/SSHDebugPS/UI/UIResources.Designer.cs
+++ b/src/SSHDebugPS/UI/UIResources.Designer.cs
@@ -97,7 +97,7 @@ namespace Microsoft.SSHDebugPS {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Cancel.
+        ///   Looks up a localized string similar to C_ancel.
         /// </summary>
         public static string CancelLabel {
             get {
@@ -124,7 +124,7 @@ namespace Microsoft.SSHDebugPS {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Executing command &apos;{0}&apos; failed with exit code {1}. {2}.
+        ///   Looks up a localized string similar to Executing command &apos;{0}&apos; failed with exit code &apos;{1}&apos;. &apos;{2}&apos;.
         /// </summary>
         public static string CommandExecutionErrorWithExitCodeFormat {
             get {
@@ -142,11 +142,20 @@ namespace Microsoft.SSHDebugPS {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to _Connection type:.
+        ///   Looks up a localized string similar to Docker _CLI host:.
         /// </summary>
         public static string ConnectionLabel {
             get {
                 return ResourceManager.GetString("ConnectionLabel", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Location from which to run the Docker CLI. To manage remote connections, in the menu go to Tools -&gt; Options and find Cross Platform -&gt; Connection Manager..
+        /// </summary>
+        public static string ConnectionToolTip {
+            get {
+                return ResourceManager.GetString("ConnectionToolTip", resourceCulture);
             }
         }
         
@@ -205,7 +214,7 @@ namespace Microsoft.SSHDebugPS {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to _Hostname (Optional):.
+        ///   Looks up a localized string similar to Docker _host (Optional):.
         /// </summary>
         public static string HostnameLabel {
             get {
@@ -214,7 +223,7 @@ namespace Microsoft.SSHDebugPS {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Specify a hostname if connecting to a different Docker daemon. .
+        ///   Looks up a localized string similar to Specify a hostname for connecting to a different Docker host. .
         /// </summary>
         public static string HostnameTip {
             get {

--- a/src/SSHDebugPS/UI/UIResources.resx
+++ b/src/SSHDebugPS/UI/UIResources.resx
@@ -150,7 +150,7 @@
     <comment>{0} = command, {1} = error message</comment>
   </data>
   <data name="CommandExecutionErrorWithExitCodeFormat" xml:space="preserve">
-    <value>Executing command '{0}' failed with exit code {1}. {2}</value>
+    <value>Executing command '{0}' failed with exit code '{1}'. '{2}'</value>
     <comment>{0} = command, {1} = exit code, {2} = error message</comment>
   </data>
   <data name="ErrorStatusTextFormat" xml:space="preserve">
@@ -194,17 +194,17 @@
     <value>_Advanced Settings</value>
   </data>
   <data name="CancelLabel" xml:space="preserve">
-    <value>Cancel</value>
+    <value>C_ancel</value>
   </data>
   <data name="ConnectionLabel" xml:space="preserve">
-    <value>_Connection type:</value>
+    <value>Docker _CLI host:</value>
   </data>
   <data name="HostnameLabel" xml:space="preserve">
-    <value>_Hostname (Optional):</value>
+    <value>Docker _host (Optional):</value>
     <comment>Hostname for Docker daemon configuration</comment>
   </data>
   <data name="HostnameTip" xml:space="preserve">
-    <value>Specify a hostname if connecting to a different Docker daemon. </value>
+    <value>Specify a hostname for connecting to a different Docker host. </value>
   </data>
   <data name="OKLabel" xml:space="preserve">
     <value>_OK</value>
@@ -229,5 +229,8 @@
   </data>
   <data name="ExpanderToolTip" xml:space="preserve">
     <value>Show Container Details</value>
+  </data>
+  <data name="ConnectionToolTip" xml:space="preserve">
+    <value>Location from which to run the Docker CLI. To manage remote connections, in the menu go to Tools -&gt; Options and find Cross Platform -&gt; Connection Manager.</value>
   </data>
 </root>


### PR DESCRIPTION
* Fix parsing of connectionstrings
* change connectionstring format to
`<containerName>;ssh=<sshConnectionString;host=<dockerhost>`
* fix labelling and tool tips
* fix instance of single quoting to only use it when host is linux. the
ingle quoting does not work on Windows.