### PR TITLE
Fix for vscode-cpptools/#2492

### DIFF
--- a/src/MICore/Debugger.cs
+++ b/src/MICore/Debugger.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft. All rights reserved.
+﻿    // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
@@ -1134,7 +1134,7 @@ namespace MICore
                         {
                             miError = results.FindString("msg");
                         }
-                        catch (MIResultFormatException ex)
+                        catch (MIResultFormatException)
                         {
                             try
                             {
@@ -1143,10 +1143,10 @@ namespace MICore
                                 // "message" instead of "msg"
                                 miError = results.FindString("message");
                             }
-                            catch
+                            catch (MIResultFormatException)
                             {
-                                // Rethrow the original exception if we can't find "message"
-                                throw ex;
+                                // make the error a generic '<Unknown Error>' message
+                                miError = MICoreResources.Error_UnknownError;
                             }
                         }
                     }

--- a/src/MICore/Debugger.cs
+++ b/src/MICore/Debugger.cs
@@ -1129,7 +1129,26 @@ namespace MICore
                     string miError = null;
                     if (results.ResultClass == ResultClass.error)
                     {
-                        miError = results.FindString("msg");
+                        // Fixes: https://github.com/microsoft/vscode-cpptools/issues/2492
+                        try
+                        {
+                            miError = results.FindString("msg");
+                        }
+                        catch (MIResultFormatException ex)
+                        {
+                            try
+                            {
+                                // TODO: Remove after update to mainline lldb-mi
+                                // lldb-mi has certain instances (such as the -exec-* commands) that calls the message
+                                // "message" instead of "msg"
+                                miError = results.FindString("message");
+                            }
+                            catch
+                            {
+                                // Rethrow the original exception if we can't find "message"
+                                throw ex;
+                            }
+                        }
                     }
                     else
                     {

--- a/src/MICore/MICoreResources.Designer.cs
+++ b/src/MICore/MICoreResources.Designer.cs
@@ -10,7 +10,6 @@
 
 namespace MICore {
     using System;
-    using System.Reflection;
     
     
     /// <summary>
@@ -20,7 +19,7 @@ namespace MICore {
     // class via a tool like ResGen or Visual Studio.
     // To add or remove a member, edit your .ResX file then rerun ResGen
     // with the /str option, or rebuild your VS project.
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "15.0.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "16.0.0.0")]
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     public class MICoreResources {
@@ -40,7 +39,7 @@ namespace MICore {
         public static global::System.Resources.ResourceManager ResourceManager {
             get {
                 if (object.ReferenceEquals(resourceMan, null)) {
-                    global::System.Resources.ResourceManager temp = new global::System.Resources.ResourceManager("MICore.MICoreResources", typeof(MICoreResources).GetTypeInfo().Assembly);
+                    global::System.Resources.ResourceManager temp = new global::System.Resources.ResourceManager("MICore.MICoreResources", typeof(MICoreResources).Assembly);
                     resourceMan = temp;
                 }
                 return resourceMan;
@@ -507,6 +506,15 @@ namespace MICore {
         public static string Error_UnknownCustomLauncher {
             get {
                 return ResourceManager.GetString("Error_UnknownCustomLauncher", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to &lt;Unknown Error&gt;.
+        /// </summary>
+        public static string Error_UnknownError {
+            get {
+                return ResourceManager.GetString("Error_UnknownError", resourceCulture);
             }
         }
         

--- a/src/MICore/MICoreResources.resx
+++ b/src/MICore/MICoreResources.resx
@@ -307,7 +307,6 @@ Error: {1}</value>
   <data name="Error_UnknownCustomLauncher" xml:space="preserve">
     <value>Unrecognized json customLauncher element '{0}'.</value>
   </data>
-
   <data name="Error_InvalidSymbolInfo" xml:space="preserve">
     <value>Invalid SymbolInfo, cannot specify a list of solibs when "WaitDynamicLoad" is false.</value>
   </data>
@@ -327,5 +326,8 @@ Error: {1}</value>
   </data>
   <data name="Error_UnableToEstablishConnectionToLauncher" xml:space="preserve">
     <value>Unable to establish a connection to the launcher.</value>
+  </data>
+  <data name="Error_UnknownError" xml:space="preserve">
+    <value>&lt;Unknown Error&gt;</value>
   </data>
 </root>


### PR DESCRIPTION
in lldb-mi there appears to be "message" instead of "msg" when an error is returned in the `-exec-*` command results. This is to handle both cases. 

Fixes https://github.com/microsoft/vscode-cpptools/issues/2492