### PR TITLE
Fix finding MICore.XmlSerializers in Nexus

### DIFF
--- a/src/MICore/LaunchOptions.cs
+++ b/src/MICore/LaunchOptions.cs
@@ -1995,10 +1995,11 @@ namespace MICore
             string thisModuleDir = Path.GetDirectoryName(thisModulePath);
             string thisModuleName = Path.GetFileNameWithoutExtension(thisModulePath);
             string serializerAssemblyPath = Path.Combine(thisModuleDir, thisModuleName + ".XmlSerializers.dll");
+            string thisModuleVersion = typeof(LaunchOptions).GetTypeInfo().Assembly.GetName().Version.ToString();
             if (!File.Exists(serializerAssemblyPath))
                 return null;
 
-            return Assembly.Load(new AssemblyName(thisModuleName + ".XmlSerializers"));
+            return Assembly.Load(new AssemblyName(thisModuleName + ".XmlSerializers, Version=" + thisModuleVersion));
         }
 
         protected void SetInitializationComplete()

--- a/src/OpenDebugAD7/App.VS.config
+++ b/src/OpenDebugAD7/App.VS.config
@@ -23,6 +23,10 @@
         <codeBase version="14.0.0.0" href="..\Microsoft.MICore.dll"/>
       </dependentAssembly>
       <dependentAssembly>
+        <assemblyIdentity name="Microsoft.MICore.XmlSerializers" culture="neutral"/>
+        <codeBase version="14.0.0.0" href="..\Microsoft.MICore.XmlSerializers.dll"/>
+      </dependentAssembly>
+      <dependentAssembly>
         <assemblyIdentity name="Microsoft.MIDebugEngine" culture="neutral"/>
         <codeBase version="14.0.0.0" href="..\Microsoft.MIDebugEngine.dll"/>
       </dependentAssembly>


### PR DESCRIPTION
Add a binding redirect and an explicit version specification to ensure that MICore.XmlSerializers can be found when running in a hosted environment.