### PR TITLE
Update VSCodeDebugAdapterHost protocol to fix exception

### DIFF
--- a/src/OpenDebugAD7/OpenDebugAD7.csproj
+++ b/src/OpenDebugAD7/OpenDebugAD7.csproj
@@ -67,7 +67,7 @@
     </Reference>
     <!-- Same version as in packages.config -->
     <Reference Include="Microsoft.VisualStudio.Shared.VSCodeDebugProtocol">
-      <HintPath>$(NuGetPackagesDirectory)/Microsoft.VisualStudio.Shared.VsCodeDebugProtocol.15.8.20719.1/lib/net45/Microsoft.VisualStudio.Shared.VSCodeDebugProtocol.dll</HintPath>
+      <HintPath>$(NuGetPackagesDirectory)/Microsoft.VisualStudio.Shared.VsCodeDebugProtocol.16.3.30820.2/lib/net45/Microsoft.VisualStudio.Shared.VSCodeDebugProtocol.dll</HintPath>
     </Reference>
     <Reference Include="Newtonsoft.Json">
       <HintPath>$(NuGetPackagesDirectory)\Newtonsoft.Json.9.0.1\lib\portable-net45+wp80+win8+wpa81\Newtonsoft.Json.dll</HintPath>

--- a/src/OpenDebugAD7/packages.config
+++ b/src/OpenDebugAD7/packages.config
@@ -6,5 +6,5 @@
   <package id="Mono.Unofficial.pdb2mdb" version="4.2.3.4" />
 
   <!-- Update the version number VsCodeDebugProtocol HintPath in OpenDebugAD7\OpenDebugAD7.csproj -->
-  <package id="Microsoft.VisualStudio.Shared.VsCodeDebugProtocol" version="15.8.20719.1" />
+  <package id="Microsoft.VisualStudio.Shared.VsCodeDebugProtocol" version="16.3.30820.2" />
 </packages>


### PR DESCRIPTION
Fixes: https://github.com/microsoft/vscode-cpptools/issues/4090 