### PR TITLE
Fix NullReferenceException Bug when Description is empty (introduced in #916)

### DIFF
--- a/src/OpenDebugAD7/AD7DebugSession.cs
+++ b/src/OpenDebugAD7/AD7DebugSession.cs
@@ -527,7 +527,7 @@ namespace OpenDebugAD7
         #region DebugAdapterBase
 
         protected override void HandleInitializeRequestAsync(IRequestResponder<InitializeArguments, InitializeResponse> responder)
-        {
+        {            
             InitializeArguments arguments = responder.Arguments;
 
             m_engineConfiguration = EngineConfiguration.TryGet(arguments.AdapterID);
@@ -596,27 +596,29 @@ namespace OpenDebugAD7
 
         protected override void HandleLaunchRequestAsync(IRequestResponder<LaunchArguments> responder)
         {
+            const string telemetryEventName = DebuggerTelemetry.TelemetryLaunchEventName;
+
             int hr;
             DateTime launchStartTime = DateTime.Now;
 
             string program = responder.Arguments.ConfigurationProperties.GetValueAsString("program")?.Trim();
             if (string.IsNullOrEmpty(program))
             {
-                responder.SetError(CreateProtocolExceptionAndLogTelemetry(DebuggerTelemetry.TelemetryLaunchEventName, 1001, "launch: property 'program' is missing or empty"));
+                responder.SetError(CreateProtocolExceptionAndLogTelemetry(telemetryEventName, 1001, "launch: property 'program' is missing or empty"));
                 return;
             }
 
             // If program is still in the default state, raise error
             if (program.EndsWith(">", StringComparison.Ordinal) && program.Contains('<'))
             {
-                responder.SetError(CreateProtocolExceptionAndLogTelemetry(DebuggerTelemetry.TelemetryLaunchEventName, 1001, "launch: launch.json must be configured. Change 'program' to the path to the executable file that you would like to debug."));
+                responder.SetError(CreateProtocolExceptionAndLogTelemetry(telemetryEventName, 1001, "launch: launch.json must be configured. Change 'program' to the path to the executable file that you would like to debug."));
                 return;
             }
 
             // Should not have a pid in launch
             if (responder.Arguments.ConfigurationProperties.ContainsKey("processId"))
             {
-                responder.SetError(CreateProtocolExceptionAndLogTelemetry(DebuggerTelemetry.TelemetryLaunchEventName, 1001, "launch: The parameter: 'processId' should not be specified on Launch. Please use request type: 'attach'"));
+                responder.SetError(CreateProtocolExceptionAndLogTelemetry(telemetryEventName, 1001, "launch: The parameter: 'processId' should not be specified on Launch. Please use request type: 'attach'"));
                 return;
             }
 
@@ -632,7 +634,7 @@ namespace OpenDebugAD7
             {
                 if (!ValidateProgramPath(ref program))
                 {
-                    responder.SetError(CreateProtocolExceptionAndLogTelemetry(DebuggerTelemetry.TelemetryLaunchEventName, 1002, String.Format(CultureInfo.CurrentCulture, "launch: program '{0}' does not exist", program)));
+                    responder.SetError(CreateProtocolExceptionAndLogTelemetry(telemetryEventName, 1002, String.Format(CultureInfo.CurrentCulture, "launch: program '{0}' does not exist", program)));
                     return;
                 }
             }
@@ -640,7 +642,7 @@ namespace OpenDebugAD7
             string workingDirectory = responder.Arguments.ConfigurationProperties.GetValueAsString("cwd");
             if (string.IsNullOrEmpty(workingDirectory))
             {
-                responder.SetError(CreateProtocolExceptionAndLogTelemetry(DebuggerTelemetry.TelemetryLaunchEventName, 1003, "launch: property 'cwd' is missing or empty"));
+                responder.SetError(CreateProtocolExceptionAndLogTelemetry(telemetryEventName, 1003, "launch: property 'cwd' is missing or empty"));
                 return;
             }
 
@@ -649,7 +651,7 @@ namespace OpenDebugAD7
                 workingDirectory = m_pathConverter.ConvertLaunchPathForVsCode(workingDirectory);
                 if (!Directory.Exists(workingDirectory))
                 {
-                    responder.SetError(CreateProtocolExceptionAndLogTelemetry(DebuggerTelemetry.TelemetryLaunchEventName, 1004, String.Format(CultureInfo.CurrentCulture, "launch: workingDirectory '{0}' does not exist", workingDirectory)));
+                    responder.SetError(CreateProtocolExceptionAndLogTelemetry(telemetryEventName, 1004, String.Format(CultureInfo.CurrentCulture, "launch: workingDirectory '{0}' does not exist", workingDirectory)));
                     return;
                 }
             }
@@ -722,7 +724,7 @@ namespace OpenDebugAD7
                         }
                         if (message != null)
                         {
-                            responder.SetError(CreateProtocolExceptionAndLogTelemetry(DebuggerTelemetry.TelemetryLaunchEventName, 1005, message));
+                            responder.SetError(CreateProtocolExceptionAndLogTelemetry(telemetryEventName, 1005, message));
                             return;
                         }
                     }
@@ -761,9 +763,15 @@ namespace OpenDebugAD7
                 properties.Add(DebuggerTelemetry.TelemetryVisualizerFileUsed, visualizerFileUsed);
                 properties.Add(DebuggerTelemetry.TelemetrySourceFileMappings, sourceFileMappings);
 
-                DebuggerTelemetry.ReportTimedEvent(DebuggerTelemetry.TelemetryLaunchEventName, DateTime.Now - launchStartTime, properties);
+                DebuggerTelemetry.ReportTimedEvent(telemetryEventName, DateTime.Now - launchStartTime, properties);
 
                 success = true;
+            }
+            catch (Exception e)
+            {
+                // Instead of failing to launch with the exception, try and wrap it better so that the information is useful for the user.
+                responder.SetError(CreateProtocolExceptionAndLogTelemetry(telemetryEventName, 1007, string.Format(CultureInfo.CurrentCulture, AD7Resources.Error_ExceptionOccured, e.InnerException?.ToString() ?? e.ToString())));
+                return;
             }
             finally
             {
@@ -793,6 +801,8 @@ namespace OpenDebugAD7
 
         protected override void HandleAttachRequestAsync(IRequestResponder<AttachArguments> responder)
         {
+            const string telemetryEventName = DebuggerTelemetry.TelemetryAttachEventName;
+
             // ProcessId can be either a string or an int. We attempt to parse as int, if that does not exist we attempt to parse as a string.
             string processId = responder.Arguments.ConfigurationProperties.GetValueAsInt("processId")?.ToString(CultureInfo.InvariantCulture) ?? responder.Arguments.ConfigurationProperties.GetValueAsString("processId");
             string miDebuggerServerAddress = responder.Arguments.ConfigurationProperties.GetValueAsString("miDebuggerServerAddress");
@@ -807,7 +817,7 @@ namespace OpenDebugAD7
             {
                 if (string.IsNullOrEmpty(processId))
                 {
-                    responder.SetError(CreateProtocolExceptionAndLogTelemetry(DebuggerTelemetry.TelemetryAttachEventName, 1001, "attach: property 'processId' needs to be specified"));
+                    responder.SetError(CreateProtocolExceptionAndLogTelemetry(telemetryEventName, 1001, "attach: property 'processId' needs to be specified"));
                     return;
                 }
             }
@@ -817,19 +827,19 @@ namespace OpenDebugAD7
 
                 if (!string.IsNullOrEmpty(miDebuggerServerAddress) && !string.IsNullOrEmpty(processId))
                 {
-                    responder.SetError(CreateProtocolExceptionAndLogTelemetry(DebuggerTelemetry.TelemetryAttachEventName, 1002, "attach: 'processId' cannot be used with " + propertyCausingRemote));
+                    responder.SetError(CreateProtocolExceptionAndLogTelemetry(telemetryEventName, 1002, "attach: 'processId' cannot be used with " + propertyCausingRemote));
                     return;
                 }
                 else if (isPipeTransport && (string.IsNullOrEmpty(processId) || string.IsNullOrEmpty(pipeTransport.GetValueAsString("debuggerPath"))))
                 {
-                    responder.SetError(CreateProtocolExceptionAndLogTelemetry(DebuggerTelemetry.TelemetryAttachEventName, 1001, "attach: properties 'processId' and 'debuggerPath' needs to be specified with " + propertyCausingRemote));
+                    responder.SetError(CreateProtocolExceptionAndLogTelemetry(telemetryEventName, 1001, "attach: properties 'processId' and 'debuggerPath' needs to be specified with " + propertyCausingRemote));
                     return;
                 }
             }
 
             int pid = 0;
 
-            ProtocolException protocolException = isLocal ? VerifyLocalProcessId(processId, DebuggerTelemetry.TelemetryAttachEventName, out pid) : VerifyProcessId(processId, DebuggerTelemetry.TelemetryAttachEventName, out pid);
+            ProtocolException protocolException = isLocal ? VerifyLocalProcessId(processId, telemetryEventName, out pid) : VerifyProcessId(processId, telemetryEventName, out pid);
 
             if (protocolException != null)
             {
@@ -856,7 +866,7 @@ namespace OpenDebugAD7
                 {
                     if (string.IsNullOrEmpty(pipeTransport.GetValueAsString("debuggerPath")))
                     {
-                        responder.SetError(CreateProtocolExceptionAndLogTelemetry(DebuggerTelemetry.TelemetryAttachEventName, 1011, "debuggerPath is required for attachTransport."));
+                        responder.SetError(CreateProtocolExceptionAndLogTelemetry(telemetryEventName, 1011, "debuggerPath is required for attachTransport."));
                         return;
                     }
                     bool debugServerUsed = false;
@@ -877,7 +887,7 @@ namespace OpenDebugAD7
 
                     if (string.IsNullOrEmpty(program))
                     {
-                        responder.SetError(CreateProtocolExceptionAndLogTelemetry(DebuggerTelemetry.TelemetryAttachEventName, 1009, "attach: property 'program' is missing or empty"));
+                        responder.SetError(CreateProtocolExceptionAndLogTelemetry(telemetryEventName, 1009, "attach: property 'program' is missing or empty"));
                         return;
                     }
                     else
@@ -890,13 +900,13 @@ namespace OpenDebugAD7
                 {
                     if (string.IsNullOrEmpty(program))
                     {
-                        responder.SetError(CreateProtocolExceptionAndLogTelemetry(DebuggerTelemetry.TelemetryAttachEventName, 1009, "attach: property 'program' is missing or empty"));
+                        responder.SetError(CreateProtocolExceptionAndLogTelemetry(telemetryEventName, 1009, "attach: property 'program' is missing or empty"));
                         return;
                     }
 
                     if (!ValidateProgramPath(ref program))
                     {
-                        responder.SetError(CreateProtocolExceptionAndLogTelemetry(DebuggerTelemetry.TelemetryAttachEventName, 1010, String.Format(CultureInfo.CurrentCulture, "attach: program path '{0}' does not exist", program)));
+                        responder.SetError(CreateProtocolExceptionAndLogTelemetry(telemetryEventName, 1010, String.Format(CultureInfo.CurrentCulture, "attach: program path '{0}' does not exist", program)));
                         return;
                     }
 
@@ -935,7 +945,7 @@ namespace OpenDebugAD7
                         }
                         if (message != null)
                         {
-                            responder.SetError(CreateProtocolExceptionAndLogTelemetry(DebuggerTelemetry.TelemetryAttachEventName, 1012, message));
+                            responder.SetError(CreateProtocolExceptionAndLogTelemetry(telemetryEventName, 1012, message));
                             return;
                         }
                     }
@@ -963,14 +973,14 @@ namespace OpenDebugAD7
                 properties.Add(DebuggerTelemetry.TelemetryVisualizerFileUsed, visualizerFileUsed);
                 properties.Add(DebuggerTelemetry.TelemetrySourceFileMappings, sourceFileMappings);
 
-                DebuggerTelemetry.ReportTimedEvent(DebuggerTelemetry.TelemetryAttachEventName, DateTime.Now - attachStartTime, properties);
+                DebuggerTelemetry.ReportTimedEvent(telemetryEventName, DateTime.Now - attachStartTime, properties);
                 success = true;
 
                 responder.SetResponse(new AttachResponse());
             }
-            catch (AD7Exception e)
+            catch (Exception e)
             {
-                responder.SetError(new ProtocolException(e.Message));
+                responder.SetError(CreateProtocolExceptionAndLogTelemetry(telemetryEventName, 1007, string.Format(CultureInfo.CurrentCulture, AD7Resources.Error_ExceptionOccured, e.InnerException?.ToString() ?? e.ToString())));
             }
             finally
             {

--- a/src/OpenDebugAD7/AD7Resources.Designer.cs
+++ b/src/OpenDebugAD7/AD7Resources.Designer.cs
@@ -10,7 +10,6 @@
 
 namespace OpenDebugAD7 {
     using System;
-    using System.Reflection;
     
     
     /// <summary>
@@ -20,7 +19,7 @@ namespace OpenDebugAD7 {
     // class via a tool like ResGen or Visual Studio.
     // To add or remove a member, edit your .ResX file then rerun ResGen
     // with the /str option, or rebuild your VS project.
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "4.0.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "16.0.0.0")]
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     internal class AD7Resources {
@@ -40,7 +39,7 @@ namespace OpenDebugAD7 {
         internal static global::System.Resources.ResourceManager ResourceManager {
             get {
                 if (object.ReferenceEquals(resourceMan, null)) {
-                    global::System.Resources.ResourceManager temp = new global::System.Resources.ResourceManager("OpenDebugAD7.AD7Resources", typeof(AD7Resources).GetTypeInfo().Assembly);
+                    global::System.Resources.ResourceManager temp = new global::System.Resources.ResourceManager("OpenDebugAD7.AD7Resources", typeof(AD7Resources).Assembly);
                     resourceMan = temp;
                 }
                 return resourceMan;
@@ -105,6 +104,15 @@ namespace OpenDebugAD7 {
         internal static string Error_CorruptingException {
             get {
                 return ResourceManager.GetString("Error_CorruptingException", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Exception occurred: &apos;{0}&apos;.
+        /// </summary>
+        internal static string Error_ExceptionOccured {
+            get {
+                return ResourceManager.GetString("Error_ExceptionOccured", resourceCulture);
             }
         }
         

--- a/src/OpenDebugAD7/AD7Resources.resx
+++ b/src/OpenDebugAD7/AD7Resources.resx
@@ -254,4 +254,8 @@
   <data name="Error_VariableIsReadonly" xml:space="preserve">
     <value>'{0}' cannot be assigned to</value>
   </data>
+  <data name="Error_ExceptionOccured" xml:space="preserve">
+    <value>Exception occurred: '{0}'</value>
+    <comment>{0} is the exception string</comment>
+  </data>
 </root>

--- a/src/OpenDebugAD7/MILaunchOptions.cs
+++ b/src/OpenDebugAD7/MILaunchOptions.cs
@@ -224,7 +224,15 @@ namespace OpenDebugAD7
 
         private static string FormatCommand(JsonCommand command)
         {
-            return String.Concat("        <Command IgnoreFailures='", command.IgnoreFailures ? "true" : "false", "' Description='", XmlSingleQuotedAttributeEncode(command.Description), "'>", command.Text, "</Command>\n");
+            return String.Concat(
+                "        <Command IgnoreFailures='", 
+                command.IgnoreFailures ? "true" : "false", 
+                "' Description='", 
+                XmlSingleQuotedAttributeEncode(command.Description), 
+                "'>", 
+                command.Text, 
+                "</Command>\n"
+                );
         }
 
         private static void AddBaseLaunchOptionsAttributes(
@@ -715,7 +723,7 @@ namespace OpenDebugAD7
 
         internal static string XmlSingleQuotedAttributeEncode(string value)
         {
-            if (value.IndexOfAny(s_specialXmlSingleQuotedAttributeChars) < 0)
+            if (string.IsNullOrWhiteSpace(value) || value.IndexOfAny(s_specialXmlSingleQuotedAttributeChars) < 0)
             {
                 return value;
             }


### PR DESCRIPTION
Fix bug introduced in https://github.com/microsoft/MIEngine/pull/916 

Add shortcut for if value is null to return

Fixes:
https://github.com/microsoft/vscode-cpptools/issues/4125
https://github.com/microsoft/vscode-cpptools/issues/4126

Make the error message more useful if we error during launch or attach.