### PR TITLE
Enable Lab.* builds for PR

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -46,3 +46,23 @@ jobs:
     inputs:
       solution: 'BuildAndTest.proj'
       configuration: 'Desktop.Release'
+
+- job: LabRelease
+  pool: 'Hosted VS2017'
+  variables:
+    TEST_LAB_BUILD: 'true'
+  steps:
+  - task: MSBuild@1
+    inputs:
+      solution: 'BuildAndTest.proj'
+      configuration: 'Lab.Release'
+
+- job: LabDebug
+  pool: 'Hosted VS2017'
+  variables:
+    TEST_LAB_BUILD: 'true'
+  steps:
+  - task: MSBuild@1
+    inputs:
+      solution: 'BuildAndTest.proj'
+      configuration: 'Lab.Debug'

--- a/build/DropFiles.targets
+++ b/build/DropFiles.targets
@@ -13,7 +13,7 @@
       <DropDir Condition="'$(DropSubDir)'!=''">$(DropRootDir)\$(DropSubDir)</DropDir>
     </PropertyGroup>
     <!--In official builds of the lab configuration, make sure that the MicroBuild props are included in any project that uses DropFiles-->
-    <Error Condition="'$(MicroBuild_SigningTargetsImported)'!='true' and '$(Lab)'!='false' and '$(BUILD_BUILDURI)'!=''" Text="MicroBuild.Core.props must be included in projects that use DropFiles." />
+    <Error Condition="'$(MicroBuild_SigningTargetsImported)'!='true' and '$(Lab)'!='false' and '$(TEST_LAB_BUILD)'=='' and '$(BUILD_BUILDURI)'!=''" Text="MicroBuild.Core.props must be included in projects that use DropFiles." />
     <MakeDir Condition="!Exists($(DropDir))" Directories="$(DropDir)" />
     <Copy DestinationFolder="$(DropDir)" SourceFiles="@(DropUnsignedFile);@(DropSignedFile)" />
   </Target>

--- a/build/miengine.settings.targets
+++ b/build/miengine.settings.targets
@@ -14,8 +14,8 @@
             <AssemblyOriginatorKeyFile>$(MSBuildThisFileDirectory)..\Keys\DevDivPublicKey.snk</AssemblyOriginatorKeyFile>
 
             <!-- Use PublicSign when TEST_LAB_BUILD is enabled -->
-            <PublicSign Condition="'$(TEST_LAB_BUILD)'==''">true</PublicSign>
-            <DelaySign Condition="'$(TEST_LAB_BUILD)'!=''">true</DelaySign>
+            <PublicSign Condition="'$(TEST_LAB_BUILD)'!=''">true</PublicSign>
+            <DelaySign Condition="'$(TEST_LAB_BUILD)'==''">true</DelaySign>
         </PropertyGroup>
     </When>
     <Otherwise>

--- a/build/miengine.settings.targets
+++ b/build/miengine.settings.targets
@@ -8,11 +8,14 @@
   <Import Project="version.settings.targets" />
 
   <Choose>
-    <When Condition="'$(Lab)' == 'true' and '$(TEST_LAB_BUILD)'==''">
+    <When Condition="'$(Lab)' == 'true'">
         <PropertyGroup>
             <!--NOTE:DevDivPublicKey.snk comes from src\\tools\\devdiv\\FinalPublicKey.snk -->
             <AssemblyOriginatorKeyFile>$(MSBuildThisFileDirectory)..\Keys\DevDivPublicKey.snk</AssemblyOriginatorKeyFile>
-            <DelaySign>true</DelaySign>
+
+            <!-- Use PublicSign when TEST_LAB_BUILD is enabled -->
+            <PublicSign Condition="'$(TEST_LAB_BUILD)'==''">true</PublicSign>
+            <DelaySign Condition="'$(TEST_LAB_BUILD)'!=''">true</DelaySign>
         </PropertyGroup>
     </When>
     <Otherwise>

--- a/build/miengine.settings.targets
+++ b/build/miengine.settings.targets
@@ -8,7 +8,7 @@
   <Import Project="version.settings.targets" />
 
   <Choose>
-    <When Condition="'$(Lab)' == 'true'">
+    <When Condition="'$(Lab)' == 'true' and '$(TEST_LAB_BUILD)'==''">
         <PropertyGroup>
             <!--NOTE:DevDivPublicKey.snk comes from src\\tools\\devdiv\\FinalPublicKey.snk -->
             <AssemblyOriginatorKeyFile>$(MSBuildThisFileDirectory)..\Keys\DevDivPublicKey.snk</AssemblyOriginatorKeyFile>

--- a/src/MICore/GenerateXmlSerializersAssembly.targets
+++ b/src/MICore/GenerateXmlSerializersAssembly.targets
@@ -80,6 +80,10 @@
           Inputs="$(XsdCodeFile);$(AssemblyOriginatorKeyFile)"
           Outputs="$(IntermediateOutputPath)sgen/$(AssemblyName).XmlSerializers.dll">
     <PropertyGroup>
+      <!-- 
+        If TEST_LAB_BUILD is set, we are public signing. 
+        sgen.exe does not have -publicsign and does not work if a keyfile is passed in. 
+      -->
       <SerializationSigningCompilerOptions Condition="'$(TEST_LAB_BUILD)'==''">/keyfile:$(AssemblyOriginatorKeyFile)</SerializationSigningCompilerOptions>
       <SerializationSigningCompilerOptions Condition="'$(DelaySign)'=='true'">$(SerializationSigningCompilerOptions) /delaysign</SerializationSigningCompilerOptions>
 

--- a/src/MICore/GenerateXmlSerializersAssembly.targets
+++ b/src/MICore/GenerateXmlSerializersAssembly.targets
@@ -80,8 +80,8 @@
           Inputs="$(XsdCodeFile);$(AssemblyOriginatorKeyFile)"
           Outputs="$(IntermediateOutputPath)sgen/$(AssemblyName).XmlSerializers.dll">
     <PropertyGroup>
-      <SerializationSigningCompilerOptions>/keyfile:$(AssemblyOriginatorKeyFile)</SerializationSigningCompilerOptions>
-      <SerializationSigningCompilerOptions Condition="'$(DelaySign)'=='true' or '$(TEST_LAB_BUILD)'!=''">$(SerializationSigningCompilerOptions) /delaysign</SerializationSigningCompilerOptions>
+      <SerializationSigningCompilerOptions Condition="'$(TEST_LAB_BUILD)'==''">/keyfile:$(AssemblyOriginatorKeyFile)</SerializationSigningCompilerOptions>
+      <SerializationSigningCompilerOptions Condition="'$(DelaySign)'=='true'">$(SerializationSigningCompilerOptions) /delaysign</SerializationSigningCompilerOptions>
 
       <CompilerPath>$(CscToolPath)$(CscToolExe)</CompilerPath>
       <CompilerPath Condition="'$(CompilerPath)' == '' and Exists('$(MSBuildBinPath)\csc.exe')">$(MSBuildBinPath)\csc.exe</CompilerPath>

--- a/src/MICore/GenerateXmlSerializersAssembly.targets
+++ b/src/MICore/GenerateXmlSerializersAssembly.targets
@@ -81,7 +81,7 @@
           Outputs="$(IntermediateOutputPath)sgen/$(AssemblyName).XmlSerializers.dll">
     <PropertyGroup>
       <SerializationSigningCompilerOptions>/keyfile:$(AssemblyOriginatorKeyFile)</SerializationSigningCompilerOptions>
-      <SerializationSigningCompilerOptions Condition="'$(DelaySign)'=='true'">$(SerializationSigningCompilerOptions) /delaysign</SerializationSigningCompilerOptions>
+      <SerializationSigningCompilerOptions Condition="'$(DelaySign)'=='true' or '$(TEST_LAB_BUILD)'!=''">$(SerializationSigningCompilerOptions) /delaysign</SerializationSigningCompilerOptions>
 
       <CompilerPath>$(CscToolPath)$(CscToolExe)</CompilerPath>
       <CompilerPath Condition="'$(CompilerPath)' == '' and Exists('$(MSBuildBinPath)\csc.exe')">$(MSBuildBinPath)\csc.exe</CompilerPath>


### PR DESCRIPTION
Created TEST_LAB_BUILD variable that will skip Signing Targets

If building Lab.* without TEST_LAB_BUILD set then it will do the signing tasks. 