### PR TITLE
Add OpenDebugAD7 support for disable auto-solib

### DIFF
--- a/src/OpenDebugAD7/MILaunchOptions.cs
+++ b/src/OpenDebugAD7/MILaunchOptions.cs
@@ -167,7 +167,7 @@ namespace OpenDebugAD7
         private class SymbolLoadInfo
         {
             [JsonProperty]
-            public bool LoadAll { get; set; }
+            public bool? LoadAll { get; set; }
 
             [JsonProperty]
             public string ExceptionList { get; set; }
@@ -509,7 +509,16 @@ namespace OpenDebugAD7
                     string miDebuggerArgs = XmlSingleQuotedAttributeEncode(jsonLaunchOptions.MIDebuggerArgs);
                     xmlLaunchOptions.Append(String.Concat("  MIDebuggerArgs='", miDebuggerArgs, "'\n"));
                 }
-                xmlLaunchOptions.Append(String.Concat("  WaitDynamicLibLoad='false'\n"));
+
+                // If we get SymbolLoadInfo and an ExceptionList. We will need to have WaitDynamicLibLoad.
+                if (jsonLaunchOptions.SymbolLoadInfo != null && !String.IsNullOrWhiteSpace(jsonLaunchOptions.SymbolLoadInfo.ExceptionList))
+                {
+                    xmlLaunchOptions.Append(String.Concat("  WaitDynamicLibLoad='true'\n"));
+                }
+                else
+                {
+                    xmlLaunchOptions.Append(String.Concat("  WaitDynamicLibLoad='false'\n"));
+                }
 
                 if (jsonLaunchOptions.MIDebuggerServerAddress != null)
                 {
@@ -596,7 +605,18 @@ namespace OpenDebugAD7
 
                 if (jsonLaunchOptions.SymbolLoadInfo != null)
                 {
-                    xmlLaunchOptions.Append("    <SymbolLoadInfo LoadAll='" + jsonLaunchOptions.SymbolLoadInfo.LoadAll.ToString().ToLower() + "' ExceptionList='" + XmlSingleQuotedAttributeEncode(jsonLaunchOptions.SymbolLoadInfo.ExceptionList) + "' />\n");
+                    xmlLaunchOptions.Append("    <SymbolLoadInfo ");
+                    if (jsonLaunchOptions.SymbolLoadInfo.LoadAll.HasValue)
+                    {
+                        xmlLaunchOptions.Append("LoadAll = '" + (jsonLaunchOptions.SymbolLoadInfo.LoadAll.Value ? "true" : "false") + "' ");
+                    }
+
+                    if (!String.IsNullOrWhiteSpace(jsonLaunchOptions.SymbolLoadInfo.ExceptionList))
+                    {
+                        xmlLaunchOptions.Append("ExceptionList='" + XmlSingleQuotedAttributeEncode(jsonLaunchOptions.SymbolLoadInfo.ExceptionList) + "' ");
+                    }
+
+                    xmlLaunchOptions.Append("/>\n");
                 }
 
                 xmlLaunchOptions.Append("</LocalLaunchOptions>");

--- a/src/OpenDebugAD7/MILaunchOptions.cs
+++ b/src/OpenDebugAD7/MILaunchOptions.cs
@@ -510,8 +510,9 @@ namespace OpenDebugAD7
                     xmlLaunchOptions.Append(String.Concat("  MIDebuggerArgs='", miDebuggerArgs, "'\n"));
                 }
 
-                // If we get SymbolLoadInfo and an ExceptionList. We will need to have WaitDynamicLibLoad.
-                if (jsonLaunchOptions.SymbolLoadInfo != null && !String.IsNullOrWhiteSpace(jsonLaunchOptions.SymbolLoadInfo.ExceptionList))
+                // If we get SymbolLoadInfo and an ExceptionList or LoadAll is set. We will need to have WaitDynamicLibLoad.
+                if (jsonLaunchOptions.SymbolLoadInfo != null && 
+                    (!String.IsNullOrWhiteSpace(jsonLaunchOptions.SymbolLoadInfo.ExceptionList) || jsonLaunchOptions.SymbolLoadInfo.LoadAll.HasValue))
                 {
                     xmlLaunchOptions.Append(String.Concat("  WaitDynamicLibLoad='true'\n"));
                 }
@@ -608,7 +609,7 @@ namespace OpenDebugAD7
                     xmlLaunchOptions.Append("    <SymbolLoadInfo ");
                     if (jsonLaunchOptions.SymbolLoadInfo.LoadAll.HasValue)
                     {
-                        xmlLaunchOptions.Append("LoadAll = '" + (jsonLaunchOptions.SymbolLoadInfo.LoadAll.Value ? "true" : "false") + "' ");
+                        xmlLaunchOptions.Append("LoadAll = '" + jsonLaunchOptions.SymbolLoadInfo.LoadAll.Value.ToString().ToLowerInvariant() + "' ");
                     }
 
                     if (!String.IsNullOrWhiteSpace(jsonLaunchOptions.SymbolLoadInfo.ExceptionList))

--- a/src/OpenDebugAD7/MILaunchOptions.cs
+++ b/src/OpenDebugAD7/MILaunchOptions.cs
@@ -99,6 +99,9 @@ namespace OpenDebugAD7
 
             [JsonProperty]
             public string CoreDumpPath { get; set; }
+
+            [JsonProperty]
+            public SymbolLoadInfo SymbolLoadInfo { get; set; }
         }
 
         [JsonObject]
@@ -158,6 +161,16 @@ namespace OpenDebugAD7
 
             [JsonProperty]
             public bool AvoidWindowsConsoleRedirection { get; set; }
+        }
+
+        [JsonObject]
+        private class SymbolLoadInfo
+        {
+            [JsonProperty]
+            public bool LoadAll { get; set; }
+
+            [JsonProperty]
+            public string ExceptionList { get; set; }
         }
 
         [JsonObject]
@@ -579,6 +592,11 @@ namespace OpenDebugAD7
                         AddEnvironmentVariable(xmlLaunchOptions, pair.Key, pair.Value);
                     }
                     xmlLaunchOptions.Append("    </Environment>\n");
+                }
+
+                if (jsonLaunchOptions.SymbolLoadInfo != null)
+                {
+                    xmlLaunchOptions.Append("    <SymbolLoadInfo LoadAll='" + jsonLaunchOptions.SymbolLoadInfo.LoadAll.ToString().ToLower() + "' ExceptionList='" + XmlSingleQuotedAttributeEncode(jsonLaunchOptions.SymbolLoadInfo.ExceptionList) + "' />\n");
                 }
 
                 xmlLaunchOptions.Append("</LocalLaunchOptions>");


### PR DESCRIPTION
Add entry for SymbolLoadInfo for OpenDebugAD7 BaseLaunchOptions.

Then read the launchJson and convert it into XML.