### PR TITLE
Support $PID in Tracepoint LogMessage

### DIFF
--- a/src/OpenDebugAD7/AD7DebugSession.cs
+++ b/src/OpenDebugAD7/AD7DebugSession.cs
@@ -34,6 +34,7 @@ namespace OpenDebugAD7
 
         private IDebugProcess2 m_process;
         private string m_processName;
+        private int m_processId;
         private IDebugEngineLaunch2 m_engineLaunch;
         private IDebugEngine2 m_engine;
         private EngineConfiguration m_engineConfiguration;
@@ -720,6 +721,7 @@ namespace OpenDebugAD7
 
                 m_sessionConfig.StopAtEntrypoint = stopAtEntrypoint;
 
+                m_processId = Constants.InvalidProcessId;
                 m_processName = program;
 
                 enum_LAUNCH_FLAGS flags = enum_LAUNCH_FLAGS.LAUNCH_DEBUG;
@@ -960,6 +962,10 @@ namespace OpenDebugAD7
                     m_isAttach = true;
                 }
 
+                if (int.TryParse(processId, out m_processId))
+                {
+                    m_processId = Constants.InvalidProcessId;
+                }
                 m_processName = program ?? string.Empty;
 
                 // attach
@@ -2157,7 +2163,7 @@ namespace OpenDebugAD7
                 {
                     foreach (var tp in tracepoints)
                     {
-                        int hr = tp.GetLogMessage(pThread, Constants.ParseRadix, m_processName, out string logMessage);
+                        int hr = tp.GetLogMessage(pThread, Constants.ParseRadix, m_processName, m_processId, out string logMessage);
                         if (hr != HRConstants.S_OK)
                         {
                             DebuggerTelemetry.ReportError(DebuggerTelemetry.TelemetryTracepointEventName, logMessage);
@@ -2480,10 +2486,14 @@ namespace OpenDebugAD7
             if (debugProcessInfoUpdated != null && 
                 debugProcessInfoUpdated.GetUpdatedProcessInfo(out string name, out uint systemProcessId) == HRConstants.S_OK)
             {
+                // Update Process Name and Id
+                m_processName = name;
+                m_processId = (int)systemProcessId;
+
                 // Send ProcessEvent to Client
                 ProcessEvent processEvent = new ProcessEvent();
-                processEvent.Name = name;
-                processEvent.SystemProcessId = (int)systemProcessId;
+                processEvent.Name = m_processName;
+                processEvent.SystemProcessId = m_processId;
 
                 if (m_isAttach)
                 {

--- a/src/OpenDebugAD7/AD7DebugSession.cs
+++ b/src/OpenDebugAD7/AD7DebugSession.cs
@@ -34,7 +34,7 @@ namespace OpenDebugAD7
 
         private IDebugProcess2 m_process;
         private string m_processName;
-        private int m_processId;
+        private int m_processId = Constants.InvalidProcessId;
         private IDebugEngineLaunch2 m_engineLaunch;
         private IDebugEngine2 m_engine;
         private EngineConfiguration m_engineConfiguration;
@@ -962,7 +962,7 @@ namespace OpenDebugAD7
                     m_isAttach = true;
                 }
 
-                if (int.TryParse(processId, out m_processId))
+                if (int.TryParse(processId, NumberStyles.None, CultureInfo.InvariantCulture, out m_processId))
                 {
                     m_processId = Constants.InvalidProcessId;
                 }

--- a/src/OpenDebugAD7/Constants.cs
+++ b/src/OpenDebugAD7/Constants.cs
@@ -32,5 +32,6 @@ namespace OpenDebugAD7
         public const uint EvaluationTimeout = 5000;
         public const int DisconnectTimeout = 2000;
         public const int DefaultTracepointCallstackDepth = 10;
+        public const int InvalidProcessId = -1;
     }
 }

--- a/src/OpenDebugAD7/Tracepoint.cs
+++ b/src/OpenDebugAD7/Tracepoint.cs
@@ -29,7 +29,7 @@ namespace OpenDebugAD7
             return new Tracepoint(logMessage);
         }
 
-        internal int GetLogMessage(IDebugThread2 pThread, uint radix, string processName, out string logMessage)
+        internal int GetLogMessage(IDebugThread2 pThread, uint radix, string processName, int processId, out string logMessage)
         {
             int hr = HRConstants.S_OK;
             string message = LogMessage;
@@ -37,14 +37,14 @@ namespace OpenDebugAD7
             // There is strings to interpolate in the log message.
             if (m_indexToExpressions.Count != 0)
             {
-                hr = GetInterpolatedLogMessage(message, pThread, radix, processName, out message);
+                hr = GetInterpolatedLogMessage(message, pThread, radix, processName, processId, out message);
             }
 
             logMessage = message;
             return hr;
         }
 
-        private int GetInterpolatedLogMessage(string logMessage, IDebugThread2 pThread, uint radix, string processName, out string message)
+        private int GetInterpolatedLogMessage(string logMessage, IDebugThread2 pThread, uint radix, string processName, int processId, out string message)
         {
             int hr = HRConstants.S_OK;
 
@@ -88,7 +88,7 @@ namespace OpenDebugAD7
                 {
                     if (keyValuePair.Value[0] == '$')
                     {
-                        value = InterpolateToken(keyValuePair.Value, pThread, topFrame[0].m_pFrame, radix, processName);
+                        value = InterpolateToken(keyValuePair.Value, pThread, topFrame[0].m_pFrame, radix, processName, processId);
                     }
                     else
                     {
@@ -117,7 +117,7 @@ namespace OpenDebugAD7
             return hr;
         }
 
-        private string InterpolateToken(string token, IDebugThread2 pThread, IDebugStackFrame2 topFrame, uint radix, string processName)
+        private string InterpolateToken(string token, IDebugThread2 pThread, IDebugStackFrame2 topFrame, uint radix, string processName, int processId)
         {
             switch (token)
             {
@@ -211,8 +211,11 @@ namespace OpenDebugAD7
                     }
                 case "$PID":
                     {
-                        // TODO: Get PID, not AD_PROCESS_ID
-                        return string.Format(CultureInfo.InvariantCulture, "<Not Implemented: ${0}>", token);
+                        if (processId != Constants.InvalidProcessId)
+                        {
+                            return processId.ToString(CultureInfo.InvariantCulture);
+                        }
+                        return string.Format(CultureInfo.InvariantCulture, "<Unknown PID>", token);
                     }
                 case "$PNAME":
                     {


### PR DESCRIPTION
Add support for $PID in LogMessages.

We retrieve the actual PID in IDebugProcessInfoUpdatedEvent158. If users try to use $PID before we get the event, it will return `<Unknown PID>`. 

Also updates m_processName from IDebugProcessInfoUpdatedEvent158 event