### PR TITLE
Fix "GetDropFiles" targets

### DIFF
--- a/src/OpenDebugAD7/OpenDebugAD7.csproj
+++ b/src/OpenDebugAD7/OpenDebugAD7.csproj
@@ -178,7 +178,7 @@
     <DropUnsignedFile Include="$(OutputPath)\cppdbg.ad7Engine.json" />
   </ItemGroup>
   <!-- Necessary because IsMonoRuntime isn't set until after DetermineCompilerBinary is run. -->
-  <Target Name="GetDropFiles" AfterTargets="DetermineCompilerBinary" BeforeTargets="DropFilesVSCode">
+  <Target Name="GetDropFiles" AfterTargets="DetermineCompilerBinary" BeforeTargets="DropFiles">
     <ItemGroup>
       <DropUnsignedFile Condition="'$(IsMonoRuntime)' == 'false'" Include="$(OutputPath)\OpenDebugAD7.pdb" />
     </ItemGroup>

--- a/src/WindowsDebugLauncher/WindowsDebugLauncher.csproj
+++ b/src/WindowsDebugLauncher/WindowsDebugLauncher.csproj
@@ -54,7 +54,7 @@
     <Compile Include="Program.cs" />
   </ItemGroup>
   <!-- Necessary because IsMonoRuntime isn't set until after DetermineCompilerBinary is run. -->
-  <Target Name="GetDropFiles" AfterTargets="DetermineCompilerBinary" BeforeTargets="DropFilesVSCode">
+  <Target Name="GetDropFiles" AfterTargets="DetermineCompilerBinary" BeforeTargets="DropFiles">
     <ItemGroup>
       <DropSignedFile Include="$(OutputPath)\WindowsDebugLauncher.exe" />
       <DropUnsignedFile Condition="'$(IsMonoRuntime)' == 'false'" Include="$(OutputPath)\WindowsDebugLauncher.pdb" />


### PR DESCRIPTION
The "GetDropFiles" targets in OpenDebugAD7 and WindowsDebugLauncher specified a "BeforeTargets" option referencing a non-existent "DropFilesVSCode" target.  This caused these targets not to run, resulting in PDBs failing to deploy.  This commit replaces the "BeforeTargets" option with a reference to the standard "DropFiles" target.