### PR TITLE
Add support for '`' instead of '-exec' prefaces for sending gdb commands

### DIFF
--- a/src/MIDebugEngine/Engine.Impl/Variables.cs
+++ b/src/MIDebugEngine/Engine.Impl/Variables.cs
@@ -431,7 +431,7 @@ namespace Microsoft.MIDebugEngine
         {
             strippedCommand = string.Empty;
             string execCommandString = "-exec ";
-            if (command.StartsWith(execCommandString))
+            if (command.StartsWith(execCommandString, StringComparison.Ordinal))
             {
                 strippedCommand = command.Substring(execCommandString.Length);
                 return true;

--- a/src/MIDebugEngine/Engine.Impl/Variables.cs
+++ b/src/MIDebugEngine/Engine.Impl/Variables.cs
@@ -421,20 +421,41 @@ namespace Microsoft.MIDebugEngine
             return val;
         }
 
+        /// <summary>
+        /// This allows console commands to be sent through the eval channel via a '-exec ' or '`' preface
+        /// </summary>
+        /// <param name="command">raw command</param>
+        /// <param name="strippedCommand">command stripped of the preface ('-exec ' or '`')</param>
+        /// <returns>true if it is a console command</returns>
+        private bool IsConsoleExecCmd(string command, out string strippedCommand)
+        {
+            strippedCommand = string.Empty;
+            string execCommandString = "-exec ";
+            if (command.StartsWith(execCommandString))
+            {
+                strippedCommand = command.Substring(execCommandString.Length);
+                return true;
+            }
+            else if (command[0] == '`')
+            {
+                strippedCommand = command.Substring(1).TrimStart(); // remove spaces if any
+                return true;
+            }
+            return false;
+        }
+
         internal async Task Eval(enum_EVALFLAGS dwFlags = 0)
         {
             this.VerifyNotDisposed();
 
             await _engine.UpdateRadixAsync(_engine.CurrentRadix());    // ensure the radix value is up-to-date
 
-            string execCommandString = "-exec ";
-
             try
             {
-                if (_strippedName.StartsWith(execCommandString))
+                string consoleCommand;
+                if (IsConsoleExecCmd(_strippedName, out consoleCommand))
                 {
                     // special case for executing raw mi commands. 
-                    string consoleCommand = _strippedName.Substring(execCommandString.Length);
                     string consoleResults = null;
 
                     consoleResults = await MIDebugCommandDispatcher.ExecuteCommand(consoleCommand, _debuggedProcess, ignoreFailures: true);

--- a/src/OpenDebugAD7/AD7DebugSession.cs
+++ b/src/OpenDebugAD7/AD7DebugSession.cs
@@ -527,7 +527,7 @@ namespace OpenDebugAD7
         #region DebugAdapterBase
 
         protected override void HandleInitializeRequestAsync(IRequestResponder<InitializeArguments, InitializeResponse> responder)
-        {            
+        {
             InitializeArguments arguments = responder.Arguments;
 
             m_engineConfiguration = EngineConfiguration.TryGet(arguments.AdapterID);
@@ -1825,10 +1825,12 @@ namespace OpenDebugAD7
             DateTime evaluationStartTime = DateTime.Now;
 
             bool isExecInConsole = false;
-            // If this is an -exec command, log telemetry
-            if (!String.IsNullOrEmpty(expression) && expression.StartsWith("-exec", StringComparison.Ordinal) && context == EvaluateArguments.ContextValue.Repl)
+            // If the expression isn't empty and its a Repl request, do additional checking
+            if (!String.IsNullOrEmpty(expression) && context == EvaluateArguments.ContextValue.Repl)
             {
-                isExecInConsole = true;
+                // If this is an -exec command (or starts with '`') treat it as a console command and log telemetry
+                if (expression.StartsWith("-exec", StringComparison.Ordinal) || expression[0] == '`')
+                    isExecInConsole = true;
             }
 
             int hr;


### PR DESCRIPTION
A first step towards making https://github.com/microsoft/vscode-cpptools/issues/106 easier to work around. 

 