### PR TITLE
Add ProcessEvent for OpenDebugAD7

### DIFF
--- a/src/MIDebugEngine/AD7.Impl/AD7Engine.cs
+++ b/src/MIDebugEngine/AD7.Impl/AD7Engine.cs
@@ -15,6 +15,7 @@ using MICore;
 using System.Globalization;
 using Microsoft.DebugEngineHost;
 using Logger = MICore.Logger;
+using Microsoft.VisualStudio.Debugger.Interop.DAP;
 
 namespace Microsoft.MIDebugEngine
 {
@@ -34,7 +35,7 @@ namespace Microsoft.MIDebugEngine
 
     [System.Runtime.InteropServices.ComVisible(true)]
     [System.Runtime.InteropServices.Guid("0fc2f352-2fc1-4f80-8736-51cd1ab28f16")]
-    sealed public class AD7Engine : IDebugEngine2, IDebugEngineLaunch2, IDebugEngine3, IDebugProgram3, IDebugEngineProgram2, IDebugMemoryBytes2, IDebugEngine110, IDisposable
+    sealed public class AD7Engine : IDebugEngine2, IDebugEngineLaunch2, IDebugEngine3, IDebugProgram3, IDebugEngineProgram2, IDebugMemoryBytes2, IDebugEngine110, IDebugProgramDAP, IDisposable
     {
         // used to send events to the debugger. Some examples of these events are thread create, exception thrown, module load.
         private EngineCallback _engineCallback;
@@ -1142,6 +1143,27 @@ namespace Microsoft.MIDebugEngine
         {
             _settingsCallback = pCallback;
             return Constants.S_OK;
+        }
+        #endregion
+
+        #region IDebugProgramDAP
+        int IDebugProgramDAP.GetPointerSize(out int pResult)
+        {
+            pResult = 0;
+            int hr = Constants.E_FAIL;
+            if (_debuggedProcess != null)
+            {
+                if (_debuggedProcess.Is64BitArch)
+                {
+                    pResult = 64;
+                }
+                else
+                {
+                    pResult = 32;
+                }
+                hr = Constants.S_OK;
+            }
+            return hr;
         }
         #endregion
 

--- a/src/Microsoft.VisualStudio.Debugger.Interop.DAP/Microsoft.VisualStudio.Debugger.Interop.DAP.cs
+++ b/src/Microsoft.VisualStudio.Debugger.Interop.DAP/Microsoft.VisualStudio.Debugger.Interop.DAP.cs
@@ -37,7 +37,7 @@ namespace Microsoft.VisualStudio.Debugger.Interop.DAP
     }
 
     /// <summary>
-    /// 
+    /// Interface to get Program information for Debug Adapter Protocol.
     /// </summary>
     [ComImport()]
     [ComVisible(true)]
@@ -46,9 +46,9 @@ namespace Microsoft.VisualStudio.Debugger.Interop.DAP
     public interface IDebugProgramDAP
     {
         /// <summary>
-        /// 
+        /// Retrieves the program's pointer size in bits. (e.g. 64 or 32)
         /// </summary>
-        /// <param name="pResult">The program's pointer size.</param>
+        /// <param name="pResult">Number of bits in a pointer.</param>
         /// [PreserveSig]
         int GetPointerSize([Out] out int pResult);
     }

--- a/src/Microsoft.VisualStudio.Debugger.Interop.DAP/Microsoft.VisualStudio.Debugger.Interop.DAP.cs
+++ b/src/Microsoft.VisualStudio.Debugger.Interop.DAP/Microsoft.VisualStudio.Debugger.Interop.DAP.cs
@@ -35,4 +35,21 @@ namespace Microsoft.VisualStudio.Debugger.Interop.DAP
         [PreserveSig]
         int EvaluateSync([In] enum_EVALFLAGS dwFlags, [In] DAPEvalFlags dapFlags, [In] uint dwTimeout, [In][MarshalAs(UnmanagedType.Interface)] IDebugEventCallback2 pExprCallback, [Out, MarshalAs(UnmanagedType.Interface)] out IDebugProperty2 ppResult);
     }
+
+    /// <summary>
+    /// 
+    /// </summary>
+    [ComImport()]
+    [ComVisible(true)]
+    [Guid("1615C23F-2BA4-4018-A135-E8B889B01F3E")]
+    [InterfaceType(1)]
+    public interface IDebugProgramDAP
+    {
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <param name="pResult">The program's pointer size.</param>
+        /// [PreserveSig]
+        int GetPointerSize([Out] out int pResult);
+    }
 }

--- a/src/OpenDebugAD7/OpenDebugAD7.csproj
+++ b/src/OpenDebugAD7/OpenDebugAD7.csproj
@@ -106,7 +106,7 @@
     </Reference>
     <!-- Same version as in packages.config -->
     <Reference Include="Microsoft.VisualStudio.Shared.VSCodeDebugProtocol">
-      <HintPath>$(NuGetPackagesDirectory)/Microsoft.VisualStudio.Shared.VsCodeDebugProtocol.16.6.40406.1/lib/net45/Microsoft.VisualStudio.Shared.VSCodeDebugProtocol.dll</HintPath>
+      <HintPath>$(NuGetPackagesDirectory)/Microsoft.VisualStudio.Shared.VsCodeDebugProtocol.16.7.40526.2/lib/net45/Microsoft.VisualStudio.Shared.VSCodeDebugProtocol.dll</HintPath>
       <ForceIncludeInVSIX>true</ForceIncludeInVSIX>
     </Reference>
     <Reference Include="Newtonsoft.Json">

--- a/src/OpenDebugAD7/packages.config
+++ b/src/OpenDebugAD7/packages.config
@@ -6,5 +6,5 @@
   <package id="Mono.Unofficial.pdb2mdb" version="4.2.3.4" />
 
   <!-- Update the version number VsCodeDebugProtocol HintPath in OpenDebugAD7\OpenDebugAD7.csproj -->
-  <package id="Microsoft.VisualStudio.Shared.VsCodeDebugProtocol" version="16.6.40406.1" />
+  <package id="Microsoft.VisualStudio.Shared.VsCodeDebugProtocol" version="16.7.40526.2" />
 </packages>


### PR DESCRIPTION
This PR adds the process name, pid, startMethod and pointerSize for ProcessEvent.

Also updating VSCodeDebugProtocol.