### PR TITLE
Fixing build failure with the addition of InternalsVisibleTo in SSHDebugPS

### DIFF
--- a/src/SSHDebugTests/SSHDebugUnitTests.csproj
+++ b/src/SSHDebugTests/SSHDebugUnitTests.csproj
@@ -17,6 +17,8 @@
     <ReferencePath>$(ProgramFiles)\Common Files\microsoft shared\VSTT\$(VisualStudioVersion)\UITestExtensionPackages</ReferencePath>
     <IsCodedUITest>False</IsCodedUITest>
     <TestProjectType>UnitTest</TestProjectType>
+    <AssemblyOriginatorKeyFile>..\..\Keys\ExternalKey.snk</AssemblyOriginatorKeyFile>
+    <SignAssembly>True</SignAssembly>
     <OutputPath>$(MIDefaultOutputPath)</OutputPath>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">


### PR DESCRIPTION
Copied these lines from MICoreUnitTest.csproj to fix error when building
Lab.* releases that use a different key.