### PR TITLE
Load Attach Docker combobox before refresh

### DIFF
--- a/src/SSHDebugPS/UI/ContainerPickerDialogWindow.xaml.cs
+++ b/src/SSHDebugPS/UI/ContainerPickerDialogWindow.xaml.cs
@@ -25,7 +25,7 @@ namespace Microsoft.SSHDebugPS.UI
         public ContainerPickerDialogWindow()
         {
             InitializeComponent();
-            this.Model = new ContainerPickerViewModel();
+            this.Model = new ContainerPickerViewModel(Dispatcher);
             this.DataContext = Model;
             this.Loaded += OnWindowLoaded;
         }
@@ -168,7 +168,6 @@ namespace Microsoft.SSHDebugPS.UI
         private void Refresh_Click(object sender, RoutedEventArgs e)
         {
             Model.RefreshContainersList();
-
             e.Handled = true;
         }
 

--- a/src/SSHDebugPS/UI/ContainerPickerDialogWindow.xaml.cs
+++ b/src/SSHDebugPS/UI/ContainerPickerDialogWindow.xaml.cs
@@ -25,7 +25,7 @@ namespace Microsoft.SSHDebugPS.UI
         public ContainerPickerDialogWindow()
         {
             InitializeComponent();
-            this.Model = new ContainerPickerViewModel(Dispatcher);
+            this.Model = new ContainerPickerViewModel();
             this.DataContext = Model;
             this.Loaded += OnWindowLoaded;
         }

--- a/src/SSHDebugPS/UI/ViewModels/ContainerPickerViewModel.cs
+++ b/src/SSHDebugPS/UI/ViewModels/ContainerPickerViewModel.cs
@@ -19,11 +19,9 @@ namespace Microsoft.SSHDebugPS.UI
     public class ContainerPickerViewModel : INotifyPropertyChanged
     {
         private Lazy<bool> _sshAvailable;
-        private Dispatcher _dispatcher;
 
-        public ContainerPickerViewModel(Dispatcher dispatcher)
+        public ContainerPickerViewModel()
         {
-            _dispatcher = dispatcher;
             InitializeConnections();
             ContainerInstances = new ObservableCollection<IContainerViewModel>();
 
@@ -67,7 +65,7 @@ namespace Microsoft.SSHDebugPS.UI
             // Render = 7
             // Loaded = 6  - Operations are processed when layout and render has finished but just before items at input priority are serviced. 
             // https://docs.microsoft.com/en-us/dotnet/api/system.windows.threading.dispatcherpriority
-            _dispatcher.BeginInvoke(DispatcherPriority.Input, (Action)(() => { RefreshContainersListInternal(); }));
+            Dispatcher.CurrentDispatcher.BeginInvoke(DispatcherPriority.Input, (Action)(() => { RefreshContainersListInternal(); }));
         }
 
         private void RefreshContainersListInternal()

--- a/src/SSHDebugPS/UI/ViewModels/ContainerPickerViewModel.cs
+++ b/src/SSHDebugPS/UI/ViewModels/ContainerPickerViewModel.cs
@@ -8,6 +8,7 @@ using System.ComponentModel;
 using System.Diagnostics;
 using System.IO;
 using System.Linq;
+using System.Windows.Threading;
 using liblinux.Persistence;
 using Microsoft.SSHDebugPS.Docker;
 using Microsoft.SSHDebugPS.SSH;
@@ -18,9 +19,11 @@ namespace Microsoft.SSHDebugPS.UI
     public class ContainerPickerViewModel : INotifyPropertyChanged
     {
         private Lazy<bool> _sshAvailable;
+        private Dispatcher _dispatcher;
 
-        public ContainerPickerViewModel()
+        public ContainerPickerViewModel(Dispatcher dispatcher)
         {
+            _dispatcher = dispatcher;
             InitializeConnections();
             ContainerInstances = new ObservableCollection<IContainerViewModel>();
 
@@ -52,16 +55,27 @@ namespace Microsoft.SSHDebugPS.UI
         {
             IsRefreshEnabled = false;
 
+            // Clear everything before retreiving the container list
+            ContainerInstances?.Clear();
+            UpdateStatusMessage(string.Empty, false);
+
+            // Set the status
+            ContainersFoundText = UIResources.QueryingForContainersMessage;
+
+            // Tell the dispatcher to run the Refresh task with a lower priority than Render.
+            // This is so that the UI does any necessary updating before the refresh task has completed. 
+            // Render = 7
+            // Loaded = 6  - Operations are processed when layout and render has finished but just before items at input priority are serviced. 
+            // https://docs.microsoft.com/en-us/dotnet/api/system.windows.threading.dispatcherpriority
+            _dispatcher.BeginInvoke(DispatcherPriority.Input, (Action)(() => { RefreshContainersListInternal(); }));
+        }
+
+        private void RefreshContainersListInternal()
+        {
             try
             {
                 IContainerViewModel selectedContainer = SelectedContainerInstance;
                 SelectedContainerInstance = null;
-
-                ContainersFoundText = UIResources.SearchingStatusText;
-
-                // Clear everything
-                ContainerInstances?.Clear();
-                UpdateStatusMessage(string.Empty, false);
 
                 IEnumerable<DockerContainerInstance> containers;
 


### PR DESCRIPTION
Queue refreshing of container lists to happen after UI has been updated.
Update status text and messaging to make it clearer what is happening
while that container text is being updated.

Fixes: https://devdiv.visualstudio.com/DevDiv/_workitems/edit/945685

@dustincoleman also please review

