### PR TITLE
Fixing Conditional Breakpoints for VS Code

### DIFF
--- a/src/MIDebugEngine/Engine.Impl/Variables.cs
+++ b/src/MIDebugEngine/Engine.Impl/Variables.cs
@@ -522,7 +522,7 @@ namespace Microsoft.MIDebugEngine
                                 }
                                 else
                                 {
-                                    Debug.Fail("Weird msg from -var-evaluate-expression");
+                                    Debug.Fail("Unexpected format of msg from -var-evaluate-expression");
                                 }
                             }
                         }
@@ -533,7 +533,7 @@ namespace Microsoft.MIDebugEngine
                     }
                     else
                     {
-                        Debug.Fail("Weird msg from -var-create");
+                        Debug.Fail("Unexpected format of msg from -var-create");
                     }
                 }
             }
@@ -570,7 +570,7 @@ namespace Microsoft.MIDebugEngine
             }
             else
             {
-                Debug.Fail("Weird msg from expression formatting");
+                Debug.Fail("Unexpected format of msg from expression formatting");
             }
         }
 

--- a/src/OpenDebugAD7/AD7DebugSession.cs
+++ b/src/OpenDebugAD7/AD7DebugSession.cs
@@ -1598,7 +1598,7 @@ namespace OpenDebugAD7
                                 breakpointRequest is AD7BreakPointRequest ad7BPRequest)
                             {
                                 // Check to see if this breakpoint has a condition that has changed.
-                                if (!StringComparer.InvariantCulture.Equals(ad7BPRequest.Condition, bp.Condition))
+                                if (!StringComparer.Ordinal.Equals(ad7BPRequest.Condition, bp.Condition))
                                 {
                                     // Condition has been modified. Delete breakpoint so it will be recreated with the updated condition.
                                     var toRemove = dict[bp.Line];
@@ -1765,7 +1765,7 @@ namespace OpenDebugAD7
                                 breakpointRequest is AD7BreakPointRequest ad7BPRequest)
                     {
                         // Check to see if this breakpoint has a condition that has changed.
-                        if (!StringComparer.InvariantCulture.Equals(ad7BPRequest.Condition, b.Condition))
+                        if (!StringComparer.Ordinal.Equals(ad7BPRequest.Condition, b.Condition))
                         {
                             // Condition has been modified. Delete breakpoint so it will be recreated with the updated condition.
                             var toRemove = m_functionBreakpoints[b.Name];


### PR DESCRIPTION
VS Code has modified the way it handles conditional breakpoints.
It used to send a SetBreakpoints that removed the breakpoint and a new
SetBreakpoints request with the updated condition.

This change now keeps track of breakpoint conditions and recreate them
if the condition has changed.