### PR TITLE
Fixes for parsing the connection string for SSH

### DIFF
--- a/src/SSHDebugPS/ConnectionManager.cs
+++ b/src/SSHDebugPS/ConnectionManager.cs
@@ -173,7 +173,7 @@ namespace Microsoft.SSHDebugPS
             }
             catch (UriFormatException)
             { }
-            
+
             // If Uri sets anything to empty string, set it back to the placeholder
             if (string.IsNullOrWhiteSpace(userName))
             {

--- a/src/SSHDebugPS/LineBuffer.cs
+++ b/src/SSHDebugPS/LineBuffer.cs
@@ -9,8 +9,7 @@ using System.Threading.Tasks;
 
 namespace Microsoft.SSHDebugPS
 {
-    // TODO: Make this internal and use IntenalsVisibleTo to allow for unit test
-    public class LineBuffer
+    internal class LineBuffer
     {
         private readonly StringBuilder _textBuffer = new StringBuilder();
 

--- a/src/SSHDebugPS/PSOutputParser.cs
+++ b/src/SSHDebugPS/PSOutputParser.cs
@@ -9,8 +9,7 @@ using Microsoft.SSHDebugPS.Utilities;
 
 namespace Microsoft.SSHDebugPS
 {
-    // TODO: Make this internal and use InternalsVisibleTo to allow for unit test
-    public class PSOutputParser
+    internal class PSOutputParser
     {
         private struct ColumnDef
         {

--- a/src/SSHDebugPS/Properties/AssemblyInfo.cs
+++ b/src/SSHDebugPS/Properties/AssemblyInfo.cs
@@ -12,6 +12,7 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyDescription("")]
 [assembly: AssemblyConfiguration("")]
 [assembly: AssemblyCulture("")]
+[assembly: InternalsVisibleTo("SSHDebugTests, PublicKey=0024000004800000940000000602000000240000525341310004000001000100653b46738aa8d82f195b27b17982973efdbb5186bf3527246108bc1653b338a3a452eb99b7ca5a425008aefe385c7e463b5a99eed4c15a786b539480e7d3dd9fe404db485dd3bb9ba85aea38be088d7412337494f9a2d525a920a4c064acde81e4c4fe1e070f4900e7b2d6e0d4cd855c062cb3feb48011fffa98734f12e987f1")]
 
 // Setting ComVisible to false makes the types in this assembly not visible 
 // to COM components.  If you need to access a type in this assembly from 

--- a/src/SSHDebugPS/SSH/SSHPortSupplier.cs
+++ b/src/SSHDebugPS/SSH/SSHPortSupplier.cs
@@ -6,6 +6,7 @@ using System.IO;
 using System.Runtime.InteropServices;
 using liblinux;
 using liblinux.Persistence;
+using Microsoft.SSHDebugPS.Utilities;
 using Microsoft.VisualStudio.Debugger.Interop;
 using Microsoft.VisualStudio.Linux.ConnectionManager;
 using Microsoft.VisualStudio.Shell;
@@ -108,7 +109,16 @@ namespace Microsoft.SSHDebugPS.SSH
 
         internal static string GetFormattedSSHConnectionName(ConnectionInfo connectionInfo)
         {
-            return connectionInfo.UserName + "@" + connectionInfo.HostNameOrAddress;
+            string connectionNameFormat = "{0}@{1}";
+            string portFormat = ":{0}";
+
+            string connectionString = connectionNameFormat.FormatInvariantWithArgs(connectionInfo.UserName, connectionInfo.HostNameOrAddress);
+            if(connectionInfo.Port != 22)
+            {
+                return string.Concat(connectionString, portFormat.FormatInvariantWithArgs(connectionInfo.Port));
+            }
+
+            return connectionString;
         }
     }
 }

--- a/src/SSHDebugTests/SSHConnectionStringTests.cs
+++ b/src/SSHDebugTests/SSHConnectionStringTests.cs
@@ -2,12 +2,11 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
-using Microsoft.VisualStudio.TestTools.UnitTesting;
-using Microsoft.SSHDebugPS;
 using System.Collections.Generic;
-using System.Linq;
-using Microsoft.SSHDebugPS.Utilities;
 using System.Globalization;
+using Microsoft.SSHDebugPS;
+using Microsoft.SSHDebugPS.Utilities;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 namespace SSHDebugTests
 {

--- a/src/SSHDebugTests/SSHConnectionStringTests.cs
+++ b/src/SSHDebugTests/SSHConnectionStringTests.cs
@@ -1,0 +1,186 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Microsoft.SSHDebugPS;
+using System.Collections.Generic;
+using System.Linq;
+using Microsoft.SSHDebugPS.Utilities;
+using System.Globalization;
+
+namespace SSHDebugTests
+{
+    [TestClass]
+    public class SSHConnectionStringTests
+    {
+        internal struct ConnectionStringTestItem
+        {
+            internal string rawConnectionString;
+            internal string expectedUsername;
+            internal string expectedHostname;
+            internal int expectedPort;
+        }
+
+        [TestMethod]
+        public void IPv6ConnectionStrings()
+        {
+            List<ConnectionStringTestItem> ipv6TestStrings = new List<ConnectionStringTestItem>();
+            ipv6TestStrings.Add(
+                new ConnectionStringTestItem()
+                {
+                    // valid
+                    rawConnectionString = "testuser@[1:2:3:4:5:6:7:8]:24",
+                    expectedUsername = "testuser",
+                    expectedHostname = "[1:2:3:4:5:6:7:8]",
+                    expectedPort = 24
+                });
+            ipv6TestStrings.Add(
+                new ConnectionStringTestItem()
+                {
+                    // valid with no port
+                    rawConnectionString = "testuser@[1:2:3:4:5:6:7:8]",
+                    expectedUsername = "testuser",
+                    expectedHostname = "[1:2:3:4:5:6:7:8]",
+                    expectedPort = ConnectionManager.DefaultSSHPort
+                });
+            ipv6TestStrings.Add(
+                new ConnectionStringTestItem()
+                {
+                    // valid with custom username
+                    rawConnectionString = "test:user@[1234::6:7:8]",
+                    expectedUsername = "test:user",
+                    expectedHostname = "[1234::6:7:8]",
+                    expectedPort = ConnectionManager.DefaultSSHPort
+                });
+            ipv6TestStrings.Add(
+                new ConnectionStringTestItem()
+                {
+                    // Valid with large port
+                    rawConnectionString = "[1:2:3:4:5:6:7:8]:12345",
+                    expectedUsername = StringResources.UserName_PlaceHolder,
+                    expectedHostname = "[1:2:3:4:5:6:7:8]",
+                    expectedPort = 12345
+                });
+            ipv6TestStrings.Add(
+                new ConnectionStringTestItem()
+                {
+                    // Invalid format
+                    rawConnectionString = "testuser@:8",
+                    expectedUsername = StringResources.UserName_PlaceHolder,
+                    expectedHostname = StringResources.HostName_PlaceHolder,
+                    expectedPort = ConnectionManager.DefaultSSHPort
+                });
+            ipv6TestStrings.Add(
+                new ConnectionStringTestItem()
+                {
+                    // Invalid string (just port)
+                    rawConnectionString = ":8",
+                    expectedUsername = StringResources.UserName_PlaceHolder,
+                    expectedHostname = StringResources.HostName_PlaceHolder,
+                    expectedPort = ConnectionManager.DefaultSSHPort
+                });
+            ipv6TestStrings.Add(
+                new ConnectionStringTestItem()
+                {
+                    // Empty String
+                    rawConnectionString = string.Empty,
+                    expectedUsername = StringResources.UserName_PlaceHolder,
+                    expectedHostname = StringResources.HostName_PlaceHolder,
+                    expectedPort = ConnectionManager.DefaultSSHPort
+                });
+            ipv6TestStrings.Add(
+                new ConnectionStringTestItem()
+                {
+                    // Invalid port
+                    rawConnectionString = "[1:2:3:4:5:6:7:8]:123456",
+                    expectedUsername = StringResources.UserName_PlaceHolder,
+                    expectedHostname = StringResources.HostName_PlaceHolder,
+                    expectedPort = ConnectionManager.DefaultSSHPort
+                });
+
+            foreach (var connection in ipv6TestStrings)
+            {
+                ParseConnectionAndValidate(connection);
+            }
+        }
+
+        [TestMethod]
+        public void Ipv4ConnectionStrings()
+        {
+            List<ConnectionStringTestItem> ipv4TestStrings = new List<ConnectionStringTestItem>();
+            ipv4TestStrings.Add(
+                new ConnectionStringTestItem()
+                {
+                    // valid no username
+                    rawConnectionString = "192.168.1.1:156",
+                    expectedUsername = StringResources.UserName_PlaceHolder,
+                    expectedHostname = "192.168.1.1",
+                    expectedPort = 156
+                });
+            ipv4TestStrings.Add(
+                new ConnectionStringTestItem()
+                {
+                    // valid username with port
+                    rawConnectionString = "customUser@192.168.1.1:65354",
+                    expectedUsername = "customUser",
+                    expectedHostname = "192.168.1.1",
+                    expectedPort = 65354
+                });
+            ipv4TestStrings.Add(
+                new ConnectionStringTestItem()
+                {
+                    // valid no username, Large port
+                    rawConnectionString = "192.168.1.1:" + (ushort.MaxValue).ToString("d", CultureInfo.InvariantCulture),
+                    expectedUsername = StringResources.UserName_PlaceHolder,
+                    expectedHostname = "192.168.1.1",
+                    expectedPort = ushort.MaxValue
+                });
+            ipv4TestStrings.Add(
+                new ConnectionStringTestItem()
+                {
+                    // valid username no port
+                    rawConnectionString = "user@10.10.10.10",
+                    expectedUsername = "user",
+                    expectedHostname = "10.10.10.10",
+                    expectedPort = ConnectionManager.DefaultSSHPort
+                });
+            ipv4TestStrings.Add(
+                new ConnectionStringTestItem()
+                {
+                    // Invalid port
+                    rawConnectionString = "192.168.1.1:123456",
+                    expectedUsername = StringResources.UserName_PlaceHolder,
+                    expectedHostname = StringResources.HostName_PlaceHolder,
+                    expectedPort = ConnectionManager.DefaultSSHPort
+                });
+            ipv4TestStrings.Add(
+                new ConnectionStringTestItem()
+                {
+                    // Invalid address
+                    rawConnectionString = "1%92.168.1.1:23",
+                    expectedUsername = StringResources.UserName_PlaceHolder,
+                    expectedHostname = StringResources.HostName_PlaceHolder,
+                    expectedPort = ConnectionManager.DefaultSSHPort
+                });
+
+            foreach (var connection in ipv4TestStrings)
+            {
+                ParseConnectionAndValidate(connection);
+            }
+        }
+
+        private const string _comparisonErrorStringFormat = "{0} - Expected:'{1}' Actual:'{2}'";
+        private void ParseConnectionAndValidate(ConnectionStringTestItem item)
+        {
+            string username;
+            string hostname;
+            int port;
+            ConnectionManager.ParseSSHConnectionString(item.rawConnectionString, out username, out hostname, out port);
+
+            Assert.IsTrue(item.expectedUsername.Equals(username, StringComparison.Ordinal), _comparisonErrorStringFormat.FormatInvariantWithArgs("UserName", item.expectedUsername, username));
+            Assert.IsTrue(item.expectedHostname.Equals(hostname, StringComparison.Ordinal), _comparisonErrorStringFormat.FormatInvariantWithArgs("Hostname", item.expectedHostname, hostname));
+            Assert.IsTrue(item.expectedPort == port, _comparisonErrorStringFormat.FormatInvariantWithArgs("Port", item.expectedPort, port));
+        }
+    }
+}

--- a/src/SSHDebugTests/SSHDebugUnitTests.csproj
+++ b/src/SSHDebugTests/SSHDebugUnitTests.csproj
@@ -69,6 +69,7 @@
     <Compile Include="LineBufferTests.cs" />
     <Compile Include="PSOutputParserTests.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="SSHConnectionStringTests.cs" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\SSHDebugPS\SSHDebugPS.csproj">


### PR DESCRIPTION
We were not handling a custom SSH port. Added support to display port in
the connection string if the port is not the default (Port 22)

Fixes: 
[Feedback] https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1025875
[Bug] https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1026403