### PR TITLE
Fixes for environment entries used for RunInTerminal Request

### DIFF
--- a/src/MICore/RunInTerminalLauncher.cs
+++ b/src/MICore/RunInTerminalLauncher.cs
@@ -17,6 +17,11 @@ namespace MICore
 
         private Dictionary<string, string> _environment;
 
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <param name="title"></param>
+        /// <param name="envEntries">Environment Entries for launching the command in the RunInTerminal Protocol call.</param>
         public RunInTerminalLauncher(string title, ReadOnlyCollection<EnvironmentEntry> envEntries)
         {
             _title = title;

--- a/src/MICore/Transports/RunInTerminalTransport.cs
+++ b/src/MICore/Transports/RunInTerminalTransport.cs
@@ -137,7 +137,7 @@ namespace MICore
                 using (FileStream dbgCmdStream = new FileStream(dbgCmdScript, FileMode.CreateNew))
                 using (StreamWriter dbgCmdWriter = new StreamWriter(dbgCmdStream, encNoBom) { AutoFlush = true })
                 {
-                    dbgCmdWriter.WriteLine("#!/bin/sh");
+                    dbgCmdWriter.WriteLine("#!/usr/bin/env sh");
                     dbgCmdWriter.Write(launchDebuggerCommand);
                     dbgCmdWriter.Flush();
                 }
@@ -154,7 +154,7 @@ namespace MICore
                 }
                 else
                 {
-                    cmdArgs.Add("sh");
+                    cmdArgs.Add("/bin/sh");
                     cmdArgs.Add(dbgCmdScript);
                 }
 
@@ -162,7 +162,8 @@ namespace MICore
                 _commandStream = new StreamWriter(stdInStream, encNoBom);
             }
 
-            RunInTerminalLauncher launcher = new RunInTerminalLauncher(windowtitle, localOptions.Environment);
+            // Do not pass the launchOptions Environment entries as those are used for the debuggee only.
+            RunInTerminalLauncher launcher = new RunInTerminalLauncher(windowtitle, new List<EnvironmentEntry>(0).AsReadOnly());
 
             launcher.Launch(
                      cmdArgs,


### PR DESCRIPTION
It was accidently using the debuggee's environment variables to also be
used for the RunInterminal Request. Also as @Smit-tay pointed out, we
should probably be using /usr/bin/env in the script and a full path to
sh in the script execution when calling RunInTerminal.

Added some fixes and a comment. We may want to support RunInTerminal
Environment Variables in the future so I did not remove the plumbing for
it, but for now I'm sending an empty object.

Fixes #979 