### PR TITLE
Modify ParseResultsList to throw instead of null

### DIFF
--- a/src/MICore/MIResults.cs
+++ b/src/MICore/MIResults.cs
@@ -730,12 +730,20 @@ namespace MICore
                     {
                         return i == s.Extent;
                     }, listStr, out rest);
+
+            Results results = new Results(resultClass, list);
+
             if (!rest.IsEmpty)
             {
                 ParseError("trailing chars", rest);
-                return null;
+
+                if (rest.Length > 1000)
+                {
+                    rest = new Span(rest.Start, 1000);    // don't show more than 1000 chars
+                }
+                throw new MIResultFormatException(rest.Extract(_resultString), results);
             }
-            return new Results(resultClass, list);
+            return results;
         }
 
         public string ParseCString(string input)

--- a/src/MICore/MIResults.cs
+++ b/src/MICore/MIResults.cs
@@ -596,6 +596,9 @@ namespace MICore
 
     public class MIResults
     {
+        // The amount of characters to send to the UI upon an error.
+        private static int PARSE_ERROR_MSG_LIMIT = 1000;
+
         struct Span
         {
             static Span _emptySpan;
@@ -733,17 +736,20 @@ namespace MICore
 
             Results results = new Results(resultClass, list);
 
-            if (!rest.IsEmpty)
+            if (rest.IsEmpty)
+            {
+                return results;
+            }
+            else
             {
                 ParseError("trailing chars", rest);
 
-                if (rest.Length > 1000)
+                if (rest.Length > PARSE_ERROR_MSG_LIMIT)
                 {
-                    rest = new Span(rest.Start, 1000);    // don't show more than 1000 chars
+                    rest = new Span(rest.Start, PARSE_ERROR_MSG_LIMIT);
                 }
                 throw new MIResultFormatException(rest.Extract(_resultString), results);
             }
-            return results;
         }
 
         public string ParseCString(string input)
@@ -1203,9 +1209,9 @@ namespace MICore
 
         private void ParseError(string message, Span input)
         {
-            if (input.Length > 1000)
+            if (input.Length > PARSE_ERROR_MSG_LIMIT)
             {
-                input = new Span(input.Start, 1000);    // don't show more than 1000 chars
+                input = new Span(input.Start, PARSE_ERROR_MSG_LIMIT);
             }
             string result = input.Extract(_resultString);
             Debug.Fail(message + ": " + result);

--- a/src/MICore/MIResults.cs
+++ b/src/MICore/MIResults.cs
@@ -596,9 +596,6 @@ namespace MICore
 
     public class MIResults
     {
-        // The amount of characters to send to the UI upon an error.
-        private static int PARSE_ERROR_MSG_LIMIT = 1000;
-
         struct Span
         {
             static Span _emptySpan;
@@ -743,12 +740,7 @@ namespace MICore
             else
             {
                 ParseError("trailing chars", rest);
-
-                if (rest.Length > PARSE_ERROR_MSG_LIMIT)
-                {
-                    rest = new Span(rest.Start, PARSE_ERROR_MSG_LIMIT);
-                }
-                throw new MIResultFormatException(rest.Extract(_resultString), results);
+                throw new MIResultFormatException(CreateErrorMessageFromSpan(rest), results);
             }
         }
 
@@ -1209,15 +1201,24 @@ namespace MICore
 
         private void ParseError(string message, Span input)
         {
+            string result = CreateErrorMessageFromSpan(input);
+            Debug.Fail(message + ": " + result);
+
+            Logger?.WriteLine(String.Format(CultureInfo.CurrentCulture, "MI parsing error: {0}: \"{1}\"", message, result));
+
+        }
+
+        // The amount of characters to send to the UI upon an error.
+        private static int PARSE_ERROR_MSG_LIMIT = 1000;
+
+        private string CreateErrorMessageFromSpan(Span input)
+        {
             if (input.Length > PARSE_ERROR_MSG_LIMIT)
             {
                 input = new Span(input.Start, PARSE_ERROR_MSG_LIMIT);
             }
-            string result = input.Extract(_resultString);
-            Debug.Fail(message + ": " + result);
-#if DEBUG
-            Logger?.WriteLine(String.Format(CultureInfo.CurrentCulture, "MI parsing error: {0}: \"{1}\"", message, result));
-#endif
+
+            return input.Extract(_resultString);
         }
     }
 }


### PR DESCRIPTION
Callers to ParseResultList expect the return value to be non-null.
However, if there is remaining characters in the span, we will return
null.

This change modifies this call to throw MIResultFormatException so it
will report an error instead of crashing.

Example error:
![image](https://user-images.githubusercontent.com/3953714/78947754-2c3d4380-7a7b-11ea-93f8-0294045c258a.png)
