### PR TITLE
Fix for sending BOM when Unicode Beta feature is enabled

### DIFF
--- a/src/OpenDebugAD7/OpenDebug/Program.cs
+++ b/src/OpenDebugAD7/OpenDebug/Program.cs
@@ -11,6 +11,7 @@ using System.Net;
 using System.Net.Sockets;
 using System.Reflection;
 using System.Runtime.InteropServices;
+using System.Text;
 using System.Threading;
 using Microsoft.DebugEngineHost;
 using Microsoft.DebugEngineHost.VSCode;
@@ -143,6 +144,12 @@ namespace OpenDebug
             {
                 // stdin/stdout
                 Console.Error.WriteLine("waiting for v8 protocol on stdin/stdout");
+                if (Utilities.IsWindows())
+                {
+                    // Avoid sending the BOM on Windows if the Beta Unicode feature is enabled in Windows 10
+                    Console.OutputEncoding = new UTF8Encoding(encoderShouldEmitUTF8Identifier: false);
+                    Console.InputEncoding = new UTF8Encoding(encoderShouldEmitUTF8Identifier: false);
+                }
                 Dispatch(Console.OpenStandardInput(), Console.OpenStandardOutput(), loggingCategories);
             }
             catch (Exception e)

--- a/src/WindowsDebugLauncher/Program.cs
+++ b/src/WindowsDebugLauncher/Program.cs
@@ -19,6 +19,10 @@ namespace WindowsDebugLauncher
             DebugLauncher.LaunchParameters parameters = new DebugLauncher.LaunchParameters();
             parameters.PipeServer = "."; // Currently only supporting local pipe connections
 
+            // Avoid sending the BOM on Windows if the Beta Unicode feature is enabled in Windows 10
+            Console.OutputEncoding = new UTF8Encoding(encoderShouldEmitUTF8Identifier: false);
+            Console.InputEncoding = new UTF8Encoding(encoderShouldEmitUTF8Identifier: false);
+
             foreach (var a in argv)
             {
                 if (String.IsNullOrEmpty(a))


### PR DESCRIPTION
This happens on Windows 10. The fix in OpenDebugAD7 fixes the problem
but to be sure, I'm including the fix also in WindowsDebugLauncher.exe

Fixes: https://github.com/microsoft/vscode-cpptools/issues/1527