### PR TITLE
Log ClientId in Telemetry

### DIFF
--- a/src/DebugEngineHost.VSCode/HostTelemetry.cs
+++ b/src/DebugEngineHost.VSCode/HostTelemetry.cs
@@ -28,14 +28,16 @@ namespace Microsoft.DebugEngineHost
         private const string TelemetryEngineVersion = @"VS.Diagnostics.Debugger.EngineVersion";
         private const string TelemetryHostVersion = @"VS.Diagnostics.Debugger.HostVersion";
         private const string TelemetryAdapterId = @"VS.Diagnostics.Debugger.AdapterId";
+        private const string TelemetryClientId = @"VS.Diagnostics.Debugger.ClientId";
 
         private static Action<string, KeyValuePair<string, object>[]> s_telemetryCallback;
         private static string s_engineName;
         private static string s_engineVersion;
         private static string s_hostVersion;
         private static string s_adapterId;
+        private static string s_clientId;
 
-        public static void InitializeTelemetry(Action<string, KeyValuePair<string, object>[]> telemetryCallback, TypeInfo engineType, string adapterId)
+        public static void InitializeTelemetry(Action<string, KeyValuePair<string, object>[]> telemetryCallback, TypeInfo engineType, string adapterId, string clientId)
         {
             Debug.Assert(telemetryCallback != null && engineType != null, "Bogus arguments to InitializeTelemetry");
             s_telemetryCallback = telemetryCallback;
@@ -43,6 +45,7 @@ namespace Microsoft.DebugEngineHost
             s_engineVersion = GetVersionAttributeValue(engineType);
             s_hostVersion = GetVersionAttributeValue(typeof(HostTelemetry).GetTypeInfo());
             s_adapterId = adapterId;
+            s_clientId = clientId;
         }
 
         /// <summary>
@@ -98,7 +101,8 @@ namespace Microsoft.DebugEngineHost
                     new KeyValuePair<string, object>(TelemetryNonFatalErrorExceptionHResult, currentException.HResult),
                     new KeyValuePair<string, object>(TelemetryEngineVersion, s_engineVersion),
                     new KeyValuePair<string, object>(TelemetryAdapterId, s_adapterId),
-                    new KeyValuePair<string, object>(TelemetryHostVersion, s_hostVersion)
+                    new KeyValuePair<string, object>(TelemetryHostVersion, s_hostVersion),
+                    new KeyValuePair<string, object>(TelemetryClientId, s_clientId)
                     );
             }
             catch

--- a/src/OpenDebugAD7/Telemetry/DebuggerTelemetry.cs
+++ b/src/OpenDebugAD7/Telemetry/DebuggerTelemetry.cs
@@ -41,10 +41,12 @@ namespace OpenDebugAD7
         private const string TelemetryEngineVersion = "EngineVersion";
         private const string TelemetryHostVersion = "HostVersion";
         private const string TelemetryAdapterId = "AdapterId";
+        private const string TelemetryClientId = "ClientId";
         private string _engineName;
         private string _engineVersion;
         private string _hostVersion;
         private string _adapterId;
+        private string _clientId;
 
         // Specific telemetry properties
         public const string TelemetryIsCoreDump = TelemetryLaunchEventName + ".IsCoreDump";
@@ -56,7 +58,7 @@ namespace OpenDebugAD7
         public const string TelemetryMIMode = "MIMode";
         public const string TelemetryStackFrameId = TelemetryExecuteInConsole + ".ExecuteInConsole";
 
-        private DebuggerTelemetry(Action<DebugEvent> callback, TypeInfo engineType, TypeInfo hostType, string adapterId)
+        private DebuggerTelemetry(Action<DebugEvent> callback, TypeInfo engineType, TypeInfo hostType, string adapterId, string clientId)
         {
             Debug.Assert(_engineName == null && _engineVersion == null, "InitializeTelemetry called more than once?");
 
@@ -65,15 +67,16 @@ namespace OpenDebugAD7
             _engineVersion = GetVersionAttributeValue(engineType);
             _hostVersion = GetVersionAttributeValue(hostType);
             _adapterId = adapterId;
+            _clientId = clientId;
         }
 
         #region Public Static Methods
 
-        public static void InitializeTelemetry(Action<DebugEvent> telemetryCallback, TypeInfo engineType, TypeInfo hostType, string adapterId)
+        public static void InitializeTelemetry(Action<DebugEvent> telemetryCallback, TypeInfo engineType, TypeInfo hostType, string adapterId, string clientId)
         {
             Debug.Assert(telemetryCallback != null, "InitializeTelemetry called with incorrect values.");
 
-            s_telemetryInstance = new DebuggerTelemetry(telemetryCallback, engineType, hostType, adapterId);
+            s_telemetryInstance = new DebuggerTelemetry(telemetryCallback, engineType, hostType, adapterId, clientId);
         }
 
         /// <summary>
@@ -209,6 +212,7 @@ namespace OpenDebugAD7
             properties[TelemetryEngineVersion] = _engineVersion;
             properties[TelemetryHostVersion] = _hostVersion;
             properties[TelemetryAdapterId] = _adapterId;
+            properties[TelemetryClientId] = _clientId;
 
             properties.Merge(eventProperties);
 


### PR DESCRIPTION
ClientId will be useful to know when repoducing crashes on specific clients.