### PR TITLE
Support ClipboardContext for Evaluate Request

### DIFF
--- a/src/DebugEngineHost.Stub/DebugEngineHost.ref.cs
+++ b/src/DebugEngineHost.Stub/DebugEngineHost.ref.cs
@@ -585,4 +585,29 @@ public sealed class HostLogger
             throw new NotImplementedException();
         }
     }
+
+    /// <summary>
+    /// Provides acceess for MIEngine to determine if it is in an EvaluateRequest with specific contexes that do not
+    /// exist in enum_PARSEFLAGS.
+    /// </summary>
+    public static class HostEvaluateRequestContext
+    {
+        /// <summary>
+        /// Returns the boolean if the current EvaluareRequest's context is a clipboard context.
+        /// </summary>
+        /// <returns>true if it is in an evaluate request with a clipboard context</returns>
+        public static bool IsClipboardContext()
+        {
+            throw new NotImplementedException();
+        }
+
+        /// <summary>
+        /// Sets the current value of Clipboard Context
+        /// </summary>
+        /// <param name="clipboardContext"></param>
+        public static void SetClipboardContext(bool clipboardContext)
+        {
+            throw new NotImplementedException();
+        }
+    }
 }

--- a/src/DebugEngineHost.VSCode/DebugEngineHost.VSCode.csproj
+++ b/src/DebugEngineHost.VSCode/DebugEngineHost.VSCode.csproj
@@ -90,6 +90,7 @@
     </Reference>
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="HostEvaluateRequestContext.cs" />
     <Compile Include="HostLogger.cs" />
     <Compile Include="HostRunInTerminal.cs" />
     <Compile Include="HostTelemetry.cs" />

--- a/src/DebugEngineHost.VSCode/HostEvaluateRequestContext.cs
+++ b/src/DebugEngineHost.VSCode/HostEvaluateRequestContext.cs
@@ -1,0 +1,35 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Diagnostics;
+
+namespace Microsoft.DebugEngineHost
+{
+    /// <summary>
+    /// Provides acceess for MIEngine to determine if it is in an EvaluateRequest with specific contexes that do not
+    /// exist in enum_PARSEFLAGS.
+    /// </summary>
+    public sealed class  HostEvaluateRequestContext
+    {
+        private static bool isClipboardContext;
+
+        /// <summary>
+        /// Returns the boolean if the current EvaluareRequest's context is a clipboard context.
+        /// </summary>
+        /// <returns>true if it is in an evaluate request with a clipboard context</returns>
+        public static bool IsClipboardContext()
+        {
+            return isClipboardContext;
+        }
+
+        /// <summary>
+        /// Sets the current value of Clipboard Context
+        /// </summary>
+        /// <param name="clipboardContext"></param>
+        public static void SetClipboardContext(bool clipboardContext)
+        {
+            isClipboardContext = clipboardContext;
+        }
+    }
+}

--- a/src/DebugEngineHost/DebugEngineHost.csproj
+++ b/src/DebugEngineHost/DebugEngineHost.csproj
@@ -146,6 +146,7 @@
     <Compile Include="HostConfigurationSection.cs" />
     <Compile Include="HostConfigurationStore.cs" />
     <Compile Include="HostConfigurationException.cs" />
+    <Compile Include="HostEvaluateRequestContext.cs" />
     <Compile Include="HostLogger.cs" />
     <Compile Include="HostRunInTerminal.cs" />
     <Compile Include="HostTelemetry.cs" />

--- a/src/DebugEngineHost/HostEvaluateRequestContext.cs
+++ b/src/DebugEngineHost/HostEvaluateRequestContext.cs
@@ -1,0 +1,32 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+
+namespace Microsoft.DebugEngineHost
+{
+    /// <summary>
+    /// Provides acceess for MIEngine to determine if it is in an EvaluateRequest with specific contexes that do not
+    /// exist in enum_PARSEFLAGS.
+    /// </summary>
+    public sealed class HostEvaluateRequestContext
+    {
+        /// <summary>
+        /// Returns the boolean if the current EvaluareRequest's context is a clipboard context.
+        /// </summary>
+        /// <returns>true if it is in an evaluate request with a clipboard context</returns>
+        public static bool IsClipboardContext()
+        {
+            throw new NotImplementedException();
+        }
+
+        /// <summary>
+        /// Sets the current value of Clipboard Context
+        /// </summary>
+        /// <param name="clipboardContext"></param>
+        public static void SetClipboardContext(bool clipboardContext)
+        {
+            throw new NotImplementedException();
+        }
+    }
+}

--- a/src/OpenDebugAD7/AD7DebugSession.cs
+++ b/src/OpenDebugAD7/AD7DebugSession.cs
@@ -588,7 +588,8 @@ namespace OpenDebugAD7
                 SupportsSetVariable = true,
                 SupportsFunctionBreakpoints = m_engineConfiguration.FunctionBP,
                 SupportsConditionalBreakpoints = m_engineConfiguration.ConditionalBP,
-                ExceptionBreakpointFilters = m_engineConfiguration.ExceptionSettings.ExceptionBreakpointFilters.Select(item => new ExceptionBreakpointsFilter() { Default = item.@default, Filter = item.filter, Label = item.label }).ToList()
+                ExceptionBreakpointFilters = m_engineConfiguration.ExceptionSettings.ExceptionBreakpointFilters.Select(item => new ExceptionBreakpointsFilter() { Default = item.@default, Filter = item.filter, Label = item.label }).ToList(),
+                SupportsClipboardContext = true
             };
 
             responder.SetResponse(initializeResponse);
@@ -1887,6 +1888,11 @@ namespace OpenDebugAD7
                 flags |= enum_EVALFLAGS.EVAL_NOSIDEEFFECTS;
             }
 
+            if (context == EvaluateArguments.ContextValue.Clipboard)
+            {
+                HostEvaluateRequestContext.SetClipboardContext(true);
+            }
+
             IDebugProperty2 property;
             hr = expressionObject.EvaluateSync(flags, Constants.EvaluationTimeout, null, out property);
             eb.CheckHR(hr);
@@ -1894,6 +1900,12 @@ namespace OpenDebugAD7
 
             DEBUG_PROPERTY_INFO[] propertyInfo = new DEBUG_PROPERTY_INFO[1];
             enum_DEBUGPROP_INFO_FLAGS propertyInfoFlags = GetDefaultPropertyInfoFlags();
+
+            if (context == EvaluateArguments.ContextValue.Clipboard)
+            {
+                HostEvaluateRequestContext.SetClipboardContext(false);
+            }
+
 
             if (context == EvaluateArguments.ContextValue.Hover) // No side effects for data tips
             {

--- a/src/OpenDebugAD7/OpenDebugAD7.csproj
+++ b/src/OpenDebugAD7/OpenDebugAD7.csproj
@@ -106,7 +106,7 @@
     </Reference>
     <!-- Same version as in packages.config -->
     <Reference Include="Microsoft.VisualStudio.Shared.VSCodeDebugProtocol">
-      <HintPath>$(NuGetPackagesDirectory)/Microsoft.VisualStudio.Shared.VsCodeDebugProtocol.16.3.30820.2/lib/net45/Microsoft.VisualStudio.Shared.VSCodeDebugProtocol.dll</HintPath>
+      <HintPath>$(NuGetPackagesDirectory)/Microsoft.VisualStudio.Shared.VsCodeDebugProtocol.16.6.40406.1/lib/net45/Microsoft.VisualStudio.Shared.VSCodeDebugProtocol.dll</HintPath>
       <ForceIncludeInVSIX>true</ForceIncludeInVSIX>
     </Reference>
     <Reference Include="Newtonsoft.Json">

--- a/src/OpenDebugAD7/packages.config
+++ b/src/OpenDebugAD7/packages.config
@@ -6,5 +6,5 @@
   <package id="Mono.Unofficial.pdb2mdb" version="4.2.3.4" />
 
   <!-- Update the version number VsCodeDebugProtocol HintPath in OpenDebugAD7\OpenDebugAD7.csproj -->
-  <package id="Microsoft.VisualStudio.Shared.VsCodeDebugProtocol" version="16.3.30820.2" />
+  <package id="Microsoft.VisualStudio.Shared.VsCodeDebugProtocol" version="16.6.40406.1" />
 </packages>


### PR DESCRIPTION
Users who want to copy the full string from the UI will use "copy value"
from the EE windows. This will send an EvaluateRequest with the context
of Clipboard.

This PR noticies the context in OpenDebugAD7 and sets the
HostEvaluateRequestContext's isClipboardContext for MIEngine to query.
If it is true, MIEngine will save the previous value of 'show print
elements', set it to unlimited, and reset it back to the original value
after it evaluates the variable. Then it will provide the full string
back to the user to copy.

**NOTE**: Requires VS Code 1.46.0 to work. Previous engines set the `expression` to be the _value_ of the original expression instead of the _actual expression_.
See https://github.com/microsoft/vscode/issues/97444#issuecomment-630049720