### PR TITLE
Add support for LogPoints in OpenDebugAD7 (#1013)

### DIFF
--- a/src/OpenDebugAD7/AD7Impl/AD7BreakPointRequest.cs
+++ b/src/OpenDebugAD7/AD7Impl/AD7BreakPointRequest.cs
@@ -112,5 +112,40 @@ namespace OpenDebugAD7.AD7Impl
                 return HRConstants.E_FAIL;
             }
         }
+
+        #region Tracepoints
+
+        private string m_logMessage;
+        private Tracepoint m_Tracepoint;
+
+        public void ClearTracepoint()
+        {
+            m_logMessage = null;
+            m_Tracepoint = null;
+        }
+
+        public bool SetLogMessage(string logMessage)
+        {
+            try
+            {
+                m_Tracepoint = Tracepoint.CreateTracepoint(logMessage);
+                DebuggerTelemetry.ReportEvent(DebuggerTelemetry.TelemetryTracepointEventName);
+            }
+            catch (InvalidTracepointException e)
+            {
+                DebuggerTelemetry.ReportError(DebuggerTelemetry.TelemetryTracepointEventName, e.Message);
+                return false;
+            }
+            m_logMessage = logMessage;
+            return true;
+        }
+
+        public string LogMessage => m_logMessage;
+
+        public bool HasTracepoint => !string.IsNullOrEmpty(m_logMessage) && m_Tracepoint != null;
+
+        public Tracepoint Tracepoint => m_Tracepoint;
+
+        #endregion
     }
 }

--- a/src/OpenDebugAD7/AD7Resources.Designer.cs
+++ b/src/OpenDebugAD7/AD7Resources.Designer.cs
@@ -135,6 +135,69 @@ namespace OpenDebugAD7 {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Unable to interpolate logMessage because frames could not be retrieved..
+        /// </summary>
+        internal static string Error_InterpolateMissingFrames {
+            get {
+                return ResourceManager.GetString("Error_InterpolateMissingFrames", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Unable to interpolate logMessage because current thread is missing..
+        /// </summary>
+        internal static string Error_InterpolateMissingThread {
+            get {
+                return ResourceManager.GetString("Error_InterpolateMissingThread", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Unable to interpolate logMessage because there is no top frame..
+        /// </summary>
+        internal static string Error_InterpolateMissingTopFrame {
+            get {
+                return ResourceManager.GetString("Error_InterpolateMissingTopFrame", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Failed to evaluate expression..
+        /// </summary>
+        internal static string Error_InterpolateVariableEvaluateFailed {
+            get {
+                return ResourceManager.GetString("Error_InterpolateVariableEvaluateFailed", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Unable to get context from frame..
+        /// </summary>
+        internal static string Error_InterpolateVariableMissingContext {
+            get {
+                return ResourceManager.GetString("Error_InterpolateVariableMissingContext", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to No expression object found..
+        /// </summary>
+        internal static string Error_InterpolateVariableMissingExpressionObject {
+            get {
+                return ResourceManager.GetString("Error_InterpolateVariableMissingExpressionObject", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Failed to get property information..
+        /// </summary>
+        internal static string Error_InterpolateVariableMissingProperties {
+            get {
+                return ResourceManager.GetString("Error_InterpolateVariableMissingProperties", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to DNX runtime process exited unexpectedly with error code {0}..
         /// </summary>
         internal static string Error_LaunchFailedNoError {
@@ -277,6 +340,15 @@ namespace OpenDebugAD7 {
         internal static string Error_TargetNotStopped {
             get {
                 return ResourceManager.GetString("Error_TargetNotStopped", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Unable to parse &apos;logMessage&apos;..
+        /// </summary>
+        internal static string Error_UnableToParseLogMessage {
+            get {
+                return ResourceManager.GetString("Error_UnableToParseLogMessage", resourceCulture);
             }
         }
         

--- a/src/OpenDebugAD7/AD7Resources.resx
+++ b/src/OpenDebugAD7/AD7Resources.resx
@@ -192,6 +192,9 @@
   <data name="Error_UnableToSetBreakpoint" xml:space="preserve">
     <value>Error setting breakpoint. {0}</value>
   </data>
+  <data name="Error_UnableToParseLogMessage" xml:space="preserve">
+    <value>Unable to parse 'logMessage'.</value>
+  </data>
   <data name="Msg_E_CRASHDUMP_UNSUPPORTED" xml:space="preserve">
     <value>This operation is not supported when debugging dump files.</value>
   </data>
@@ -257,5 +260,26 @@
   <data name="Error_ExceptionOccured" xml:space="preserve">
     <value>Exception occurred: '{0}'</value>
     <comment>{0} is the exception string</comment>
+  </data>
+  <data name="Error_InterpolateMissingFrames" xml:space="preserve">
+    <value>Unable to interpolate logMessage because frames could not be retrieved.</value>
+  </data>
+  <data name="Error_InterpolateMissingThread" xml:space="preserve">
+    <value>Unable to interpolate logMessage because current thread is missing.</value>
+  </data>
+  <data name="Error_InterpolateMissingTopFrame" xml:space="preserve">
+    <value>Unable to interpolate logMessage because there is no top frame.</value>
+  </data>
+  <data name="Error_InterpolateVariableEvaluateFailed" xml:space="preserve">
+    <value>Failed to evaluate expression.</value>
+  </data>
+  <data name="Error_InterpolateVariableMissingContext" xml:space="preserve">
+    <value>Unable to get context from frame.</value>
+  </data>
+  <data name="Error_InterpolateVariableMissingExpressionObject" xml:space="preserve">
+    <value>No expression object found.</value>
+  </data>
+  <data name="Error_InterpolateVariableMissingProperties" xml:space="preserve">
+    <value>Failed to get property information.</value>
   </data>
 </root>

--- a/src/OpenDebugAD7/Constants.cs
+++ b/src/OpenDebugAD7/Constants.cs
@@ -28,7 +28,9 @@ namespace OpenDebugAD7
     {
         // POST_PREVIEW_TODO: no-func-eval support, radix, timeout
         public const uint EvaluationRadix = 10;
+        public const uint ParseRadix = 10;
         public const uint EvaluationTimeout = 5000;
         public const int DisconnectTimeout = 2000;
+        public const int DefaultTracepointCallstackDepth = 10;
     }
 }

--- a/src/OpenDebugAD7/OpenDebugAD7.csproj
+++ b/src/OpenDebugAD7/OpenDebugAD7.csproj
@@ -147,6 +147,7 @@
     <Compile Include="Telemetry\TelemetryHelper.cs" />
     <Compile Include="TextPositionTuple.cs" />
     <Compile Include="ThreadFrameEnumInfo.cs" />
+    <Compile Include="Tracepoint.cs" />
     <Compile Include="VariableManager.cs" />
     <Compile Include="AD7DebugSession.cs" />
   </ItemGroup>

--- a/src/OpenDebugAD7/Telemetry/DebuggerTelemetry.cs
+++ b/src/OpenDebugAD7/Telemetry/DebuggerTelemetry.cs
@@ -28,6 +28,7 @@ namespace OpenDebugAD7
         public const string TelemetryAttachEventName = "Attach";
         public const string TelemetryEvaluateEventName = "Evaluate";
         public const string TelemetryPauseEventName = "Pause";
+        public const string TelemetryTracepointEventName = "Tracepoint";
 
         // Common telemetry properties
         public const string TelemetryErrorType = "ErrorType";
@@ -54,7 +55,7 @@ namespace OpenDebugAD7
         public const string TelemetryVisualizerFileUsed = "VisualizerFileUsed";
         public const string TelemetrySourceFileMappings = "SourceFileMappings";
         public const string TelemetryMIMode = "MIMode";
-        public const string TelemetryStackFrameId = TelemetryExecuteInConsole + ".ExecuteInConsole";
+        public const string TelemetryStackFrameId = TelemetryExecuteInConsole + ".StackFrameId";
 
         private DebuggerTelemetry(Action<DebugEvent> callback, TypeInfo engineType, TypeInfo hostType, string adapterId)
         {

--- a/src/OpenDebugAD7/Tracepoint.cs
+++ b/src/OpenDebugAD7/Tracepoint.cs
@@ -1,0 +1,545 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Text;
+
+using Microsoft.VisualStudio.Debugger.Interop;
+
+namespace OpenDebugAD7
+{
+    internal class Tracepoint
+    {
+        // LogMessage after it has been Parsed()
+        public string LogMessage { get; set; }
+
+        // Map of the index in LogMessage to insert the evaluated expression ($TOKEN or { expression })
+        private readonly IDictionary<int, string> m_indexToExpressions;
+
+        private Tracepoint(string logMessage)
+        {
+            m_indexToExpressions = new Dictionary<int, string>();
+            LogMessage = Parse(logMessage);
+        }
+
+        internal static Tracepoint CreateTracepoint(string logMessage)
+        {
+            return new Tracepoint(logMessage);
+        }
+
+        internal int GetLogMessage(IDebugThread2 pThread, uint radix, string processName, out string logMessage)
+        {
+            int hr = HRConstants.S_OK;
+            string message = LogMessage;
+
+            // There is strings to interpolate in the log message.
+            if (m_indexToExpressions.Count != 0)
+            {
+                hr = GetInterpolatedLogMessage(message, pThread, radix, processName, out message);
+            }
+
+            logMessage = message;
+            return hr;
+        }
+
+        private int GetInterpolatedLogMessage(string logMessage, IDebugThread2 pThread, uint radix, string processName, out string message)
+        {
+            int hr = HRConstants.S_OK;
+
+            if (pThread == null)
+            {
+                message = AD7Resources.Error_InterpolateMissingThread;
+                return HRConstants.E_FAIL;
+            }
+
+            // Get topFrame
+            IEnumDebugFrameInfo2 frameInfoEnum;
+            hr = pThread.EnumFrameInfo(enum_FRAMEINFO_FLAGS.FIF_FRAME | enum_FRAMEINFO_FLAGS.FIF_FLAGS, Constants.EvaluationRadix, out frameInfoEnum);
+            if (hr < 0)
+            {
+                message = AD7Resources.Error_InterpolateMissingFrames;
+                return hr;
+            }
+
+            FRAMEINFO[] topFrame = new FRAMEINFO[1];
+            uint fetched = 0;
+            hr = frameInfoEnum.Next(1, topFrame, ref fetched);
+            if (hr < 0 || fetched != 1 || topFrame[0].m_pFrame == null)
+            {
+                message = AD7Resources.Error_InterpolateMissingTopFrame;
+                return hr;
+            }
+
+            Dictionary<string, string> seenExpressions = new Dictionary<string, string>();
+            StringBuilder sb = new StringBuilder();
+            int currIndex = 0;
+
+            foreach (KeyValuePair<int, string> keyValuePair in m_indexToExpressions)
+            {
+                // Add all characters between current index to the insertion index.
+                sb.Append(LogMessage.Substring(currIndex, keyValuePair.Key - currIndex));
+
+                // Move current index to end of replaced string.
+                currIndex = keyValuePair.Key + keyValuePair.Value.Length;
+
+                if (!seenExpressions.TryGetValue(keyValuePair.Value, out string value))
+                {
+                    if (keyValuePair.Value[0] == '$')
+                    {
+                        value = InterpolateToken(keyValuePair.Value, pThread, topFrame[0].m_pFrame, radix, processName);
+                    }
+                    else
+                    {
+                        string toInterpolate = keyValuePair.Value;
+                        if (InterpolateVariable(toInterpolate.Substring(1, toInterpolate.Length - 2), topFrame[0].m_pFrame, radix, out value) < 0)
+                        {
+                            hr = HRConstants.E_FAIL;
+                            DebuggerTelemetry.ReportError(DebuggerTelemetry.TelemetryTracepointEventName, value);
+
+                            // Re-write error message
+                            value = string.Format(CultureInfo.CurrentCulture, "<Failed to interpolate {0}: \"{1}\">", toInterpolate, value);
+                        }
+                    }
+
+                    // Cache expression
+                    seenExpressions[keyValuePair.Value] = value;
+                }
+                sb.Append(value);
+            }
+
+            // Append the rest of LogMessage
+            sb.Append(LogMessage.Substring(currIndex, LogMessage.Length - currIndex));
+
+            message = sb.ToString();
+
+            return hr;
+        }
+
+        private string InterpolateToken(string token, IDebugThread2 pThread, IDebugStackFrame2 topFrame, uint radix, string processName)
+        {
+            switch (token)
+            {
+                case "$FUNCTION":
+                    {
+                        int hr = topFrame.GetCodeContext(out IDebugCodeContext2 pCodeContext);
+                        if (hr >= 0)
+                        {
+                            CONTEXT_INFO[] pInfo = new CONTEXT_INFO[1];
+                            hr = pCodeContext.GetInfo(enum_CONTEXT_INFO_FIELDS.CIF_FUNCTION, pInfo);
+                            if (hr >= 0)
+                            {
+                                return pInfo[0].bstrFunction;
+                            }
+                        }
+                        return string.Format(CultureInfo.InvariantCulture, "<No Function Found>");
+                    }
+                case "$ADDRESS":
+                    {
+                        int hr = topFrame.GetCodeContext(out IDebugCodeContext2 pCodeContext);
+                        if (hr >= 0)
+                        {
+                            CONTEXT_INFO[] pInfo = new CONTEXT_INFO[1];
+                            hr = pCodeContext.GetInfo(enum_CONTEXT_INFO_FIELDS.CIF_ADDRESS, pInfo);
+                            if (hr >= 0)
+                            {
+                                return pInfo[0].bstrAddress;
+                            }
+                        }
+                        return string.Format(CultureInfo.InvariantCulture, "<No Address Found>");
+                    }
+                case "$FILEPOS":
+                    {
+                        int hr = topFrame.GetDocumentContext(out IDebugDocumentContext2 pDocumentContext);
+                        if (hr >= 0)
+                        {
+                            hr = pDocumentContext.GetName(enum_GETNAME_TYPE.GN_FILENAME, out string fileName);
+                            if (hr >= 0)
+                            {
+                                TEXT_POSITION[] textPosBeg = new TEXT_POSITION[1];
+                                TEXT_POSITION[] textPosEnd = new TEXT_POSITION[1];
+                                hr = pDocumentContext.GetStatementRange(textPosBeg, textPosEnd);
+                                if (hr >= 0)
+                                {
+                                    return string.Format(CultureInfo.InvariantCulture, "{0}({1})", fileName, textPosBeg[0].dwLine + 1);
+                                }
+                            }
+                        }
+                        return string.Format(CultureInfo.InvariantCulture, "<No File Position>");
+                    }
+                case "$CALLER":
+                    {
+                        IEnumDebugFrameInfo2 frameInfoEnum;
+                        int hr = pThread.EnumFrameInfo(enum_FRAMEINFO_FLAGS.FIF_FRAME | enum_FRAMEINFO_FLAGS.FIF_FLAGS, Constants.EvaluationRadix, out frameInfoEnum);
+                        if (hr >= 0)
+                        {
+                            FRAMEINFO[] frames = new FRAMEINFO[2];
+                            uint fetched = 0;
+                            hr = frameInfoEnum.Next(2, frames, ref fetched);
+                            if (hr < 0 && fetched == 2)
+                            {
+                                return frames[1].m_bstrFuncName;
+                            }
+                        }
+                        return string.Format(CultureInfo.InvariantCulture, "<No Caller Avaliable>");
+                    }
+                case "$TID":
+                    {
+                        int hr = pThread.GetThreadId(out uint threadId);
+                        if (hr == 0)
+                        {
+                            if (radix == 16)
+                            {
+                                return string.Format(CultureInfo.InvariantCulture, "{0:X}", threadId);
+                            }
+                            else
+                            {
+                                return string.Format(CultureInfo.InvariantCulture, "{0}", threadId);
+                            }
+                        }
+                        return string.Format(CultureInfo.InvariantCulture, "<No Thread Id>");
+                    }
+                case "$TNAME":
+                    {
+                        int hr = pThread.GetName(out string name);
+                        if (hr == 0)
+                        {
+                            return name;
+                        }
+                        return string.Format(CultureInfo.InvariantCulture, "<No Thread Name>");
+                    }
+                case "$PID":
+                    {
+                        // TODO: Get PID, not AD_PROCESS_ID
+                        return string.Format(CultureInfo.InvariantCulture, "<Not Implemented: ${0}>", token);
+                    }
+                case "$PNAME":
+                    {
+                        return processName;
+                    }
+                case "$CALLSTACK":
+                    {
+                        IEnumDebugFrameInfo2 frameInfoEnum;
+                        int hr = pThread.EnumFrameInfo(enum_FRAMEINFO_FLAGS.FIF_FRAME | enum_FRAMEINFO_FLAGS.FIF_FLAGS, Constants.EvaluationRadix, out frameInfoEnum);
+                        int count = 0;
+                        StringBuilder sb = new StringBuilder();
+                        while (count < Constants.DefaultTracepointCallstackDepth)
+                        {
+                            FRAMEINFO[] frames = new FRAMEINFO[1];
+                            uint fetched = 0;
+                            hr = frameInfoEnum.Next(1, frames, ref fetched);
+                            if (fetched == 1)
+                            {
+                                // TODO: Do we want function arguments?
+                                frames[0].m_pFrame.GetName(out string name);
+                                sb.AppendLine(name);
+                            }
+                            count++;
+                        }
+                        return sb.ToString();
+                    }
+                case "$TICK":
+                    return string.Format(CultureInfo.InvariantCulture, "{0}", Environment.TickCount);
+                default:
+                    return string.Format(CultureInfo.InvariantCulture, "<Unknown Token: ${0}>", token);
+            }
+        }
+
+        private int InterpolateVariable(string variable, IDebugStackFrame2 topFrame, uint radix, out string interpolatedVariableStr)
+        {
+            int hr = HRConstants.S_OK;
+
+            IDebugExpressionContext2 expressionContext;
+            hr = topFrame.GetExpressionContext(out expressionContext);
+            if (hr < 0)
+            {
+                interpolatedVariableStr = AD7Resources.Error_InterpolateVariableMissingContext;
+                return hr;
+            }
+
+            IDebugExpression2 expressionObject;
+            hr = expressionContext.ParseText(variable, enum_PARSEFLAGS.PARSE_EXPRESSION, radix, out expressionObject, out string errStr, out uint errIdx);
+            if (hr < 0)
+            {
+                interpolatedVariableStr = string.Format(CultureInfo.InvariantCulture, "{0} at index {1}", errStr, errIdx);
+                return hr;
+            }
+            if (expressionObject == null)
+            {
+                interpolatedVariableStr = AD7Resources.Error_InterpolateVariableMissingExpressionObject;
+                return HRConstants.E_FAIL;
+            }
+
+            IDebugProperty2 property;
+            enum_EVALFLAGS flags = enum_EVALFLAGS.EVAL_RETURNVALUE |
+                enum_EVALFLAGS.EVAL_NOEVENTS |
+                (enum_EVALFLAGS)enum_EVALFLAGS110.EVAL110_FORCE_REAL_FUNCEVAL |
+                enum_EVALFLAGS.EVAL_NOSIDEEFFECTS;
+            hr = expressionObject.EvaluateSync(flags, Constants.EvaluationTimeout, null, out property);
+            if (hr < 0 || property == null)
+            {
+                interpolatedVariableStr = AD7Resources.Error_InterpolateVariableEvaluateFailed;
+                return hr;
+            }
+
+            DEBUG_PROPERTY_INFO[] propertyInfo = new DEBUG_PROPERTY_INFO[1];
+            enum_DEBUGPROP_INFO_FLAGS propertyInfoFlags = enum_DEBUGPROP_INFO_FLAGS.DEBUGPROP_INFO_NAME |
+                enum_DEBUGPROP_INFO_FLAGS.DEBUGPROP_INFO_VALUE |
+                enum_DEBUGPROP_INFO_FLAGS.DEBUGPROP_INFO_TYPE |
+                enum_DEBUGPROP_INFO_FLAGS.DEBUGPROP_INFO_ATTRIB |
+                enum_DEBUGPROP_INFO_FLAGS.DEBUGPROP_INFO_PROP |
+                enum_DEBUGPROP_INFO_FLAGS.DEBUGPROP_INFO_FULLNAME |
+                (enum_DEBUGPROP_INFO_FLAGS)enum_DEBUGPROP_INFO_FLAGS110.DEBUGPROP110_INFO_FORCE_REAL_FUNCEVAL |
+                (enum_DEBUGPROP_INFO_FLAGS)enum_DEBUGPROP_INFO_FLAGS110.DEBUGPROP110_INFO_NOSIDEEFFECTS;
+            hr = property.GetPropertyInfo(propertyInfoFlags, Constants.EvaluationRadix, Constants.EvaluationTimeout, null, 0, propertyInfo);
+            if (hr < 0)
+            {
+                interpolatedVariableStr = AD7Resources.Error_InterpolateVariableMissingProperties;
+                return hr;
+            }
+
+            if ((propertyInfo[0].dwAttrib & enum_DBG_ATTRIB_FLAGS.DBG_ATTRIB_VALUE_ERROR) == enum_DBG_ATTRIB_FLAGS.DBG_ATTRIB_VALUE_ERROR)
+            {
+                // bstrValue has useful information.
+                interpolatedVariableStr = propertyInfo[0].bstrValue;
+                return HRConstants.E_FAIL;
+            }
+
+            interpolatedVariableStr = propertyInfo[0].bstrValue;
+
+            return hr;
+        }
+
+        #region Tracepoint Parsing
+
+        /// <summary>
+        /// The parse method for Tracepoints.
+        /// 
+        /// Algorithm:
+        ///     Go though each character in the string.
+        ///         1. If previous character was an escape, check to see if current is curl brace. If so, just output curl brace, else output escape and character.
+        ///         2. If it is an escape character, toggle isEscape to be true. Goto 1.
+        ///         3. If it is a '$', find the end of the token. If it is a known token, it will be added to m_indexToExpressions and skip over all the characters
+        ///             in the token. If not, it will just add $ and continue.
+        ///         4. If it is a open curl brace, try to find end match curl brace for the interpolated expression. Add to m_indexToExpressions.
+        ///             If there is no matching end brace, an exception will be thrown.
+        ///         5. Other character, just add to message to output.
+        /// </summary>
+        /// <param name="input">The logMessage to parse</param>
+        /// <returns>The new string after it has been parsed, it will check for excaped curl braces.</returns>
+        private string Parse(string input)
+        {
+            StringBuilder replace = new StringBuilder();
+            bool isEscaped = false;
+            for (int index = 0; index < input.Length; index++)
+            {
+                char c = input[index];
+
+                if (isEscaped)
+                {
+                    if (c != '{' && c != '}')
+                    {
+                        replace.Append('\\');
+                    }
+
+                    // Not interpolating, output character for user's string.
+                    replace.Append(c);
+                    isEscaped = false;
+                }
+                else
+                {
+                    if (c == '\\')
+                    {
+                        isEscaped = true;
+                    }
+                    else if (c == '$')
+                    {
+                        if (FindToken(input.Substring(index), out int endIndex))
+                        {
+                            string buffer = input.Substring(index, endIndex + 1);
+
+                            m_indexToExpressions[replace.Length] = buffer;
+
+                            replace.Append(input.Substring(index, endIndex + 1));
+
+                            index += endIndex;
+                        }
+                        else
+                        {
+                            replace.Append(c);
+                        }
+                    }
+                    else if (c == '{')
+                    {
+                        if (FindInterpolatedExpression(input.Substring(index), out int endIndex))
+                        {
+                            string buffer = input.Substring(index, endIndex + 1);
+
+                            if (!string.IsNullOrWhiteSpace(buffer))
+                            {
+                                m_indexToExpressions[replace.Length] = buffer;
+                            }
+
+                            replace.Append(input.Substring(index, endIndex + 1));
+
+                            index += endIndex;
+                        }
+                        else
+                        {
+                            throw new InvalidTracepointException("Can not find matching brace '}' for interpolated expression.");
+                        }
+                    }
+                    else
+                    {
+                        replace.Append(c);
+                    }
+                }
+            }
+
+            return replace.ToString();
+        }
+
+        private bool FindToken(string input, out int endIndex)
+        {
+            StringBuilder buffer = new StringBuilder("$");
+            int index;
+            for (index = 1; index < input.Length; index++)
+            {
+                if (!char.IsUpper(input[index]))
+                {
+                    break;
+                }
+                buffer.Append(input[index]);
+            }
+            endIndex = index - 1;
+
+            string token = buffer.ToString();
+            switch (token)
+            {
+                case "$FILEPOS":
+                case "$FUNCTION":
+                case "$ADDRESS":
+                case "$TID":
+                case "$TNAME":
+                case "$PID":
+                case "$PNAME":
+                case "$CALLER":
+                case "$CALLSTACK":
+                case "$TICK":
+                    return true;
+                default:
+                    return false;
+            }
+        }
+
+        /// <summary>
+        /// Method to find the end matching quote.
+        /// </summary>
+        /// <param name="input">string to find quote. Index 0 is the open quote.</param>
+        /// <param name="endIndex">output of where the index of the end quote relative to 'input'</param>
+        /// <returns>true if a end quote was found</returns>
+        private bool FindEndQuote(string input, out int endIndex)
+        {
+            endIndex = -1;
+
+            int index;
+            bool isEscaped = false;
+            for (index = 1; index < input.Length; index++)
+            {
+                char c = input[index];
+
+                if (c == '"' && !isEscaped)
+                {
+                    endIndex = index;
+                    return true;
+                }
+
+                if (isEscaped)
+                {
+                    isEscaped = false;
+                }
+
+                if (c == '\\')
+                {
+                    isEscaped = true;
+                }
+            }
+
+            return false;
+        }
+
+        /// <summary>
+        /// Method to find the interpolated expression.
+        /// E.g. Find the end curl brace. 
+        /// </summary>
+        /// <param name="input">String to find the end brace. Index 0 is '{'</param>
+        /// <param name="endIndex">Index of '}' relative to input.</param>
+        /// <returns>true if an end brace was found.</returns>
+        private bool FindInterpolatedExpression(string input, out int endIndex)
+        {
+            endIndex = -1;
+            int index = 0;
+            StringBuilder buffer = new StringBuilder();
+            int nested = 0;
+            bool isEscaped = false;
+            while (++index < input.Length)
+            {
+                char c = input[index];
+                if (isEscaped)
+                {
+                    buffer.Append(c);
+                    isEscaped = false;
+                }
+                else
+                {
+                    if (c == '\\')
+                    {
+                        isEscaped = true;
+                    }
+                    else if (c == '{')
+                    {
+                        nested++;
+                    }
+                    else if (c == '}')
+                    {
+                        if (nested > 0)
+                        {
+                            nested--;
+                        }
+                        else
+                        {
+                            endIndex = index;
+                            return true;
+                        }
+                    }
+                    else if (c == '"')
+                    {
+                        if (FindEndQuote(input.Substring(index), out int length))
+                        {
+                            length = length + 1;
+                        }
+                        else
+                        {
+                            length = input.Length - index;
+                        }
+                        buffer.Append(input.Substring(index, length));
+                        index += length;
+                    }
+                }
+            }
+
+            return false;
+        }
+
+        #endregion
+    }
+
+    public class InvalidTracepointException : Exception
+    {
+        public InvalidTracepointException(string message) : base(message)
+        {
+        }
+    }
+
+}


### PR DESCRIPTION
* Add support for LogPoints in OpenDebugAD7

This PR adds LogMessage (Tracepoint) support for OpenDebugAD7.

The messages with curl braces will have the expression inside of them evaluated.
There is also support to replace tokens such as $PNAME,$TNAME,$TID,$CALLSTACK,$CALLER will have their values replaced.