### PR TITLE
Win: Fix encoding issue on ANSI code page 

### DIFF
--- a/src/OpenDebugAD7/OpenDebug/Program.cs
+++ b/src/OpenDebugAD7/OpenDebug/Program.cs
@@ -144,7 +144,7 @@ namespace OpenDebug
             {
                 // stdin/stdout
                 Console.Error.WriteLine("waiting for v8 protocol on stdin/stdout");
-                if (Utilities.IsWindows())
+                if (Utilities.IsWindows() && Console.InputEncoding.CodePage == 65001)
                 {
                     // Avoid sending the BOM on Windows if the Beta Unicode feature is enabled in Windows 10
                     Console.OutputEncoding = new UTF8Encoding(encoderShouldEmitUTF8Identifier: false);

--- a/src/WindowsDebugLauncher/Program.cs
+++ b/src/WindowsDebugLauncher/Program.cs
@@ -20,8 +20,11 @@ namespace WindowsDebugLauncher
             parameters.PipeServer = "."; // Currently only supporting local pipe connections
 
             // Avoid sending the BOM on Windows if the Beta Unicode feature is enabled in Windows 10
-            Console.OutputEncoding = new UTF8Encoding(encoderShouldEmitUTF8Identifier: false);
-            Console.InputEncoding = new UTF8Encoding(encoderShouldEmitUTF8Identifier: false);
+            if (Console.InputEncoding.CodePage == 65001)
+            {
+                Console.OutputEncoding = new UTF8Encoding(encoderShouldEmitUTF8Identifier: false);
+                Console.InputEncoding = new UTF8Encoding(encoderShouldEmitUTF8Identifier: false);
+            }
 
             foreach (var a in argv)
             {


### PR DESCRIPTION
The original change was introduced in https://github.com/microsoft/MIEngine/pull/942 and I believe it causes users who use ANSI code page can't input characters upper than 127 when using internal console because as I understand that code would set the encoding to utf8 regardless the original value.

For example:

```c
#include <stdio.h>
#include <stdlib.h>

int main() {
    //system("chcp 437"); // Sorry, won't work for internal console. Change the chcp in $profile instead.
    char s[10];
    gets(s); // input ü
    puts(s);
    system("pause");
}
```

Here is the result:

![图片](https://user-images.githubusercontent.com/24759802/89241004-51f4e680-d630-11ea-9b08-4cc37511ad67.png)

![图片](https://user-images.githubusercontent.com/24759802/89241062-76e95980-d630-11ea-8b9a-d74e1b0efee4.png)

But I don't know how to build this project and cpptools, so I can't test it.

If it works, could you also test `chcp 936` and `你好`?
If the issue still exists, then there must be a change between cpptools 0.26.0 and 0.26.1 that caused this problem.
And if it works, `microsoft/vscode-cpptools#1527` also needs testing in case regression.

Squash is recommended.

Fix https://github.com/microsoft/vscode-cpptools/issues/5308
Fix https://github.com/microsoft/vscode-cpptools/issues/5325