### PR TITLE
Check to find '-break-insert' versions.

### DIFF
--- a/src/MICore/CommandFactories/MICommandFactory.cs
+++ b/src/MICore/CommandFactories/MICommandFactory.cs
@@ -418,7 +418,7 @@ namespace MICore
 
         #region Breakpoints
 
-        protected virtual StringBuilder BuildBreakInsert(string condition, bool enabled)
+        protected virtual Task<StringBuilder> BuildBreakInsert(string condition, bool enabled)
         {
             StringBuilder cmd = new StringBuilder("-break-insert -f ");
             if (condition != null)
@@ -431,7 +431,7 @@ namespace MICore
             {
                 cmd.Append("-d ");
             }
-            return cmd;
+            return Task<StringBuilder>.FromResult(cmd);
         }
 
         internal bool PreparePath(string path, bool useUnixFormat, out string pathMI)
@@ -453,7 +453,7 @@ namespace MICore
 
         public virtual async Task<Results> BreakInsert(string filename, bool useUnixFormat, uint line, string condition, bool enabled, IEnumerable<Checksum> checksums = null, ResultClass resultClass = ResultClass.done)
         {
-            StringBuilder cmd = BuildBreakInsert(condition, enabled);
+            StringBuilder cmd = await BuildBreakInsert(condition, enabled);
 
             if (checksums != null && checksums.Count() != 0)
             {
@@ -480,7 +480,7 @@ namespace MICore
 
         public virtual async Task<Results> BreakInsert(string functionName, string condition, bool enabled, ResultClass resultClass = ResultClass.done)
         {
-            StringBuilder cmd = BuildBreakInsert(condition, enabled);
+            StringBuilder cmd = await BuildBreakInsert(condition, enabled);
             // TODO: Add support of break function type filename:function locations
             cmd.Append(functionName);
             return await _debugger.CmdAsync(cmd.ToString(), resultClass);
@@ -488,7 +488,7 @@ namespace MICore
 
         public virtual async Task<Results> BreakInsert(ulong codeAddress, string condition, bool enabled, ResultClass resultClass = ResultClass.done)
         {
-            StringBuilder cmd = BuildBreakInsert(condition, enabled);
+            StringBuilder cmd = await BuildBreakInsert(condition, enabled);
             cmd.Append('*');
             cmd.Append(codeAddress);
             return await _debugger.CmdAsync(cmd.ToString(), resultClass);
@@ -672,6 +672,11 @@ namespace MICore
         public virtual bool SupportsBreakpointChecksums()
         {
             return false;
+        }
+
+        public virtual Task<bool> RequiresOnKeywordForBreakInsert()
+        {
+            return Task<bool>.FromResult(false);
         }
 
         #endregion

--- a/src/MICore/CommandFactories/lldb.cs
+++ b/src/MICore/CommandFactories/lldb.cs
@@ -46,12 +46,15 @@ namespace MICore
             }
         }
 
-        protected override StringBuilder BuildBreakInsert(string condition, bool enabled)
+        protected async override Task<StringBuilder> BuildBreakInsert(string condition, bool enabled)
         {
-            // LLDB's use of the pending flag requires an optional parameter or else it fails.
+            // LLDB's 3.5 use of the pending flag requires an optional parameter or else it fails.
             // We will use "on" for now. 
-            // TODO: Fix this on LLDB-MI's side
-            string pendingFlag = "-f on ";
+            string pendingFlag = "-f ";
+            if (await RequiresOnKeywordForBreakInsert())
+            {
+                pendingFlag = "-f on ";
+            }
 
             StringBuilder cmd = new StringBuilder("-break-insert ");
             cmd.Append(pendingFlag);
@@ -191,6 +194,32 @@ namespace MICore
                 string value = results.FindString("value");
                 return await base.VarAssign(variableName, value, threadId, frameLevel);
             }
+        }
+
+        private bool? _requiresOnKeywordForBreakInsert;
+
+        // In LLDB 3.5, -break-insert -f requires a string before the actual method name.
+        // We use a placeholder 'on' for this.
+        // Later versions do not require the 'on' keyword.
+        public override async Task<bool> RequiresOnKeywordForBreakInsert()
+        {
+            if (!_requiresOnKeywordForBreakInsert.HasValue)
+            {
+                _requiresOnKeywordForBreakInsert = false;
+                try
+                {
+                    // Test to see if -break-insert -f main works.
+                    string breakInsertMainCommand = "-break-insert -f main";
+                    Results results = await _debugger.CmdAsync(breakInsertMainCommand, ResultClass.done);
+                    await this.BreakDelete(results.Find("bkpt").FindString("number"));
+                }
+                catch (UnexpectedMIResultException)
+                {
+                    _requiresOnKeywordForBreakInsert = true;
+                }
+            }
+
+            return _requiresOnKeywordForBreakInsert.Value;
         }
     }
 }

--- a/src/MIDebugEngine/Engine.Impl/DebuggedProcess.cs
+++ b/src/MIDebugEngine/Engine.Impl/DebuggedProcess.cs
@@ -572,7 +572,7 @@ namespace Microsoft.MIDebugEngine
             try
             {
                 await this.MICommandFactory.EnableTargetAsyncOption();
-                List<LaunchCommand> commands = GetInitializeCommands();
+                List<LaunchCommand> commands = await GetInitializeCommands();
                 _childProcessHandler?.Enable();
 
                 total = commands.Count();
@@ -632,7 +632,7 @@ namespace Microsoft.MIDebugEngine
             token.ThrowIfCancellationRequested();
         }
 
-        private List<LaunchCommand> GetInitializeCommands()
+        private async Task<List<LaunchCommand>> GetInitializeCommands()
         {
             List<LaunchCommand> commands = new List<LaunchCommand>();
 
@@ -834,7 +834,7 @@ namespace Microsoft.MIDebugEngine
                         return Task.FromResult(0);
                     };
 
-                    commands.Add(new LaunchCommand(GetBreakInsertMainCommand(), ignoreFailures: true, successResultsHandler: breakMainSuccessResultsHandler));
+                    commands.Add(new LaunchCommand(await GetBreakInsertMainCommand(), ignoreFailures: true, successResultsHandler: breakMainSuccessResultsHandler));
 
                     if (null != localLaunchOptions)
                     {
@@ -863,13 +863,13 @@ namespace Microsoft.MIDebugEngine
         /// <summary>
         /// Gets a break-insert command for main that will allow pending bps and supports different debuggers
         /// </summary>
-        private string GetBreakInsertMainCommand()
+        private async Task<string> GetBreakInsertMainCommand()
         {
             // Allow main breakpoint to be pending.
             string breakInsertMainFormat = "-break-insert -f{0} main";
-            if (this.MICommandFactory.Mode == MIMode.Lldb)
+            if (await this.MICommandFactory.RequiresOnKeywordForBreakInsert())
             {
-                // break-insert -f requires 'on' in lldb scenario
+                // break-insert -f requires 'on' in lldb 3.5 scenario
                 return string.Format(CultureInfo.InvariantCulture, breakInsertMainFormat, " on");
             }
             return string.Format(CultureInfo.InvariantCulture, breakInsertMainFormat, string.Empty);


### PR DESCRIPTION
If '-break-insert -f main' returns unknown command, we revert to use
'-break-insert -f on main'

We need to do all this break-insert command fetching async so that we
run the command and get the result. Otherwise we just hang and
never actually process the result.