### PR TITLE
Fix MIEngine file version

### DIFF
--- a/build/version.settings.targets
+++ b/build/version.settings.targets
@@ -2,10 +2,12 @@
   <PropertyGroup>    
     <!--SxS: These three properties should be changed at the start of a new version, VersionZeroYear should be the year
     before the start of the project. When updating the version, also update MIEngine\metadata.json.-->
-    <!-- Note: If you change the version number, make sure that you notify partner teams such as C++ IOT -->
-    <MajorVersion>14</MajorVersion>
-    <MinorVersion>0</MinorVersion>
-    <VersionZeroYear>2013</VersionZeroYear>
+    <MajorVersion>16</MajorVersion>
+    <MinorVersion>5</MinorVersion>
+    <VersionZeroYear>2019</VersionZeroYear>
+    <!-- Note: for compatibility, we leave the default assembly version of the repo at 14.0.
+    If we ever decide to change this, make sure that you notify partner teams such as C++ IOT -->
+    <AssemblyVersion Condition="'$(AssemblyVersion)'==''">14.0.0.0</AssemblyVersion>
 
     <!--Compute the major and minor build number-->
     <!--Team build passes the build number in the BUILD_BUILDNUMBER variable. It has the format 'Master_20140922.4' where
@@ -20,8 +22,6 @@
     <BuildNumberMajor>$(BuildNumber_Year)$(BuildNumber_Month)$(BuildNumber_Day)</BuildNumberMajor>
     <BuildNumberMinor>0</BuildNumberMinor>
     <BuildNumberMinor Condition="$(BuildDateRevision.Length) &gt; 9">$(BuildDateRevision.Substring(9))</BuildNumberMinor>
-
-    <AssemblyVersion Condition="'$(AssemblyVersion)'==''">$(MajorVersion).$(MinorVersion).0.0</AssemblyVersion>
     <BuildVersion>$(MajorVersion).$(MinorVersion).$(BuildNumberMajor).$(BuildNumberMinor)</BuildVersion>
     <BuildVersionExtended>$(BuildVersion)</BuildVersionExtended>
     <BuildVersionExtended Condition="'$(BUILD_SOURCEVERSION)'!=''">$(BuildVersionExtended) commit:$(BUILD_SOURCEVERSION)</BuildVersionExtended>

--- a/metadata.json
+++ b/metadata.json
@@ -1,5 +1,5 @@
 {
   "correlationId": "595D6107-E618-4BD9-85A0-C323EFC400D1",
   "owner":"miengine",
-  "version": "14.0"
+  "version": "16.5"
 }

--- a/src/JDbgUnitTests/JDbgUnitTests.csproj
+++ b/src/JDbgUnitTests/JDbgUnitTests.csproj
@@ -84,8 +84,8 @@
   <ItemGroup>
     <None Include="packages.config" />
   </ItemGroup>
-  <Import Project="..\..\build\miengine.targets" />
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <Import Project="..\..\build\miengine.targets" />
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
     <PropertyGroup>
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>

--- a/src/JDbgUnitTests/Properties/AssemblyInfo.cs
+++ b/src/JDbgUnitTests/Properties/AssemblyInfo.cs
@@ -11,9 +11,6 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyTitle("JDbgUnitTests")]
 [assembly: AssemblyDescription("")]
 [assembly: AssemblyConfiguration("")]
-[assembly: AssemblyCompany("")]
-[assembly: AssemblyProduct("JDbgUnitTests")]
-[assembly: AssemblyCopyright("Copyright \u00A9  2014")]
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]
 
@@ -24,16 +21,3 @@ using System.Runtime.InteropServices;
 
 // The following GUID is for the ID of the typelib if this project is exposed to COM
 [assembly: Guid("8109cd04-a8a1-4a3c-87fb-0895d4b8353b")]
-
-// Version information for an assembly consists of the following four values:
-//
-//      Major Version
-//      Minor Version 
-//      Build Number
-//      Revision
-//
-// You can specify all the values or you can default the Build and Revision Numbers 
-// by using the '*' as shown below:
-// [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.0.0.0")]
-[assembly: AssemblyFileVersion("1.0.0.0")]

--- a/src/MICoreUnitTests/MICoreUnitTests.csproj
+++ b/src/MICoreUnitTests/MICoreUnitTests.csproj
@@ -136,9 +136,9 @@
       </ItemGroup>
     </When>
   </Choose>
-  <Import Project="..\..\build\miengine.targets" />
   <Import Project="$(VSToolsPath)\TeamTest\Microsoft.TestTools.targets" Condition="Exists('$(VSToolsPath)\TeamTest\Microsoft.TestTools.targets')" />
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <Import Project="..\..\build\miengine.targets" />
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
     <PropertyGroup>
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>

--- a/src/MICoreUnitTests/Properties/AssemblyInfo.cs
+++ b/src/MICoreUnitTests/Properties/AssemblyInfo.cs
@@ -11,9 +11,6 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyTitle("GDBUnitTests")]
 [assembly: AssemblyDescription("")]
 [assembly: AssemblyConfiguration("")]
-[assembly: AssemblyCompany("")]
-[assembly: AssemblyProduct("GDBUnitTests")]
-[assembly: AssemblyCopyright("Copyright \u00A9  2014")]
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]
 
@@ -24,16 +21,3 @@ using System.Runtime.InteropServices;
 
 // The following GUID is for the ID of the typelib if this project is exposed to COM
 [assembly: Guid("a855e156-8441-4782-b161-0fbc3a54a5ae")]
-
-// Version information for an assembly consists of the following four values:
-//
-//      Major Version
-//      Minor Version 
-//      Build Number
-//      Revision
-//
-// You can specify all the values or you can default the Build and Revision Numbers 
-// by using the '*' as shown below:
-// [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.0.0.0")]
-[assembly: AssemblyFileVersion("1.0.0.0")]

--- a/src/SSHDebugTests/Properties/AssemblyInfo.cs
+++ b/src/SSHDebugTests/Properties/AssemblyInfo.cs
@@ -11,9 +11,6 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyTitle("SSHDebugTests")]
 [assembly: AssemblyDescription("")]
 [assembly: AssemblyConfiguration("")]
-[assembly: AssemblyCompany("")]
-[assembly: AssemblyProduct("SSHDebugTests")]
-[assembly: AssemblyCopyright("Copyright \u00A9  2016")]
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]
 
@@ -24,16 +21,3 @@ using System.Runtime.InteropServices;
 
 // The following GUID is for the ID of the typelib if this project is exposed to COM
 [assembly: Guid("54a2c83d-e889-46e7-b974-0d8d8a51397f")]
-
-// Version information for an assembly consists of the following four values:
-//
-//      Major Version
-//      Minor Version 
-//      Build Number
-//      Revision
-//
-// You can specify all the values or you can default the Build and Revision Numbers 
-// by using the '*' as shown below:
-// [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.0.0.0")]
-[assembly: AssemblyFileVersion("1.0.0.0")]

--- a/src/SSHDebugTests/SSHDebugUnitTests.csproj
+++ b/src/SSHDebugTests/SSHDebugUnitTests.csproj
@@ -94,9 +94,9 @@
       </ItemGroup>
     </When>
   </Choose>
-  <Import Project="..\..\build\miengine.targets" />
   <Import Project="$(VSToolsPath)\TeamTest\Microsoft.TestTools.targets" Condition="Exists('$(VSToolsPath)\TeamTest\Microsoft.TestTools.targets')" />
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <Import Project="..\..\build\miengine.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">


### PR DESCRIPTION
This changes MIEngine so that the file version of all of the files built in the repo is 16.5.* instead of 14.0.*. This is important because our date-based version numbers overflowed 2^16 due to our lack of dilegance in updating it, and the project wouldn't build.

I left the assembly version as 14.0 for compatibility.
This also fixes the build of our various unit test projects. I don't know how this wasn't a problem before, but now it works.

Testing: Verified SSH attach to process

This fixes #949 