### PR TITLE
Allow consoleCommand to exec while process run

### DIFF
--- a/src/MICore/CommandFactories/gdb.cs
+++ b/src/MICore/CommandFactories/gdb.cs
@@ -158,7 +158,7 @@ namespace MICore
         public override async Task<List<ulong>> StartAddressesForLine(string file, uint line)
         {
             string cmd = "info line " + file + ":" + line;
-            var result = await _debugger.ConsoleCmdAsync(cmd);
+            var result = await _debugger.ConsoleCmdAsync(cmd, allowWhileRunning: false);
             List<ulong> addresses = new List<ulong>();
             using (StringReader stringReader = new StringReader(result))
             {
@@ -276,7 +276,7 @@ namespace MICore
         public override async Task Catch(string name, bool onlyOnce = false, ResultClass resultClass = ResultClass.done)
         {
             string command = onlyOnce ? "tcatch " : "catch ";
-            await _debugger.ConsoleCmdAsync(command + name);
+            await _debugger.ConsoleCmdAsync(command + name, allowWhileRunning: false);
         }
     }
 }

--- a/src/MICore/CommandFactories/lldb.cs
+++ b/src/MICore/CommandFactories/lldb.cs
@@ -225,6 +225,7 @@ namespace MICore
 
         private async Task<string> Version()
         {
+            // 'Version' does not require the debuggee to be stopped.
             return await _debugger.ConsoleCmdAsync("version", allowWhileRunning: true);
         }
     }

--- a/src/MICore/CommandFactories/lldb.cs
+++ b/src/MICore/CommandFactories/lldb.cs
@@ -225,7 +225,7 @@ namespace MICore
 
         private async Task<string> Version()
         {
-            return await _debugger.ConsoleCmdAsync("version");
+            return await _debugger.ConsoleCmdAsync("version", allowWhileRunning: true);
         }
     }
 }

--- a/src/MICore/Debugger.cs
+++ b/src/MICore/Debugger.cs
@@ -794,9 +794,9 @@ namespace MICore
             return outStr.ToString();
         }
 
-        public async Task<string> ConsoleCmdAsync(string cmd, bool ignoreFailures = false)
+        public async Task<string> ConsoleCmdAsync(string cmd, bool allowWhileRunning, bool ignoreFailures = false)
         {
-            if (this.ProcessState != ProcessState.Stopped && this.ProcessState != ProcessState.NotConnected)
+            if (!allowWhileRunning && this.ProcessState != ProcessState.Stopped && this.ProcessState != ProcessState.NotConnected)
             {
                 if (this.ProcessState == MICore.ProcessState.Exited)
                 {
@@ -811,7 +811,7 @@ namespace MICore
             using (ExclusiveLockToken lockToken = await _commandLock.AquireExclusive())
             {
                 // check again now that we have the lock
-                if (this.ProcessState != MICore.ProcessState.Stopped && this.ProcessState != ProcessState.NotConnected)
+                if (!allowWhileRunning && this.ProcessState != MICore.ProcessState.Stopped && this.ProcessState != ProcessState.NotConnected)
                 {
                     if (this.ProcessState == MICore.ProcessState.Exited)
                     {

--- a/src/MICore/Debugger.cs
+++ b/src/MICore/Debugger.cs
@@ -796,9 +796,11 @@ namespace MICore
 
         public async Task<string> ConsoleCmdAsync(string cmd, bool allowWhileRunning, bool ignoreFailures = false)
         {
-            if (!allowWhileRunning && this.ProcessState != ProcessState.Stopped && this.ProcessState != ProcessState.NotConnected)
+            if (!(this.ProcessState == ProcessState.Running && allowWhileRunning) &&
+                this.ProcessState != ProcessState.Stopped &&
+                this.ProcessState != ProcessState.NotConnected)
             {
-                if (this.ProcessState == MICore.ProcessState.Exited)
+                if (this.ProcessState == ProcessState.Exited)
                 {
                     throw new DebuggerDisposedException(GetTargetProcessExitedReason());
                 }
@@ -811,9 +813,11 @@ namespace MICore
             using (ExclusiveLockToken lockToken = await _commandLock.AquireExclusive())
             {
                 // check again now that we have the lock
-                if (!allowWhileRunning && this.ProcessState != MICore.ProcessState.Stopped && this.ProcessState != ProcessState.NotConnected)
+                if (!(this.ProcessState == ProcessState.Running && allowWhileRunning) &&
+                    this.ProcessState != ProcessState.Stopped &&
+                    this.ProcessState != ProcessState.NotConnected)
                 {
-                    if (this.ProcessState == MICore.ProcessState.Exited)
+                    if (this.ProcessState == ProcessState.Exited)
                     {
                         throw new DebuggerDisposedException(GetTargetProcessExitedReason());
                     }

--- a/src/MICore/Debugger.cs
+++ b/src/MICore/Debugger.cs
@@ -794,6 +794,13 @@ namespace MICore
             return outStr.ToString();
         }
 
+        /// <summary>
+        /// Sends 'cmd' to the debuggee as a console command.
+        /// </summary>
+        /// <param name="cmd">The command to send.</param>
+        /// <param name="allowWhileRunning">Set to 'true' if the process can be running while the command is executed.</param>
+        /// <param name="ignoreFailures">Ignore any failure that occur when executing the command.</param>
+        /// <returns></returns>
         public async Task<string> ConsoleCmdAsync(string cmd, bool allowWhileRunning, bool ignoreFailures = false)
         {
             if (!(this.ProcessState == ProcessState.Running && allowWhileRunning) &&

--- a/src/MIDebugEngine/Engine.Impl/DebugUnixChildProcess.cs
+++ b/src/MIDebugEngine/Engine.Impl/DebugUnixChildProcess.cs
@@ -64,7 +64,7 @@ namespace Microsoft.MIDebugEngine
                 uint inf = _process.InferiorByPid(state.Newpid);
                 if (inf != 0)
                 {
-                    await _process.ConsoleCmdAsync("inferior " + inf.ToString());
+                    await _process.ConsoleCmdAsync("inferior " + inf.ToString(), allowWhileRunning: false);
                     if (!string.IsNullOrEmpty(_mainBreak))
                     {
                         await _process.MICommandFactory.BreakDelete(_mainBreak);
@@ -84,7 +84,7 @@ namespace Microsoft.MIDebugEngine
                 uint inf = _process.InferiorByPid(state.Newpid);
                 if (inf != 0)
                 {
-                    await _process.ConsoleCmdAsync("inferior " + inf.ToString());
+                    await _process.ConsoleCmdAsync("inferior " + inf.ToString(), allowWhileRunning: false);
                     await SetBreakAtMain();
                     state.State = State.AtExec;
                     await _process.MICommandFactory.ExecContinue();  // run the child
@@ -100,7 +100,7 @@ namespace Microsoft.MIDebugEngine
                 uint inf = _process.InferiorByPid(state.Newpid);
                 if (inf != 0)
                 {
-                    await _process.ConsoleCmdAsync("inferior " + inf.ToString());
+                    await _process.ConsoleCmdAsync("inferior " + inf.ToString(), allowWhileRunning: false);
                     await _process.MICommandFactory.ExecContinue();  // run the child
                 }
             }
@@ -147,9 +147,9 @@ namespace Microsoft.MIDebugEngine
             uint inf = _process.InferiorByPid(state.Newpid);
             if (inf == 0)
                 return false;    // cannot process the child
-            await _process.ConsoleCmdAsync("inferior " + inf.ToString());
+            await _process.ConsoleCmdAsync("inferior " + inf.ToString(), allowWhileRunning: false);
             await _process.MICommandFactory.TargetDetach();     // detach from the child
-            await _process.ConsoleCmdAsync("inferior 1");
+            await _process.ConsoleCmdAsync("inferior 1", allowWhileRunning: false);
             return true;
         }
 

--- a/src/MIDebugEngine/Engine.Impl/DebuggedProcess.cs
+++ b/src/MIDebugEngine/Engine.Impl/DebuggedProcess.cs
@@ -611,7 +611,7 @@ namespace Microsoft.MIDebugEngine
                     }
                     else
                     {
-                        string resultString = await ConsoleCmdAsync(command.CommandText, command.IgnoreFailures);
+                        string resultString = await ConsoleCmdAsync(command.CommandText, allowWhileRunning: false, ignoreFailures: command.IgnoreFailures);
                         if (command.SuccessHandler != null)
                         {
                             await command.SuccessHandler(resultString);
@@ -1317,7 +1317,7 @@ namespace Microsoft.MIDebugEngine
                 // When the terminal window is closed, a SIGHUP is sent to lldb-mi and LLDB's default is to stop.
                 // We want to not stop (break) when this happens and the SIGHUP to be sent to the debuggee process.
                 // LLDB requires this command to be issued after the process has started.
-                await ConsoleCmdAsync("process handle --pass true --stop false --notify false SIGHUP", true);
+                await ConsoleCmdAsync("process handle --pass true --stop false --notify false SIGHUP", allowWhileRunning: false, ignoreFailures: true);
             }
 
             if (this._deleteEntryPointBreakpoint && !String.IsNullOrWhiteSpace(this._entryPointBreakpoint))
@@ -1483,7 +1483,7 @@ namespace Microsoft.MIDebugEngine
 
         private async Task<string> LoadSymbols(string filename)
         {
-            return await ConsoleCmdAsync("sharedlibrary " + filename);
+            return await ConsoleCmdAsync("sharedlibrary " + filename, allowWhileRunning: false);
         }
 
         private async Task CheckModules()
@@ -1491,7 +1491,7 @@ namespace Microsoft.MIDebugEngine
             // NOTE: The version of GDB that comes in the Android SDK doesn't support -file-list-shared-library
             // so we need to use the console command
             //string results = await MICommandFactory.GetSharedLibrary();
-            string results = await ConsoleCmdAsync("info sharedlibrary");
+            string results = await ConsoleCmdAsync("info sharedlibrary", allowWhileRunning: false);
 
             using (StringReader stringReader = new StringReader(results))
             {
@@ -2244,7 +2244,7 @@ namespace Microsoft.MIDebugEngine
         /// <returns></returns>
         private Task<string> ResetConsole()
         {
-            return ConsoleCmdAsync(@"shell echo -e \\033c 1>&2");
+            return ConsoleCmdAsync(@"shell echo -e \\033c 1>&2", allowWhileRunning: false);
         }
 
         public bool IsChildProcessDebugging => _childProcessHandler != null;

--- a/src/MIDebugEngine/MIDebugCommandDispatcher.cs
+++ b/src/MIDebugEngine/MIDebugCommandDispatcher.cs
@@ -47,7 +47,7 @@ namespace Microsoft.MIDebugEngine
             }
             else
             {
-                return process.ConsoleCmdAsync(command, allowWhileRunning: false, ignoreFailures);
+                return process.ConsoleCmdAsync(command, allowWhileRunning: false, ignoreFailures: ignoreFailures);
             }
         }
 

--- a/src/MIDebugEngine/MIDebugCommandDispatcher.cs
+++ b/src/MIDebugEngine/MIDebugCommandDispatcher.cs
@@ -47,7 +47,7 @@ namespace Microsoft.MIDebugEngine
             }
             else
             {
-                return process.ConsoleCmdAsync(command, ignoreFailures);
+                return process.ConsoleCmdAsync(command, allowWhileRunning: false, ignoreFailures);
             }
         }
 


### PR DESCRIPTION
Added flag allowWhileRunning to consoleAsyncCmd since certain commands
such as 'version' do not require the process to be stopped in order to execute.