### PR TITLE
Fixes quoting around elevation script to be a single quote

### DIFF
--- a/src/MICore/Transports/RunInTerminalTransport.cs
+++ b/src/MICore/Transports/RunInTerminalTransport.cs
@@ -137,6 +137,7 @@ namespace MICore
                 using (FileStream dbgCmdStream = new FileStream(dbgCmdScript, FileMode.CreateNew))
                 using (StreamWriter dbgCmdWriter = new StreamWriter(dbgCmdStream, encNoBom) { AutoFlush = true })
                 {
+                    dbgCmdWriter.WriteLine("#!/bin/sh");
                     dbgCmdWriter.Write(launchDebuggerCommand);
                     dbgCmdWriter.Flush();
                 }


### PR DESCRIPTION
Fixes: https://github.com/microsoft/vscode-cpptools/issues/4133
Since there is no variable in the string for -p, we will wrap it in a
single quote instead.

I will file a bug to investigate how to resolve this in a POSIX compliant manner since this is currently bash only.