### PR TITLE
Support ClipboardContext for Evaluate Request

### DIFF
--- a/src/DebugEngineHost.VSCode/VSCode/EngineConfiguration.cs
+++ b/src/DebugEngineHost.VSCode/VSCode/EngineConfiguration.cs
@@ -32,6 +32,7 @@ namespace Microsoft.DebugEngineHost.VSCode
         private readonly ExceptionSettings _exceptionSettings = new ExceptionSettings();
         private bool _conditionalBP;
         private bool _functionBP;
+        private bool _clipboardContext;
 
         // NOTE: CoreCLR doesn't support providing a code base when loading assemblies. So all debug engines
         // must be placed in the directory of OpenDebugAD7.exe
@@ -66,6 +67,12 @@ namespace Microsoft.DebugEngineHost.VSCode
             get { return _functionBP; }
             set { SetProperty(out _functionBP, value); }
         }
+
+        public bool ClipboardContext { 
+            get { return _clipboardContext; } 
+            set { SetProperty(out _clipboardContext, value); }
+        }
+
 
         /// <summary>
         /// Provides the directory of the debug adapter. This is the directory where

--- a/src/DebugEngineHost.VSCode/VSCode/EngineConfiguration.cs
+++ b/src/DebugEngineHost.VSCode/VSCode/EngineConfiguration.cs
@@ -68,7 +68,8 @@ namespace Microsoft.DebugEngineHost.VSCode
             set { SetProperty(out _functionBP, value); }
         }
 
-        public bool ClipboardContext { 
+        public bool ClipboardContext
+        { 
             get { return _clipboardContext; } 
             set { SetProperty(out _clipboardContext, value); }
         }

--- a/src/MIDebugEngine.sln
+++ b/src/MIDebugEngine.sln
@@ -100,6 +100,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "MakePIAPortable", "MakePIAP
 		{D582C0B6-032F-4686-B01D-EB55694059CB} = {D582C0B6-032F-4686-B01D-EB55694059CB}
 	EndProjectSection
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Microsoft.VisualStudio.Debugger.Interop.DAP", "Microsoft.VisualStudio.Debugger.Interop.DAP\Microsoft.VisualStudio.Debugger.Interop.DAP.csproj", "{23DE943C-1F84-4E23-9490-50FE1DEDE858}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -302,6 +304,18 @@ Global
 		{114039A0-87B5-425B-90C9-6AFC1960A247}.Lab.Debug|Any CPU.ActiveCfg = Desktop.Release|Any CPU
 		{114039A0-87B5-425B-90C9-6AFC1960A247}.Lab.Release|Any CPU.ActiveCfg = Desktop.Release|Any CPU
 		{114039A0-87B5-425B-90C9-6AFC1960A247}.Release|Any CPU.ActiveCfg = Desktop.Release|Any CPU
+		{23DE943C-1F84-4E23-9490-50FE1DEDE858}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{23DE943C-1F84-4E23-9490-50FE1DEDE858}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{23DE943C-1F84-4E23-9490-50FE1DEDE858}.Desktop.Debug|Any CPU.ActiveCfg = Desktop.Debug|Any CPU
+		{23DE943C-1F84-4E23-9490-50FE1DEDE858}.Desktop.Debug|Any CPU.Build.0 = Desktop.Debug|Any CPU
+		{23DE943C-1F84-4E23-9490-50FE1DEDE858}.Desktop.Release|Any CPU.ActiveCfg = Desktop.Release|Any CPU
+		{23DE943C-1F84-4E23-9490-50FE1DEDE858}.Desktop.Release|Any CPU.Build.0 = Desktop.Release|Any CPU
+		{23DE943C-1F84-4E23-9490-50FE1DEDE858}.Lab.Debug|Any CPU.ActiveCfg = Lab.Debug|Any CPU
+		{23DE943C-1F84-4E23-9490-50FE1DEDE858}.Lab.Debug|Any CPU.Build.0 = Lab.Debug|Any CPU
+		{23DE943C-1F84-4E23-9490-50FE1DEDE858}.Lab.Release|Any CPU.ActiveCfg = Lab.Release|Any CPU
+		{23DE943C-1F84-4E23-9490-50FE1DEDE858}.Lab.Release|Any CPU.Build.0 = Lab.Release|Any CPU
+		{23DE943C-1F84-4E23-9490-50FE1DEDE858}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{23DE943C-1F84-4E23-9490-50FE1DEDE858}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/src/MIDebugEngine/AD7.Impl/AD7Expression.cs
+++ b/src/MIDebugEngine/AD7.Impl/AD7Expression.cs
@@ -67,7 +67,7 @@ namespace Microsoft.MIDebugEngine
         // This method evaluates the expression synchronously.
         int IDebugExpression2.EvaluateSync(enum_EVALFLAGS dwFlags, uint dwTimeout, IDebugEventCallback2 pExprCallback, out IDebugProperty2 ppResult)
         {
-            return EvaluateSync(dwFlags, DAPEvalFlags.NONE, dwTimeout, pExprCallback, out ppResult);
+            return EvaluateSyncInternal(dwFlags, DAPEvalFlags.NONE, dwTimeout, pExprCallback, out ppResult);
         }
 
         #endregion
@@ -76,12 +76,12 @@ namespace Microsoft.MIDebugEngine
 
         int IDebugExpressionDAP.EvaluateSync(enum_EVALFLAGS dwFlags, DAPEvalFlags dapFlags, uint dwTimeout, IDebugEventCallback2 pExprCallback, out IDebugProperty2 ppResult)
         {
-            return EvaluateSync(dwFlags, dapFlags, dwTimeout, pExprCallback, out ppResult);
+            return EvaluateSyncInternal(dwFlags, dapFlags, dwTimeout, pExprCallback, out ppResult);
         }
 
         #endregion
 
-        private int EvaluateSync(enum_EVALFLAGS dwFlags, DAPEvalFlags dapFlags, uint dwTimeout, IDebugEventCallback2 pExprCallback, out IDebugProperty2 ppResult)
+        private int EvaluateSyncInternal(enum_EVALFLAGS dwFlags, DAPEvalFlags dapFlags, uint dwTimeout, IDebugEventCallback2 pExprCallback, out IDebugProperty2 ppResult)
         {
             ppResult = null;
             if ((dwFlags & enum_EVALFLAGS.EVAL_NOSIDEEFFECTS) != 0 && _var.IsVisualized)

--- a/src/MIDebugEngine/AD7.Impl/AD7Expression.cs
+++ b/src/MIDebugEngine/AD7.Impl/AD7Expression.cs
@@ -67,25 +67,7 @@ namespace Microsoft.MIDebugEngine
         // This method evaluates the expression synchronously.
         int IDebugExpression2.EvaluateSync(enum_EVALFLAGS dwFlags, uint dwTimeout, IDebugEventCallback2 pExprCallback, out IDebugProperty2 ppResult)
         {
-            ppResult = null;
-            if ((dwFlags & enum_EVALFLAGS.EVAL_NOSIDEEFFECTS) != 0 && _var.IsVisualized)
-            {
-                IVariableInformation variable = _engine.DebuggedProcess.Natvis.Cache.Lookup(_var);
-                if (variable == null)
-                {
-                    ppResult = new AD7ErrorProperty(_var.Name, ResourceStrings.NoSideEffectsVisualizerMessage);
-                }
-                else
-                {
-                    _var = variable;
-                    ppResult = new AD7Property(_engine, _var);
-                }
-                return Constants.S_OK;
-            }
-
-            _var.SyncEval(dwFlags);
-            ppResult = new AD7Property(_engine, _var);
-            return Constants.S_OK;
+            return EvaluateSync(dwFlags, DAPEvalFlags.NONE, dwTimeout, pExprCallback, out ppResult);
         }
 
         #endregion
@@ -93,6 +75,13 @@ namespace Microsoft.MIDebugEngine
         #region IDebugExpressionDAP
 
         int IDebugExpressionDAP.EvaluateSync(enum_EVALFLAGS dwFlags, DAPEvalFlags dapFlags, uint dwTimeout, IDebugEventCallback2 pExprCallback, out IDebugProperty2 ppResult)
+        {
+            return EvaluateSync(dwFlags, dapFlags, dwTimeout, pExprCallback, out ppResult);
+        }
+
+        #endregion
+
+        private int EvaluateSync(enum_EVALFLAGS dwFlags, DAPEvalFlags dapFlags, uint dwTimeout, IDebugEventCallback2 pExprCallback, out IDebugProperty2 ppResult)
         {
             ppResult = null;
             if ((dwFlags & enum_EVALFLAGS.EVAL_NOSIDEEFFECTS) != 0 && _var.IsVisualized)
@@ -110,12 +99,10 @@ namespace Microsoft.MIDebugEngine
                 return Constants.S_OK;
             }
 
-            _var.SyncEval(dapFlags, dwFlags);
+            _var.SyncEval(dwFlags, dapFlags);
             ppResult = new AD7Property(_engine, _var);
             return Constants.S_OK;
         }
-
-        #endregion
 
     }
 }

--- a/src/MIDebugEngine/MIDebugEngine.csproj
+++ b/src/MIDebugEngine/MIDebugEngine.csproj
@@ -172,7 +172,7 @@
     <ProjectReference Include="..\Microsoft.VisualStudio.Debugger.Interop.DAP\Microsoft.VisualStudio.Debugger.Interop.DAP.csproj">
       <Project>{23DE943C-1F84-4E23-9490-50FE1DEDE858}</Project>
       <Name>Microsoft.VisualStudio.Debugger.Interop.DAP</Name>
-	  <EmbedInteropTypes>True</EmbedInteropTypes>
+      <EmbedInteropTypes>True</EmbedInteropTypes>
     </ProjectReference>
     <ProjectReference Include="..\Microsoft.VisualStudio.Debugger.Interop.UnixPortSupplier\Microsoft.VisualStudio.Debugger.Interop.UnixPortSupplier.DesignTime.csproj">
       <Project>{7654cfbb-30db-4c20-bde3-a960cba2036c}</Project>

--- a/src/MIDebugEngine/MIDebugEngine.csproj
+++ b/src/MIDebugEngine/MIDebugEngine.csproj
@@ -169,6 +169,11 @@
       <Project>{54c33afa-438d-4932-a2f0-d0f2bb2fadc9}</Project>
       <Name>MICore</Name>
     </ProjectReference>
+    <ProjectReference Include="..\Microsoft.VisualStudio.Debugger.Interop.DAP\Microsoft.VisualStudio.Debugger.Interop.DAP.csproj">
+      <Project>{23DE943C-1F84-4E23-9490-50FE1DEDE858}</Project>
+      <Name>Microsoft.VisualStudio.Debugger.Interop.DAP</Name>
+	  <EmbedInteropTypes>True</EmbedInteropTypes>
+    </ProjectReference>
     <ProjectReference Include="..\Microsoft.VisualStudio.Debugger.Interop.UnixPortSupplier\Microsoft.VisualStudio.Debugger.Interop.UnixPortSupplier.DesignTime.csproj">
       <Project>{7654cfbb-30db-4c20-bde3-a960cba2036c}</Project>
       <Name>Microsoft.VisualStudio.Debugger.Interop.UnixPortSupplier.DesignTime</Name>

--- a/src/MIDebugEngine/Natvis.Impl/Natvis.cs
+++ b/src/MIDebugEngine/Natvis.Impl/Natvis.cs
@@ -54,8 +54,7 @@ namespace Microsoft.MIDebugEngine.Natvis
         public VariableInformation FindChildByName(string name) => Parent.FindChildByName(name);
         public string EvalDependentExpression(string expr) => Parent.EvalDependentExpression(expr);
         public void AsyncEval(IDebugEventCallback2 pExprCallback) => Parent.AsyncEval(pExprCallback);
-        public void SyncEval(enum_EVALFLAGS dwFlags) => this.SyncEval(DAPEvalFlags.NONE, dwFlags);
-        public void SyncEval(DAPEvalFlags dwDAPFlags, enum_EVALFLAGS dwFlags) => Parent.SyncEval(dwDAPFlags, dwFlags);
+        public void SyncEval(enum_EVALFLAGS dwFlags, DAPEvalFlags dwDAPFlags) => Parent.SyncEval(dwFlags, dwDAPFlags);
         public virtual string FullName() => Name;
         public void EnsureChildren() => Parent.EnsureChildren();
         public void AsyncError(IDebugEventCallback2 pExprCallback, IDebugProperty2 error)

--- a/src/MIDebugEngine/Natvis.Impl/Natvis.cs
+++ b/src/MIDebugEngine/Natvis.Impl/Natvis.cs
@@ -19,6 +19,7 @@ using Microsoft.DebugEngineHost;
 using System.Reflection;
 
 using Logger = MICore.Logger;
+using Microsoft.VisualStudio.Debugger.Interop.DAP;
 
 namespace Microsoft.MIDebugEngine.Natvis
 {
@@ -53,7 +54,8 @@ namespace Microsoft.MIDebugEngine.Natvis
         public VariableInformation FindChildByName(string name) => Parent.FindChildByName(name);
         public string EvalDependentExpression(string expr) => Parent.EvalDependentExpression(expr);
         public void AsyncEval(IDebugEventCallback2 pExprCallback) => Parent.AsyncEval(pExprCallback);
-        public void SyncEval(enum_EVALFLAGS dwFlags) => Parent.SyncEval(dwFlags);
+        public void SyncEval(enum_EVALFLAGS dwFlags) => this.SyncEval(DAPEvalFlags.NONE, dwFlags);
+        public void SyncEval(DAPEvalFlags dwDAPFlags, enum_EVALFLAGS dwFlags) => Parent.SyncEval(dwDAPFlags, dwFlags);
         public virtual string FullName() => Name;
         public void EnsureChildren() => Parent.EnsureChildren();
         public void AsyncError(IDebugEventCallback2 pExprCallback, IDebugProperty2 error)

--- a/src/Microsoft.VisualStudio.Debugger.Interop.DAP/Microsoft.VisualStudio.Debugger.Interop.DAP.cs
+++ b/src/Microsoft.VisualStudio.Debugger.Interop.DAP/Microsoft.VisualStudio.Debugger.Interop.DAP.cs
@@ -1,0 +1,42 @@
+﻿using System;
+using System.Runtime.InteropServices;
+
+namespace Microsoft.VisualStudio.Debugger.Interop.DAP
+{
+    /// <summary>
+    /// An extended set of evaluate flags that are in Debug Adapter Protocol but not listed in AD7
+    /// </summary>
+    public enum DAPEvalFlags
+    {
+        /// <summary>
+        /// No additional Eval Flags from DAP
+        /// </summary>
+        NONE = 0,
+        /// <summary>
+        /// Evaluation is for a clipboard context
+        /// </summary>
+        CLIPBOARD_CONTEXT = 1
+    }
+
+    /// <summary>
+    /// IDebugExpresssion for Debug Adapter Protocol
+    /// </summary>
+    [ComImport()]
+    [ComVisible(true)]
+    [Guid("76C710C4-CE66-4422-AC7C-1E41B3FC0BE3")]
+    [InterfaceType(1)]
+    public interface IDebugExpressionDAP
+    {
+        /// <summary>
+        /// Evaluate for IDebugExpressionDAP
+        /// </summary>
+        /// <param name="dwFlags"></param>
+        /// <param name="dapFlags"></param>
+        /// <param name="dwTimeout"></param>
+        /// <param name="pExprCallback"></param>
+        /// <param name="ppResult"></param>
+        /// <returns></returns>
+        [PreserveSig]
+        int EvaluateSync([In] enum_EVALFLAGS dwFlags, [In] DAPEvalFlags dapFlags, [In] uint dwTimeout, [In][MarshalAs(UnmanagedType.Interface)] IDebugEventCallback2 pExprCallback, [Out, MarshalAs(UnmanagedType.Interface)] out IDebugProperty2 ppResult);
+    }
+}

--- a/src/Microsoft.VisualStudio.Debugger.Interop.DAP/Microsoft.VisualStudio.Debugger.Interop.DAP.cs
+++ b/src/Microsoft.VisualStudio.Debugger.Interop.DAP/Microsoft.VisualStudio.Debugger.Interop.DAP.cs
@@ -20,7 +20,7 @@ namespace Microsoft.VisualStudio.Debugger.Interop.DAP
     }
 
     /// <summary>
-    /// IDebugExpresssion for Debug Adapter Protocol
+    /// IDebugExpression for Debug Adapter Protocol
     /// </summary>
     [ComImport()]
     [ComVisible(true)]
@@ -29,14 +29,9 @@ namespace Microsoft.VisualStudio.Debugger.Interop.DAP
     public interface IDebugExpressionDAP
     {
         /// <summary>
-        /// Evaluate for IDebugExpressionDAP
+        /// The IDebugExpression.EvaluateSync interface which includes DAPEvalFlags. 
+        /// This method is to be used with calls from clients using the Debug Adapter Protocol.
         /// </summary>
-        /// <param name="dwFlags"></param>
-        /// <param name="dapFlags"></param>
-        /// <param name="dwTimeout"></param>
-        /// <param name="pExprCallback"></param>
-        /// <param name="ppResult"></param>
-        /// <returns></returns>
         [PreserveSig]
         int EvaluateSync([In] enum_EVALFLAGS dwFlags, [In] DAPEvalFlags dapFlags, [In] uint dwTimeout, [In][MarshalAs(UnmanagedType.Interface)] IDebugEventCallback2 pExprCallback, [Out, MarshalAs(UnmanagedType.Interface)] out IDebugProperty2 ppResult);
     }

--- a/src/Microsoft.VisualStudio.Debugger.Interop.DAP/Microsoft.VisualStudio.Debugger.Interop.DAP.cs
+++ b/src/Microsoft.VisualStudio.Debugger.Interop.DAP/Microsoft.VisualStudio.Debugger.Interop.DAP.cs
@@ -6,6 +6,7 @@ namespace Microsoft.VisualStudio.Debugger.Interop.DAP
     /// <summary>
     /// An extended set of evaluate flags that are in Debug Adapter Protocol but not listed in AD7
     /// </summary>
+    [Flags]
     public enum DAPEvalFlags
     {
         /// <summary>

--- a/src/Microsoft.VisualStudio.Debugger.Interop.DAP/Microsoft.VisualStudio.Debugger.Interop.DAP.csproj
+++ b/src/Microsoft.VisualStudio.Debugger.Interop.DAP/Microsoft.VisualStudio.Debugger.Interop.DAP.csproj
@@ -1,0 +1,78 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <!-- miengine.settings.targets must be imported first as it sets $(NuGetPackagesDirectory) -->
+  <Import Project="..\..\build\miengine.settings.targets" />
+  <Import Project="$(NuGetPackagesDirectory)\MicroBuild.Core.0.2.0\build\MicroBuild.Core.props" Condition="Exists('$(NuGetPackagesDirectory)\MicroBuild.Core.0.2.0\build\MicroBuild.Core.props')" />
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{23DE943C-1F84-4E23-9490-50FE1DEDE858}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>Microsoft.VisualStudio.Debugger.Interop.DAP</RootNamespace>
+    <AssemblyName>Microsoft.VisualStudio.Debugger.Interop.DAP</AssemblyName>
+    <OutputPath>bin\$(Configuration)</OutputPath>
+    <DocumentationFile>$(DropRootDir)\ReferenceAssemblies\$(AssemblyName).xml</DocumentationFile>
+    <CodeAnalysisRuleSet>..\IDECodeAnalysis.ruleset</CodeAnalysisRuleSet>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+    <DebugSymbols>false</DebugSymbols>
+    <DebugType>pdbonly</DebugType>
+    <NonShipping>true</NonShipping>
+    <EnableSourceLink>false</EnableSourceLink>
+    <TargetFrameworkVersion>v4.6.2</TargetFrameworkVersion>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <Optimize>false</Optimize>
+    <DefineConstants>$(DefineConstants);DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <DefineConstants>$(DefineConstants);TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Desktop.Debug|AnyCPU'">
+    <Optimize>false</Optimize>
+    <DefineConstants>$(DefineConstants);DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+    <Prefer32Bit>false</Prefer32Bit>
+    <RunCodeAnalysis>true</RunCodeAnalysis>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Desktop.Release|AnyCPU'">
+    <DefineConstants>$(DefineConstants);TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+    <Prefer32Bit>false</Prefer32Bit>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Lab.Debug|AnyCPU'">
+    <DefineConstants>$(DefineConstants);DEBUG;TRACE</DefineConstants>
+    <PlatformTarget>AnyCPU</PlatformTarget>
+    <ErrorReport>prompt</ErrorReport>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Lab.Release|AnyCPU'">
+    <DefineConstants>$(DefineConstants);TRACE</DefineConstants>
+    <Optimize>true</Optimize>
+    <PlatformTarget>AnyCPU</PlatformTarget>
+    <ErrorReport>prompt</ErrorReport>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="System" />
+    <Reference Include="Microsoft.VisualStudio.Debugger.InteropA">
+      <HintPath>$(NuGetPackagesDirectory)/Microsoft.VisualStudio.Debugger.Interop.Portable.1.0.1/lib/portable-net45+net46+dnxcore50/Microsoft.VisualStudio.Debugger.InteropA.dll</HintPath>
+    </Reference>
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="Microsoft.VisualStudio.Debugger.Interop.DAP.cs" />
+    <Compile Include="Properties\AssemblyInfo.cs" />
+  </ItemGroup>
+  <PropertyGroup>
+    <DropSubDir>ReferenceAssemblies</DropSubDir>
+  </PropertyGroup>
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <Import Project="..\..\build\miengine.targets" />
+  <Import Project="$(NuGetPackagesDirectory)\MicroBuild.Core.0.2.0\build\MicroBuild.Core.targets" Condition="Exists('$(NuGetPackagesDirectory)\MicroBuild.Core.0.2.0\build\MicroBuild.Core.targets')" />
+  <Import Project="..\..\build\DropFiles.targets" />
+</Project>

--- a/src/Microsoft.VisualStudio.Debugger.Interop.DAP/Properties/AssemblyInfo.cs
+++ b/src/Microsoft.VisualStudio.Debugger.Interop.DAP/Properties/AssemblyInfo.cs
@@ -1,0 +1,21 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Reflection;
+using System.Runtime.InteropServices;
+using System;
+
+// General Information about an assembly is controlled through the following
+// set of attributes. Change these attribute values to modify the information
+// associated with an assembly.
+[assembly: AssemblyTitle("Microsoft.VisualStudio.Debugger.Interop.DAP")]
+[assembly: AssemblyDescription("Additional interop interfaces for the Debug Adapter Protocol.")]
+[assembly: AssemblyConfiguration("")]
+[assembly: AssemblyTrademark("")]
+[assembly: AssemblyCulture("")]
+
+// The following GUID is for the ID of the typelib if this project is exposed to COM
+[assembly: Guid("23de943c-1f84-4e23-9490-50fe1dede858")]
+
+// Add the PrimaryInteropAssemblyAttribute so that this assembly can be used with 'Embed Interop Types'
+[assembly: System.Runtime.InteropServices.PrimaryInteropAssemblyAttribute(1, 0)]

--- a/src/OpenDebugAD7/AD7DebugSession.cs
+++ b/src/OpenDebugAD7/AD7DebugSession.cs
@@ -1864,8 +1864,6 @@ namespace OpenDebugAD7
             hr = frame.GetExpressionContext(out expressionContext);
             eb.CheckHR(hr);
 
-            System.Diagnostics.Debugger.Launch();
-
             const uint InputRadix = 10;
             DAPEvalFlags dapEvalFlags = DAPEvalFlags.NONE;
             IDebugExpression2 expressionObject;
@@ -1898,14 +1896,15 @@ namespace OpenDebugAD7
             }
 
             IDebugProperty2 property;
-            if (dapEvalFlags != DAPEvalFlags.NONE)
+            if (expressionObject is IDebugExpressionDAP expressionDapObject)
             {
-                hr = ((IDebugExpressionDAP)expressionObject).EvaluateSync(flags, dapEvalFlags, Constants.EvaluationTimeout, null, out property);
+                hr = expressionDapObject.EvaluateSync(flags, dapEvalFlags, Constants.EvaluationTimeout, null, out property);
             }
             else
             {
                 hr = expressionObject.EvaluateSync(flags, Constants.EvaluationTimeout, null, out property);
             }
+
             eb.CheckHR(hr);
             eb.CheckOutput(property);
 

--- a/src/OpenDebugAD7/OpenDebugAD7.csproj
+++ b/src/OpenDebugAD7/OpenDebugAD7.csproj
@@ -164,7 +164,7 @@
     <ProjectReference Include="..\Microsoft.VisualStudio.Debugger.Interop.DAP\Microsoft.VisualStudio.Debugger.Interop.DAP.csproj">
       <Project>{23DE943C-1F84-4E23-9490-50FE1DEDE858}</Project>
       <Name>Microsoft.VisualStudio.Debugger.Interop.DAP</Name>
-	  <EmbedInteropTypes>True</EmbedInteropTypes>
+      <EmbedInteropTypes>True</EmbedInteropTypes>
     </ProjectReference>
   </ItemGroup>
   <ItemGroup>

--- a/src/OpenDebugAD7/OpenDebugAD7.csproj
+++ b/src/OpenDebugAD7/OpenDebugAD7.csproj
@@ -106,7 +106,7 @@
     </Reference>
     <!-- Same version as in packages.config -->
     <Reference Include="Microsoft.VisualStudio.Shared.VSCodeDebugProtocol">
-      <HintPath>$(NuGetPackagesDirectory)/Microsoft.VisualStudio.Shared.VsCodeDebugProtocol.16.3.30820.2/lib/net45/Microsoft.VisualStudio.Shared.VSCodeDebugProtocol.dll</HintPath>
+      <HintPath>$(NuGetPackagesDirectory)/Microsoft.VisualStudio.Shared.VsCodeDebugProtocol.16.6.40406.1/lib/net45/Microsoft.VisualStudio.Shared.VSCodeDebugProtocol.dll</HintPath>
       <ForceIncludeInVSIX>true</ForceIncludeInVSIX>
     </Reference>
     <Reference Include="Newtonsoft.Json">
@@ -160,6 +160,11 @@
     <ProjectReference Include="..\DebugEngineHost.VSCode\DebugEngineHost.VSCode.csproj">
       <Project>{81de2423-fb5e-4069-b3c5-4c13ce76dc0a}</Project>
       <Name>DebugEngineHost.VSCode</Name>
+    </ProjectReference>
+    <ProjectReference Include="..\Microsoft.VisualStudio.Debugger.Interop.DAP\Microsoft.VisualStudio.Debugger.Interop.DAP.csproj">
+      <Project>{23DE943C-1F84-4E23-9490-50FE1DEDE858}</Project>
+      <Name>Microsoft.VisualStudio.Debugger.Interop.DAP</Name>
+	  <EmbedInteropTypes>True</EmbedInteropTypes>
     </ProjectReference>
   </ItemGroup>
   <ItemGroup>

--- a/src/OpenDebugAD7/cppdbg.ad7Engine.json
+++ b/src/OpenDebugAD7/cppdbg.ad7Engine.json
@@ -2,5 +2,6 @@
   "engineAssemblyName": "Microsoft.MIDebugEngine, Version=14.0.0.0",
   "engineClassName": "Microsoft.MIDebugEngine.AD7Engine",
   "conditionalBP": true,
-  "functionBP": true
+  "functionBP": true,
+  "clipboardContext": true
 }

--- a/src/OpenDebugAD7/packages.config
+++ b/src/OpenDebugAD7/packages.config
@@ -6,5 +6,5 @@
   <package id="Mono.Unofficial.pdb2mdb" version="4.2.3.4" />
 
   <!-- Update the version number VsCodeDebugProtocol HintPath in OpenDebugAD7\OpenDebugAD7.csproj -->
-  <package id="Microsoft.VisualStudio.Shared.VsCodeDebugProtocol" version="16.3.30820.2" />
+  <package id="Microsoft.VisualStudio.Shared.VsCodeDebugProtocol" version="16.6.40406.1" />
 </packages>


### PR DESCRIPTION
    Users who want to copy the full string from the UI will use "copy value"
    from the EE windows. This will send an EvaluateRequest with the context
    of Clipboard.

    This PR noticies the context in OpenDebugAD7 and uses IDebugExpressionDAP
    with DAPEvalFlag ClipboardContext set for MIEngine to query.
    If it is set, MIEngine will save the previous value of 'show print
    elements', set it to unlimited, and reset it back to the original value
    after it evaluates the variable. Then it will provide the full string
    back to the user to copy.

NOTE: Requires VS Code 1.46.0 to work. Previous engines set the expression to be the value of the original expression instead of the actual expression.