### PR TITLE
Support QuoteArgs in OpenDebugAD7

### DIFF
--- a/src/OpenDebugAD7/MILaunchOptions.cs
+++ b/src/OpenDebugAD7/MILaunchOptions.cs
@@ -310,7 +310,7 @@ namespace OpenDebugAD7
             // ExeArguments
             // Build the exe's argument list as a string
             StringBuilder exeArguments = new StringBuilder();
-            exeArguments.Append(CreateArgumentList(exeArgsArray, quoteArgs: true)); // Always quote exe arguments
+            exeArguments.Append(CreateArgumentList(exeArgsArray));
             XmlSingleQuotedAttributeEncode(exeArguments);
             xmlLaunchOptions.Append(String.Concat("  ExeArguments='", exeArguments, "'\n"));
 
@@ -384,7 +384,13 @@ namespace OpenDebugAD7
             return arguments;
         }
 
-        private static string CreateArgumentList(IEnumerable<string> args, bool quoteArgs)
+        /// <summary>
+        /// Converts a list of strings arguments to a string representation.
+        /// </summary>
+        /// <param name="args">The list of arguments to convert into a string.</param>
+        /// <param name="quoteArgs">Only used for PipeTransports. This disables quote handling if the user requests it.</param>
+        /// <returns></returns>
+        private static string CreateArgumentList(IEnumerable<string> args, bool quoteArgs = true)
         {
             StringBuilder stringBuilder = new StringBuilder();
             if (args != null)

--- a/src/OpenDebugAD7/MILaunchOptions.cs
+++ b/src/OpenDebugAD7/MILaunchOptions.cs
@@ -388,7 +388,7 @@ namespace OpenDebugAD7
         /// Converts a list of strings arguments to a string representation.
         /// </summary>
         /// <param name="args">The list of arguments to convert into a string.</param>
-        /// <param name="quoteArgs">Only used for PipeTransports. This disables quote handling if the user requests it.</param>
+        /// <param name="quoteArgs">Only used for PipeTransports. Setting this to false disables quote handling if the user requests it.</param>
         /// <returns></returns>
         private static string CreateArgumentList(IEnumerable<string> args, bool quoteArgs = true)
         {


### PR DESCRIPTION
This PR adds in the QuoteArgs toggle that we have in
MIEngineLaunchOptions. This will toggle if we quote the debugger command
or not.

**Examples:**
**Configuration:**
```
"pipeTransport": {
                "debuggerPath": "/usr/bin/gdb",
                "pipeProgram": "${env:windir}\\system32\\bash.exe",
                "pipeArgs": ["-c", "${debuggerCommand}"],
                "pipeCwd": "",
                "quoteArgs": true
},
```
**Output:**
`1: (8103) Starting: "C:\windows\sysnative\bash.exe" -c "/usr/bin/gdb --interpreter=mi"`
**Configuration:**
```
"pipeTransport": {
                "debuggerPath": "/usr/bin/gdb",
                "pipeProgram": "${env:windir}\\system32\\wsl.exe",
                "pipeArgs": ["${debuggerCommand}"],
                "pipeCwd": "",
                "quoteArgs": false
},
```
**Output:**
`
1: (6374) Starting: "C:\windows\sysnative\wsl.exe" /usr/bin/gdb --interpreter=mi
`

In this case, we will not be quoting anything at all in the arguments and it is up to the user to quote their arguments. E.g. pipeArgs: ["\"quoted argument with spaces\""]