### PR TITLE
Add option to disable SSH Connections

### DIFF
--- a/src/SSHDebugPS/ConnectionManager.cs
+++ b/src/SSHDebugPS/ConnectionManager.cs
@@ -20,7 +20,7 @@ namespace Microsoft.SSHDebugPS
 {
     internal class ConnectionManager
     {
-        public static DockerConnection GetDockerConnection(string name)
+        public static DockerConnection GetDockerConnection(string name, bool supportSSHConnections)
         {
            if (string.IsNullOrWhiteSpace(name))
                 return null;
@@ -32,7 +32,7 @@ namespace Microsoft.SSHDebugPS
             {
                 string connectionString;
 
-                bool success = ShowContainerPickerWindow(IntPtr.Zero, out connectionString);
+                bool success = ShowContainerPickerWindow(IntPtr.Zero, supportSSHConnections, out connectionString);
                 if (success)
                 {
                     success = DockerConnection.TryConvertConnectionStringToSettings(connectionString, out settings, out remoteConnection);
@@ -118,10 +118,10 @@ namespace Microsoft.SSHDebugPS
         /// <param name="hwnd">Parent hwnd or IntPtr.Zero</param>
         /// <param name="connectionString">[out] connection string obtained by the dialog</param>
         /// <returns></returns>
-        public static bool ShowContainerPickerWindow(IntPtr hwnd, out string connectionString)
+        public static bool ShowContainerPickerWindow(IntPtr hwnd, bool supportSSHConnections, out string connectionString)
         {
             ThreadHelper.ThrowIfNotOnUIThread("Microsoft.SSHDebugPS.ShowContainerPickerWindow");
-            ContainerPickerDialogWindow dialog = new ContainerPickerDialogWindow();
+            ContainerPickerDialogWindow dialog = new ContainerPickerDialogWindow(supportSSHConnections);
 
             if (hwnd == IntPtr.Zero) // get the VS main window hwnd
             {
@@ -146,7 +146,7 @@ namespace Microsoft.SSHDebugPS
             bool? dialogResult = dialog.ShowModal();
             if (dialogResult.GetValueOrDefault(false))
             {
-                connectionString = dialog.SelectedContainerConnectionString;
+                connectionString = dialog.Model.SelectedContainerConnectionString;
                 return true;
             }
 

--- a/src/SSHDebugPS/ConnectionManager.cs
+++ b/src/SSHDebugPS/ConnectionManager.cs
@@ -146,7 +146,7 @@ namespace Microsoft.SSHDebugPS
             bool? dialogResult = dialog.ShowModal();
             if (dialogResult.GetValueOrDefault(false))
             {
-                connectionString = dialog.Model.SelectedContainerConnectionString;
+                connectionString = dialog.SelectedContainerConnectionString;
                 return true;
             }
 

--- a/src/SSHDebugPS/ConnectionManager.cs
+++ b/src/SSHDebugPS/ConnectionManager.cs
@@ -116,8 +116,8 @@ namespace Microsoft.SSHDebugPS
         /// Open the ContainerPickerDialog
         /// </summary>
         /// <param name="hwnd">Parent hwnd or IntPtr.Zero</param>
+        /// <param name="supportSSHConnections">SSHConnections are supported</param>
         /// <param name="connectionString">[out] connection string obtained by the dialog</param>
-        /// <returns></returns>
         public static bool ShowContainerPickerWindow(IntPtr hwnd, bool supportSSHConnections, out string connectionString)
         {
             ThreadHelper.ThrowIfNotOnUIThread("Microsoft.SSHDebugPS.ShowContainerPickerWindow");

--- a/src/SSHDebugPS/Docker/DockerPort.cs
+++ b/src/SSHDebugPS/Docker/DockerPort.cs
@@ -11,7 +11,7 @@ namespace Microsoft.SSHDebugPS.Docker
 
         protected override Connection GetConnectionInternal()
         {
-            return ConnectionManager.GetDockerConnection(Name);
+            return ConnectionManager.GetDockerConnection(Name, supportSSHConnections: true);
         }
     }
 }

--- a/src/SSHDebugPS/Docker/DockerPortPicker.cs
+++ b/src/SSHDebugPS/Docker/DockerPortPicker.cs
@@ -15,20 +15,37 @@ namespace Microsoft.SSHDebugPS.Docker
     [ComVisible(true)]
     //{91BDF293-E6A0-49C4-B033-6F36CFC4FF98}
     [Guid("91BDF293-E6A0-49C4-B033-6F36CFC4FF98")]
-    public class DockerPortPicker : IDebugPortPicker
+    public class DockerLinuxPortPicker : DockerPortPickerBase
     {
-        private VisualStudio.OLE.Interop.IServiceProvider _serviceProvider = null;
+        internal override bool SupportSSHConnections => true;
+    }
+    
+    [ComVisible(true)]
+    //{AE75778B-70E8-4F53-B3FE-59E048D3D01B}
+    [Guid("AE75778B-70E8-4F53-B3FE-59E048D3D01B")]
+    public class DockerWindowsPortPicker : DockerPortPickerBase
+    {
+        internal override bool SupportSSHConnections => false;
+    }
+
+    [ComVisible(true)]
+    public abstract class DockerPortPickerBase : IDebugPortPicker
+    {
+        internal abstract bool SupportSSHConnections { get; }
+
         int IDebugPortPicker.DisplayPortPicker(IntPtr hwndParentDialog, out string pbstrPortId)
         {
             // If this is null, then the PortPicker handler shows an error. Set to empty by default
-            return ConnectionManager.ShowContainerPickerWindow(hwndParentDialog, out pbstrPortId) ?
+            return ConnectionManager.ShowContainerPickerWindow(hwndParentDialog, SupportSSHConnections, out pbstrPortId) ?
                 VSConstants.S_OK : VSConstants.S_FALSE;
         }
 
+        private VisualStudio.OLE.Interop.IServiceProvider _serviceProvider = null;
         int IDebugPortPicker.SetSite(VisualStudio.OLE.Interop.IServiceProvider pSP)
         {
             _serviceProvider = pSP;
             return VSConstants.S_OK;
         }
+
     }
 }

--- a/src/SSHDebugPS/Microsoft.SSHDebugPS.pkgdef
+++ b/src/SSHDebugPS/Microsoft.SSHDebugPS.pkgdef
@@ -27,7 +27,13 @@
 
 [$RootKey$\CLSID\{91BDF293-E6A0-49C4-B033-6F36CFC4FF98}]
 "Assembly"="Microsoft.SSHDebugPS"
-"Class"="Microsoft.SSHDebugPS.Docker.DockerPortPicker"
+"Class"="Microsoft.SSHDebugPS.Docker.DockerLinuxPortPicker"
+"InprocServer32"="$WinDir$\SYSTEM32\MSCOREE.DLL"
+"CodeBase"="$PackageFolder$\Microsoft.SSHDebugPS.dll"
+
+[$RootKey$\CLSID\{AE75778B-70E8-4F53-B3FE-59E048D3D01B}]
+"Assembly"="Microsoft.SSHDebugPS"
+"Class"="Microsoft.SSHDebugPS.Docker.DockerWindowsPortPicker"
 "InprocServer32"="$WinDir$\SYSTEM32\MSCOREE.DLL"
 "CodeBase"="$PackageFolder$\Microsoft.SSHDebugPS.dll"
 

--- a/src/SSHDebugPS/UI/Commands/ContainerUICommand.cs
+++ b/src/SSHDebugPS/UI/Commands/ContainerUICommand.cs
@@ -11,6 +11,7 @@ namespace Microsoft.SSHDebugPS.UI
     {
         string Label { get; }
         string ToolTip { get; }
+        void NotifyCanExecuteChanged();
     }
 
     internal class ContainerUICommand : IContainerUICommand
@@ -53,6 +54,11 @@ namespace Microsoft.SSHDebugPS.UI
             {
                 Debug.Fail("Why is the executeFunc null?");
             }
+        }
+
+        public void NotifyCanExecuteChanged()
+        {
+            CanExecuteChanged?.Invoke(this, EventArgs.Empty);
         }
 
         public string Label { get; }

--- a/src/SSHDebugPS/UI/ContainerPickerDialogWindow.xaml
+++ b/src/SSHDebugPS/UI/ContainerPickerDialogWindow.xaml
@@ -21,8 +21,7 @@
                  FontFamily="{DynamicResource VsFont.EnvironmentFontFamily}"
                  FontSize="{DynamicResource VsFont.EnvironmentFontSize}"
                  Title="{x:Static local:UIResources.DialogTitle}"
-                 WindowStartupLocation="CenterOwner"
-                 KeyDown="DialogWindow_KeyDown">
+                 WindowStartupLocation="CenterOwner">
     <platformui:DialogWindow.Resources>
         <!-- Converters-->
         <docker:BoolToVisibilityConverter x:Key="BoolToVisibilityConverter" />
@@ -38,6 +37,25 @@
                     <Setter Property="Stroke"
                             Value="{DynamicResource {x:Static platformui:TreeViewColors.GlyphMouseOverBrushKey}}" />
                  </DataTrigger>
+            </Style.Triggers>
+        </Style>
+        <Style x:Key="ConnectionTypeComboBoxStyle"
+               TargetType="{x:Type ComboBox}">
+            <Style.Triggers>
+                <DataTrigger Binding="{Binding SupportSSHConnections}"
+                             Value="true">
+                    <Setter Property="Grid.ColumnSpan"
+                            Value="1" />
+                    <Setter Property="IsEnabled"
+                            Value="True" />
+                </DataTrigger>
+                <DataTrigger Binding="{Binding SupportSSHConnections}"
+                             Value="false">
+                    <Setter Property="Grid.ColumnSpan"
+                            Value="2" />
+                    <Setter Property="IsEnabled"
+                            Value="False" />
+                </DataTrigger>
             </Style.Triggers>
         </Style>
         <Style x:Key="MainLabelStyle"
@@ -464,21 +482,22 @@
                   ItemsSource="{Binding SupportedConnections}"
                   SelectedItem="{Binding SelectedConnection}"
                   DisplayMemberPath="DisplayName"
-                  IsEnabled="{Binding IsRefreshEnabled}"
-                  ItemContainerStyle="{StaticResource ComboBoxItemStyle}" />
+                  ItemContainerStyle="{StaticResource ComboBoxItemStyle}"
+                  Style="{StaticResource ConnectionTypeComboBoxStyle}">
+        </ComboBox>
         <Button Grid.Row="1"
                 Grid.Column="1"
                 x:Uid="uidAddConnection"
                 x:Name="AddConnection"  
-                AutomationProperties.Name="{x:Static local:UIResources.AddNewSSHConnectionLabel}"
+                AutomationProperties.Name="{x:Static local:UIResources.AddNewSSHConnectionAutomationName}"
                 Margin="12,4,0,0"
                 MinWidth="75"
                 MinHeight="23"
                 Command="{Binding AddSSHConnectionCommand}"
                 CommandParameter="{Binding}"
-                IsEnabled="{Binding AddSSHConnectionCommand.CanExecute}"
-                Content="{x:Static local:UIResources.AddNewSSHConnectionButtonLabel}"
-                ToolTip="{x:Static local:UIResources.AddNewSSHConnectionToolTip}"/>
+                Content="{Binding AddSSHConnectionCommand.Label}"
+                ToolTip="{Binding AddSSHConnectionCommand.ToolTip}"
+                Visibility="{Binding SupportSSHConnections, Converter={StaticResource BoolToVisibilityConverter}, Mode=OneWay}"/>
 
         <!-- Hostname label and textbox -->
 
@@ -499,9 +518,11 @@
                  x:Uid="uidHostnameTextBox"
                  x:Name="hostnameTextBox"
                  AutomationProperties.Name="{x:Static local:UIResources.HostnameAutomationName}"
-                 PreviewKeyDown="HostnameTextbox_PreviewKeyDown"
-                 Text="{Binding Path=Hostname, Mode=TwoWay,UpdateSourceTrigger=PropertyChanged}"
+                 Text="{Binding Path=Hostname, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
                  ToolTip="{x:Static local:UIResources.HostnameTip}">
+            <TextBox.InputBindings>
+                <KeyBinding Key="Enter" Command="{Binding RefreshCommand}" />
+            </TextBox.InputBindings>
         </TextBox>
 
         <!-- Container Count Text and Refresh Button -->
@@ -518,11 +539,10 @@
                 x:Name="RefreshContainerListButton"
                 Margin="12,9,0,0"
                 HorizontalAlignment="Right"
-                Content="{x:Static local:UIResources.RefreshHyperlink}"
-                ToolTip="{x:Static local:UIResources.RefreshToolTip}"
-                Style="{StaticResource HyperlinkButton}"
-                Click="Refresh_Click"
-                IsEnabled="{Binding IsRefreshEnabled}" />
+                Command="{Binding RefreshCommand}"
+                Content="{Binding RefreshCommand.Label}"
+                ToolTip="{Binding RefreshCommand.ToolTip}"
+                Style="{StaticResource HyperlinkButton}" />
 
         <!-- Container Instance display-->
         <ui:ContainerListBox Grid.Row="5"
@@ -572,18 +592,18 @@
                     MinHeight="23"
                     MinWidth="75"
                     IsDefault="True"
-                    Click="OkButton_Click"
+                    Command="{Binding OKCommand}"
                     CommandParameter="{Binding ElementName=ContainerPickerDialog}"
-                    Content="{x:Static local:UIResources.OKLabel}" />
+                    Content="{Binding OKCommand.Label}"/>
             <Button x:Uid="uidCancelButton"
                     x:Name="CancelButton"
                     Margin="6,0,0,0"
                     MinHeight="23"
                     MinWidth="75"
                     IsCancel="True"
-                    Click="CancelButton_Click"
+                    Command="{Binding CancelCommand}"
                     CommandParameter="{Binding ElementName=ContainerPickerDialog}"
-                    Content="{x:Static local:UIResources.CancelLabel}" />
+                    Content="{Binding CancelCommand.Label}" />
         </UniformGrid>
 
     </Grid>

--- a/src/SSHDebugPS/UI/ContainerPickerDialogWindow.xaml
+++ b/src/SSHDebugPS/UI/ContainerPickerDialogWindow.xaml
@@ -36,19 +36,16 @@
                              Value="True">
                     <Setter Property="Stroke"
                             Value="{DynamicResource {x:Static platformui:TreeViewColors.GlyphMouseOverBrushKey}}" />
-                 </DataTrigger>
+                </DataTrigger>
             </Style.Triggers>
         </Style>
         <Style x:Key="ConnectionTypeComboBoxStyle"
                TargetType="{x:Type ComboBox}">
-            <Style.Triggers>
-                <DataTrigger Binding="{Binding SupportSSHConnections}"
-                             Value="true">
-                    <Setter Property="Grid.ColumnSpan"
+            <Setter Property="Grid.ColumnSpan"
                             Value="1" />
-                    <Setter Property="IsEnabled"
+            <Setter Property="IsEnabled"
                             Value="True" />
-                </DataTrigger>
+            <Style.Triggers>
                 <DataTrigger Binding="{Binding SupportSSHConnections}"
                              Value="false">
                     <Setter Property="Grid.ColumnSpan"

--- a/src/SSHDebugPS/UI/ContainerPickerDialogWindow.xaml.cs
+++ b/src/SSHDebugPS/UI/ContainerPickerDialogWindow.xaml.cs
@@ -25,8 +25,8 @@ namespace Microsoft.SSHDebugPS.UI
         public ContainerPickerDialogWindow(bool supportSSHConnections)
         {
             InitializeComponent();
-            this.Model = new ContainerPickerViewModel(supportSSHConnections);
-            this.DataContext = Model;
+            _model = new ContainerPickerViewModel(supportSSHConnections);
+            this.DataContext = _model;
             this.Loaded += OnWindowLoaded;
         }
 
@@ -66,16 +66,11 @@ namespace Microsoft.SSHDebugPS.UI
             PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(name));
         }
 
-        public ContainerPickerViewModel Model
+        public string SelectedContainerConnectionString
         {
             get
             {
-                return _model;
-            }
-            set
-            {
-                _model = value;
-                OnPropertyChanged(nameof(Model));
+                return _model.SelectedContainerConnectionString;
             }
         }
         #endregion

--- a/src/SSHDebugPS/UI/ContainerPickerDialogWindow.xaml.cs
+++ b/src/SSHDebugPS/UI/ContainerPickerDialogWindow.xaml.cs
@@ -22,10 +22,10 @@ namespace Microsoft.SSHDebugPS.UI
     /// </summary>
     public partial class ContainerPickerDialogWindow : DialogWindow
     {
-        public ContainerPickerDialogWindow()
+        public ContainerPickerDialogWindow(bool supportSSHConnections)
         {
             InitializeComponent();
-            this.Model = new ContainerPickerViewModel();
+            this.Model = new ContainerPickerViewModel(supportSSHConnections);
             this.DataContext = Model;
             this.Loaded += OnWindowLoaded;
         }
@@ -66,16 +66,6 @@ namespace Microsoft.SSHDebugPS.UI
             PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(name));
         }
 
-        // The formatted string for the ConnectionType dialog
-        private string _selectedContainerConnectionString;
-        public string SelectedContainerConnectionString
-        {
-            get
-            {
-                return _selectedContainerConnectionString;
-            }
-        }
-
         public ContainerPickerViewModel Model
         {
             get
@@ -100,75 +90,6 @@ namespace Microsoft.SSHDebugPS.UI
             {
                 item.IsSelected = true;
             }
-        }
-
-        private void OkButton_Click(object sender, RoutedEventArgs e)
-        {
-            this.DialogResult = ComputeContainerConnectionString();
-            this.Close();
-
-            e.Handled = true;
-        }
-
-        private void DialogWindow_KeyDown(object sender, System.Windows.Input.KeyEventArgs e)
-        {
-            if (e.Key == Key.Escape)
-            {
-                this.Close();
-                e.Handled = true;
-            }
-            else if (e.Key == Key.Enter)
-            {
-                this.DialogResult = ComputeContainerConnectionString();
-                if (this.DialogResult.GetValueOrDefault(false))
-                {
-                    e.Handled = true;
-                }
-            }
-        }
-
-        private void HostnameTextbox_PreviewKeyDown(object sender, KeyEventArgs e)
-        {
-            if (e.Key == Key.Enter)
-            {
-                Model.RefreshContainersList();
-                e.Handled = true;
-            }
-        }
-
-        private bool ComputeContainerConnectionString()
-        {
-            if (Model.SelectedContainerInstance != null)
-            {
-                string remoteConnectionString = string.Empty;
-                string containerId;
-                if (Model.SelectedConnection.Connection == null)
-                {
-
-                    Model.SelectedContainerInstance.GetResult(out containerId);
-                }
-                else
-                {
-                    Model.SelectedContainerInstance.GetResult(out containerId);
-                    remoteConnectionString = Model.SelectedConnection.Connection.Name;
-                }
-
-                _selectedContainerConnectionString = DockerConnection.CreateConnectionString(containerId, remoteConnectionString, Model.Hostname);
-                return true;
-            }
-
-            return false;
-        }
-
-        private void CancelButton_Click(object sender, RoutedEventArgs e)
-        {
-            this.Close();
-        }
-
-        private void Refresh_Click(object sender, RoutedEventArgs e)
-        {
-            Model.RefreshContainersList();
-            e.Handled = true;
         }
 
         private void ContainerListBox_GotKeyboardFocus(object sender, KeyboardFocusChangedEventArgs e)

--- a/src/SSHDebugPS/UI/UIResources.Designer.cs
+++ b/src/SSHDebugPS/UI/UIResources.Designer.cs
@@ -61,16 +61,16 @@ namespace Microsoft.SSHDebugPS {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Add....
+        ///   Looks up a localized string similar to Add New SSH Connection.
         /// </summary>
-        public static string AddNewSSHConnectionButtonLabel {
+        public static string AddNewSSHConnectionAutomationName {
             get {
-                return ResourceManager.GetString("AddNewSSHConnectionButtonLabel", resourceCulture);
+                return ResourceManager.GetString("AddNewSSHConnectionAutomationName", resourceCulture);
             }
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Add New SSH Connection.
+        ///   Looks up a localized string similar to Add....
         /// </summary>
         public static string AddNewSSHConnectionLabel {
             get {

--- a/src/SSHDebugPS/UI/UIResources.resx
+++ b/src/SSHDebugPS/UI/UIResources.resx
@@ -184,7 +184,7 @@
   <data name="StatusLabelText" xml:space="preserve">
     <value>Status: </value>
   </data>
-  <data name="AddNewSSHConnectionButtonLabel" xml:space="preserve">
+  <data name="AddNewSSHConnectionLabel" xml:space="preserve">
     <value>Add...</value>
   </data>
   <data name="QueryingForContainersMessage" xml:space="preserve">
@@ -215,7 +215,7 @@
   <data name="RefreshToolTip" xml:space="preserve">
     <value>Refresh Container List</value>
   </data>
-  <data name="AddNewSSHConnectionLabel" xml:space="preserve">
+  <data name="AddNewSSHConnectionAutomationName" xml:space="preserve">
     <value>Add New SSH Connection</value>
   </data>
   <data name="OptionalHintText" xml:space="preserve">


### PR DESCRIPTION
* Add ability to launch DockerPortPicker UI with SSH Disabled
* Fixed bug where user can enter hostname and hit ok which would return
a local container wiht a hostname, creating an invalid connection
string.
* Fixed it so you can't hit ok until a container has been selected