### PR TITLE
Fix escaping with the procfs script

### DIFF
--- a/src/SSHDebugPS/Docker/TransportSettings/DockerContainerTransportSettings.cs
+++ b/src/SSHDebugPS/Docker/TransportSettings/DockerContainerTransportSettings.cs
@@ -52,8 +52,12 @@ namespace Microsoft.SSHDebugPS.Docker
         {
             get
             {
-                string subCommandFormat = this.HostIsUnix ? _subCommandArgsFormatWithShellLinuxHost : _subCommandArgsFormatWithShell; 
-                return (_makeInteractive ? _interactiveFlag : string.Empty) + (_runInShell ? subCommandFormat : _subCommandArgsFormat).FormatInvariantWithArgs(ContainerName, _commandToExecute);
+                string subCommandFormat = this.HostIsUnix ? _subCommandArgsFormatWithShellLinuxHost : _subCommandArgsFormatWithShell;
+                // Because _subCommandArgsFormatWithShellLinuxHost single quotes the the subcommand arguments, we need to escape the command's single quotes
+                // by closing the single quotes and adding an escaped single quote and then reopening the single quote.
+                string command = this.HostIsUnix ? _commandToExecute.Replace("'", "'\\''") : _commandToExecute;
+                return (_makeInteractive ? _interactiveFlag : string.Empty) + 
+                    (_runInShell ? subCommandFormat : _subCommandArgsFormat).FormatInvariantWithArgs(ContainerName, command);
             }
         }
     }

--- a/src/SSHDebugPS/PipeConnection.cs
+++ b/src/SSHDebugPS/PipeConnection.cs
@@ -201,8 +201,11 @@ namespace Microsoft.SSHDebugPS
 
             int exitCode;
             string commandOutput;
-            // If used accross SSH, assume host is running Linux and escape the command (specifically the '$')
-            if (!ExecuteCommand(this.OuterConnection == null ? ProcFSOutputParser.CommandText : ProcFSOutputParser.EscapedCommandText, Timeout.Infinite, true, out commandOutput, out errorMessage, out exitCode))
+            // For a remote connection, the command will be passing through another instances of Linux, so we escape the text.
+            string command = this.OuterConnection == null ?
+                ProcFSOutputParser.CommandText :
+                ProcFSOutputParser.EscapedCommandText;
+            if (!ExecuteCommand(command, Timeout.Infinite, false, out commandOutput, out errorMessage, out exitCode))
             {
                 errorMessage = StringResources.Error_ProcFSError.FormatCurrentCultureWithArgs(errorMessage);
                 return false;

--- a/src/SSHDebugPS/PipeConnection.cs
+++ b/src/SSHDebugPS/PipeConnection.cs
@@ -201,10 +201,10 @@ namespace Microsoft.SSHDebugPS
 
             int exitCode;
             string commandOutput;
-            // For a remote connection, the command will be passing through another instances of Linux, so we escape the text.
+            // For a remote connection, the command will be passing through another instances of Linux and is passed in single quotes, so we escape any single quotes.
             string command = this.OuterConnection == null ?
                 ProcFSOutputParser.CommandText :
-                ProcFSOutputParser.EscapedCommandText;
+                ProcFSOutputParser.CommandText.Replace("'", "'\\''");
             if (!ExecuteCommand(command, Timeout.Infinite, false, out commandOutput, out errorMessage, out exitCode))
             {
                 errorMessage = StringResources.Error_ProcFSError.FormatCurrentCultureWithArgs(errorMessage);

--- a/src/SSHDebugPS/PipeConnection.cs
+++ b/src/SSHDebugPS/PipeConnection.cs
@@ -201,11 +201,7 @@ namespace Microsoft.SSHDebugPS
 
             int exitCode;
             string commandOutput;
-            // For a remote connection, the command will be passing through another instances of Linux and is passed in single quotes, so we escape any single quotes.
-            string command = this.OuterConnection == null ?
-                ProcFSOutputParser.CommandText :
-                ProcFSOutputParser.CommandText.Replace("'", "'\\''");
-            if (!ExecuteCommand(command, Timeout.Infinite, false, out commandOutput, out errorMessage, out exitCode))
+            if (!ExecuteCommand(ProcFSOutputParser.CommandText, Timeout.Infinite, false, out commandOutput, out errorMessage, out exitCode))
             {
                 errorMessage = StringResources.Error_ProcFSError.FormatCurrentCultureWithArgs(errorMessage);
                 return false;

--- a/src/SSHDebugPS/ProcFSOutputParser.cs
+++ b/src/SSHDebugPS/ProcFSOutputParser.cs
@@ -15,8 +15,6 @@ namespace Microsoft.SSHDebugPS
     {
         // for process user, can also use 'stat -c %U /proc/<pid>/exe'
         public static string CommandText => @"echo shell-process:$$; for filename in /proc/[0-9]*; do echo $filename,cmdline:$(tr '\0' ' ' < $filename/cmdline 2>/dev/null),ls:$(ls -lh $filename/exe 2>/dev/null); done";
-        // make sure that the single quotes are all escaped since we wrap the overall command text in single quotes. 
-        public static string EscapedCommandText => CommandText.Replace("'", "'\\''"); 
         private const string ShellProcessPrefix = "shell-process:";
         private readonly Regex _linePattern = new Regex(@"^/proc/([0-9]+),cmdline:(.*),ls:(.*)$", RegexOptions.None);
 

--- a/src/SSHDebugPS/ProcFSOutputParser.cs
+++ b/src/SSHDebugPS/ProcFSOutputParser.cs
@@ -15,7 +15,8 @@ namespace Microsoft.SSHDebugPS
     {
         // for process user, can also use 'stat -c %U /proc/<pid>/exe'
         public static string CommandText => @"echo shell-process:$$; for filename in /proc/[0-9]*; do echo $filename,cmdline:$(tr '\0' ' ' < $filename/cmdline 2>/dev/null),ls:$(ls -lh $filename/exe 2>/dev/null); done";
-        public static string EscapedCommandText => CommandText.Replace("$", "\\$");
+        // make sure that the single quotes are all escaped since we wrap the overall command text in single quotes. 
+        public static string EscapedCommandText => CommandText.Replace("'", "'\\''"); 
         private const string ShellProcessPrefix = "shell-process:";
         private readonly Regex _linePattern = new Regex(@"^/proc/([0-9]+),cmdline:(.*),ls:(.*)$", RegexOptions.None);
 

--- a/src/SSHDebugPS/StringResources.Designer.cs
+++ b/src/SSHDebugPS/StringResources.Designer.cs
@@ -106,15 +106,6 @@ namespace Microsoft.SSHDebugPS {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to docker exec {0} \&quot;{1}\&quot;.
-        /// </summary>
-        internal static string DockerExecCommandFormat {
-            get {
-                return ResourceManager.GetString("DockerExecCommandFormat", resourceCulture);
-            }
-        }
-        
-        /// <summary>
         ///   Looks up a localized string similar to Command failed to execute.
         /// </summary>
         internal static string Error_CommandFailed {

--- a/src/SSHDebugPS/StringResources.resx
+++ b/src/SSHDebugPS/StringResources.resx
@@ -133,11 +133,6 @@
     <value>Microsoft-SSHPortSupplier-FileCopy-</value>
     <comment>Do Not localize</comment>
   </data>
-  <data name="DockerExecCommandFormat" xml:space="preserve">
-    <value>docker exec {0} \"{1}\"</value>
-    <comment>{0} = ContainerName
-{1} = Command to run in the container</comment>
-  </data>
   <data name="Docker_PSDescription" xml:space="preserve">
     <value>The Docker (Linux Container) connection type allows Visual Studio to connect to Docker containers running locally or remotely (using SSH).</value>
   </data>


### PR DESCRIPTION
It turns out that we didn't need to escape the '$' but instead we needed
to escape the inner ''' character because it is inside an already quoted
string.

Fixes: #948