### PR TITLE
[Docker] Fix remote containers list, add OutputWindow error support and Telemetry

### DIFF
--- a/src/SSHDebugPS/Docker/DockerContainerInstance.cs
+++ b/src/SSHDebugPS/Docker/DockerContainerInstance.cs
@@ -13,20 +13,19 @@ namespace Microsoft.SSHDebugPS.Docker
         /// <summary>
         /// Create a DockerContainerInstance from the results of docker ps in JSON format
         /// </summary>
-        public static DockerContainerInstance Create(string json)
+        public static bool TryCreate(string json, out DockerContainerInstance instance)
         {
+            instance = null;
             try
             {
                 JObject obj = JObject.Parse(json);
-                var instance = obj.ToObject<DockerContainerInstance>();
-                if (instance != null)
-                    return instance;
+                instance = obj.ToObject<DockerContainerInstance>();
             }
             catch (Exception e)
             {
                 Debug.Fail(e.ToString());
             }
-            return null;
+            return instance != null;
         }
 
         private DockerContainerInstance() { }

--- a/src/SSHDebugPS/Docker/DockerContainerInstance.cs
+++ b/src/SSHDebugPS/Docker/DockerContainerInstance.cs
@@ -13,9 +13,10 @@ namespace Microsoft.SSHDebugPS.Docker
         /// <summary>
         /// Create a DockerContainerInstance from the results of docker ps in JSON format
         /// </summary>
-        public static bool TryCreate(string json, out DockerContainerInstance instance)
+        public static bool TryCreate(string json, out DockerContainerInstance instance, out string error)
         {
             instance = null;
+            error = string.Empty;
             try
             {
                 JObject obj = JObject.Parse(json);
@@ -23,7 +24,8 @@ namespace Microsoft.SSHDebugPS.Docker
             }
             catch (Exception e)
             {
-                Debug.Fail(e.ToString());
+                error = e.ToString();
+                Debug.Fail(error);
             }
             return instance != null;
         }

--- a/src/SSHDebugPS/Docker/DockerContainerInstance.cs
+++ b/src/SSHDebugPS/Docker/DockerContainerInstance.cs
@@ -4,7 +4,6 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
-
 using Microsoft.DebugEngineHost;
 using Microsoft.SSHDebugPS.Utilities;
 using Newtonsoft.Json;
@@ -28,9 +27,9 @@ namespace Microsoft.SSHDebugPS.Docker
             }
             catch (Exception e)
             {
-                List<KeyValuePair<string, object>> eventProperties = new List<KeyValuePair<string, object>>();
-                eventProperties.Add(new KeyValuePair<string, object>(Property_ExceptionName, e.GetType().Name));
-                HostTelemetry.SendEvent(Telemetry.Event_DockerPSParseFailure, eventProperties.ToArray());
+                HostTelemetry.SendEvent(Telemetry.Event_DockerPSParseFailure, new KeyValuePair<string, object>[] {
+                    new KeyValuePair<string, object>(Property_ExceptionName, e.GetType().Name)
+                });
 
                 string error = e.ToString();
                 VsOutputWindowWrapper.WriteLine(StringResources.Error_DockerPSParseFailed.FormatCurrentCultureWithArgs(json, error), StringResources.Docker_PSName);

--- a/src/SSHDebugPS/Docker/DockerHelper.cs
+++ b/src/SSHDebugPS/Docker/DockerHelper.cs
@@ -7,8 +7,7 @@ using System.ComponentModel;
 using System.Linq;
 using System.Text;
 using System.Threading;
-using EnvDTE;
-using Microsoft.DebugEngineHost;
+
 using Microsoft.SSHDebugPS.SSH;
 using Microsoft.SSHDebugPS.Utilities;
 
@@ -60,7 +59,10 @@ namespace Microsoft.SSHDebugPS.Docker
                         }
                         else
                         {
-                            AddOutputLineToContainersList(args, ref containers);
+                            if (DockerContainerInstance.TryCreate(args, out DockerContainerInstance containerInstance))
+                            {
+                                containers.Add(containerInstance);
+                            }
                         }
                     }
                 });
@@ -210,24 +212,14 @@ namespace Microsoft.SSHDebugPS.Docker
 
                 foreach (var item in outputLines)
                 {
-                    AddOutputLineToContainersList(item, ref containers);
+                    if (DockerContainerInstance.TryCreate(item, out DockerContainerInstance containerInstance))
+                    {
+                        containers.Add(containerInstance);
+                    }
                 }
             }
 
             return containers;
-        }
-
-        private static void AddOutputLineToContainersList(string item, ref List<DockerContainerInstance> containers)
-        {
-            if (DockerContainerInstance.TryCreate(item, out DockerContainerInstance containerInstance, out string error))
-            {
-                containers.Add(containerInstance);
-            }
-            else
-            {
-                HostTelemetry.SendEvent(Telemetry.Event_DockerPSParseFailure);
-                OutputWindow.Instance.WriteLine(StringResources.Error_DockerPSParseFailed.FormatCurrentCultureWithArgs(item, error), StringResources.Docker_PSName);
-            }
         }
     }
 }

--- a/src/SSHDebugPS/Docker/DockerHelper.cs
+++ b/src/SSHDebugPS/Docker/DockerHelper.cs
@@ -210,7 +210,11 @@ namespace Microsoft.SSHDebugPS.Docker
 
                 foreach (var item in outputLines)
                 {
-                    containers.Add(DockerContainerInstance.Create(item));
+                    DockerContainerInstance instance = DockerContainerInstance.Create(item);
+                    if (instance != null)
+                    {
+                        containers.Add(instance);
+                    }
                 }
             }
 

--- a/src/SSHDebugPS/Docker/DockerHelper.cs
+++ b/src/SSHDebugPS/Docker/DockerHelper.cs
@@ -58,8 +58,7 @@ namespace Microsoft.SSHDebugPS.Docker
                         }
                         else
                         {
-                            var containerInstance = DockerContainerInstance.Create(args);
-                            if (containerInstance != null)
+                            if (DockerContainerInstance.TryCreate(args, out DockerContainerInstance containerInstance))
                                 containers.Add(containerInstance);
                         }
                     }
@@ -210,10 +209,9 @@ namespace Microsoft.SSHDebugPS.Docker
 
                 foreach (var item in outputLines)
                 {
-                    DockerContainerInstance instance = DockerContainerInstance.Create(item);
-                    if (instance != null)
+                    if (DockerContainerInstance.TryCreate(item, out DockerContainerInstance containerInstance))
                     {
-                        containers.Add(instance);
+                        containers.Add(containerInstance);
                     }
                 }
             }

--- a/src/SSHDebugPS/OutputWindow.cs
+++ b/src/SSHDebugPS/OutputWindow.cs
@@ -1,0 +1,123 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+
+using System;
+using System.Collections.Generic;
+using Microsoft.VisualStudio;
+using Microsoft.VisualStudio.Shell;
+using Microsoft.VisualStudio.Shell.Interop;
+
+namespace Microsoft.SSHDebugPS
+{
+    class OutputWindow
+    {
+        private static OutputWindow _instance;
+
+        public static OutputWindow Instance
+        {
+            get
+            {
+                if (_instance == null)
+                {
+                    _instance = new OutputWindow();
+                }
+
+                return _instance;
+            }
+        }
+
+        private class PaneInfo
+        {
+            public PaneInfo(Guid paneId)
+            {
+                this.paneId = paneId;
+                this.Shown = false;
+            }
+
+            internal Guid paneId;
+            internal bool Shown { get; set; }
+        }
+
+        private IVsOutputWindow outputWindow;
+        private IVsUIShell shell;
+
+        private Dictionary<string, PaneInfo> panes = new Dictionary<string, PaneInfo>()
+        {
+            // The 'Debug' pane exists by default
+            { "Debug", new PaneInfo(VSConstants.GUID_OutWindowDebugPane) }
+        };
+
+        private OutputWindow()
+        {
+            outputWindow = Package.GetGlobalService(typeof(SVsOutputWindow)) as IVsOutputWindow;
+            shell = Package.GetGlobalService(typeof(SVsUIShell)) as IVsUIShell;
+            if (outputWindow == null || shell == null)
+            {
+                throw new NullReferenceException("Could not create OutputWindow");
+            }
+        }
+
+        /// <summary>
+        /// Writes text directly to the VS Output window.
+        /// </summary>
+        public void Write(string message, string pane = "Debug")
+        {
+            ThreadHelper.JoinableTaskFactory.Run(async delegate
+            {
+                await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
+                try
+                {
+                    // Get the pane guid
+                    PaneInfo paneInfo;
+                    if (!panes.TryGetValue(pane, out paneInfo))
+                    {
+                        // Pane didn't exist, create it
+                        paneInfo = new PaneInfo(Guid.NewGuid());
+                        panes.Add(pane, paneInfo);
+                    }
+
+                    // Get the pane
+                    IVsOutputWindowPane outputPane;
+                    if (outputWindow.GetPane(ref paneInfo.paneId, out outputPane) != VSConstants.S_OK)
+                    {
+                        // Failed to get the pane - might need to create it first
+                        outputWindow.CreatePane(ref paneInfo.paneId, pane, fInitVisible: 1, fClearWithSolution: 1);
+                        outputWindow.GetPane(ref paneInfo.paneId, out outputPane);
+                    }
+
+                    // The first time we output text to a pane, ensure it's visible
+                    if (!paneInfo.Shown)
+                    {
+                        paneInfo.Shown = true;
+
+                        // Switch to the pane of the Output window
+                        outputPane.Activate();
+
+                        // Show the output window
+                        if (shell != null)
+                        {
+                            Guid commandSet = VSConstants.GUID_VSStandardCommandSet97;
+                            object inputVariant = null;
+                            shell.PostExecCommand(commandSet, (uint)VSConstants.VSStd97CmdID.OutputWindow, 0, ref inputVariant);
+                        }
+                    }
+
+                    // Output the text
+                    outputPane.OutputString(message);
+                }
+                catch (Exception)
+                {
+                }
+            });
+        }
+
+        /// <summary>
+        /// Writes text directly to the VS Output window, appending a newline.
+        /// </summary>
+        public void WriteLine(string message, string pane = "Debug")
+        {
+            Write(string.Concat(message, Environment.NewLine), pane);
+        }
+    }
+}

--- a/src/SSHDebugPS/SSHDebugPS.csproj
+++ b/src/SSHDebugPS/SSHDebugPS.csproj
@@ -127,7 +127,7 @@
     <Compile Include="AD7\AD7Program.cs" />
     <Compile Include="AD7\AD7UnixAsyncCommand.cs" />
     <Compile Include="Docker\DockerContainerInstance.cs" />
-    <Compile Include="OutputWindow.cs" />
+    <Compile Include="VsOutputWindowWrapper.cs" />
     <Compile Include="ProcFSOutputParser.cs" />
     <Compile Include="Docker\DockerAsyncCommand.cs" />
     <Compile Include="Docker\DockerHelper.cs" />

--- a/src/SSHDebugPS/SSHDebugPS.csproj
+++ b/src/SSHDebugPS/SSHDebugPS.csproj
@@ -127,6 +127,7 @@
     <Compile Include="AD7\AD7Program.cs" />
     <Compile Include="AD7\AD7UnixAsyncCommand.cs" />
     <Compile Include="Docker\DockerContainerInstance.cs" />
+    <Compile Include="OutputWindow.cs" />
     <Compile Include="ProcFSOutputParser.cs" />
     <Compile Include="Docker\DockerAsyncCommand.cs" />
     <Compile Include="Docker\DockerHelper.cs" />
@@ -183,6 +184,7 @@
     </Compile>
     <Compile Include="AD7\AD7UnixAsyncShellCommand.cs" />
     <Compile Include="UI\ViewModels\ConnectionViewModel.cs" />
+    <Compile Include="Utilities\Telemetry.cs" />
     <Compile Include="Utilities\VSMessageBoxHelper.cs" />
     <Compile Include="VSOperationWaiter.cs" />
   </ItemGroup>

--- a/src/SSHDebugPS/StringResources.Designer.cs
+++ b/src/SSHDebugPS/StringResources.Designer.cs
@@ -178,20 +178,20 @@ namespace Microsoft.SSHDebugPS {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Failed to parse json &apos;{0}&apos;.\r\nError: &apos;{1}&apos;.
+        /// </summary>
+        internal static string Error_DockerPSParseFailed {
+            get {
+                return ResourceManager.GetString("Error_DockerPSParseFailed", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Ensure the selected Docker Connection target is a Linux container..
         /// </summary>
         internal static string Error_EnsureDockerContainerIsLinux {
             get {
                 return ResourceManager.GetString("Error_EnsureDockerContainerIsLinux", resourceCulture);
-            }
-        }
-        
-        ///   Looks up a localized string similar to Failed to parse json &apos;{0}&apos;.
-        ///Error: &apos;{1}&apos;.
-        /// </summary>
-        internal static string Error_DockerPSParseFailed {
-            get {
-                return ResourceManager.GetString("Error_DockerPSParseFailed", resourceCulture);
             }
         }
         

--- a/src/SSHDebugPS/StringResources.Designer.cs
+++ b/src/SSHDebugPS/StringResources.Designer.cs
@@ -186,6 +186,15 @@ namespace Microsoft.SSHDebugPS {
             }
         }
         
+        ///   Looks up a localized string similar to Failed to parse json &apos;{0}&apos;.
+        ///Error: &apos;{1}&apos;.
+        /// </summary>
+        internal static string Error_DockerPSParseFailed {
+            get {
+                return ResourceManager.GetString("Error_DockerPSParseFailed", resourceCulture);
+            }
+        }
+        
         /// <summary>
         ///   Looks up a localized string similar to Unable to parse exit code..
         /// </summary>

--- a/src/SSHDebugPS/StringResources.resx
+++ b/src/SSHDebugPS/StringResources.resx
@@ -165,6 +165,10 @@
   <data name="Error_EnsureDockerContainerIsLinux" xml:space="preserve">
     <value>Ensure the selected Docker Connection target is a Linux container.</value>
   </data>
+  <data name="Error_DockerPSParseFailed" xml:space="preserve">
+    <value>Failed to parse json '{0}'.\r\nError: '{1}'</value>
+    <comment>{0} is a json output item from the output 'docker ps' and {1} is the error message</comment>
+  </data>
   <data name="Error_ExitCodeNotParseable" xml:space="preserve">
     <value>Unable to parse exit code.</value>
   </data>

--- a/src/SSHDebugPS/UI/UIResources.Designer.cs
+++ b/src/SSHDebugPS/UI/UIResources.Designer.cs
@@ -178,11 +178,20 @@ namespace Microsoft.SSHDebugPS {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Found {0} containers, Failed to parse {1}..
+        ///   Looks up a localized string similar to Failed to parse {0} containers. See output window for more information..
         /// </summary>
-        public static string ContainersNotAllFoundStatusText {
+        public static string ContainersNotAllParsedStatusText {
             get {
-                return ResourceManager.GetString("ContainersNotAllFoundStatusText", resourceCulture);
+                return ResourceManager.GetString("ContainersNotAllParsedStatusText", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Displaying {0} of {1} containers found..
+        /// </summary>
+        public static string ContainersNotAllParsedText {
+            get {
+                return ResourceManager.GetString("ContainersNotAllParsedText", resourceCulture);
             }
         }
         

--- a/src/SSHDebugPS/UI/UIResources.Designer.cs
+++ b/src/SSHDebugPS/UI/UIResources.Designer.cs
@@ -178,6 +178,15 @@ namespace Microsoft.SSHDebugPS {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Found {0} containers, Failed to parse {1}..
+        /// </summary>
+        public static string ContainersNotAllFoundStatusText {
+            get {
+                return ResourceManager.GetString("ContainersNotAllFoundStatusText", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Container Status:.
         /// </summary>
         public static string ContainerStatusTextBox {

--- a/src/SSHDebugPS/UI/UIResources.resx
+++ b/src/SSHDebugPS/UI/UIResources.resx
@@ -245,4 +245,8 @@
   <data name="ContainerStatusTextBox" xml:space="preserve">
     <value>Container Status:</value>
   </data>
+  <data name="ContainersNotAllFoundStatusText" xml:space="preserve">
+    <value>Found {0} containers, Failed to parse {1}.</value>
+    <comment>{0} is the number of containers successfuly shown. {1} is the number of containers that we attempted to parse.</comment>
+  </data>
 </root>

--- a/src/SSHDebugPS/UI/UIResources.resx
+++ b/src/SSHDebugPS/UI/UIResources.resx
@@ -245,8 +245,12 @@
   <data name="ContainerStatusTextBox" xml:space="preserve">
     <value>Container Status:</value>
   </data>
-  <data name="ContainersNotAllFoundStatusText" xml:space="preserve">
-    <value>Found {0} containers, Failed to parse {1}.</value>
-    <comment>{0} is the number of containers successfuly shown. {1} is the number of containers that we attempted to parse.</comment>
+  <data name="ContainersNotAllParsedStatusText" xml:space="preserve">
+    <value>Failed to parse {0} containers. See output window for more information.</value>
+    <comment>{0} is the number of containers we failed to parse.</comment>
+  </data>
+  <data name="ContainersNotAllParsedText" xml:space="preserve">
+    <value>Displaying {0} of {1} containers found.</value>
+    <comment>{0} is the number of containers successfuly shown. {1} is the total.</comment>
   </data>
 </root>

--- a/src/SSHDebugPS/UI/ViewModels/ContainerPickerViewModel.cs
+++ b/src/SSHDebugPS/UI/ViewModels/ContainerPickerViewModel.cs
@@ -138,6 +138,7 @@ namespace Microsoft.SSHDebugPS.UI
 
         private void RefreshContainersListInternal()
         {
+            int totalContainers = 0;
             try
             {
                 IContainerViewModel selectedContainer = SelectedContainerInstance;
@@ -147,7 +148,7 @@ namespace Microsoft.SSHDebugPS.UI
 
                 if (SelectedConnection is LocalConnectionViewModel)
                 {
-                    containers = DockerHelper.GetLocalDockerContainers(Hostname);
+                    containers = DockerHelper.GetLocalDockerContainers(Hostname, out totalContainers);
                 }
                 else
                 {
@@ -158,7 +159,7 @@ namespace Microsoft.SSHDebugPS.UI
                         UpdateStatusMessage(UIResources.SSHConnectionFailedStatusText, isError: true);
                         return;
                     }
-                    containers = DockerHelper.GetRemoteDockerContainers(connection, Hostname);
+                    containers = DockerHelper.GetRemoteDockerContainers(connection, Hostname, out totalContainers);
                 }
 
                 ContainerInstances = new ObservableCollection<IContainerViewModel>(containers.Select(item => new DockerContainerViewModel(item)).ToList());
@@ -188,7 +189,14 @@ namespace Microsoft.SSHDebugPS.UI
             {
                 if (ContainerInstances.Count() > 0)
                 {
-                    ContainersFoundText = UIResources.ContainersFoundStatusText.FormatCurrentCultureWithArgs(ContainerInstances.Count());
+                    if (ContainerInstances.Count() < totalContainers)
+                    {
+                        ContainersFoundText = UIResources.ContainersNotAllFoundStatusText.FormatCurrentCultureWithArgs(totalContainers, totalContainers - ContainerInstances.Count());
+                    }
+                    else
+                    {
+                        ContainersFoundText = UIResources.ContainersFoundStatusText.FormatCurrentCultureWithArgs(ContainerInstances.Count());
+                    }
                 }
                 else
                 {

--- a/src/SSHDebugPS/UI/ViewModels/ContainerPickerViewModel.cs
+++ b/src/SSHDebugPS/UI/ViewModels/ContainerPickerViewModel.cs
@@ -191,7 +191,8 @@ namespace Microsoft.SSHDebugPS.UI
                 {
                     if (ContainerInstances.Count() < totalContainers)
                     {
-                        ContainersFoundText = UIResources.ContainersNotAllFoundStatusText.FormatCurrentCultureWithArgs(totalContainers, totalContainers - ContainerInstances.Count());
+                        UpdateStatusMessage(UIResources.ContainersNotAllParsedStatusText.FormatCurrentCultureWithArgs(totalContainers - ContainerInstances.Count()), isError: false);
+                        ContainersFoundText = UIResources.ContainersNotAllParsedText.FormatCurrentCultureWithArgs(ContainerInstances.Count(), totalContainers);
                     }
                     else
                     {

--- a/src/SSHDebugPS/UI/ViewModels/ContainerViewModel.cs
+++ b/src/SSHDebugPS/UI/ViewModels/ContainerViewModel.cs
@@ -155,7 +155,7 @@ namespace Microsoft.SSHDebugPS.UI
         }
 
         // Gets the first 12 characters and appends an ellipsis
-        public string ShortId { get => Id.Length > 12 ? Id.Substring(0, 12) : Id; }
+        public string ShortId { get => !string.IsNullOrEmpty(Id) && Id.Length > 12 ? Id.Substring(0, 12) : Id; }
         public string Image => Instance?.Image;
         public string Command => Instance.Command;
         public string Status => Instance.Status;

--- a/src/SSHDebugPS/Utilities/Telemetry.cs
+++ b/src/SSHDebugPS/Utilities/Telemetry.cs
@@ -3,7 +3,7 @@
 
 namespace Microsoft.SSHDebugPS.Utilities
 {
-    internal class Telemetry
+    internal static class Telemetry
     {
         public const string Event_DockerPSParseFailure = @"VS/Diagnostics/Debugger/SSHDebugPS/DockerPSParseFailure";
     }

--- a/src/SSHDebugPS/Utilities/Telemetry.cs
+++ b/src/SSHDebugPS/Utilities/Telemetry.cs
@@ -1,0 +1,10 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Microsoft.SSHDebugPS.Utilities
+{
+    internal class Telemetry
+    {
+        public const string Event_DockerPSParseFailure = @"VS/Diagnostics/Debugger/SSHDebugPS/DockerPSParseFailure";
+    }
+}

--- a/src/SSHDebugPS/VsOutputWindowWrapper.cs
+++ b/src/SSHDebugPS/VsOutputWindowWrapper.cs
@@ -16,39 +16,32 @@ namespace Microsoft.SSHDebugPS
     {
         private static Lazy<IVsOutputWindow> outputWindowLazy = new Lazy<IVsOutputWindow>(() =>
         {
-            return ThreadHelper.JoinableTaskFactory.Run(async delegate
+            IVsOutputWindow outputWindow = null;
+            try
             {
-                IVsOutputWindow outputWindow = null;
-                try
-                {
-                    await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
-                    outputWindow = Package.GetGlobalService(typeof(SVsOutputWindow)) as IVsOutputWindow;
-                }
-                catch (Exception)
-                {
-                    Debug.Fail("Could not get OutputWindow service.");
-                }
-                return outputWindow;
-            });
-            // Use "PublicationOnly", because the implementation of GetService does its own locking
+                ThreadHelper.ThrowIfNotOnUIThread();
+                outputWindow = Package.GetGlobalService(typeof(SVsOutputWindow)) as IVsOutputWindow;
+            }
+            catch (Exception)
+            {
+                Debug.Fail("Could not get OutputWindow service.");
+            }
+            return outputWindow;
         }, LazyThreadSafetyMode.PublicationOnly);
 
         private static Lazy<IVsUIShell> shellLazy = new Lazy<IVsUIShell>(() =>
         {
-            return ThreadHelper.JoinableTaskFactory.Run(async delegate
+            IVsUIShell shell = null;
+            try
             {
-                IVsUIShell shell = null;
-                try
-                {
-                    await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
-                    shell = Package.GetGlobalService(typeof(SVsUIShell)) as IVsUIShell;
-                }
-                catch (Exception)
-                {
-                    Debug.Fail("Could not get VSShell service.");
-                }
-                return shell;
-            });
+                ThreadHelper.ThrowIfNotOnUIThread();
+                shell = Package.GetGlobalService(typeof(SVsUIShell)) as IVsUIShell;
+            }
+            catch (Exception)
+            {
+                Debug.Fail("Could not get VSShell service.");
+            }
+            return shell;
             // Use "PublicationOnly", because the implementation of GetService does its own locking
         }, LazyThreadSafetyMode.PublicationOnly);
 
@@ -77,7 +70,7 @@ namespace Microsoft.SSHDebugPS
         /// </summary>
         public static void Write(string message, string pane = DefaultOutputPane)
         {
-            ThreadHelper.JoinableTaskFactory.Run(async delegate
+            ThreadHelper.JoinableTaskFactory.RunAsync(async delegate
             {
                 await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
                 try
@@ -131,7 +124,7 @@ namespace Microsoft.SSHDebugPS
                 {
                     Debug.Fail("Failed to write to output pane.");
                 }
-            });
+            }).FileAndForget("vs/SSHDebugPS/VsOutputWindowWrapper/Write");
         }
 
         /// <summary>

--- a/src/SSHDebugPS/VsOutputWindowWrapper.cs
+++ b/src/SSHDebugPS/VsOutputWindowWrapper.cs
@@ -124,7 +124,7 @@ namespace Microsoft.SSHDebugPS
                 {
                     Debug.Fail("Failed to write to output pane.");
                 }
-            }).FileAndForget("vs/SSHDebugPS/VsOutputWindowWrapper/Write");
+            }).FileAndForget("VS/Diagnostics/Debugger/SSHDebugPS/VsOutputWindowWrapper/Write");
         }
 
         /// <summary>


### PR DESCRIPTION
In the Container Picker Dialog, it uses Name and ShortId. However, if
Id is null, ShortId tries to get the length of the Id and this causes a
NullRefException.

We also are adding null containers for GetRemoteDockerContainers. Added
a null check. We do the same in:
https://github.com/microsoft/MIEngine/blob/185e133c3f051a364252e65dd4159d5e8a6ca408/src/SSHDebugPS/Docker/DockerHelper.cs#L62

Adding a null check on Id so it just returns null.

Added support for logging errors to the output window.

Added telemetry to count for errors in Docker process listings 