### PR TITLE
Support checking gdb.exe on Windows

### DIFF
--- a/src/MICore/LaunchOptions.cs
+++ b/src/MICore/LaunchOptions.cs
@@ -541,6 +541,8 @@ namespace MICore
         {
             string pathVar = System.Environment.GetEnvironmentVariable("PATH");
 
+            bool checkForWindowsExe = PlatformUtilities.IsWindows() && String.IsNullOrEmpty(Path.GetExtension(command));
+
             // Check each portion of the PATH environment variable to see if it contains the requested file
             foreach (string pathPart in pathVar.Split(Path.PathSeparator))
             {
@@ -552,7 +554,7 @@ namespace MICore
                     return candidate;
                 }
 
-                if (PlatformUtilities.IsWindows() && String.IsNullOrEmpty(Path.GetExtension(command)))
+                if (checkForWindowsExe)
                 {
                     string exeCandidate = candidate + ".exe";
                     if (File.Exists(exeCandidate))

--- a/src/MICore/LaunchOptions.cs
+++ b/src/MICore/LaunchOptions.cs
@@ -551,6 +551,13 @@ namespace MICore
                 {
                     return candidate;
                 }
+
+                string exeCandidate = candidate + ".exe";
+
+                if (PlatformUtilities.IsWindows() && File.Exists(exeCandidate))
+                {
+                    return exeCandidate;
+                }
             }
 
             return null;

--- a/src/MICore/LaunchOptions.cs
+++ b/src/MICore/LaunchOptions.cs
@@ -552,11 +552,13 @@ namespace MICore
                     return candidate;
                 }
 
-                string exeCandidate = candidate + ".exe";
-
-                if (PlatformUtilities.IsWindows() && File.Exists(exeCandidate))
+                if (PlatformUtilities.IsWindows() && String.IsNullOrEmpty(Path.GetExtension(command)))
                 {
-                    return exeCandidate;
+                    string exeCandidate = candidate + ".exe";
+                    if (File.Exists(exeCandidate))
+                    {
+                        return exeCandidate;
+                    }
                 }
             }
 


### PR DESCRIPTION
This PR adds additional checks to look for gdb on Windows.
If a user does not specify miDebuggerPath, we will check for gdb and
gdb.exe in PATH. If a miDebuggerPath is provided and does not supply any
directory, we will search that binary and binary.exe in PATH.

https://github.com/microsoft/vscode-cpptools/issues/3076