### PR TITLE
Replace 'miMode' to 'MIMode'

### DIFF
--- a/src/OpenDebugAD7/AD7DebugSession.cs
+++ b/src/OpenDebugAD7/AD7DebugSession.cs
@@ -601,7 +601,7 @@ namespace OpenDebugAD7
             int hr;
             DateTime launchStartTime = DateTime.Now;
 
-            string mimode = responder.Arguments.ConfigurationProperties.GetValueAsString("miMode");
+            string mimode = responder.Arguments.ConfigurationProperties.GetValueAsString("MIMode");
             string program = responder.Arguments.ConfigurationProperties.GetValueAsString("program")?.Trim();
             if (string.IsNullOrEmpty(program))
             {
@@ -814,7 +814,7 @@ namespace OpenDebugAD7
             bool isLocal = string.IsNullOrEmpty(miDebuggerServerAddress) && !isPipeTransport;
             bool visualizerFileUsed = false;
             int sourceFileMappings = 0;
-            string mimode = responder.Arguments.ConfigurationProperties.GetValueAsString("miMode");
+            string mimode = responder.Arguments.ConfigurationProperties.GetValueAsString("MIMode");
 
             if (isLocal)
             {


### PR DESCRIPTION
The MIMode
Telemetry broke because we try to retrieve the string as "miMode" instead of "MIMode". Fixing it to be "MIMode" as state in our launch.json schema and MIEngineLaunchOptions also looks for "MIMode". 