### PR TITLE
Revert "Check to find '-break-insert' versions. (#952)"

### DIFF
--- a/src/MICore/CommandFactories/MICommandFactory.cs
+++ b/src/MICore/CommandFactories/MICommandFactory.cs
@@ -418,7 +418,7 @@ namespace MICore
 
         #region Breakpoints
 
-        protected virtual Task<StringBuilder> BuildBreakInsert(string condition, bool enabled)
+        protected virtual StringBuilder BuildBreakInsert(string condition, bool enabled)
         {
             StringBuilder cmd = new StringBuilder("-break-insert -f ");
             if (condition != null)
@@ -431,7 +431,7 @@ namespace MICore
             {
                 cmd.Append("-d ");
             }
-            return Task<StringBuilder>.FromResult(cmd);
+            return cmd;
         }
 
         internal bool PreparePath(string path, bool useUnixFormat, out string pathMI)
@@ -453,7 +453,7 @@ namespace MICore
 
         public virtual async Task<Results> BreakInsert(string filename, bool useUnixFormat, uint line, string condition, bool enabled, IEnumerable<Checksum> checksums = null, ResultClass resultClass = ResultClass.done)
         {
-            StringBuilder cmd = await BuildBreakInsert(condition, enabled);
+            StringBuilder cmd = BuildBreakInsert(condition, enabled);
 
             if (checksums != null && checksums.Count() != 0)
             {
@@ -480,7 +480,7 @@ namespace MICore
 
         public virtual async Task<Results> BreakInsert(string functionName, string condition, bool enabled, ResultClass resultClass = ResultClass.done)
         {
-            StringBuilder cmd = await BuildBreakInsert(condition, enabled);
+            StringBuilder cmd = BuildBreakInsert(condition, enabled);
             // TODO: Add support of break function type filename:function locations
             cmd.Append(functionName);
             return await _debugger.CmdAsync(cmd.ToString(), resultClass);
@@ -488,7 +488,7 @@ namespace MICore
 
         public virtual async Task<Results> BreakInsert(ulong codeAddress, string condition, bool enabled, ResultClass resultClass = ResultClass.done)
         {
-            StringBuilder cmd = await BuildBreakInsert(condition, enabled);
+            StringBuilder cmd = BuildBreakInsert(condition, enabled);
             cmd.Append('*');
             cmd.Append(codeAddress);
             return await _debugger.CmdAsync(cmd.ToString(), resultClass);
@@ -672,11 +672,6 @@ namespace MICore
         public virtual bool SupportsBreakpointChecksums()
         {
             return false;
-        }
-
-        public virtual Task<bool> RequiresOnKeywordForBreakInsert()
-        {
-            return Task<bool>.FromResult(false);
         }
 
         #endregion

--- a/src/MICore/CommandFactories/lldb.cs
+++ b/src/MICore/CommandFactories/lldb.cs
@@ -46,15 +46,12 @@ namespace MICore
             }
         }
 
-        protected async override Task<StringBuilder> BuildBreakInsert(string condition, bool enabled)
+        protected override StringBuilder BuildBreakInsert(string condition, bool enabled)
         {
-            // LLDB's 3.5 use of the pending flag requires an optional parameter or else it fails.
+            // LLDB's use of the pending flag requires an optional parameter or else it fails.
             // We will use "on" for now. 
-            string pendingFlag = "-f ";
-            if (await RequiresOnKeywordForBreakInsert())
-            {
-                pendingFlag = "-f on ";
-            }
+            // TODO: Fix this on LLDB-MI's side
+            string pendingFlag = "-f on ";
 
             StringBuilder cmd = new StringBuilder("-break-insert ");
             cmd.Append(pendingFlag);
@@ -194,32 +191,6 @@ namespace MICore
                 string value = results.FindString("value");
                 return await base.VarAssign(variableName, value, threadId, frameLevel);
             }
-        }
-
-        private bool? _requiresOnKeywordForBreakInsert;
-
-        // In LLDB 3.5, -break-insert -f requires a string before the actual method name.
-        // We use a placeholder 'on' for this.
-        // Later versions do not require the 'on' keyword.
-        public override async Task<bool> RequiresOnKeywordForBreakInsert()
-        {
-            if (!_requiresOnKeywordForBreakInsert.HasValue)
-            {
-                _requiresOnKeywordForBreakInsert = false;
-                try
-                {
-                    // Test to see if -break-insert -f main works.
-                    string breakInsertMainCommand = "-break-insert -f main";
-                    Results results = await _debugger.CmdAsync(breakInsertMainCommand, ResultClass.done);
-                    await this.BreakDelete(results.Find("bkpt").FindString("number"));
-                }
-                catch (UnexpectedMIResultException)
-                {
-                    _requiresOnKeywordForBreakInsert = true;
-                }
-            }
-
-            return _requiresOnKeywordForBreakInsert.Value;
         }
     }
 }

--- a/src/MIDebugEngine/Engine.Impl/DebuggedProcess.cs
+++ b/src/MIDebugEngine/Engine.Impl/DebuggedProcess.cs
@@ -572,7 +572,7 @@ namespace Microsoft.MIDebugEngine
             try
             {
                 await this.MICommandFactory.EnableTargetAsyncOption();
-                List<LaunchCommand> commands = await GetInitializeCommands();
+                List<LaunchCommand> commands = GetInitializeCommands();
                 _childProcessHandler?.Enable();
 
                 total = commands.Count();
@@ -632,7 +632,7 @@ namespace Microsoft.MIDebugEngine
             token.ThrowIfCancellationRequested();
         }
 
-        private async Task<List<LaunchCommand>> GetInitializeCommands()
+        private List<LaunchCommand> GetInitializeCommands()
         {
             List<LaunchCommand> commands = new List<LaunchCommand>();
 
@@ -834,7 +834,7 @@ namespace Microsoft.MIDebugEngine
                         return Task.FromResult(0);
                     };
 
-                    commands.Add(new LaunchCommand(await GetBreakInsertMainCommand(), ignoreFailures: true, successResultsHandler: breakMainSuccessResultsHandler));
+                    commands.Add(new LaunchCommand(GetBreakInsertMainCommand(), ignoreFailures: true, successResultsHandler: breakMainSuccessResultsHandler));
 
                     if (null != localLaunchOptions)
                     {
@@ -863,13 +863,13 @@ namespace Microsoft.MIDebugEngine
         /// <summary>
         /// Gets a break-insert command for main that will allow pending bps and supports different debuggers
         /// </summary>
-        private async Task<string> GetBreakInsertMainCommand()
+        private string GetBreakInsertMainCommand()
         {
             // Allow main breakpoint to be pending.
             string breakInsertMainFormat = "-break-insert -f{0} main";
-            if (await this.MICommandFactory.RequiresOnKeywordForBreakInsert())
+            if (this.MICommandFactory.Mode == MIMode.Lldb)
             {
-                // break-insert -f requires 'on' in lldb 3.5 scenario
+                // break-insert -f requires 'on' in lldb scenario
                 return string.Format(CultureInfo.InvariantCulture, breakInsertMainFormat, " on");
             }
             return string.Format(CultureInfo.InvariantCulture, breakInsertMainFormat, string.Empty);


### PR DESCRIPTION
per @WardenGnaw this breaks existing functionality with lldb 3.8. Reverting until the correct fix can go in.

This reverts commit 119956f50a4fba624d5fb69e131e8441e8796c54.