### PR TITLE
Use FxCop Analyzers instead of Legacy Analyzers

### DIFF
--- a/build/Analyzers.targets
+++ b/build/Analyzers.targets
@@ -1,0 +1,21 @@
+ <Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <!-- Disable Legacy FxCop -->
+    <RunCodeAnalysis>false</RunCodeAnalysis>
+
+    <!-- Point to ruleset -->
+    <CodeAnalysisRuleSet>..\IDECodeAnalysis.ruleset</CodeAnalysisRuleSet>
+  </PropertyGroup>
+  
+  <ItemGroup>
+    <Analyzer Include="$(NugetPackagesDirectory)\Microsoft.CodeAnalysis.VersionCheckAnalyzer.3.3.0\analyzers\dotnet\cs\Microsoft.CodeAnalysis.VersionCheckAnalyzer.resources.dll" />
+    <Analyzer Include="$(NugetPackagesDirectory)\Microsoft.CodeAnalysis.VersionCheckAnalyzer.3.3.0\analyzers\dotnet\Microsoft.CodeAnalysis.VersionCheckAnalyzer.dll" />
+    <Analyzer Include="$(NugetPackagesDirectory)\Microsoft.CodeQuality.Analyzers.3.3.0\analyzers\dotnet\cs\Humanizer.dll" />
+    <Analyzer Include="$(NugetPackagesDirectory)\Microsoft.CodeQuality.Analyzers.3.3.0\analyzers\dotnet\cs\Microsoft.CodeQuality.Analyzers.dll" />
+    <Analyzer Include="$(NugetPackagesDirectory)\Microsoft.CodeQuality.Analyzers.3.3.0\analyzers\dotnet\cs\Microsoft.CodeQuality.CSharp.Analyzers.dll" />
+    <Analyzer Include="$(NugetPackagesDirectory)\Microsoft.NetCore.Analyzers.3.3.0\analyzers\dotnet\cs\Microsoft.NetCore.Analyzers.dll" />
+    <Analyzer Include="$(NugetPackagesDirectory)\Microsoft.NetCore.Analyzers.3.3.0\analyzers\dotnet\cs\Microsoft.NetCore.CSharp.Analyzers.dll" />
+    <Analyzer Include="$(NugetPackagesDirectory)\Microsoft.NetFramework.Analyzers.3.3.0\analyzers\dotnet\cs\Microsoft.NetFramework.Analyzers.dll" />
+    <Analyzer Include="$(NugetPackagesDirectory)\Microsoft.NetFramework.Analyzers.3.3.0\analyzers\dotnet\cs\Microsoft.NetFramework.CSharp.Analyzers.dll" />
+  </ItemGroup>
+</Project>

--- a/build/miengine.targets
+++ b/build/miengine.targets
@@ -5,6 +5,8 @@
     <GeneratedAssemblyInfoFile>$(IntermediateOutputPath)GeneratedAssemblyInfo$(DefaultLanguageSourceExtension)</GeneratedAssemblyInfoFile>
   </PropertyGroup>
 
+  <Import Project=".\Analyzers.targets" />
+
   <PropertyGroup>
     <CoreCompileDependsOn>GenerateAssemblyInfoFile;$(CoreCompileDependsOn)</CoreCompileDependsOn>
     <BuildDependsOn Condition="'$(IsXPlat)' == 'true'">DetermineCompilerBinary;$(BuildDependsOn)</BuildDependsOn>

--- a/src/AndroidDebugLauncher/AndroidDebugLauncher.csproj
+++ b/src/AndroidDebugLauncher/AndroidDebugLauncher.csproj
@@ -23,8 +23,6 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <Prefer32Bit>false</Prefer32Bit>
-    <RunCodeAnalysis>true</RunCodeAnalysis>
-    <CodeAnalysisRuleSet>..\IDECodeAnalysis.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>

--- a/src/AndroidDebugLauncher/AndroidLaunchOptions.cs
+++ b/src/AndroidDebugLauncher/AndroidLaunchOptions.cs
@@ -19,7 +19,7 @@ namespace AndroidDebugLauncher
         {
             if (xmlOptions == null)
             {
-                throw new ArgumentNullException("xmlOptions");
+                throw new ArgumentNullException(nameof(xmlOptions));
             }
 
             this.Package = LaunchOptions.RequireAttribute(xmlOptions.Package, "Package");

--- a/src/AndroidDebugLauncher/InstallPaths.cs
+++ b/src/AndroidDebugLauncher/InstallPaths.cs
@@ -240,12 +240,12 @@ namespace AndroidDebugLauncher
 
             if (string.IsNullOrEmpty(ndkRoot))
             {
-                throw new ArgumentNullException("ndkRoot");
+                throw new ArgumentNullException(nameof(ndkRoot));
             }
 
             if (possiblePaths == null || !possiblePaths.Any())
             {
-                throw new ArgumentOutOfRangeException("possiblePaths");
+                throw new ArgumentOutOfRangeException(nameof(possiblePaths));
             }
 
             string value = TryGetRegistryValue(RegistryRoot.Value + @"\Debugger", registryValueName, RegistryView.Default);

--- a/src/AndroidDebugLauncher/Launcher.cs
+++ b/src/AndroidDebugLauncher/Launcher.cs
@@ -46,9 +46,9 @@ namespace AndroidDebugLauncher
         void IPlatformAppLauncher.Initialize(HostConfigurationStore configStore, IDeviceAppLauncherEventCallback eventCallback)
         {
             if (configStore == null)
-                throw new ArgumentNullException("configStore");
+                throw new ArgumentNullException(nameof(configStore));
             if (eventCallback == null)
-                throw new ArgumentNullException("eventCallback");
+                throw new ArgumentNullException(nameof(eventCallback));
 
             _eventCallback = eventCallback;
             RegistryRoot.Set(configStore.RegistryRoot);
@@ -58,7 +58,7 @@ namespace AndroidDebugLauncher
         void IPlatformAppLauncher.SetLaunchOptions(string exePath, string args, string dir, object launcherXmlOptions, TargetEngine targetEngine)
         {
             if (launcherXmlOptions == null)
-                throw new ArgumentNullException("launcherXmlOptions");
+                throw new ArgumentNullException(nameof(launcherXmlOptions));
 
             var androidXmlOptions = (MICore.Xml.LaunchOptions.AndroidLaunchOptions)launcherXmlOptions;
 

--- a/src/AndroidDebugLauncher/NdkReleaseId.cs
+++ b/src/AndroidDebugLauncher/NdkReleaseId.cs
@@ -30,7 +30,7 @@ namespace AndroidDebugLauncher
         {
             if (releaseNumber == 0)
             {
-                throw new ArgumentOutOfRangeException("releaseNumber");
+                throw new ArgumentOutOfRangeException(nameof(releaseNumber));
             }
 
             this.ReleaseNumber = releaseNumber;

--- a/src/AndroidDebugLauncher/NdkToolVersion.cs
+++ b/src/AndroidDebugLauncher/NdkToolVersion.cs
@@ -25,7 +25,7 @@ namespace AndroidDebugLauncher
         {
             if (versionParts == null)
             {
-                throw new ArgumentNullException("versionParts");
+                throw new ArgumentNullException(nameof(versionParts));
             }
 
             _versionParts = versionParts;

--- a/src/DebugEngineHost.Stub/DebugEngineHost.Stub.csproj
+++ b/src/DebugEngineHost.Stub/DebugEngineHost.Stub.csproj
@@ -35,7 +35,6 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <CodeAnalysisRuleSet>Contract.ruleset</CodeAnalysisRuleSet>
-    <RunCodeAnalysis>true</RunCodeAnalysis>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>
@@ -52,7 +51,6 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <CodeAnalysisRuleSet>Contract.ruleset</CodeAnalysisRuleSet>
-    <RunCodeAnalysis>true</RunCodeAnalysis>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Desktop.Release|AnyCPU'">
     <DebugType>pdbonly</DebugType>

--- a/src/DebugEngineHost.VSCode/DebugEngineHost.VSCode.csproj
+++ b/src/DebugEngineHost.VSCode/DebugEngineHost.VSCode.csproj
@@ -33,8 +33,6 @@
     <DefineConstants>$(DefineConstants);DEBUG;TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
-    <RunCodeAnalysis>true</RunCodeAnalysis>
-    <CodeAnalysisRuleSet>..\IDECodeAnalysis.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Desktop.Release|AnyCPU'">
     <DebugType>pdbonly</DebugType>
@@ -42,8 +40,6 @@
     <DefineConstants>$(DefineConstants);TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
-    <RunCodeAnalysis>true</RunCodeAnalysis>
-    <CodeAnalysisRuleSet>..\IDECodeAnalysis.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Lab.Debug|AnyCPU'">
     <DebugSymbols>true</DebugSymbols>
@@ -69,8 +65,6 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <Prefer32Bit>false</Prefer32Bit>
-    <RunCodeAnalysis>true</RunCodeAnalysis>
-    <CodeAnalysisRuleSet>..\IDECodeAnalysis.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>

--- a/src/DebugEngineHost.VSCode/HostConfigurationSection.cs
+++ b/src/DebugEngineHost.VSCode/HostConfigurationSection.cs
@@ -16,7 +16,10 @@ namespace Microsoft.DebugEngineHost
             _defaultTriggers = defaultTriggers;
         }
 
-        public void Dispose() { }
+        public void Dispose() 
+        {
+            GC.SuppressFinalize(this);
+        }
 
         public object GetValue(string valueName)
         {

--- a/src/DebugEngineHost.VSCode/HostConfigurationStore.cs
+++ b/src/DebugEngineHost.VSCode/HostConfigurationStore.cs
@@ -18,7 +18,7 @@ namespace Microsoft.DebugEngineHost
             _config = EngineConfiguration.TryGet(adapterId);
             if (_config == null)
             {
-                throw new ArgumentOutOfRangeException("adapterId");
+                throw new ArgumentOutOfRangeException(nameof(adapterId));
             }
         }
 

--- a/src/DebugEngineHost.VSCode/HostMarshal.cs
+++ b/src/DebugEngineHost.VSCode/HostMarshal.cs
@@ -30,7 +30,7 @@ namespace Microsoft.DebugEngineHost
         {
             if (documentPosition == null)
             {
-                throw new ArgumentNullException("documentPosition");
+                throw new ArgumentNullException(nameof(documentPosition));
             }
 
             lock (s_documentPositions)
@@ -43,7 +43,7 @@ namespace Microsoft.DebugEngineHost
         {
             if (functionPosition == null)
             {
-                throw new ArgumentNullException("functionPosition");
+                throw new ArgumentNullException(nameof(functionPosition));
             }
 
             lock (s_functionPositions)
@@ -96,7 +96,7 @@ namespace Microsoft.DebugEngineHost
                 IDebugDocumentPosition2 documentPosition;
                 if (!s_documentPositions.TryGet((int)documentPositionId, out documentPosition))
                 {
-                    throw new ArgumentOutOfRangeException("documentPositionId");
+                    throw new ArgumentOutOfRangeException(nameof(documentPositionId));
                 }
 
                 return documentPosition;
@@ -110,7 +110,7 @@ namespace Microsoft.DebugEngineHost
                 IDebugFunctionPosition2 functionPosition;
                 if (!s_functionPositions.TryGet((int)functionPositionId, out functionPosition))
                 {
-                    throw new ArgumentOutOfRangeException("functionPositionId");
+                    throw new ArgumentOutOfRangeException(nameof(functionPositionId));
                 }
 
                 return functionPosition;

--- a/src/DebugEngineHost.VSCode/VSCode/EngineConfiguration.cs
+++ b/src/DebugEngineHost.VSCode/VSCode/EngineConfiguration.cs
@@ -102,7 +102,7 @@ namespace Microsoft.DebugEngineHost.VSCode
         {
             if (adapterDirectory == null)
             {
-                throw new ArgumentNullException("adapterDirectory");
+                throw new ArgumentNullException(nameof(adapterDirectory));
             }
 
             if (Interlocked.CompareExchange(ref s_adapterDirectory, adapterDirectory, null) != null)

--- a/src/DebugEngineHost.VSCode/VSCode/HandleCollection.cs
+++ b/src/DebugEngineHost.VSCode/VSCode/HandleCollection.cs
@@ -61,7 +61,7 @@ namespace Microsoft.DebugEngineHost.VSCode
                 T value;
                 if (!TryGet(handle, out value))
                 {
-                    throw new ArgumentOutOfRangeException("handle");
+                    throw new ArgumentOutOfRangeException(nameof(handle));
                 }
 
                 return value;

--- a/src/DebugEngineHost/DebugEngineHost.csproj
+++ b/src/DebugEngineHost/DebugEngineHost.csproj
@@ -37,8 +37,6 @@
     <DefineConstants>$(DefineConstants);DEBUG;TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
-    <CodeAnalysisRuleSet>..\IDECodeAnalysis.ruleset</CodeAnalysisRuleSet>
-    <RunCodeAnalysis>true</RunCodeAnalysis>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>
@@ -46,7 +44,6 @@
     <DefineConstants>$(DefineConstants);TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
-    <CodeAnalysisRuleSet>..\IDECodeAnalysis.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Lab.Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -55,7 +52,6 @@
     <DefineConstants>$(DefineConstants);DEBUG;TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
-    <CodeAnalysisRuleSet>..\IDECodeAnalysis.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Lab.Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>
@@ -63,7 +59,6 @@
     <DefineConstants>$(DefineConstants);TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
-    <CodeAnalysisRuleSet>..\IDECodeAnalysis.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="Microsoft.VisualStudio.ComponentModelHost, Version=15.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">

--- a/src/DebugEngineHost/HostConfigurationStore.cs
+++ b/src/DebugEngineHost/HostConfigurationStore.cs
@@ -25,7 +25,7 @@ namespace Microsoft.DebugEngineHost
         public HostConfigurationStore(string registryRoot)
         {
             if (string.IsNullOrEmpty(registryRoot))
-                throw new ArgumentNullException("registryRoot");
+                throw new ArgumentNullException(nameof(registryRoot));
 
             _registryRoot = registryRoot;
             _configKey = Registry.LocalMachine.OpenSubKey(registryRoot);
@@ -91,7 +91,7 @@ namespace Microsoft.DebugEngineHost
         {
             if (string.IsNullOrEmpty(logFileName))
             {
-                throw new ArgumentNullException("logFileName");
+                throw new ArgumentNullException(nameof(logFileName));
             }
             object enableLoggingValue;
             if (!string.IsNullOrEmpty(enableLoggingSettingName))

--- a/src/DebugEngineHost/HostConfigurationStore.cs
+++ b/src/DebugEngineHost/HostConfigurationStore.cs
@@ -26,8 +26,6 @@ namespace Microsoft.DebugEngineHost
         {
             if (string.IsNullOrEmpty(registryRoot))
                 throw new ArgumentNullException("registryRoot");
-            if (string.IsNullOrEmpty("engineId"))
-                throw new ArgumentNullException("engineId");
 
             _registryRoot = registryRoot;
             _configKey = Registry.LocalMachine.OpenSubKey(registryRoot);

--- a/src/DebugEngineHost/HostLogger.cs
+++ b/src/DebugEngineHost/HostLogger.cs
@@ -83,7 +83,7 @@ namespace Microsoft.DebugEngineHost
             }
             else
             {
-                throw new ArgumentException(null, nameof(logFileName));
+                throw new ArgumentOutOfRangeException(nameof(logFileName));
             }
             return writer;
         }

--- a/src/DebugEngineHost/HostLogger.cs
+++ b/src/DebugEngineHost/HostLogger.cs
@@ -83,7 +83,7 @@ namespace Microsoft.DebugEngineHost
             }
             else
             {
-                throw new ArgumentException("logFileName");
+                throw new ArgumentException(null, nameof(logFileName));
             }
             return writer;
         }

--- a/src/IDECodeAnalysis.ruleset
+++ b/src/IDECodeAnalysis.ruleset
@@ -99,6 +99,5 @@
 
     <Rule Id="CA1810" Action="None" />
     <Rule Id="CA1715" Action="None" />
-    <Rule Id="CA2211" Action="None" />
   </Rules>
 </RuleSet>

--- a/src/IDECodeAnalysis.ruleset
+++ b/src/IDECodeAnalysis.ruleset
@@ -86,7 +86,6 @@
     <Rule Id="CA2007" Action="None" />
     <Rule Id="CA2008" Action="None" />
     <Rule Id="CA2207" Action="None" />
-    <Rule Id="CA2208" Action="None" />
     <Rule Id="CA2227" Action="None" />
     <Rule Id="CA2237" Action="None" />
 

--- a/src/IDECodeAnalysis.ruleset
+++ b/src/IDECodeAnalysis.ruleset
@@ -85,7 +85,6 @@
     <Rule Id="CA2002" Action="None" />
     <Rule Id="CA2007" Action="None" />
     <Rule Id="CA2008" Action="None" />
-    <Rule Id="CA2207" Action="None" />
     <Rule Id="CA2227" Action="None" />
     <Rule Id="CA2237" Action="None" />
 

--- a/src/IDECodeAnalysis.ruleset
+++ b/src/IDECodeAnalysis.ruleset
@@ -96,7 +96,5 @@
     <Rule Id="CA2213" Action="None" />
     <Rule Id="CA1802" Action="None" />
     <Rule Id="CA2213" Action="None" />
-
-    <Rule Id="CA1810" Action="None" />
   </Rules>
 </RuleSet>

--- a/src/IDECodeAnalysis.ruleset
+++ b/src/IDECodeAnalysis.ruleset
@@ -63,9 +63,8 @@
     <Rule Id="CA1063" Action="None" />
     <Rule Id="CA1065" Action="None" />
     <Rule Id="CA1507" Action="None" />
-    <Rule Id="CA1714" Action="None" />
+
     <Rule Id="CA1716" Action="None" />
-    <Rule Id="CA1717" Action="None" />
     <Rule Id="CA1724" Action="None" />
     <Rule Id="CA1801" Action="None" />
     <Rule Id="CA1805" Action="None" />

--- a/src/IDECodeAnalysis.ruleset
+++ b/src/IDECodeAnalysis.ruleset
@@ -5,6 +5,7 @@
     <Rule Id="CA1305" Action="Error" />
     <Rule Id="CA1306" Action="Error" />
     <Rule Id="CA1307" Action="Error" />
+    <Rule Id="CA1309" Action="Error" />
     <Rule Id="CA2100" Action="Error" />
     <Rule Id="CA2102" Action="Error" />
     <Rule Id="CA2103" Action="Error" />
@@ -51,7 +52,6 @@
     <Rule Id="CA1707" Action="None" />
 
     <!-- TODO ENABLE -->
-    <RUle Id="CA1309" Action="None" />
     <Rule Id="CA1812" Action="None" />
 
     <Rule Id="CA1724" Action="None" />

--- a/src/IDECodeAnalysis.ruleset
+++ b/src/IDECodeAnalysis.ruleset
@@ -78,8 +78,6 @@
     <Rule Id="CA1824" Action="None" />
     <Rule Id="CA1825" Action="None" />
     <Rule Id="CA1827" Action="None" />
-    <Rule Id="CA1829" Action="None" />
-    <Rule Id="CA1830" Action="None" />
     <Rule Id="CA2000" Action="None" />
     <Rule Id="CA2007" Action="None" />
     <Rule Id="CA2008" Action="None" />

--- a/src/IDECodeAnalysis.ruleset
+++ b/src/IDECodeAnalysis.ruleset
@@ -70,8 +70,6 @@
     <Rule Id="CA1801" Action="None" />
     <Rule Id="CA1805" Action="None" />
     <Rule Id="CA1812" Action="None" />
-    <Rule Id="CA1816" Action="None" />
-    <Rule Id="CA1819" Action="None" />
     <Rule Id="CA1819" Action="None" />
     <Rule Id="CA1824" Action="None" />
     <Rule Id="CA2000" Action="None" />

--- a/src/IDECodeAnalysis.ruleset
+++ b/src/IDECodeAnalysis.ruleset
@@ -82,7 +82,6 @@
     <Rule Id="CA1830" Action="None" />
     <Rule Id="CA1834" Action="None" />
     <Rule Id="CA2000" Action="None" />
-    <Rule Id="CA2002" Action="None" />
     <Rule Id="CA2007" Action="None" />
     <Rule Id="CA2008" Action="None" />
     <Rule Id="CA2227" Action="None" />

--- a/src/IDECodeAnalysis.ruleset
+++ b/src/IDECodeAnalysis.ruleset
@@ -2,6 +2,7 @@
 <RuleSet Name="Rules for MICore" Description="Code analysis rules for MICore.csproj." ToolsVersion="14.0">
   <Rules AnalyzerId="Microsoft.Analyzers.ManagedCodeAnalysis" RuleNamespace="Microsoft.Rules.Managed">
     <Rule Id="CA1304" Action="Error" />
+    <Rule Id="CA1305" Action="Error" />
     <Rule Id="CA1306" Action="Error" />
     <Rule Id="CA2100" Action="Error" />
     <Rule Id="CA2102" Action="Error" />
@@ -49,7 +50,6 @@
     <Rule Id="CA1707" Action="None" />
 
     <!-- TODO ENABLE -->
-    <Rule Id="CA1305" Action="None" />
     <Rule Id="CA1307" Action="None" />
     <RUle Id="CA1309" Action="None" />
     <Rule Id="CA1812" Action="None" />

--- a/src/IDECodeAnalysis.ruleset
+++ b/src/IDECodeAnalysis.ruleset
@@ -62,7 +62,6 @@
     <Rule Id="CA1062" Action="None" />
     <Rule Id="CA1063" Action="None" />
     <Rule Id="CA1065" Action="None" />
-    <Rule Id="CA1507" Action="None" />
 
     <Rule Id="CA1716" Action="None" />
     <Rule Id="CA1724" Action="None" />

--- a/src/IDECodeAnalysis.ruleset
+++ b/src/IDECodeAnalysis.ruleset
@@ -88,7 +88,6 @@
     <Rule Id="CA2207" Action="None" />
     <Rule Id="CA2208" Action="None" />
     <Rule Id="CA2227" Action="None" />
-    <Rule Id="CA2234" Action="None" />
     <Rule Id="CA2237" Action="None" />
 
     <!-- Warnings -->

--- a/src/IDECodeAnalysis.ruleset
+++ b/src/IDECodeAnalysis.ruleset
@@ -77,7 +77,6 @@
     <Rule Id="CA1822" Action="None" />
     <Rule Id="CA1824" Action="None" />
     <Rule Id="CA1825" Action="None" />
-    <Rule Id="CA1827" Action="None" />
     <Rule Id="CA2000" Action="None" />
     <Rule Id="CA2007" Action="None" />
     <Rule Id="CA2008" Action="None" />

--- a/src/IDECodeAnalysis.ruleset
+++ b/src/IDECodeAnalysis.ruleset
@@ -1,100 +1,95 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <RuleSet Name="Rules for MICore" Description="Code analysis rules for MICore.csproj." ToolsVersion="14.0">
   <Rules AnalyzerId="Microsoft.Analyzers.ManagedCodeAnalysis" RuleNamespace="Microsoft.Rules.Managed">
-    <Rule Id="CA1304" Action="Error" />
-    <Rule Id="CA1305" Action="Error" />
-    <Rule Id="CA1306" Action="Error" />
-    <Rule Id="CA1307" Action="Error" />
-    <Rule Id="CA1309" Action="Error" />
-    <Rule Id="CA2100" Action="Error" />
-    <Rule Id="CA2102" Action="Error" />
-    <Rule Id="CA2103" Action="Error" />
-    <Rule Id="CA2104" Action="Error" />
-    <Rule Id="CA2105" Action="Error" />
-    <Rule Id="CA2106" Action="Error" />
-    <Rule Id="CA2107" Action="Error" />
-    <Rule Id="CA2108" Action="Error" />
-    <Rule Id="CA2109" Action="Error" />
-    <Rule Id="CA2111" Action="Error" />
-    <Rule Id="CA2112" Action="Error" />
-    <Rule Id="CA2114" Action="Error" />
-    <Rule Id="CA2115" Action="Error" />
-    <Rule Id="CA2116" Action="Error" />
-    <Rule Id="CA2117" Action="Error" />
-    <Rule Id="CA2118" Action="Error" />
-    <Rule Id="CA2119" Action="Error" />
-    <Rule Id="CA2120" Action="Error" />
-    <Rule Id="CA2121" Action="Error" />
-    <Rule Id="CA2122" Action="Error" />
-    <Rule Id="CA2123" Action="Error" />
-    <Rule Id="CA2124" Action="Error" />
-    <Rule Id="CA2126" Action="Error" />
-    <Rule Id="CA2130" Action="Error" />
-    <Rule Id="CA2131" Action="Error" />
-    <Rule Id="CA2132" Action="Error" />
-    <Rule Id="CA2133" Action="Error" />
-    <Rule Id="CA2134" Action="Error" />
-    <Rule Id="CA2135" Action="Error" />
-    <Rule Id="CA2136" Action="Error" />
-    <Rule Id="CA2137" Action="Error" />
-    <Rule Id="CA2138" Action="Error" />
-    <Rule Id="CA2139" Action="Error" />
-    <Rule Id="CA2140" Action="Error" />
-    <Rule Id="CA2141" Action="Error" />
-    <Rule Id="CA2142" Action="Error" />
-    <Rule Id="CA2143" Action="Error" />
-    <Rule Id="CA2144" Action="Error" />
-    <Rule Id="CA2145" Action="Error" />
-    <Rule Id="CA2146" Action="Error" />
-    <Rule Id="CA2147" Action="Error" />
-    <Rule Id="CA2149" Action="Error" />
+    <Rule Id="CA1304" Action="Error" Description="CA1304: Specify CultureInfo" />
+    <Rule Id="CA1305" Action="Error" Description="CA1305: Specify IFormatProvider" />
+    <Rule Id="CA1306" Action="Error" Description="CA1306: Set locale for data types" />
+    <Rule Id="CA1307" Action="Error" Description="CA1307: Specify StringComparison for clarity" />
+    <Rule Id="CA1309" Action="Error" Description="CA1309: Use ordinal StringComparison" />
+    <Rule Id="CA2100" Action="Error" Description="CA2100: Review SQL queries for security vulnerabilities" />
+    <Rule Id="CA2102" Action="Error" Description="CA2102: Catch non-CLSCompliant exceptions in general handlers" />
+    <Rule Id="CA2103" Action="Error" Description="CA2103: Review imperative security" />
+    <Rule Id="CA2104" Action="Error" Description="CA2104: Do not declare read only mutable reference types" />
+    <Rule Id="CA2105" Action="Error" Description="CA2105: Array fields should not be read only" />
+    <Rule Id="CA2106" Action="Error" Description="CA2106: Secure asserts" />
+    <Rule Id="CA2107" Action="Error" Description="CA2107: Review deny and permit only usage" />
+    <Rule Id="CA2108" Action="Error" Description="CA2108: Review declarative security on value types" />
+    <Rule Id="CA2109" Action="Error" Description="CA2109: Review visible event handlers" />
+    <Rule Id="CA2111" Action="Error" Description="CA2111: Pointers should not be visible" />
+    <Rule Id="CA2112" Action="Error" Description="CA2112: Secured types should not expose fields" />
+    <Rule Id="CA2114" Action="Error" Description="CA2114: Method security should be a superset of type" />
+    <Rule Id="CA2115" Action="Error" Description="Call GC.KeepAlive when using native resources" />
+    <Rule Id="CA2116" Action="Error" Description="CA2116: APTCA methods should only call APTCA methods" />
+    <Rule Id="CA2117" Action="Error" Description="CA2117: APTCA types should only extend APTCA base types" />
+    <Rule Id="CA2118" Action="Error" Description="CA2118: Review SuppressUnmanagedCodeSecurityAttribute usage" />
+    <Rule Id="CA2119" Action="Error" Description="CA2119: Seal methods that satisfy private interfaces" />
+    <Rule Id="CA2120" Action="Error" Description="CA2120: Secure serialization constructors" />
+    <Rule Id="CA2121" Action="Error" Description="CA2121: Static constructors should be private" />
+    <Rule Id="CA2122" Action="Error" Description="CA2122: Do not indirectly expose methods with link demands" />
+    <Rule Id="CA2123" Action="Error" Description="CA2123: Override link demands should be identical to base" />
+    <Rule Id="CA2124" Action="Error" Description="CA2124: Wrap vulnerable finally clauses in outer try" />
+    <Rule Id="CA2126" Action="Error" Description="CA2126: Type link demands require inheritance demands" />
+    <Rule Id="CA2130" Action="Error" Description="CA2130: Security critical constants should be transparent" />
+    <Rule Id="CA2131" Action="Error" Description="CA2131: Security critical types may not participate in type equivalence" />
+    <Rule Id="CA2132" Action="Error" Description="CA2132: Default constructors must be at least as critical as base type default constructors" />
+    <Rule Id="CA2133" Action="Error" Description="CA2133: Delegates must bind to methods with consistent transparency" />
+    <Rule Id="CA2134" Action="Error" Description="CA2134: Methods must keep consistent transparency when overriding base methods" />
+    <Rule Id="CA2135" Action="Error" Description="CA2135: Level 2 assemblies should not contain LinkDemands" />
+    <Rule Id="CA2136" Action="Error" Description="CA2136: Members should not have conflicting transparency annotations" />
+    <Rule Id="CA2137" Action="Error" Description="CA2137: Transparent methods must contain only verifiable IL" />
+    <Rule Id="CA2138" Action="Error" Description="CA2138: Transparent methods must not call methods with the SuppressUnmanagedCodeSecurity attribute" />
+    <Rule Id="CA2139" Action="Error" Description="CA2139: Transparent methods may not use the HandleProcessCorruptingExceptions attribute" />
+    <Rule Id="CA2140" Action="Error" Description="CA2140: Transparent code must not reference security critical items" />
+    <Rule Id="CA2141" Action="Error" Description="CA2141:Transparent methods must not satisfy LinkDemands" />
+    <Rule Id="CA2142" Action="Error" Description="CA2142: Transparent code should not be protected with LinkDemands" />
+    <Rule Id="CA2143" Action="Error" Description="CA2143: Transparent methods should not use security demands" />
+    <Rule Id="CA2144" Action="Error" Description="CA2144: Transparent code should not load assemblies from byte arrays" />
+    <Rule Id="CA2145" Action="Error" Description="CA2145: Transparent methods should not be decorated with the SuppressUnmanagedCodeSecurityAttribute" />
+    <Rule Id="CA2146" Action="Error" Description="CA2146: Types must be at least as critical as their base types and interfaces" />
+    <Rule Id="CA2147" Action="Error" Description="CA2147: Transparent methods may not use security asserts" />
+    <Rule Id="CA2149" Action="Error" Description="CA2149: Transparent methods must not call into native code" />
 
-    <Rule Id="CA1707" Action="None" />
+    <!-- TODO(waan): Enable errors and warnings below -->
 
-    <!-- TODO ENABLE -->
-    <Rule Id="CA1001" Action="None" />
-    <Rule Id="CA1031" Action="None" />
-    <Rule Id="CA1032" Action="None" />
-    <Rule Id="CA1034" Action="None" />
-    <Rule Id="CA1051" Action="None" />
-    <Rule Id="CA1054" Action="None" />
-    <Rule Id="CA1056" Action="None" />
-    <Rule Id="CA1062" Action="None" />
-    <Rule Id="CA1063" Action="None" />
-    <Rule Id="CA1065" Action="None" />
-
-    <Rule Id="CA1716" Action="None" />
-    <Rule Id="CA1724" Action="None" />
-    <Rule Id="CA1801" Action="None" />
-    <Rule Id="CA1805" Action="None" />
-    <Rule Id="CA1812" Action="None" />
-    <Rule Id="CA1819" Action="None" />
-    <Rule Id="CA1824" Action="None" />
-    <Rule Id="CA2000" Action="None" />
-    <Rule Id="CA2007" Action="None" />
-    <Rule Id="CA2008" Action="None" />
-    <Rule Id="CA2227" Action="None" />
-    <Rule Id="CA2237" Action="None" />
+    <!-- Errors -->
+    <Rule Id="CA1001" Action="None" Description="CA1001: Types that own disposable fields should be disposable" />
+    <Rule Id="CA1031" Action="None" Description="CA1031: Do not catch general exception types" />
+    <Rule Id="CA1032" Action="None" Description="CA1032: Implement standard exception constructors" />
+    <Rule Id="CA1034" Action="None" Description="CA1034: Nested types should not be visible" />
+    <Rule Id="CA1051" Action="None" Description="CA1051: Do not declare visible instance fields" />
+    <Rule Id="CA1054" Action="None" Description="CA1054: URI parameters should not be strings" />
+    <Rule Id="CA1056" Action="None" Description="CA1056: URI properties should not be strings" />
+    <Rule Id="CA1062" Action="None" Description="CA1062: Validate arguments of public methods" />
+    <Rule Id="CA1063" Action="None" Description="CA1063: Implement IDisposable correctly" />
+    <Rule Id="CA1065" Action="None" Description="CA1065: Do not raise exceptions in unexpected locations" />
+    <Rule Id="CA1707" Action="None" Description="CA1707: Identifiers should not contain underscores" />
+    <Rule Id="CA1716" Action="None" Description="CA1716: Identifiers should not match keywords" />
+    <Rule Id="CA1724" Action="None" Description="CA1724: Type names should not match namespaces" />
+    <Rule Id="CA1801" Action="None" Description="CA1801: Review unused parameters" />
+    <Rule Id="CA1805" Action="None" Description="CA1805: Do not initialize unnecessarily." />
+    <Rule Id="CA1812" Action="None" Description="CA1812: Avoid uninstantiated internal classes" />
+    <Rule Id="CA1819" Action="None" Description="CA1819: Properties should not return arrays" />
+    <Rule Id="CA1824" Action="None" Description="CA1824: Mark assemblies with NeutralResourcesLanguageAttribute" />
+    <Rule Id="CA2000" Action="None" Description="CA2000: Dispose objects before losing scope" />
+    <Rule Id="CA2007" Action="None" Description="CA2007: Do not directly await a Task" />
+    <Rule Id="CA2008" Action="None" Description="CA2008: Do not create tasks without passing a TaskScheduler" />
+    <Rule Id="CA2227" Action="None" Description="CA2227: Collection properties should be read only" />
+    <Rule Id="CA2237" Action="None" Description="CA2237: Mark ISerializable types with SerializableAttribute" />
 
     <!-- Warnings -->
-    <Rule Id="CA1822" Action="None" />
-    <Rule Id="CA1707" Action="None" />
-    <Rule Id="CA1825" Action="None" />
-    <Rule Id="CA1806" Action="None" />
-    <Rule Id="CA2248" Action="None" />
-    <Rule Id="CA1308" Action="None" />
-    <Rule Id="CA1823" Action="None" />
-    <Rule Id="CA2241" Action="None" />
-    <Rule Id="CA1303" Action="None" />
-    <Rule Id="CA1806" Action="None" />
-    <Rule Id="CA1064" Action="None" />
-
-    <Rule Id="CA1815" Action="None" />
-    <Rule Id="CA1052" Action="None" />
-    <Rule Id="CA1068" Action="None" />
-
-    <Rule Id="CA2213" Action="None" />
-    <Rule Id="CA1802" Action="None" />
-    <Rule Id="CA2213" Action="None" />
+    <Rule Id="CA1052" Action="None" Description="CA1052: Static holder types should be Static or NotInheritable" />
+    <Rule Id="CA1064" Action="None" Description="CA1064: Exceptions should be public" />
+    <Rule Id="CA1068" Action="None" Description="CA1068: CancellationToken parameters must come last" />
+    <Rule Id="CA1303" Action="None" Description="CA1303: Do not pass literals as localized parameters" />
+    <Rule Id="CA1308" Action="None" Description="CA1308: Normalize strings to uppercase" />
+    <Rule Id="CA1802" Action="None" Description="CA1802: Use Literals Where Appropriate" />
+    <Rule Id="CA1806" Action="None" Description="CA1806: Do not ignore method results" />
+    <Rule Id="CA1815" Action="None" Description="CA1815: Override equals and operator equals on value types" />
+    <Rule Id="CA1822" Action="None" Description="CA1822: Mark members as static" />
+    <Rule Id="CA1823" Action="None" Description="CA1823: Avoid unused private fields" />
+    <Rule Id="CA1825" Action="None" Description="CA1825: Avoid zero-length array allocations" />
+    <Rule Id="CA2213" Action="None" Description="CA2213: Disposable fields should be disposed" />
+    <Rule Id="CA2241" Action="None" Description="CA2241: Provide correct arguments to formatting methods" />
+    <Rule Id="CA2248" Action="None" Description="CA2248: Provide correct enum argument to Enum.HasFlag" />
   </Rules>
 </RuleSet>

--- a/src/IDECodeAnalysis.ruleset
+++ b/src/IDECodeAnalysis.ruleset
@@ -52,54 +52,44 @@
     <Rule Id="CA1707" Action="None" />
 
     <!-- TODO ENABLE -->
-    <Rule Id="CA1812" Action="None" />
-
-    <Rule Id="CA1724" Action="None" />
-    <Rule Id="CA1822" Action="None" />
-    <Rule Id="CA1801" Action="None" />
-    <Rule Id="CA1062" Action="None" />
-    <Rule Id="CA1051" Action="None" />
-    <Rule Id="CA1063" Action="None" />
-
-    <Rule Id="CA1805" Action="None" />
     <Rule Id="CA1001" Action="None" />
-    <Rule Id="CA1819" Action="None" />
-    <Rule Id="CA1819" Action="None" />
-
-    <Rule Id="CA1032" Action="None" />
-    <Rule Id="CA2237" Action="None" />
-    <Rule Id="CA1717" Action="None" />
-    <Rule Id="CA1714" Action="None" />
-    <Rule Id="CA1507" Action="None" />
-
-    <Rule Id="CA2227" Action="None" />
-    <Rule Id="CA1056" Action="None" />
-    <Rule Id="CA1034" Action="None" />
-
-    <Rule Id="CA2007" Action="None" />
     <Rule Id="CA1031" Action="None" />
-    <Rule Id="CA2208" Action="None" />
-    <Rule Id="CA2000" Action="None" />
-    <Rule Id="CA1825" Action="None" />
-    <Rule Id="CA1834" Action="None" />
-
-    <Rule Id="CA2002" Action="None" />
-    <Rule Id="CA2234" Action="None" />
-    <Rule Id="CA1065" Action="None" />
-
-    <Rule Id="CA2207" Action="None" />
+    <Rule Id="CA1032" Action="None" />
+    <Rule Id="CA1034" Action="None" />
+    <Rule Id="CA1051" Action="None" />
     <Rule Id="CA1054" Action="None" />
-    <Rule Id="CA1816" Action="None" />
+    <Rule Id="CA1056" Action="None" />
+    <Rule Id="CA1062" Action="None" />
+    <Rule Id="CA1063" Action="None" />
+    <Rule Id="CA1065" Action="None" />
+    <Rule Id="CA1507" Action="None" />
+    <Rule Id="CA1714" Action="None" />
     <Rule Id="CA1716" Action="None" />
-
-    <Rule Id="CA1829" Action="None" />
+    <Rule Id="CA1717" Action="None" />
+    <Rule Id="CA1724" Action="None" />
+    <Rule Id="CA1801" Action="None" />
+    <Rule Id="CA1805" Action="None" />
+    <Rule Id="CA1812" Action="None" />
+    <Rule Id="CA1816" Action="None" />
+    <Rule Id="CA1819" Action="None" />
+    <Rule Id="CA1819" Action="None" />
     <Rule Id="CA1820" Action="None" />
-    <Rule Id="CA5397" Action="None" />
-
-    <Rule Id="CA1827" Action="None" />
-    <Rule Id="CA1830" Action="None" />
-    <Rule Id="CA2008" Action="None" />
+    <Rule Id="CA1822" Action="None" />
     <Rule Id="CA1824" Action="None" />
+    <Rule Id="CA1825" Action="None" />
+    <Rule Id="CA1827" Action="None" />
+    <Rule Id="CA1829" Action="None" />
+    <Rule Id="CA1830" Action="None" />
+    <Rule Id="CA1834" Action="None" />
+    <Rule Id="CA2000" Action="None" />
+    <Rule Id="CA2002" Action="None" />
+    <Rule Id="CA2007" Action="None" />
+    <Rule Id="CA2008" Action="None" />
+    <Rule Id="CA2207" Action="None" />
+    <Rule Id="CA2208" Action="None" />
+    <Rule Id="CA2227" Action="None" />
+    <Rule Id="CA2234" Action="None" />
+    <Rule Id="CA2237" Action="None" />
 
     <!-- Warnings -->
     <Rule Id="CA1822" Action="None" />

--- a/src/IDECodeAnalysis.ruleset
+++ b/src/IDECodeAnalysis.ruleset
@@ -4,6 +4,7 @@
     <Rule Id="CA1304" Action="Error" />
     <Rule Id="CA1305" Action="Error" />
     <Rule Id="CA1306" Action="Error" />
+    <Rule Id="CA1307" Action="Error" />
     <Rule Id="CA2100" Action="Error" />
     <Rule Id="CA2102" Action="Error" />
     <Rule Id="CA2103" Action="Error" />
@@ -50,7 +51,6 @@
     <Rule Id="CA1707" Action="None" />
 
     <!-- TODO ENABLE -->
-    <Rule Id="CA1307" Action="None" />
     <RUle Id="CA1309" Action="None" />
     <Rule Id="CA1812" Action="None" />
 

--- a/src/IDECodeAnalysis.ruleset
+++ b/src/IDECodeAnalysis.ruleset
@@ -2,10 +2,7 @@
 <RuleSet Name="Rules for MICore" Description="Code analysis rules for MICore.csproj." ToolsVersion="14.0">
   <Rules AnalyzerId="Microsoft.Analyzers.ManagedCodeAnalysis" RuleNamespace="Microsoft.Rules.Managed">
     <Rule Id="CA1304" Action="Error" />
-    <Rule Id="CA1305" Action="Error" />
     <Rule Id="CA1306" Action="Error" />
-    <Rule Id="CA1307" Action="Error" />
-    <Rule Id="CA1309" Action="Error" />
     <Rule Id="CA2100" Action="Error" />
     <Rule Id="CA2102" Action="Error" />
     <Rule Id="CA2103" Action="Error" />
@@ -48,5 +45,85 @@
     <Rule Id="CA2146" Action="Error" />
     <Rule Id="CA2147" Action="Error" />
     <Rule Id="CA2149" Action="Error" />
+
+    <Rule Id="CA1707" Action="None" />
+
+    <!-- TODO ENABLE -->
+    <Rule Id="CA1305" Action="None" />
+    <Rule Id="CA1307" Action="None" />
+    <RUle Id="CA1309" Action="None" />
+    <Rule Id="CA1812" Action="None" />
+
+    <Rule Id="CA1724" Action="None" />
+    <Rule Id="CA1822" Action="None" />
+    <Rule Id="CA1801" Action="None" />
+    <Rule Id="CA1062" Action="None" />
+    <Rule Id="CA1051" Action="None" />
+    <Rule Id="CA1063" Action="None" />
+
+    <Rule Id="CA1805" Action="None" />
+    <Rule Id="CA1001" Action="None" />
+    <Rule Id="CA1819" Action="None" />
+    <Rule Id="CA1819" Action="None" />
+
+    <Rule Id="CA1032" Action="None" />
+    <Rule Id="CA2237" Action="None" />
+    <Rule Id="CA1717" Action="None" />
+    <Rule Id="CA1714" Action="None" />
+    <Rule Id="CA1507" Action="None" />
+
+    <Rule Id="CA2227" Action="None" />
+    <Rule Id="CA1056" Action="None" />
+    <Rule Id="CA1034" Action="None" />
+
+    <Rule Id="CA2007" Action="None" />
+    <Rule Id="CA1031" Action="None" />
+    <Rule Id="CA2208" Action="None" />
+    <Rule Id="CA2000" Action="None" />
+    <Rule Id="CA1825" Action="None" />
+    <Rule Id="CA1834" Action="None" />
+
+    <Rule Id="CA2002" Action="None" />
+    <Rule Id="CA2234" Action="None" />
+    <Rule Id="CA1065" Action="None" />
+
+    <Rule Id="CA2207" Action="None" />
+    <Rule Id="CA1054" Action="None" />
+    <Rule Id="CA1816" Action="None" />
+    <Rule Id="CA1716" Action="None" />
+
+    <Rule Id="CA1829" Action="None" />
+    <Rule Id="CA1820" Action="None" />
+    <Rule Id="CA5397" Action="None" />
+
+    <Rule Id="CA1827" Action="None" />
+    <Rule Id="CA1830" Action="None" />
+    <Rule Id="CA2008" Action="None" />
+    <Rule Id="CA1824" Action="None" />
+
+    <!-- Warnings -->
+    <Rule Id="CA1822" Action="None" />
+    <Rule Id="CA1707" Action="None" />
+    <Rule Id="CA1825" Action="None" />
+    <Rule Id="CA1806" Action="None" />
+    <Rule Id="CA2248" Action="None" />
+    <Rule Id="CA1308" Action="None" />
+    <Rule Id="CA1823" Action="None" />
+    <Rule Id="CA2241" Action="None" />
+    <Rule Id="CA1303" Action="None" />
+    <Rule Id="CA1806" Action="None" />
+    <Rule Id="CA1064" Action="None" />
+
+    <Rule Id="CA1815" Action="None" />
+    <Rule Id="CA1052" Action="None" />
+    <Rule Id="CA1068" Action="None" />
+
+    <Rule Id="CA2213" Action="None" />
+    <Rule Id="CA1802" Action="None" />
+    <Rule Id="CA2213" Action="None" />
+
+    <Rule Id="CA1810" Action="None" />
+    <Rule Id="CA1715" Action="None" />
+    <Rule Id="CA2211" Action="None" />
   </Rules>
 </RuleSet>

--- a/src/IDECodeAnalysis.ruleset
+++ b/src/IDECodeAnalysis.ruleset
@@ -98,6 +98,5 @@
     <Rule Id="CA2213" Action="None" />
 
     <Rule Id="CA1810" Action="None" />
-    <Rule Id="CA1715" Action="None" />
   </Rules>
 </RuleSet>

--- a/src/IDECodeAnalysis.ruleset
+++ b/src/IDECodeAnalysis.ruleset
@@ -80,7 +80,6 @@
     <Rule Id="CA1827" Action="None" />
     <Rule Id="CA1829" Action="None" />
     <Rule Id="CA1830" Action="None" />
-    <Rule Id="CA1834" Action="None" />
     <Rule Id="CA2000" Action="None" />
     <Rule Id="CA2007" Action="None" />
     <Rule Id="CA2008" Action="None" />

--- a/src/IDECodeAnalysis.ruleset
+++ b/src/IDECodeAnalysis.ruleset
@@ -73,10 +73,7 @@
     <Rule Id="CA1816" Action="None" />
     <Rule Id="CA1819" Action="None" />
     <Rule Id="CA1819" Action="None" />
-    <Rule Id="CA1820" Action="None" />
-    <Rule Id="CA1822" Action="None" />
     <Rule Id="CA1824" Action="None" />
-    <Rule Id="CA1825" Action="None" />
     <Rule Id="CA2000" Action="None" />
     <Rule Id="CA2007" Action="None" />
     <Rule Id="CA2008" Action="None" />

--- a/src/IOSDebugLauncher/IOSDebugLauncher.csproj
+++ b/src/IOSDebugLauncher/IOSDebugLauncher.csproj
@@ -22,8 +22,6 @@
     <DefineConstants>$(DefineConstants);DEBUG;TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
-    <RunCodeAnalysis>true</RunCodeAnalysis>
-    <CodeAnalysisRuleSet>..\IDECodeAnalysis.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>

--- a/src/IOSDebugLauncher/IOSLaunchOptions.cs
+++ b/src/IOSDebugLauncher/IOSLaunchOptions.cs
@@ -27,9 +27,9 @@ namespace IOSDebugLauncher
         public IOSLaunchOptions(string exePath, MICore.Xml.LaunchOptions.IOSLaunchOptions xmlOptions)
         {
             if (string.IsNullOrEmpty(exePath))
-                throw new ArgumentNullException("exePath");
+                throw new ArgumentNullException(nameof(exePath));
             if (xmlOptions == null)
-                throw new ArgumentNullException("xmlOptions");
+                throw new ArgumentNullException(nameof(xmlOptions));
 
             this.ExePath = exePath;
             this.RemoteMachineName = LaunchOptions.RequireAttribute(xmlOptions.RemoteMachineName, "RemoteMachineName");

--- a/src/IOSDebugLauncher/Launcher.cs
+++ b/src/IOSDebugLauncher/Launcher.cs
@@ -44,7 +44,7 @@ namespace IOSDebugLauncher
         void IPlatformAppLauncher.SetLaunchOptions(string exePath, string args, string dir, object launcherXmlOptions, TargetEngine targetEngine)
         {
             if (launcherXmlOptions == null)
-                throw new ArgumentNullException("launcherXmlOptions");
+                throw new ArgumentNullException(nameof(launcherXmlOptions));
 
             if (targetEngine != TargetEngine.Native)
                 throw new LauncherException(String.Format(CultureInfo.CurrentCulture, LauncherResources.Error_BadTargetEngine, targetEngine.ToString()));

--- a/src/IOSDebugLauncher/VcRemoteClient.cs
+++ b/src/IOSDebugLauncher/VcRemoteClient.cs
@@ -118,7 +118,7 @@ namespace IOSDebugLauncher
                         }
                         else
                         {
-                            exceptionDispatchInfo = ExceptionDispatchInfo.Capture(new LauncherException(string.Format(LauncherResources.Error_VcRemoteUnknown, response.StatusCode.ToString())));
+                            exceptionDispatchInfo = ExceptionDispatchInfo.Capture(new LauncherException(string.Format(CultureInfo.CurrentCulture, LauncherResources.Error_VcRemoteUnknown, response.StatusCode.ToString())));
                             failureCode = Telemetry.VcRemoteFailureCode.VcRemoteUnkown.ToString();
                         }
                     }

--- a/src/JDbg/JDbg.csproj
+++ b/src/JDbg/JDbg.csproj
@@ -21,8 +21,6 @@
     <DefineConstants>$(DefineConstants);DEBUG;TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
-    <RunCodeAnalysis>true</RunCodeAnalysis>
-    <CodeAnalysisRuleSet>..\IDECodeAnalysis.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>

--- a/src/JDbg/Jdwp.cs
+++ b/src/JDbg/Jdwp.cs
@@ -45,7 +45,7 @@ namespace JDbg
 
             if (packet.Length < JdwpCommand.HEADER_SIZE)
             {
-                throw new ArgumentException("buffer too small to be a full packet", "packet");
+                throw new ArgumentException("buffer too small to be a full packet", nameof(packet));
             }
 
             //byte 8 of the packet header tells us whether this is a reply or not

--- a/src/JDbgUnitTests/JDbgUnitTests.csproj
+++ b/src/JDbgUnitTests/JDbgUnitTests.csproj
@@ -29,8 +29,6 @@
     <DefineConstants>$(DefineConstants);DEBUG;TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
-    <RunCodeAnalysis>true</RunCodeAnalysis>
-    <CodeAnalysisRuleSet>..\IDECodeAnalysis.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>

--- a/src/MICore/Checksum.cs
+++ b/src/MICore/Checksum.cs
@@ -121,7 +121,7 @@ namespace MICore
             {
                 if (builder.Length > 0)
                 {
-                    builder.Append(" ");
+                    builder.Append(' ');
                 }
                 builder.Append(string.Format(CultureInfo.InvariantCulture, "--{0}checksum ", group.Key.ToString()));
                 builder.Append(string.Join(",", group));

--- a/src/MICore/Checksum.cs
+++ b/src/MICore/Checksum.cs
@@ -37,7 +37,7 @@ namespace MICore
         {
             if (checksumBytes == null)
             {
-                throw new ArgumentNullException("checksumBytes");
+                throw new ArgumentNullException(nameof(checksumBytes));
             }
 
             return new Checksum(hashAlgorithmName, checksumBytes);
@@ -53,7 +53,7 @@ namespace MICore
         {
             if (checksumString == null)
             {
-                throw new ArgumentNullException("checksumString");
+                throw new ArgumentNullException(nameof(checksumString));
             }
 
             Checksum checksum = new Checksum(hashAlgorithmName, StringToBytes(checksumString));

--- a/src/MICore/CommandFactories/MICommandFactory.cs
+++ b/src/MICore/CommandFactories/MICommandFactory.cs
@@ -60,7 +60,7 @@ namespace MICore
                     commandFactory = new ClrdbgMICommandFactory();
                     break;
                 default:
-                    throw new ArgumentException("mode");
+                    throw new ArgumentException(null, nameof(mode));
             }
             commandFactory._debugger = debugger;
             commandFactory.Mode = mode;

--- a/src/MICore/CommandFactories/MICommandFactory.cs
+++ b/src/MICore/CommandFactories/MICommandFactory.cs
@@ -458,21 +458,21 @@ namespace MICore
             if (checksums != null && checksums.Count() != 0)
             {
                 cmd.Append(Checksum.GetMIString(checksums));
-                cmd.Append(" ");
+                cmd.Append(' ');
             }
 
             string filenameMI;
             bool quotes = PreparePath(filename, useUnixFormat, out filenameMI);
             if (quotes)
             {
-                cmd.Append("\"");
+                cmd.Append('\"');
             }
             cmd.Append(filenameMI);
-            cmd.Append(":");
+            cmd.Append(':');
             cmd.Append(line.ToString(CultureInfo.InvariantCulture));
             if (quotes)
             {
-                cmd.Append("\"");
+                cmd.Append('\"');
             }
 
             return await _debugger.CmdAsync(cmd.ToString(), resultClass);

--- a/src/MICore/CommandFactories/MICommandFactory.cs
+++ b/src/MICore/CommandFactories/MICommandFactory.cs
@@ -21,7 +21,7 @@ namespace MICore
         Clrdbg
     }
 
-    public enum PrintValues
+    public enum PrintValue
     {
         NoValues = 0,
         AllValues = 1,
@@ -29,7 +29,7 @@ namespace MICore
     }
 
     [Flags]
-    public enum ExceptionBreakpointState
+    public enum ExceptionBreakpointStates
     {
         None = 0,
         BreakUserHandled = 0x1,
@@ -155,7 +155,7 @@ namespace MICore
         /// <param name="threadId"></param>
         /// <param name="frameLevel"></param>
         /// <returns></returns>
-        public async Task<ResultValue> StackListLocals(PrintValues printValues, int threadId, uint frameLevel)
+        public async Task<ResultValue> StackListLocals(PrintValue printValues, int threadId, uint frameLevel)
         {
             string cmd = string.Format(CultureInfo.InvariantCulture, @"-stack-list-locals {0}", (int)printValues);
 
@@ -171,7 +171,7 @@ namespace MICore
         /// <param name="lowFrameLevel"></param>
         /// <param name="hiFrameLevel"></param>
         /// <returns>This returns an array of results of frames, which contains a level and an args array. </returns>
-        public virtual async Task<TupleValue[]> StackListArguments(PrintValues printValues, int threadId, uint lowFrameLevel, uint hiFrameLevel)
+        public virtual async Task<TupleValue[]> StackListArguments(PrintValue printValues, int threadId, uint lowFrameLevel, uint hiFrameLevel)
         {
             string cmd = string.Format(CultureInfo.InvariantCulture, @"-stack-list-arguments {0} {1} {2}", (int)printValues, lowFrameLevel, hiFrameLevel);
             Results argumentsResults = await ThreadCmdAsync(cmd, ResultClass.done, threadId);
@@ -188,7 +188,7 @@ namespace MICore
         /// <param name="threadId"></param>
         /// <param name="frameLevel"></param>
         /// <returns>This returns an array of results for args, which have a name and a value, etc.</returns>
-        public async Task<ListValue> StackListArguments(PrintValues printValues, int threadId, uint frameLevel)
+        public async Task<ListValue> StackListArguments(PrintValue printValues, int threadId, uint frameLevel)
         {
             TupleValue[] frameResults = await StackListArguments(printValues, threadId, frameLevel, frameLevel);
 
@@ -204,7 +204,7 @@ namespace MICore
         /// <param name="threadId"></param>
         /// <param name="frameLevel"></param>
         /// <returns>Returns an array of results for variables</returns>
-        public async Task<ValueListValue> StackListVariables(PrintValues printValues, int threadId, uint frameLevel)
+        public async Task<ValueListValue> StackListVariables(PrintValue printValues, int threadId, uint frameLevel)
         {
             string cmd = string.Format(CultureInfo.InvariantCulture, @"-stack-list-variables {0}", (int)printValues);
 
@@ -554,7 +554,7 @@ namespace MICore
         /// exceptions in the category. Note that this clear all previous exception breakpoints set in this category.</param>
         /// <param name="exceptionBreakpointState">Indicates when the exception breakpoint should fire</param>
         /// <returns>Task containing the exception breakpoint id's for the various set exceptions</returns>
-        public virtual Task<IEnumerable<ulong>> SetExceptionBreakpoints(Guid exceptionCategory, /*OPTIONAL*/ IEnumerable<string> exceptionNames, ExceptionBreakpointState exceptionBreakpointState)
+        public virtual Task<IEnumerable<ulong>> SetExceptionBreakpoints(Guid exceptionCategory, /*OPTIONAL*/ IEnumerable<string> exceptionNames, ExceptionBreakpointStates exceptionBreakpointState)
         {
             // NOTES:
             // GDB /MI has no support for exceptions. Though they do have it through the non-MI through a 'catch' command. Example:
@@ -581,10 +581,10 @@ namespace MICore
         /// <param name="miExceptionResult">Results object for the exception-received event</param>
         /// <param name="exceptionCategory">AD7 Exception Category to return</param>
         /// <param name="state">Exception state</param>
-        public virtual void DecodeExceptionReceivedProperties(Results miExceptionResult, out Guid? exceptionCategory, out ExceptionBreakpointState state)
+        public virtual void DecodeExceptionReceivedProperties(Results miExceptionResult, out Guid? exceptionCategory, out ExceptionBreakpointStates state)
         {
             exceptionCategory = null;
-            state = ExceptionBreakpointState.None;
+            state = ExceptionBreakpointStates.None;
         }
 
         #endregion

--- a/src/MICore/CommandFactories/MICommandFactory.cs
+++ b/src/MICore/CommandFactories/MICommandFactory.cs
@@ -112,7 +112,7 @@ namespace MICore
 
         public async Task<Results> StackInfoDepth(int threadId, int maxDepth = 1000, ResultClass resultClass = ResultClass.done)
         {
-            string command = string.Format(@"-stack-info-depth {0}", maxDepth);
+            string command = string.Format(CultureInfo.InvariantCulture, @"-stack-info-depth {0}", maxDepth);
             Results results = await ThreadCmdAsync(command, resultClass, threadId);
 
             return results;
@@ -120,7 +120,7 @@ namespace MICore
 
         public async Task<TupleValue[]> StackListFrames(int threadId, uint lowFrameLevel, uint highFrameLevel = 1000)
         {
-            string command = string.Format(@"-stack-list-frames {0} {1}", lowFrameLevel, highFrameLevel);
+            string command = string.Format(CultureInfo.InvariantCulture, @"-stack-list-frames {0} {1}", lowFrameLevel, highFrameLevel);
             Results results = await ThreadCmdAsync(command, ResultClass.done, threadId);
 
             ListValue list = results.Find<ListValue>("stack");
@@ -157,7 +157,7 @@ namespace MICore
         /// <returns></returns>
         public async Task<ResultValue> StackListLocals(PrintValues printValues, int threadId, uint frameLevel)
         {
-            string cmd = string.Format(@"-stack-list-locals {0}", (int)printValues);
+            string cmd = string.Format(CultureInfo.InvariantCulture, @"-stack-list-locals {0}", (int)printValues);
 
             Results localsResults = await ThreadFrameCmdAsync(cmd, ResultClass.done, threadId, frameLevel);
             return localsResults.Find("locals");
@@ -173,7 +173,7 @@ namespace MICore
         /// <returns>This returns an array of results of frames, which contains a level and an args array. </returns>
         public virtual async Task<TupleValue[]> StackListArguments(PrintValues printValues, int threadId, uint lowFrameLevel, uint hiFrameLevel)
         {
-            string cmd = string.Format(@"-stack-list-arguments {0} {1} {2}", (int)printValues, lowFrameLevel, hiFrameLevel);
+            string cmd = string.Format(CultureInfo.InvariantCulture, @"-stack-list-arguments {0} {1} {2}", (int)printValues, lowFrameLevel, hiFrameLevel);
             Results argumentsResults = await ThreadCmdAsync(cmd, ResultClass.done, threadId);
 
             return argumentsResults.Find<ListValue>("stack-args").IsEmpty()
@@ -206,7 +206,7 @@ namespace MICore
         /// <returns>Returns an array of results for variables</returns>
         public async Task<ValueListValue> StackListVariables(PrintValues printValues, int threadId, uint frameLevel)
         {
-            string cmd = string.Format(@"-stack-list-variables {0}", (int)printValues);
+            string cmd = string.Format(CultureInfo.InvariantCulture, @"-stack-list-variables {0}", (int)printValues);
 
             Results variablesResults = await ThreadFrameCmdAsync(cmd, ResultClass.done, threadId, frameLevel);
             return variablesResults.Find<ValueListValue>("variables");
@@ -337,7 +337,7 @@ namespace MICore
         public virtual async Task<Results> VarCreate(string expression, int threadId, uint frameLevel, enum_EVALFLAGS dwFlags, ResultClass resultClass = ResultClass.done)
         {
             string quoteEscapedExpression = EscapeQuotes(expression);
-            string command = string.Format("-var-create - * \"{0}\"", quoteEscapedExpression);
+            string command = string.Format(CultureInfo.InvariantCulture, "-var-create - * \"{0}\"", quoteEscapedExpression);
             Results results = await ThreadFrameCmdAsync(command, resultClass, threadId, frameLevel);
 
             return results;
@@ -345,7 +345,7 @@ namespace MICore
 
         public async Task<Results> VarSetFormat(string variableName, string format, ResultClass resultClass = ResultClass.done)
         {
-            string command = string.Format(@"-var-set-format {0} {1}", variableName, format);
+            string command = string.Format(CultureInfo.InvariantCulture, @"-var-set-format {0} {1}", variableName, format);
             Results results = await _debugger.CmdAsync(command, resultClass);
 
             return results;
@@ -354,7 +354,7 @@ namespace MICore
         public virtual async Task<Results> VarListChildren(string variableReference, enum_DEBUGPROP_INFO_FLAGS dwFlags, ResultClass resultClass = ResultClass.done)
         {
             // Limit the number of children expanded to 1000 in case memory is uninitialized
-            string command = string.Format("-var-list-children --simple-values \"{0}\" 0 1000", variableReference);
+            string command = string.Format(CultureInfo.InvariantCulture, "-var-list-children --simple-values \"{0}\" 0 1000", variableReference);
             Results results = await _debugger.CmdAsync(command, resultClass);
 
             return results;
@@ -362,7 +362,7 @@ namespace MICore
 
         public async Task<Results> VarEvaluateExpression(string variableName, ResultClass resultClass = ResultClass.done)
         {
-            string command = string.Format(@"-var-evaluate-expression {0}", variableName);
+            string command = string.Format(CultureInfo.InvariantCulture, @"-var-evaluate-expression {0}", variableName);
             Results results = await _debugger.CmdAsync(command, resultClass);
 
             return results;
@@ -370,14 +370,14 @@ namespace MICore
 
         public virtual async Task<string> VarAssign(string variableName, string expression, int threadId, uint frameLevel)
         {
-            string command = string.Format("-var-assign {0} \"{1}\"", variableName, expression);
+            string command = string.Format(CultureInfo.InvariantCulture, "-var-assign {0} \"{1}\"", variableName, expression);
             Results results = await _debugger.CmdAsync(command, ResultClass.done);
             return results.FindString("value");
         }
 
         public async Task<string> VarShowAttributes(string variableName)
         {
-            string command = string.Format("-var-show-attributes {0}", variableName);
+            string command = string.Format(CultureInfo.InvariantCulture, "-var-show-attributes {0}", variableName);
             Results results = await _debugger.CmdAsync(command, ResultClass.done);
 
             string attribute = string.Empty;
@@ -397,13 +397,13 @@ namespace MICore
 
         public async Task VarDelete(string variableName)
         {
-            string command = string.Format("-var-delete {0}", variableName);
+            string command = string.Format(CultureInfo.InvariantCulture, "-var-delete {0}", variableName);
             await _debugger.CmdAsync(command, ResultClass.None);
         }
 
         public async Task<string> VarInfoPathExpression(string variableName)
         {
-            string command = string.Format("-var-info-path-expression {0}", variableName);
+            string command = string.Format(CultureInfo.InvariantCulture, "-var-info-path-expression {0}", variableName);
             Results results = await _debugger.CmdAsync(command, ResultClass.done);
             return results.FindString("path_expr");
         }
@@ -469,7 +469,7 @@ namespace MICore
             }
             cmd.Append(filenameMI);
             cmd.Append(":");
-            cmd.Append(line.ToString());
+            cmd.Append(line.ToString(CultureInfo.InvariantCulture));
             if (quotes)
             {
                 cmd.Append("\"");
@@ -535,7 +535,7 @@ namespace MICore
             {
                 expr = string.Empty;
             }
-            string command = string.Format("-break-condition {0} {1}", bkptno, expr);
+            string command = string.Format(CultureInfo.InvariantCulture, "-break-condition {0} {1}", bkptno, expr);
             await _debugger.CmdAsync(command, ResultClass.done);
         }
 
@@ -596,7 +596,7 @@ namespace MICore
 
         public virtual async Task<Results> SetOption(string variable, string value, ResultClass resultClass = ResultClass.done)
         {
-            string command = string.Format("-gdb-set {0} {1}", variable, value);
+            string command = string.Format(CultureInfo.InvariantCulture, "-gdb-set {0} {1}", variable, value);
             Results results = await _debugger.CmdAsync(command, resultClass);
 
             return results;

--- a/src/MICore/CommandFactories/MICommandFactory.cs
+++ b/src/MICore/CommandFactories/MICommandFactory.cs
@@ -455,7 +455,7 @@ namespace MICore
         {
             StringBuilder cmd = await BuildBreakInsert(condition, enabled);
 
-            if (checksums != null && checksums.Count() != 0)
+            if (checksums != null && checksums.Any())
             {
                 cmd.Append(Checksum.GetMIString(checksums));
                 cmd.Append(' ');

--- a/src/MICore/CommandFactories/clrdbg.cs
+++ b/src/MICore/CommandFactories/clrdbg.cs
@@ -73,14 +73,14 @@ namespace MICore
 
         protected override async Task<Results> ThreadFrameCmdAsync(string command, ResultClass expectedResultClass, int threadId, uint frameLevel)
         {
-            string threadFrameCommand = string.Format(@"{0} --thread {1} --frame {2}", command, threadId, frameLevel);
+            string threadFrameCommand = string.Format(CultureInfo.InvariantCulture, @"{0} --thread {1} --frame {2}", command, threadId, frameLevel);
 
             return await _debugger.CmdAsync(threadFrameCommand, expectedResultClass);
         }
 
         protected override async Task<Results> ThreadCmdAsync(string command, ResultClass expectedResultClass, int threadId)
         {
-            string threadCommand = string.Format(@"{0} --thread {1}", command, threadId);
+            string threadCommand = string.Format(CultureInfo.InvariantCulture, @"{0} --thread {1}", command, threadId);
 
             return await _debugger.CmdAsync(threadCommand, expectedResultClass);
         }
@@ -214,7 +214,7 @@ namespace MICore
 
         public override async Task<Results> VarCreate(string expression, int threadId, uint frameLevel, enum_EVALFLAGS dwFlags, ResultClass resultClass = ResultClass.done)
         {
-            string command = string.Format("-var-create - * \"{0}\" --evalFlags {1}", expression, (uint)dwFlags);
+            string command = string.Format(CultureInfo.InvariantCulture, "-var-create - * \"{0}\" --evalFlags {1}", expression, (uint)dwFlags);
             Results results = await ThreadFrameCmdAsync(command, resultClass, threadId, frameLevel);
 
             return results;
@@ -223,7 +223,7 @@ namespace MICore
         public override async Task<Results> VarListChildren(string variableReference, enum_DEBUGPROP_INFO_FLAGS dwFlags, ResultClass resultClass = ResultClass.done)
         {
             // Limit the number of children expanded to 1000 in case memory is uninitialized
-            string command = string.Format("-var-list-children --simple-values \"{0}\" --propertyInfoFlags {1} 0 1000", variableReference, (uint)dwFlags);
+            string command = string.Format(CultureInfo.InvariantCulture, "-var-list-children --simple-values \"{0}\" --propertyInfoFlags {1} 0 1000", variableReference, (uint)dwFlags);
             Results results = await _debugger.CmdAsync(command, resultClass);
 
             return results;

--- a/src/MICore/CommandFactories/clrdbg.cs
+++ b/src/MICore/CommandFactories/clrdbg.cs
@@ -65,7 +65,7 @@ namespace MICore
             return results.ResultClass == ResultClass.done;
         }
 
-        public override Task<TupleValue[]> StackListArguments(PrintValues printValues, int threadId, uint lowFrameLevel, uint hiFrameLevel)
+        public override Task<TupleValue[]> StackListArguments(PrintValue printValues, int threadId, uint lowFrameLevel, uint hiFrameLevel)
         {
             // CLRDBG supports stack frame formatting, so this should not be used
             throw new NotImplementedException();
@@ -100,7 +100,7 @@ namespace MICore
             return s_exceptionCategories;
         }
 
-        public override async Task<IEnumerable<ulong>> SetExceptionBreakpoints(Guid exceptionCategory, /*OPTIONAL*/ IEnumerable<string> exceptionNames, ExceptionBreakpointState exceptionBreakpointState)
+        public override async Task<IEnumerable<ulong>> SetExceptionBreakpoints(Guid exceptionCategory, /*OPTIONAL*/ IEnumerable<string> exceptionNames, ExceptionBreakpointStates exceptionBreakpointState)
         {
             List<string> commandTokens = new List<string>();
             commandTokens.Add("-break-exception-insert");
@@ -114,16 +114,16 @@ namespace MICore
                 throw new ArgumentOutOfRangeException("exceptionCategory");
             }
 
-            if (exceptionBreakpointState.HasFlag(ExceptionBreakpointState.BreakThrown))
+            if (exceptionBreakpointState.HasFlag(ExceptionBreakpointStates.BreakThrown))
             {
-                if (exceptionBreakpointState.HasFlag(ExceptionBreakpointState.BreakUserHandled))
+                if (exceptionBreakpointState.HasFlag(ExceptionBreakpointStates.BreakUserHandled))
                     commandTokens.Add("throw+user-unhandled");
                 else
                     commandTokens.Add("throw");
             }
             else
             {
-                if (exceptionBreakpointState.HasFlag(ExceptionBreakpointState.BreakUserHandled))
+                if (exceptionBreakpointState.HasFlag(ExceptionBreakpointStates.BreakUserHandled))
                     commandTokens.Add("user-unhandled");
                 else
                     commandTokens.Add("unhandled");
@@ -164,7 +164,7 @@ namespace MICore
             return _debugger.CmdAsync(command, ResultClass.done);
         }
 
-        public override void DecodeExceptionReceivedProperties(Results miExceptionResult, out Guid? exceptionCategory, out ExceptionBreakpointState state)
+        public override void DecodeExceptionReceivedProperties(Results miExceptionResult, out Guid? exceptionCategory, out ExceptionBreakpointStates state)
         {
             string category = miExceptionResult.FindString("exception-category");
             if (category == "mda")
@@ -181,20 +181,20 @@ namespace MICore
             switch (stage)
             {
                 case "throw":
-                    state = ExceptionBreakpointState.BreakThrown;
+                    state = ExceptionBreakpointStates.BreakThrown;
                     break;
 
                 case "user-unhandled":
-                    state = ExceptionBreakpointState.BreakUserHandled;
+                    state = ExceptionBreakpointStates.BreakUserHandled;
                     break;
 
                 case "unhandled":
-                    state = ExceptionBreakpointState.None;
+                    state = ExceptionBreakpointStates.None;
                     break;
 
                 default:
                     Debug.Fail("Unknown exception-stage value");
-                    state = ExceptionBreakpointState.None;
+                    state = ExceptionBreakpointStates.None;
                     break;
             }
         }

--- a/src/MICore/CommandFactories/clrdbg.cs
+++ b/src/MICore/CommandFactories/clrdbg.cs
@@ -111,7 +111,7 @@ namespace MICore
             }
             else if (exceptionCategory != s_exceptionCategory_CLR)
             {
-                throw new ArgumentOutOfRangeException("exceptionCategory");
+                throw new ArgumentOutOfRangeException(nameof(exceptionCategory));
             }
 
             if (exceptionBreakpointState.HasFlag(ExceptionBreakpointStates.BreakThrown))

--- a/src/MICore/CommandFactories/gdb.cs
+++ b/src/MICore/CommandFactories/gdb.cs
@@ -118,7 +118,7 @@ namespace MICore
         {
             if (ExclusiveLockToken.IsNullOrClosed(lockToken))
             {
-                throw new ArgumentNullException("lockToken");
+                throw new ArgumentNullException(nameof(lockToken));
             }
 
             if (threadId != _currentThreadId)
@@ -134,7 +134,7 @@ namespace MICore
         {
             if (ExclusiveLockToken.IsNullOrClosed(lockToken))
             {
-                throw new ArgumentNullException("lockToken");
+                throw new ArgumentNullException(nameof(lockToken));
             }
 
             if (frameLevel != _currentFrameLevel)

--- a/src/MICore/CommandFactories/gdb.cs
+++ b/src/MICore/CommandFactories/gdb.cs
@@ -123,7 +123,7 @@ namespace MICore
 
             if (threadId != _currentThreadId)
             {
-                string command = string.Format("-thread-select {0}", threadId);
+                string command = string.Format(CultureInfo.InvariantCulture, "-thread-select {0}", threadId);
                 await _debugger.ExclusiveCmdAsync(command, ResultClass.done, lockToken);
                 _currentThreadId = threadId;
                 _currentFrameLevel = 0;
@@ -139,7 +139,7 @@ namespace MICore
 
             if (frameLevel != _currentFrameLevel)
             {
-                string command = string.Format("-stack-select-frame {0}", frameLevel);
+                string command = string.Format(CultureInfo.InvariantCulture, "-stack-select-frame {0}", frameLevel);
                 await _debugger.ExclusiveCmdAsync(command, ResultClass.done, lockToken);
                 _currentFrameLevel = frameLevel;
             }
@@ -269,7 +269,7 @@ namespace MICore
 
         public override async Task Signal(string sig)
         {
-            string command = String.Format("-interpreter-exec console \"signal {0}\"", sig);
+            string command = String.Format(CultureInfo.InvariantCulture, "-interpreter-exec console \"signal {0}\"", sig);
             await _debugger.CmdAsync(command, ResultClass.running);
         }
 

--- a/src/MICore/CommandFactories/gdb.cs
+++ b/src/MICore/CommandFactories/gdb.cs
@@ -210,7 +210,7 @@ namespace MICore
                 case 8:
                     return "double";
                 default:
-                    throw new ArgumentException("size");
+                    throw new ArgumentException(null, nameof(size));
             }
         }
 

--- a/src/MICore/CommandFactories/gdb.cs
+++ b/src/MICore/CommandFactories/gdb.cs
@@ -168,7 +168,7 @@ namespace MICore
                     if (resultLine == null)
                         break;
 
-                    int pos = resultLine.IndexOf("starts at address ");
+                    int pos = resultLine.IndexOf("starts at address ", StringComparison.Ordinal);
                     if (pos > 0)
                     {
                         ulong address;

--- a/src/MICore/CommandFactories/lldb.cs
+++ b/src/MICore/CommandFactories/lldb.cs
@@ -77,7 +77,7 @@ namespace MICore
         public override async Task<Results> VarCreate(string expression, int threadId, uint frameLevel, enum_EVALFLAGS dwFlags, ResultClass resultClass = ResultClass.done)
         {
             string quoteEscapedExpression = EscapeQuotes(expression);
-            string command = string.Format("-var-create - - \"{0}\"", quoteEscapedExpression);  // use '-' to indicate that "--frame" should be used to determine the frame number
+            string command = string.Format(CultureInfo.InvariantCulture, "-var-create - - \"{0}\"", quoteEscapedExpression);  // use '-' to indicate that "--frame" should be used to determine the frame number
             Results results = await ThreadFrameCmdAsync(command, resultClass, threadId, frameLevel);
 
             return results;
@@ -88,7 +88,7 @@ namespace MICore
             // This override is necessary because lldb treats any object with children as not a simple object.
             // This prevents char* and char** from returning a value when queried by -var-list-children
             // Limit the number of children expanded to 1000 in case memory is uninitialized
-            string command = string.Format("-var-list-children --all-values \"{0}\" 0 1000", variableReference);
+            string command = string.Format(CultureInfo.InvariantCulture, "-var-list-children --all-values \"{0}\" 0 1000", variableReference);
             Results results = await _debugger.CmdAsync(command, resultClass);
 
             return results;
@@ -96,14 +96,14 @@ namespace MICore
 
         protected override async Task<Results> ThreadFrameCmdAsync(string command, ResultClass exepctedResultClass, int threadId, uint frameLevel)
         {
-            string threadFrameCommand = string.Format(@"{0} --thread {1} --frame {2}", command, threadId, frameLevel);
+            string threadFrameCommand = string.Format(CultureInfo.InvariantCulture, @"{0} --thread {1} --frame {2}", command, threadId, frameLevel);
 
             return await _debugger.CmdAsync(threadFrameCommand, exepctedResultClass);
         }
 
         protected override async Task<Results> ThreadCmdAsync(string command, ResultClass expectedResultClass, int threadId)
         {
-            string threadCommand = string.Format(@"{0} --thread {1}", command, threadId);
+            string threadCommand = string.Format(CultureInfo.InvariantCulture, @"{0} --thread {1}", command, threadId);
 
             return await _debugger.CmdAsync(threadCommand, expectedResultClass);
         }

--- a/src/MICore/CommandLock.cs
+++ b/src/MICore/CommandLock.cs
@@ -25,10 +25,10 @@ namespace MICore
         {
             // Either both commandLock and value are non-zero (non-Null case), or both are zero (Null case)
             if (commandLock == null)
-                throw new ArgumentNullException("commandLock");
+                throw new ArgumentNullException(nameof(commandLock));
 
             if (value == 0)
-                throw new ArgumentOutOfRangeException("value");
+                throw new ArgumentOutOfRangeException(nameof(value));
 
             _commandLock = commandLock;
             _value = value;

--- a/src/MICore/Debugger.cs
+++ b/src/MICore/Debugger.cs
@@ -878,7 +878,7 @@ namespace MICore
         {
             if (ExclusiveLockToken.IsNullOrClosed(exclusiveLockToken))
             {
-                throw new ArgumentNullException("exclusiveLockToken");
+                throw new ArgumentNullException(nameof(exclusiveLockToken));
             }
 
             return CmdAsyncInternal(command, expectedResultClass);

--- a/src/MICore/Debugger.cs
+++ b/src/MICore/Debugger.cs
@@ -257,7 +257,7 @@ namespace MICore
         {
             string reason = results.TryFindString("reason");
 
-            if (reason.StartsWith("exited") || reason.StartsWith("disconnected"))
+            if (reason.StartsWith("exited", StringComparison.Ordinal) || reason.StartsWith("disconnected", StringComparison.Ordinal))
             {
                 if (this.ProcessState != ProcessState.Exited)
                 {

--- a/src/MICore/Debugger.cs
+++ b/src/MICore/Debugger.cs
@@ -469,7 +469,7 @@ namespace MICore
                     break;
 
                 default:
-                    throw new ArgumentOutOfRangeException("options.TargetArchitecture");
+                    throw new ArgumentOutOfRangeException(nameof(arch));
             }
         }
 
@@ -1626,7 +1626,7 @@ namespace MICore
             {
                 if (throwOnError)
                 {
-                    throw new ArgumentNullException();
+                    throw new ArgumentNullException(nameof(addr));
                 }
                 return 0;
             }
@@ -1662,7 +1662,7 @@ namespace MICore
             {
                 if (throwOnError)
                 {
-                    throw new ArgumentException();
+                    throw new ArgumentException(null, nameof(str));
                 }
                 return value;
             }

--- a/src/MICore/LaunchCommand.cs
+++ b/src/MICore/LaunchCommand.cs
@@ -28,10 +28,10 @@ namespace MICore
         public LaunchCommand(string commandText, string description = null, bool ignoreFailures = false, Action<string> failureHandler = null, Func<string, Task> successHandler = null, Func<Results, Task> successResultsHandler = null)
         {
             if (commandText == null)
-                throw new ArgumentNullException("commandText");
+                throw new ArgumentNullException(nameof(commandText));
             commandText = commandText.Trim();
             if (commandText.Length == 0)
-                throw new ArgumentOutOfRangeException("commandText");
+                throw new ArgumentOutOfRangeException(nameof(commandText));
             this.IsMICommand = commandText[0] == '-';
             this.CommandText = commandText;
             this.Description = description;

--- a/src/MICore/LaunchOptions.cs
+++ b/src/MICore/LaunchOptions.cs
@@ -80,7 +80,7 @@ namespace MICore
         public PipeLaunchOptions(string pipePath, string pipeArguments, string pipeCommandArguments, string pipeCwd, IList<EnvironmentEntry> pipeEnvironment)
         {
             if (string.IsNullOrEmpty(pipePath))
-                throw new ArgumentNullException("PipePath");
+                throw new ArgumentNullException(nameof(pipePath));
 
             this.PipePath = pipePath;
             this.PipeArguments = pipeArguments;
@@ -214,11 +214,11 @@ namespace MICore
         {
             if (string.IsNullOrEmpty(hostname))
             {
-                throw new ArgumentException("hostname");
+                throw new ArgumentException(null, nameof(hostname));
             }
             if (port <= 0)
             {
-                throw new ArgumentException("port");
+                throw new ArgumentException(null, nameof(port));
             }
 
             this.Hostname = hostname;

--- a/src/MICore/LaunchOptions.cs
+++ b/src/MICore/LaunchOptions.cs
@@ -380,7 +380,7 @@ namespace MICore
         public LocalLaunchOptions(string MIDebuggerPath, string MIDebuggerServerAddress)
         {
             if (string.IsNullOrEmpty(MIDebuggerPath))
-                throw new ArgumentNullException("MIDebuggerPath");
+                throw new ArgumentNullException(nameof(MIDebuggerPath));
 
             this.MIDebuggerPath = MIDebuggerPath;
             this.MIDebuggerServerAddress = MIDebuggerServerAddress;
@@ -813,7 +813,7 @@ namespace MICore
                         break;
 
                     default:
-                        throw new ArgumentOutOfRangeException("miMode");
+                        throw new ArgumentOutOfRangeException(nameof(miMode));
                 }
             }
 
@@ -895,7 +895,7 @@ namespace MICore
             get { return _miMode; }
             set
             {
-                VerifyCanModifyProperty("DebuggerMIMode");
+                VerifyCanModifyProperty(nameof(DebuggerMIMode));
                 _miMode = value;
             }
         }
@@ -913,7 +913,7 @@ namespace MICore
             {
                 if (value == null)
                     throw new ArgumentNullException("BaseOptions");
-                VerifyCanModifyProperty("BaseOptions");
+                VerifyCanModifyProperty(nameof(BaseOptions));
 
                 _baseOptions = value;
             }
@@ -932,7 +932,7 @@ namespace MICore
             {
                 if (string.IsNullOrWhiteSpace(value))
                     throw new ArgumentOutOfRangeException("ExePath");
-                VerifyCanModifyProperty("ExePath");
+                VerifyCanModifyProperty(nameof(ExePath));
 
                 _exePath = value;
             }
@@ -947,7 +947,7 @@ namespace MICore
             get { return _exeArguments; }
             set
             {
-                VerifyCanModifyProperty("ExeArguments");
+                VerifyCanModifyProperty(nameof(ExeArguments));
                 _exeArguments = value;
             }
         }
@@ -962,7 +962,7 @@ namespace MICore
             get { return _processId; }
             protected set
             {
-                VerifyCanModifyProperty("ProcessId");
+                VerifyCanModifyProperty(nameof(ProcessId));
                 _processId = value;
             }
         }
@@ -979,7 +979,7 @@ namespace MICore
             }
             protected set
             {
-                VerifyCanModifyProperty("CoreDumpPath");
+                VerifyCanModifyProperty(nameof(CoreDumpPath));
 
                 // CoreDumpPath is allowed to be null/empty
                 _coreDumpPath = value;
@@ -999,7 +999,7 @@ namespace MICore
             get { return _workingDirectory; }
             set
             {
-                VerifyCanModifyProperty("WorkingDirectory");
+                VerifyCanModifyProperty(nameof(WorkingDirectory));
                 _workingDirectory = value;
             }
         }
@@ -1013,7 +1013,7 @@ namespace MICore
             get { return _absolutePrefixSoLibSearchPath; }
             set
             {
-                VerifyCanModifyProperty("AbsolutePrefixSOLibSearchPath");
+                VerifyCanModifyProperty(nameof(AbsolutePrefixSOLibSearchPath));
                 _absolutePrefixSoLibSearchPath = value;
             }
         }
@@ -1027,7 +1027,7 @@ namespace MICore
             get { return _additionalSOLibSearchPath; }
             set
             {
-                VerifyCanModifyProperty("AdditionalSOLibSearchPath");
+                VerifyCanModifyProperty(nameof(AdditionalSOLibSearchPath));
                 _additionalSOLibSearchPath = value;
             }
         }
@@ -1041,7 +1041,7 @@ namespace MICore
             get { return _visualizerFile; }
             set
             {
-                VerifyCanModifyProperty("VisualizerFile");
+                VerifyCanModifyProperty(nameof(VisualizerFile));
                 _visualizerFile = value;
             }
         }
@@ -1055,7 +1055,7 @@ namespace MICore
             get { return _waitDynamicLibLoad; }
             set
             {
-                VerifyCanModifyProperty("WaitDynamicLibLoad");
+                VerifyCanModifyProperty(nameof(WaitDynamicLibLoad));
                 _waitDynamicLibLoad = value;
             }
         }
@@ -1069,7 +1069,7 @@ namespace MICore
             get { return _siLoadAll;  }
             set
             {
-                VerifyCanModifyProperty("SymbolInfoLoadAll");
+                VerifyCanModifyProperty(nameof(SymbolInfoLoadAll));
                 _siLoadAll = value;
             }
         }
@@ -1084,7 +1084,7 @@ namespace MICore
             get { return _siExceptionList; }
             set
             {
-                VerifyCanModifyProperty("SymbolInfoExceptionList");
+                VerifyCanModifyProperty(nameof(SymbolInfoExceptionList));
                 _siExceptionList = value;
             }
         }
@@ -1110,7 +1110,7 @@ namespace MICore
             get { return _targetArchitecture; }
             set
             {
-                VerifyCanModifyProperty("TargetArchitecture");
+                VerifyCanModifyProperty(nameof(TargetArchitecture));
                 _targetArchitecture = value;
             }
         }
@@ -1147,7 +1147,7 @@ namespace MICore
                 if (value == null)
                     throw new ArgumentNullException("SetupCommands");
 
-                VerifyCanModifyProperty("SetupCommands");
+                VerifyCanModifyProperty(nameof(SetupCommands));
                 _setupCommands = value;
             }
         }
@@ -1165,7 +1165,7 @@ namespace MICore
             get { return _customLaunchSetupCommands; }
             set
             {
-                VerifyCanModifyProperty("CustomLaunchSetupCommands");
+                VerifyCanModifyProperty(nameof(CustomLaunchSetupCommands));
                 _customLaunchSetupCommands = value;
             }
         }
@@ -1177,7 +1177,7 @@ namespace MICore
             get { return _launchCompleteCommand; }
             set
             {
-                VerifyCanModifyProperty("LaunchCompleteCommand");
+                VerifyCanModifyProperty(nameof(LaunchCompleteCommand));
                 _launchCompleteCommand = value;
             }
         }
@@ -1189,7 +1189,7 @@ namespace MICore
             get { return _debugChildProcesses; }
             protected set
             {
-                VerifyCanModifyProperty("DebugChildProcesses");
+                VerifyCanModifyProperty(nameof(DebugChildProcesses));
                 _debugChildProcesses = value;
             }
         }
@@ -1201,7 +1201,7 @@ namespace MICore
             get { return _sourceMap; }
             set
             {
-                VerifyCanModifyProperty("SourceMap");
+                VerifyCanModifyProperty(nameof(SourceMap));
                 _sourceMap = value;
             }
         }
@@ -1213,7 +1213,7 @@ namespace MICore
             get { return _environment; }
             set
             {
-                VerifyCanModifyProperty("Environment");
+                VerifyCanModifyProperty(nameof(Environment));
                 _environment = value;
             }
         }
@@ -1257,7 +1257,7 @@ namespace MICore
         public static LaunchOptions GetInstance(HostConfigurationStore configStore, string exePath, string args, string dir, string options, bool noDebug, IDeviceAppLauncherEventCallback eventCallback, TargetEngine targetEngine, Logger logger)
         {
             if (string.IsNullOrWhiteSpace(exePath))
-                throw new ArgumentNullException("exePath");
+                throw new ArgumentNullException(nameof(exePath));
 
             options = options?.Trim();
             if (string.IsNullOrEmpty(options))

--- a/src/MICore/LaunchOptions.cs
+++ b/src/MICore/LaunchOptions.cs
@@ -335,7 +335,7 @@ namespace MICore
 
         public static ReadOnlyCollection<SourceMapEntry> CreateCollection(Dictionary<string, object> source)
         {
-            IList<SourceMapEntry> sourceMaps = new List<SourceMapEntry>(source.Keys.Count());
+            IList<SourceMapEntry> sourceMaps = new List<SourceMapEntry>(source.Keys.Count);
 
             foreach (var item in source)
             {

--- a/src/MICore/MICore.csproj
+++ b/src/MICore/MICore.csproj
@@ -31,8 +31,6 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <Prefer32Bit>false</Prefer32Bit>
-    <RunCodeAnalysis>true</RunCodeAnalysis>
-    <CodeAnalysisRuleSet>..\IDECodeAnalysis.ruleset</CodeAnalysisRuleSet>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
@@ -51,8 +49,6 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <Prefer32Bit>false</Prefer32Bit>
-    <RunCodeAnalysis>true</RunCodeAnalysis>
-    <CodeAnalysisRuleSet>..\IDECodeAnalysis.ruleset</CodeAnalysisRuleSet>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Desktop.Release|AnyCPU'">

--- a/src/MICore/MIResults.cs
+++ b/src/MICore/MIResults.cs
@@ -743,7 +743,7 @@ namespace MICore
         {
             if (input == null)
             {
-                throw new ArgumentNullException("input");
+                throw new ArgumentNullException(nameof(input));
             }
             else if (string.IsNullOrEmpty(input))
             {

--- a/src/MICore/MIResults.cs
+++ b/src/MICore/MIResults.cs
@@ -619,7 +619,7 @@ namespace MICore
             {
                 if (start < 0)
                 {
-                    throw new ArgumentException("start");
+                    throw new ArgumentException(null, nameof(start));
                 }
                 Start = start;
                 Length = len;
@@ -628,7 +628,7 @@ namespace MICore
             {
                 if (len > Length)
                 {
-                    throw new ArgumentException("len");
+                    throw new ArgumentException(null, nameof(len));
                 }
                 return new Span(Start + len, Length - len);
             }
@@ -636,7 +636,7 @@ namespace MICore
             {
                 if (Start > pos || pos > Start + Length)
                 {
-                    throw new ArgumentException("pos");
+                    throw new ArgumentException(null, nameof(pos));
                 }
                 return new Span(pos, Length - (pos - Start));
             }
@@ -644,7 +644,7 @@ namespace MICore
             {
                 if (len > Length)
                 {
-                    throw new ArgumentException("len");
+                    throw new ArgumentException(null, nameof(len));
                 }
                 return new Span(Start, len);
             }

--- a/src/MICore/MIResults.cs
+++ b/src/MICore/MIResults.cs
@@ -745,7 +745,7 @@ namespace MICore
             {
                 throw new ArgumentNullException("input");
             }
-            else if (input == String.Empty)
+            else if (string.IsNullOrEmpty(input))
             {
                 return string.Empty;
             }

--- a/src/MICore/MIResults.cs
+++ b/src/MICore/MIResults.cs
@@ -598,17 +598,12 @@ namespace MICore
     {
         struct Span
         {
-            static Span _emptySpan;
+            static Span _emptySpan = new Span(0, 0);
             public int Start { get; private set; }  // index first character in the substring
             public int Length { get; private set; } // length of the substring
             public int Extent { get { return Start + Length; } }
             public bool IsEmpty { get { return Length == 0; } }
             public static Span Empty { get { return _emptySpan; } }
-
-            static Span()
-            {
-                _emptySpan = new Span(0, 0);
-            }
 
             public Span(string s)
             {

--- a/src/MICore/MIResults.cs
+++ b/src/MICore/MIResults.cs
@@ -349,7 +349,7 @@ namespace MICore
         {
             StringBuilder builder = new StringBuilder();
             builder.Append(Name);
-            builder.Append("=");
+            builder.Append('=');
             builder.Append(Value.ToString());
             return builder.ToString();
         }
@@ -382,16 +382,16 @@ namespace MICore
         public override string ToString()
         {
             StringBuilder outTuple = new StringBuilder();
-            outTuple.Append("{");
+            outTuple.Append('{');
             for (int i = 0; i < Content.Count; ++i)
             {
                 if (i != 0)
                 {
-                    outTuple.Append(",");
+                    outTuple.Append(',');
                 }
                 outTuple.Append(Content[i].ToString());
             }
-            outTuple.Append("}");
+            outTuple.Append('}');
             return outTuple.ToString();
         }
         public ResultValue[] FindAll(string name)
@@ -469,16 +469,16 @@ namespace MICore
         public override string ToString()
         {
             StringBuilder outList = new StringBuilder();
-            outList.Append("[");
+            outList.Append('[');
             for (int i = 0; i < Content.Length; ++i)
             {
                 if (i != 0)
                 {
-                    outList.Append(",");
+                    outList.Append(',');
                 }
                 outList.Append(Content[i].ToString());
             }
-            outList.Append("]");
+            outList.Append(']');
             return outList.ToString();
         }
     }
@@ -532,18 +532,18 @@ namespace MICore
         public override string ToString()
         {
             StringBuilder outList = new StringBuilder();
-            outList.Append("[");
+            outList.Append('[');
             for (int i = 0; i < Content.Length; ++i)
             {
                 if (i != 0)
                 {
-                    outList.Append(",");
+                    outList.Append(',');
                 }
                 outList.Append(Content[i].Name);
-                outList.Append("=");
+                outList.Append('=');
                 outList.Append(Content[i].Value.ToString());
             }
-            outList.Append("]");
+            outList.Append(']');
             return outList.ToString();
         }
     }

--- a/src/MICore/ProcessMonitor.cs
+++ b/src/MICore/ProcessMonitor.cs
@@ -46,6 +46,8 @@ namespace MICore
         public void Dispose()
         {
             _exitMonitorTimer?.Dispose();
+
+            GC.SuppressFinalize(this);
         }
     }
 }

--- a/src/MICore/Transports/PipeTransport.cs
+++ b/src/MICore/Transports/PipeTransport.cs
@@ -16,6 +16,8 @@ namespace MICore
 {
     public class PipeTransport : StreamTransport
     {
+        private static readonly object _lock = new object();
+
         private Process _process;
         private StreamReader _stdErrReader;
         private int _remainingReaders;
@@ -73,7 +75,7 @@ namespace MICore
             _process.StartInfo.UseShellExecute = false;
             _process.StartInfo.CreateNoWindow = true;
 
-            lock (_process)
+            lock (_lock)
             {
                 this.Callback.AppendToInitializationLog(string.Format(CultureInfo.InvariantCulture, "Starting: \"{0}\" {1}", _process.StartInfo.FileName, _process.StartInfo.Arguments));
 
@@ -281,7 +283,7 @@ namespace MICore
             // Wait until 'Init' gets a chance to set m_Reader/m_Writer before sending up the debugger exit event
             if (_reader == null || _writer == null)
             {
-                lock (_process)
+                lock (_lock)
                 {
                     if (_reader == null || _writer == null)
                     {

--- a/src/MICore/Transports/TcpTransport.cs
+++ b/src/MICore/Transports/TcpTransport.cs
@@ -60,8 +60,14 @@ namespace MICore
                     callback,
                     null /*UserCertificateSelectionCallback */
                     );
-
+#if !XPLAT
+                // Starting with .NET Framework 4.7, this method authenticates using None, which allows the operating system to choose the best protocol to use, and to block protocols that are not secure.
                 sslStream.AuthenticateAsClientAsync(tcpOptions.Hostname, certStore.Certificates, System.Security.Authentication.SslProtocols.None, false /* checkCertificateRevocation */).Wait();
+
+#else
+                //  In .NET Framework 4.6 (and .NET Framework 4.5 with the latest security patches installed), the allowed TLS/SSL protocols versions are 1.2, 1.1, and 1.0 (unless you disable strong cryptography by editing the Windows Registry).
+                sslStream.AuthenticateAsClientAsync(tcpOptions.Hostname, certStore.Certificates, System.Security.Authentication.SslProtocols.Tls12, false /* checkCertificateRevocation */).Wait();
+#endif
                 reader = new StreamReader(sslStream);
                 writer = new StreamWriter(sslStream);
             }

--- a/src/MICore/Transports/TcpTransport.cs
+++ b/src/MICore/Transports/TcpTransport.cs
@@ -61,7 +61,7 @@ namespace MICore
                     null /*UserCertificateSelectionCallback */
                     );
 
-                sslStream.AuthenticateAsClientAsync(tcpOptions.Hostname, certStore.Certificates, System.Security.Authentication.SslProtocols.Tls, false /* checkCertificateRevocation */).Wait();
+                sslStream.AuthenticateAsClientAsync(tcpOptions.Hostname, certStore.Certificates, System.Security.Authentication.SslProtocols.None, false /* checkCertificateRevocation */).Wait();
                 reader = new StreamReader(sslStream);
                 writer = new StreamWriter(sslStream);
             }

--- a/src/MICore/Transports/UnixShellPortTransport.cs
+++ b/src/MICore/Transports/UnixShellPortTransport.cs
@@ -93,7 +93,8 @@ namespace MICore
             {
                 using (HttpClient httpClient = new HttpClient())
                 {
-                    using (var response = await httpClient.GetStreamAsync(getclrdbgUri))
+                    Uri uri = new Uri(getclrdbgUri);
+                    using (var response = await httpClient.GetStreamAsync(uri))
                     {
                         using (TextReader textReader = new StreamReader(response))
                         {

--- a/src/MICore/Transports/UnixShellPortTransport.cs
+++ b/src/MICore/Transports/UnixShellPortTransport.cs
@@ -167,7 +167,7 @@ namespace MICore
                         _callback.OnStdErrorLine(line.Substring(ErrorPrefix.Length).Trim());
                     }
 
-                    if (line.Equals("Info: Launching clrdbg"))
+                    if (line.Equals("Info: Launching clrdbg", StringComparison.Ordinal))
                     {
                         _debuggerLaunched = true;
                         UnixShellPortLaunchOptions.SetSuccessfulLaunch(_launchOptions);

--- a/src/MICoreUnitTests/AndroidLauncherTests.cs
+++ b/src/MICoreUnitTests/AndroidLauncherTests.cs
@@ -73,7 +73,7 @@ namespace MICoreUnitTests
             expectedRoots.Add(new SourceRoot("d:\\someotherdir\\src\\", true));
             expectedRoots.Add(new SourceRoot("d://otherdir//src//", true));
 
-            Assert.Equal(expectedRoots.Count(), actualRoots.Count());
+            Assert.Equal(expectedRoots.Count, actualRoots.Length);
             var comparer = new SourceRootComparer();
             expectedRoots.All(x => actualRoots.Contains(x, comparer));
         }

--- a/src/MICoreUnitTests/AndroidLauncherTests.cs
+++ b/src/MICoreUnitTests/AndroidLauncherTests.cs
@@ -82,7 +82,7 @@ namespace MICoreUnitTests
         {
             public bool Equals(SourceRoot x, SourceRoot y)
             {
-                return x.Path.Equals(y.Path) && x.RecursiveSearchEnabled == y.RecursiveSearchEnabled;
+                return x.Path.Equals(y.Path, StringComparison.Ordinal) && x.RecursiveSearchEnabled == y.RecursiveSearchEnabled;
             }
 
             public int GetHashCode(SourceRoot obj)

--- a/src/MICoreUnitTests/BasicLaunchOptionsTests.cs
+++ b/src/MICoreUnitTests/BasicLaunchOptionsTests.cs
@@ -141,7 +141,7 @@ namespace MICoreUnitTests
             Assert.Equal(options.SetupCommands[0].CommandText, "-gdb-set my-example-setting on");
             Assert.True(options.SetupCommands[0].Description.Contains("gdb-set"));
             Assert.False(options.SetupCommands[0].IgnoreFailures);
-            Assert.True(options.PipeEnvironment.Count() == 0);
+            Assert.True(options.PipeEnvironment.Count == 0);
         }
 
         [Fact]

--- a/src/MICoreUnitTests/MICoreUnitTests.csproj
+++ b/src/MICoreUnitTests/MICoreUnitTests.csproj
@@ -34,8 +34,6 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <Prefer32Bit>false</Prefer32Bit>
-    <RunCodeAnalysis>true</RunCodeAnalysis>
-    <CodeAnalysisRuleSet>..\IDECodeAnalysis.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>

--- a/src/MIDebugEngine/AD7.Impl/AD7Engine.cs
+++ b/src/MIDebugEngine/AD7.Impl/AD7Engine.cs
@@ -287,7 +287,7 @@ namespace Microsoft.MIDebugEngine
 
                 if (processId > int.MaxValue)
                 {
-                    throw new ArgumentOutOfRangeException("processId");
+                    throw new ArgumentOutOfRangeException(nameof(processId));
                 }
 
                 string getClrDbgUrl = GetMetric("GetClrDbgUrl") as string;

--- a/src/MIDebugEngine/AD7.Impl/AD7Engine.cs
+++ b/src/MIDebugEngine/AD7.Impl/AD7Engine.cs
@@ -199,7 +199,7 @@ namespace Microsoft.MIDebugEngine
             if (celtPrograms != 1)
             {
                 Debug.Fail("SampleEngine only expects to see one program in a process");
-                throw new ArgumentException();
+                throw new ArgumentException(null, nameof(celtPrograms));
             }
             IDebugProgram2 portProgram = portProgramArray[0];
 
@@ -220,7 +220,7 @@ namespace Microsoft.MIDebugEngine
                     if (processId.ProcessIdType != (uint)enum_AD_PROCESS_ID.AD_PROCESS_ID_SYSTEM)
                     {
                         Debug.Fail("Invalid process to attach to");
-                        throw new ArgumentException();
+                        throw new ArgumentException(nameof(processId));
                     }
 
                     IDebugPort2 port;

--- a/src/MIDebugEngine/AD7.Impl/AD7Engine.cs
+++ b/src/MIDebugEngine/AD7.Impl/AD7Engine.cs
@@ -194,7 +194,7 @@ namespace Microsoft.MIDebugEngine
             if (celtPrograms != 1)
             {
                 Debug.Fail("SampleEngine only expects to see one program in a process");
-                throw new ArgumentException(null, nameof(celtPrograms));
+                throw new ArgumentOutOfRangeException(nameof(celtPrograms));
             }
             IDebugProgram2 portProgram = portProgramArray[0];
 
@@ -215,7 +215,7 @@ namespace Microsoft.MIDebugEngine
                     if (processId.ProcessIdType != (uint)enum_AD_PROCESS_ID.AD_PROCESS_ID_SYSTEM)
                     {
                         Debug.Fail("Invalid process to attach to");
-                        throw new ArgumentException(nameof(processId));
+                        throw new ArgumentOutOfRangeException(nameof(portProgramArray), "Could not find processId in given portProgramArray.");
                     }
 
                     IDebugPort2 port;

--- a/src/MIDebugEngine/AD7.Impl/AD7Engine.cs
+++ b/src/MIDebugEngine/AD7.Impl/AD7Engine.cs
@@ -62,16 +62,11 @@ namespace Microsoft.MIDebugEngine
 
         private IDebugSettingsCallback110 _settingsCallback;
 
-        private static List<int> s_childProcessLaunch;
+        private static List<int> s_childProcessLaunch = new List<int>();
 
         private static int s_bpLongBindTimeout = 0;
 
         private IDebugUnixShellPort _unixPort;
-
-        static AD7Engine()
-        {
-            s_childProcessLaunch = new List<int>();
-        }
 
         public AD7Engine()
         {

--- a/src/MIDebugEngine/AD7.Impl/AD7Enums.cs
+++ b/src/MIDebugEngine/AD7.Impl/AD7Enums.cs
@@ -15,6 +15,8 @@ namespace Microsoft.MIDebugEngine
     #region Base Class
     internal class AD7Enum<T, I> where I : class
     {
+        private static readonly object _lock = new object();
+
         private readonly T[] _data;
         private uint _position;
 
@@ -43,7 +45,7 @@ namespace Microsoft.MIDebugEngine
 
         public int Reset()
         {
-            lock (this)
+            lock (_lock)
             {
                 _position = 0;
 
@@ -60,7 +62,7 @@ namespace Microsoft.MIDebugEngine
 
         private int Move(uint celt, T[] rgelt, out uint celtFetched)
         {
-            lock (this)
+            lock (_lock)
             {
                 int hr = Constants.S_OK;
                 celtFetched = (uint)_data.Length - _position;

--- a/src/MIDebugEngine/AD7.Impl/AD7Events.cs
+++ b/src/MIDebugEngine/AD7.Impl/AD7Events.cs
@@ -403,7 +403,7 @@ namespace Microsoft.MIDebugEngine
     {
         public const string IID = "51A94113-8788-4A54-AE15-08B74FF922D0";
 
-        public AD7ExceptionEvent(string name, string description, uint code, Guid? exceptionCategory, ExceptionBreakpointState state)
+        public AD7ExceptionEvent(string name, string description, uint code, Guid? exceptionCategory, ExceptionBreakpointStates state)
         {
             _name = name;
             _code = code;
@@ -412,15 +412,15 @@ namespace Microsoft.MIDebugEngine
 
             switch (state)
             {
-                case ExceptionBreakpointState.None:
+                case ExceptionBreakpointStates.None:
                     _state = enum_EXCEPTION_STATE.EXCEPTION_STOP_SECOND_CHANCE;
                     break;
 
-                case ExceptionBreakpointState.BreakThrown:
+                case ExceptionBreakpointStates.BreakThrown:
                     _state = enum_EXCEPTION_STATE.EXCEPTION_STOP_FIRST_CHANCE | enum_EXCEPTION_STATE.EXCEPTION_STOP_USER_FIRST_CHANCE;
                     break;
 
-                case ExceptionBreakpointState.BreakUserHandled:
+                case ExceptionBreakpointStates.BreakUserHandled:
                     _state = enum_EXCEPTION_STATE.EXCEPTION_STOP_USER_UNCAUGHT;
                     break;
 

--- a/src/MIDebugEngine/AD7.Impl/HashAlgorithmId.cs
+++ b/src/MIDebugEngine/AD7.Impl/HashAlgorithmId.cs
@@ -28,10 +28,10 @@ namespace Microsoft.MIDebugEngine
             MIHashAlgorithmName = hashAlgorithmName;
         }
 
-        public static HashAlgorithmId MD5 = new HashAlgorithmId(AD7Guids.guidSourceHashMD5, 16, MIHashAlgorithmName.MD5);
-        public static HashAlgorithmId SHA1 = new HashAlgorithmId(AD7Guids.guidSourceHashSHA1, 20, MIHashAlgorithmName.SHA1);
-        public static HashAlgorithmId SHA1Normalized = new HashAlgorithmId(AD7Guids.guidSourceHashSHA1Normalized, 20, MIHashAlgorithmName.SHA1);
-        public static HashAlgorithmId SHA256 = new HashAlgorithmId(AD7Guids.guidSourceHashSHA256, 32, MIHashAlgorithmName.SHA256);
-        public static HashAlgorithmId SHA256Normalized = new HashAlgorithmId(AD7Guids.guidSourceHashSHA256Normalized, 32, MIHashAlgorithmName.SHA256);
+        public static readonly HashAlgorithmId MD5 = new HashAlgorithmId(AD7Guids.guidSourceHashMD5, 16, MIHashAlgorithmName.MD5);
+        public static readonly HashAlgorithmId SHA1 = new HashAlgorithmId(AD7Guids.guidSourceHashSHA1, 20, MIHashAlgorithmName.SHA1);
+        public static readonly HashAlgorithmId SHA1Normalized = new HashAlgorithmId(AD7Guids.guidSourceHashSHA1Normalized, 20, MIHashAlgorithmName.SHA1);
+        public static readonly HashAlgorithmId SHA256 = new HashAlgorithmId(AD7Guids.guidSourceHashSHA256, 32, MIHashAlgorithmName.SHA256);
+        public static readonly HashAlgorithmId SHA256Normalized = new HashAlgorithmId(AD7Guids.guidSourceHashSHA256Normalized, 32, MIHashAlgorithmName.SHA256);
     }
 }

--- a/src/MIDebugEngine/Engine.Impl/DebugUnixChildProcess.cs
+++ b/src/MIDebugEngine/Engine.Impl/DebugUnixChildProcess.cs
@@ -13,7 +13,7 @@ using System.Globalization;
 
 namespace Microsoft.MIDebugEngine
 {
-    public interface ProcessSequence
+    public interface IProcessSequence
     {
         Task Enable();
         /// <summary>
@@ -26,7 +26,7 @@ namespace Microsoft.MIDebugEngine
         void ThreadCreatedEvent(Results results);
     }
 
-    internal class DebugUnixChild : ProcessSequence
+    internal class DebugUnixChild : IProcessSequence
     {
         private enum State
         {

--- a/src/MIDebugEngine/Engine.Impl/DebugUnixChildProcess.cs
+++ b/src/MIDebugEngine/Engine.Impl/DebugUnixChildProcess.cs
@@ -64,7 +64,7 @@ namespace Microsoft.MIDebugEngine
                 uint inf = _process.InferiorByPid(state.Newpid);
                 if (inf != 0)
                 {
-                    await _process.ConsoleCmdAsync("inferior " + inf.ToString(), allowWhileRunning: false);
+                    await _process.ConsoleCmdAsync("inferior " + inf.ToString(CultureInfo.InvariantCulture), allowWhileRunning: false);
                     if (!string.IsNullOrEmpty(_mainBreak))
                     {
                         await _process.MICommandFactory.BreakDelete(_mainBreak);
@@ -84,7 +84,7 @@ namespace Microsoft.MIDebugEngine
                 uint inf = _process.InferiorByPid(state.Newpid);
                 if (inf != 0)
                 {
-                    await _process.ConsoleCmdAsync("inferior " + inf.ToString(), allowWhileRunning: false);
+                    await _process.ConsoleCmdAsync("inferior " + inf.ToString(CultureInfo.InvariantCulture), allowWhileRunning: false);
                     await SetBreakAtMain();
                     state.State = State.AtExec;
                     await _process.MICommandFactory.ExecContinue();  // run the child
@@ -100,7 +100,7 @@ namespace Microsoft.MIDebugEngine
                 uint inf = _process.InferiorByPid(state.Newpid);
                 if (inf != 0)
                 {
-                    await _process.ConsoleCmdAsync("inferior " + inf.ToString(), allowWhileRunning: false);
+                    await _process.ConsoleCmdAsync("inferior " + inf.ToString(CultureInfo.InvariantCulture), allowWhileRunning: false);
                     await _process.MICommandFactory.ExecContinue();  // run the child
                 }
             }
@@ -147,7 +147,7 @@ namespace Microsoft.MIDebugEngine
             uint inf = _process.InferiorByPid(state.Newpid);
             if (inf == 0)
                 return false;    // cannot process the child
-            await _process.ConsoleCmdAsync("inferior " + inf.ToString(), allowWhileRunning: false);
+            await _process.ConsoleCmdAsync("inferior " + inf.ToString(CultureInfo.InvariantCulture), allowWhileRunning: false);
             await _process.MICommandFactory.TargetDetach();     // detach from the child
             await _process.ConsoleCmdAsync("inferior 1", allowWhileRunning: false);
             return true;

--- a/src/MIDebugEngine/Engine.Impl/DebuggedProcess.cs
+++ b/src/MIDebugEngine/Engine.Impl/DebuggedProcess.cs
@@ -1953,7 +1953,7 @@ namespace Microsoft.MIDebugEngine
 
         internal async Task<uint> ReadProcessMemory(ulong address, uint count, byte[] bytes)
         {
-            string cmd = "-data-read-memory-bytes " + EngineUtils.AsAddr(address, Is64BitArch) + " " + count.ToString();
+            string cmd = "-data-read-memory-bytes " + EngineUtils.AsAddr(address, Is64BitArch) + " " + count.ToString(CultureInfo.InvariantCulture);
             Results results = await CmdAsync(cmd, ResultClass.None);
             if (results.ResultClass == ResultClass.error)
             {
@@ -1996,7 +1996,7 @@ namespace Microsoft.MIDebugEngine
         internal async Task<Tuple<ulong, ulong>> FindValidMemoryRange(ulong address, uint count, int offset)
         {
             var ret = new Tuple<ulong, ulong>(0, 0);    // init to an empty range
-            string cmd = String.Format(CultureInfo.InvariantCulture, "-data-read-memory-bytes -o {0} {1} {2}", offset.ToString(), EngineUtils.AsAddr(address, Is64BitArch), count.ToString());
+            string cmd = String.Format(CultureInfo.InvariantCulture, "-data-read-memory-bytes -o {0} {1} {2}", offset.ToString(CultureInfo.InvariantCulture), EngineUtils.AsAddr(address, Is64BitArch), count.ToString(CultureInfo.InvariantCulture));
             Results results = await CmdAsync(cmd, ResultClass.None);
             if (results.ResultClass == ResultClass.error)
             {

--- a/src/MIDebugEngine/Engine.Impl/DebuggedProcess.cs
+++ b/src/MIDebugEngine/Engine.Impl/DebuggedProcess.cs
@@ -575,7 +575,7 @@ namespace Microsoft.MIDebugEngine
                 List<LaunchCommand> commands = await GetInitializeCommands();
                 _childProcessHandler?.Enable();
 
-                total = commands.Count();
+                total = commands.Count;
                 var i = 0;
                 foreach (var command in commands)
                 {

--- a/src/MIDebugEngine/Engine.Impl/DebuggedProcess.cs
+++ b/src/MIDebugEngine/Engine.Impl/DebuggedProcess.cs
@@ -243,7 +243,7 @@ namespace Microsoft.MIDebugEngine
             }
             else
             {
-                throw new ArgumentOutOfRangeException(null, nameof(_launchOptions));
+                throw new ArgumentOutOfRangeException(nameof(launchOptions));
             }
 
             MIDebugCommandDispatcher.AddProcess(this);

--- a/src/MIDebugEngine/Engine.Impl/DebuggedProcess.cs
+++ b/src/MIDebugEngine/Engine.Impl/DebuggedProcess.cs
@@ -243,7 +243,7 @@ namespace Microsoft.MIDebugEngine
             }
             else
             {
-                throw new ArgumentOutOfRangeException("LaunchInfo.options");
+                throw new ArgumentOutOfRangeException(null, nameof(_launchOptions));
             }
 
             MIDebugCommandDispatcher.AddProcess(this);

--- a/src/MIDebugEngine/Engine.Impl/DebuggedProcess.cs
+++ b/src/MIDebugEngine/Engine.Impl/DebuggedProcess.cs
@@ -1508,11 +1508,11 @@ namespace Microsoft.MIDebugEngine
 
                     ulong startAddr = 0;
                     ulong endAddr = 0;
-                    if (line.StartsWith("From")) // header line, ignore
+                    if (line.StartsWith("From", StringComparison.Ordinal)) // header line, ignore
                     {
                         continue;
                     }
-                    else if (line.StartsWith("0x"))  // module with load address
+                    else if (line.StartsWith("0x", StringComparison.Ordinal))  // module with load address
                     {
                         // line format: 0x<hex start addr>  0x<hex end addr>  [ Yes | No ]  <filename>
                         line = MICommandFactory.SpanNextAddr(line, out startAddr);
@@ -1528,12 +1528,12 @@ namespace Microsoft.MIDebugEngine
                     }
                     line = line.Trim();
                     bool symbolsLoaded;
-                    if (line.StartsWith("Yes"))
+                    if (line.StartsWith("Yes", StringComparison.Ordinal))
                     {
                         symbolsLoaded = true;
                         line = line.Substring(3);
                     }
-                    else if (line.StartsWith("No"))
+                    else if (line.StartsWith("No", StringComparison.Ordinal))
                     {
                         symbolsLoaded = false;
                         line = line.Substring(2);

--- a/src/MIDebugEngine/Engine.Impl/DebuggedProcess.cs
+++ b/src/MIDebugEngine/Engine.Impl/DebuggedProcess.cs
@@ -48,7 +48,7 @@ namespace Microsoft.MIDebugEngine
         private readonly EngineTelemetry _engineTelemetry = new EngineTelemetry();
         private bool _needTerminalReset;
         private HashSet<Tuple<string, string>> _fileTimestampWarnings;
-        private ProcessSequence _childProcessHandler;
+        private IProcessSequence _childProcessHandler;
         private bool _deleteEntryPointBreakpoint;
         private string _entryPointBreakpoint = string.Empty;
 

--- a/src/MIDebugEngine/Engine.Impl/DebuggedProcess.cs
+++ b/src/MIDebugEngine/Engine.Impl/DebuggedProcess.cs
@@ -1291,7 +1291,7 @@ namespace Microsoft.MIDebugEngine
 
                 string description = results.Results.FindString("exception");
                 Guid? exceptionCategory;
-                ExceptionBreakpointState state;
+                ExceptionBreakpointStates state;
                 MICommandFactory.DecodeExceptionReceivedProperties(results.Results, out exceptionCategory, out state);
 
                 _callback.OnException(thread, exceptionName, description, 0, exceptionCategory, state);
@@ -1863,7 +1863,7 @@ namespace Microsoft.MIDebugEngine
         {
             List<VariableInformation> variables = new List<VariableInformation>();
 
-            ValueListValue localsAndParameters = await MICommandFactory.StackListVariables(PrintValues.NoValues, thread.Id, ctx.Level);
+            ValueListValue localsAndParameters = await MICommandFactory.StackListVariables(PrintValue.NoValues, thread.Id, ctx.Level);
 
             foreach (var localOrParamResult in localsAndParameters.Content)
             {
@@ -1883,7 +1883,7 @@ namespace Microsoft.MIDebugEngine
         {
             List<SimpleVariableInformation> parameters = new List<SimpleVariableInformation>();
 
-            ValueListValue localAndParameters = await MICommandFactory.StackListVariables(PrintValues.SimpleValues, thread.Id, ctx.Level);
+            ValueListValue localAndParameters = await MICommandFactory.StackListVariables(PrintValue.SimpleValues, thread.Id, ctx.Level);
 
             foreach (var results in localAndParameters.Content.Where(r => r.TryFindString("arg") == "1"))
             {
@@ -1898,7 +1898,7 @@ namespace Microsoft.MIDebugEngine
         public async Task<List<ArgumentList>> GetParameterInfoOnly(AD7Thread thread, bool values, bool types, uint low, uint high)
         {
             // If values are requested, request simple values, otherwise we'll use -var-create to get the type of argument it is.
-            var frames = await MICommandFactory.StackListArguments(values ? PrintValues.SimpleValues : PrintValues.NoValues, thread.Id, low, high);
+            var frames = await MICommandFactory.StackListArguments(values ? PrintValue.SimpleValues : PrintValue.NoValues, thread.Id, low, high);
             List<ArgumentList> parameters = new List<ArgumentList>();
 
             foreach (var f in frames)

--- a/src/MIDebugEngine/Engine.Impl/DebuggedThread.cs
+++ b/src/MIDebugEngine/Engine.Impl/DebuggedThread.cs
@@ -43,7 +43,7 @@ namespace Microsoft.MIDebugEngine
         private List<DebuggedThread> _deadThreads;
         private List<DebuggedThread> _newThreads;
         private Dictionary<string, List<int>> _threadGroups;
-        private static uint s_targetId;
+        private static uint s_targetId = uint.MaxValue;
         private const string c_defaultGroupId = "i1";  // gdb's default group id, also used for any process without group ids
 
         private List<DebuggedThread> DeadThreads
@@ -68,11 +68,6 @@ namespace Microsoft.MIDebugEngine
                 }
                 return _newThreads;
             }
-        }
-
-        static ThreadCache()
-        {
-            s_targetId = uint.MaxValue;
         }
 
         internal ThreadCache(ISampleEngineCallback callback, DebuggedProcess debugger)

--- a/src/MIDebugEngine/Engine.Impl/Disassembly.cs
+++ b/src/MIDebugEngine/Engine.Impl/Disassembly.cs
@@ -9,6 +9,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using System.Diagnostics;
 using MICore;
+using System.Globalization;
 
 namespace Microsoft.MIDebugEngine
 {
@@ -324,7 +325,7 @@ namespace Microsoft.MIDebugEngine
             {
                 file = process.EscapeSymbolPath(file);
             }
-            string cmd = "-data-disassemble -f " + file + " -l " + line.ToString() + " -n " + dwInstructions.ToString() + " -- 1";
+            string cmd = "-data-disassemble -f " + file + " -l " + line.ToString(CultureInfo.InvariantCulture) + " -n " + dwInstructions.ToString(CultureInfo.InvariantCulture) + " -- 1";
             Results results = await process.CmdAsync(cmd, ResultClass.None);
             if (results.ResultClass != ResultClass.done)
             {

--- a/src/MIDebugEngine/Engine.Impl/EngineCallback.cs
+++ b/src/MIDebugEngine/Engine.Impl/EngineCallback.cs
@@ -208,7 +208,7 @@ namespace Microsoft.MIDebugEngine
         }
 
         // Exception events are sent when an exception occurs in the debuggee that the debugger was not expecting.
-        public void OnException(DebuggedThread thread, string name, string description, uint code, Guid? exceptionCategory = null, ExceptionBreakpointState state = ExceptionBreakpointState.None)
+        public void OnException(DebuggedThread thread, string name, string description, uint code, Guid? exceptionCategory = null, ExceptionBreakpointStates state = ExceptionBreakpointStates.None)
         {
             AD7ExceptionEvent eventObject = new AD7ExceptionEvent(name, description, code, exceptionCategory, state);
 

--- a/src/MIDebugEngine/Engine.Impl/OperationThread.cs
+++ b/src/MIDebugEngine/Engine.Impl/OperationThread.cs
@@ -95,7 +95,7 @@ namespace Microsoft.MIDebugEngine
         public void RunOperation(Operation op)
         {
             if (op == null)
-                throw new ArgumentNullException();
+                throw new ArgumentNullException(nameof(op));
 
             SetOperationInternal(op);
         }
@@ -108,7 +108,7 @@ namespace Microsoft.MIDebugEngine
         public void RunOperation(AsyncOperation op)
         {
             if (op == null)
-                throw new ArgumentNullException();
+                throw new ArgumentNullException(nameof(op));
 
             SetOperationInternal(op);
         }
@@ -116,7 +116,7 @@ namespace Microsoft.MIDebugEngine
         public void RunOperation(string text, CancellationTokenSource canTokenSource, AsyncProgressOperation op)
         {
             if (op == null)
-                throw new ArgumentNullException();
+                throw new ArgumentNullException(nameof(op));
 
             SetOperationInternalWithProgress(op, text, canTokenSource);
         }
@@ -192,7 +192,7 @@ namespace Microsoft.MIDebugEngine
         public void PostOperation(Operation op)
         {
             if (op == null)
-                throw new ArgumentNullException();
+                throw new ArgumentNullException(nameof(op));
 
             if (_isClosed)
                 throw new ObjectDisposedException("WorkerThread");

--- a/src/MIDebugEngine/Engine.Impl/Structures.cs
+++ b/src/MIDebugEngine/Engine.Impl/Structures.cs
@@ -94,7 +94,7 @@ namespace Microsoft.MIDebugEngine
         /// <param name="message">[Required] message to send</param>
         void OnError(string message);
         void OnBreakpoint(DebuggedThread thread, ReadOnlyCollection<object> clients);
-        void OnException(DebuggedThread thread, string name, string description, uint code, Guid? exceptionCategory = null, ExceptionBreakpointState state = ExceptionBreakpointState.None);
+        void OnException(DebuggedThread thread, string name, string description, uint code, Guid? exceptionCategory = null, ExceptionBreakpointStates state = ExceptionBreakpointStates.None);
         void OnStepComplete(DebuggedThread thread);
         void OnAsyncBreakComplete(DebuggedThread thread);
         void OnLoadComplete();

--- a/src/MIDebugEngine/Engine.Impl/Variables.cs
+++ b/src/MIDebugEngine/Engine.Impl/Variables.cs
@@ -566,7 +566,7 @@ namespace Microsoft.MIDebugEngine
                             _attribsFetched = true;
                         }
                         Value = results.TryFindString("value");
-                        if ((Value == String.Empty || _format != null) && !string.IsNullOrEmpty(_internalName))
+                        if ((string.IsNullOrEmpty(Value) || _format != null) && !string.IsNullOrEmpty(_internalName))
                         {
                             if (_format != null)
                             {

--- a/src/MIDebugEngine/Engine.Impl/Variables.cs
+++ b/src/MIDebugEngine/Engine.Impl/Variables.cs
@@ -164,11 +164,6 @@ namespace Microsoft.MIDebugEngine
             }
         }
 
-        static VariableInformation()
-        {
-            s_isFunction = new Regex(@".+\(.*\).*");
-        }
-
         private VariableInformation(ThreadContext ctx, AD7Engine engine, AD7Thread thread)
         {
             _engine = engine;
@@ -339,7 +334,7 @@ namespace Microsoft.MIDebugEngine
                                  @"^const +char *\[[0-9]*\]$"
                              };
 
-        private static Regex s_isFunction;
+        private static Regex s_isFunction = new Regex(@".+\(.*\).*");
 
         private string StripFormatSpecifier(string exp, out string formatSpecifier)
         {

--- a/src/MIDebugEngine/Engine.Impl/Variables.cs
+++ b/src/MIDebugEngine/Engine.Impl/Variables.cs
@@ -618,7 +618,7 @@ namespace Microsoft.MIDebugEngine
                 else
                     message = e.Message;
 
-                SetAsError(string.Format(ResourceStrings.Failed_ExecCommandError, message));
+                SetAsError(string.Format(CultureInfo.CurrentCulture, ResourceStrings.Failed_ExecCommandError, message));
             }
         }
 
@@ -695,7 +695,7 @@ namespace Microsoft.MIDebugEngine
                     {
                         if (children[p].TryFindUint("numchild") > 0)
                         {
-                            var variable = new VariableInformation("[" + (p / 2).ToString() + "]", this);
+                            var variable = new VariableInformation("[" + (p / 2).ToString(CultureInfo.InvariantCulture) + "]", this);
                             variable.CountChildren = 2;
                             var first = new VariableInformation(children[p], variable, "first");
                             var second = new VariableInformation(children[p + 1], this, "second");

--- a/src/MIDebugEngine/MIDebugCommandDispatcher.cs
+++ b/src/MIDebugEngine/MIDebugCommandDispatcher.cs
@@ -32,7 +32,7 @@ namespace Microsoft.MIDebugEngine
         internal static Task<string> ExecuteCommand(string command, DebuggedProcess process, bool ignoreFailures = false)
         {
             if (string.IsNullOrWhiteSpace(command))
-                throw new ArgumentNullException("command");
+                throw new ArgumentNullException(nameof(command));
 
             if (process == null)
             {

--- a/src/MIDebugEngine/MIDebugEngine.csproj
+++ b/src/MIDebugEngine/MIDebugEngine.csproj
@@ -26,8 +26,6 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <Prefer32Bit>false</Prefer32Bit>
-    <RunCodeAnalysis>true</RunCodeAnalysis>
-    <CodeAnalysisRuleSet>..\IDECodeAnalysis.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>
@@ -45,8 +43,6 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <Prefer32Bit>false</Prefer32Bit>
-    <RunCodeAnalysis>true</RunCodeAnalysis>
-    <CodeAnalysisRuleSet>..\IDECodeAnalysis.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Desktop.Release|AnyCPU'">
     <DebugType>pdbonly</DebugType>

--- a/src/MIDebugEngine/Natvis.Impl/Natvis.cs
+++ b/src/MIDebugEngine/Natvis.Impl/Natvis.cs
@@ -142,9 +142,9 @@ namespace Microsoft.MIDebugEngine.Natvis
             }
         }
 
-        private static Regex s_variableName;
-        private static Regex s_subfieldNameHere;
-        private static Regex s_expression;
+        private static Regex s_variableName = new Regex("[a-zA-Z$_][a-zA-Z$_0-9]*");
+        private static Regex s_subfieldNameHere = new Regex(@"\G((\.|->)[a-zA-Z$_][a-zA-Z$_0-9]*)+");
+        private static Regex s_expression = new Regex(@"^\{[^\}]*\}");
         private List<FileInfo> _typeVisualizers;
         private DebuggedProcess _process;
         private Dictionary<string, VisualizerInfo> _vizCache;
@@ -164,13 +164,6 @@ namespace Microsoft.MIDebugEngine.Natvis
             ForVisualizedItems
         }
         public DisplayStringsState ShowDisplayStrings { get; set; }
-
-        static Natvis()
-        {
-            s_variableName = new Regex("[a-zA-Z$_][a-zA-Z$_0-9]*");
-            s_subfieldNameHere = new Regex(@"\G((\.|->)[a-zA-Z$_][a-zA-Z$_0-9]*)+");
-            s_expression = new Regex(@"^\{[^\}]*\}");
-        }
 
         internal Natvis(DebuggedProcess process, bool showDisplayString)
         {

--- a/src/MIDebugEngine/Natvis.Impl/NatvisNames.cs
+++ b/src/MIDebugEngine/Natvis.Impl/NatvisNames.cs
@@ -32,16 +32,9 @@ namespace Microsoft.MIDebugEngine.Natvis
             Dimensions = Dims;
         }
 
-        private static Regex s_identifier;
-        private static Regex s_numeric;
-        private static Regex s_simpleType;
-        private static readonly TypeName s_any;
-
-        static TypeName()
-        {
-            s_identifier = new Regex("^[a-zA-Z$_][a-zA-Z$_0-9]*");
-            s_numeric = new Regex("^[0-9]+(u|l|ul)*");        // only decimal constants
-            s_simpleType = new Regex(
+        private static Regex s_identifier = new Regex("^[a-zA-Z$_][a-zA-Z$_0-9]*");
+        private static Regex s_numeric = new Regex("^[0-9]+(u|l|ul)*");        // only decimal constants
+        private static Regex s_simpleType = new Regex(
                     @"^(signed\s+char|unsigned\s+char|char16_t|char32_t|wchar_t|char|"
                     + @"signed\s+short\s+int|signed\s+short|unsigned\s+short\s+int|unsigned\s+short|short\s+int|short|"
                     + @"signed\s+int|unsigned\s+int|int|"
@@ -50,9 +43,10 @@ namespace Microsoft.MIDebugEngine.Natvis
                     + @"float|double|"
                     + @"long\s+double|bool|void)\b" // matches prefixes ending in '$' (e.g. void$Foo), these are checked for below
                 );
-            s_any = new TypeName();
-            s_any.IsWildcard = true;
-        }
+        private static readonly TypeName s_any = new TypeName()
+        {
+            IsWildcard = true
+        };
 
         private TypeName()
         {

--- a/src/MIDebugPackage/MIDebugPackage.csproj
+++ b/src/MIDebugPackage/MIDebugPackage.csproj
@@ -22,8 +22,6 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <PlatformTarget>AnyCPU</PlatformTarget>
-    <RunCodeAnalysis>true</RunCodeAnalysis>
-    <CodeAnalysisRuleSet>..\IDECodeAnalysis.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>
@@ -31,7 +29,6 @@
     <DefineConstants>$(DefineConstants);TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
-    <RunCodeAnalysis>true</RunCodeAnalysis>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Lab.Debug|AnyCPU'">
     <DebugSymbols>true</DebugSymbols>
@@ -46,7 +43,6 @@
     <Optimize>true</Optimize>
     <DebugType>pdbonly</DebugType>
     <PlatformTarget>AnyCPU</PlatformTarget>
-    <RunCodeAnalysis>true</RunCodeAnalysis>
     <ErrorReport>prompt</ErrorReport>
     <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
@@ -58,8 +54,6 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <PlatformTarget>AnyCPU</PlatformTarget>
-    <RunCodeAnalysis>true</RunCodeAnalysis>
-    <CodeAnalysisRuleSet>..\IDECodeAnalysis.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Desktop.Release|AnyCPU'">
     <DebugType>pdbonly</DebugType>
@@ -67,7 +61,6 @@
     <DefineConstants>$(DefineConstants);TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
-    <RunCodeAnalysis>true</RunCodeAnalysis>
   </PropertyGroup>
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <Import Project="SuppressFromVsix.targets" />

--- a/src/MIDebugPackage/MIDebugPackagePackage.cs
+++ b/src/MIDebugPackage/MIDebugPackagePackage.cs
@@ -352,7 +352,7 @@ namespace Microsoft.MIDebugPackage
             if (results != null && results.Length > 0)
             {
                 // Make sure that we are printing whole lines
-                if (!results.EndsWith("\n") && !results.EndsWith("\r\n"))
+                if (!results.EndsWith("\n", StringComparison.Ordinal) && !results.EndsWith("\r\n", StringComparison.Ordinal))
                 {
                     results = results + "\n";
                 }

--- a/src/MakePIAPortable/MakePIAPortable.csproj
+++ b/src/MakePIAPortable/MakePIAPortable.csproj
@@ -36,8 +36,6 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <Externalconsole>true</Externalconsole>
-    <RunCodeAnalysis>true</RunCodeAnalysis>
-    <CodeAnalysisRuleSet>..\IDECodeAnalysis.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="System" />

--- a/src/Microsoft.VisualStudio.Debugger.Interop.DAP/Microsoft.VisualStudio.Debugger.Interop.DAP.csproj
+++ b/src/Microsoft.VisualStudio.Debugger.Interop.DAP/Microsoft.VisualStudio.Debugger.Interop.DAP.csproj
@@ -14,7 +14,6 @@
     <AssemblyName>Microsoft.VisualStudio.Debugger.Interop.DAP</AssemblyName>
     <OutputPath>bin\$(Configuration)</OutputPath>
     <DocumentationFile>$(DropRootDir)\ReferenceAssemblies\$(AssemblyName).xml</DocumentationFile>
-    <CodeAnalysisRuleSet>..\IDECodeAnalysis.ruleset</CodeAnalysisRuleSet>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <DebugSymbols>false</DebugSymbols>
     <DebugType>pdbonly</DebugType>
@@ -39,7 +38,7 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <Prefer32Bit>false</Prefer32Bit>
-    <RunCodeAnalysis>true</RunCodeAnalysis>
+    
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Desktop.Release|AnyCPU'">
     <DefineConstants>$(DefineConstants);TRACE</DefineConstants>

--- a/src/Microsoft.VisualStudio.Debugger.Interop.UnixPortSupplier/Microsoft.VisualStudio.Debugger.Interop.UnixPortSupplier.DesignTime.csproj
+++ b/src/Microsoft.VisualStudio.Debugger.Interop.UnixPortSupplier/Microsoft.VisualStudio.Debugger.Interop.UnixPortSupplier.DesignTime.csproj
@@ -20,7 +20,6 @@
     so we don't want it in the default output directory -->
     <OutputPath>bin\$(Configuration)</OutputPath>
     <DocumentationFile>$(DropRootDir)\ReferenceAssemblies\$(AssemblyName).xml</DocumentationFile>
-    <CodeAnalysisRuleSet>..\IDECodeAnalysis.ruleset</CodeAnalysisRuleSet>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <DebugSymbols>false</DebugSymbols>
     <DebugType>pdbonly</DebugType>
@@ -45,7 +44,7 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <Prefer32Bit>false</Prefer32Bit>
-    <RunCodeAnalysis>true</RunCodeAnalysis>
+    
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Desktop.Release|AnyCPU'">
     <DefineConstants>$(DefineConstants);TRACE</DefineConstants>

--- a/src/OpenDebugAD7/AD7DebugSession.cs
+++ b/src/OpenDebugAD7/AD7DebugSession.cs
@@ -191,7 +191,7 @@ namespace OpenDebugAD7
                     try
                     {
                         sourceFileMap = sourceFileMapProperty.ToObject<Dictionary<string, string>>();
-                        sourceFileMappings = sourceFileMap.Count();
+                        sourceFileMappings = sourceFileMap.Count;
                     }
                     catch (Exception e)
                     {

--- a/src/OpenDebugAD7/AD7Impl/AD7Port.cs
+++ b/src/OpenDebugAD7/AD7Impl/AD7Port.cs
@@ -66,7 +66,7 @@ namespace OpenDebugAD7.AD7Impl
             var ad7Process = process as AD7Process;
             if (ad7Process == null)
             {
-                throw new ArgumentOutOfRangeException("process");
+                throw new ArgumentOutOfRangeException(nameof(process));
             }
 
             lock (_processMap)

--- a/src/OpenDebugAD7/Document.cs
+++ b/src/OpenDebugAD7/Document.cs
@@ -86,7 +86,7 @@ namespace OpenDebugAD7
             }
             else
             {
-                throw new ArgumentException(null, nameof(guidHashAlgorithm));
+                throw new ArgumentOutOfRangeException(nameof(guidHashAlgorithm));
             }
 
             checksumBytes = null;

--- a/src/OpenDebugAD7/Document.cs
+++ b/src/OpenDebugAD7/Document.cs
@@ -86,7 +86,7 @@ namespace OpenDebugAD7
             }
             else
             {
-                throw new ArgumentException("guidHashAlgorithm");
+                throw new ArgumentException(null, nameof(guidHashAlgorithm));
             }
 
             checksumBytes = null;

--- a/src/OpenDebugAD7/OpenDebugAD7.csproj
+++ b/src/OpenDebugAD7/OpenDebugAD7.csproj
@@ -43,8 +43,6 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <Externalconsole>true</Externalconsole>
-    <RunCodeAnalysis>true</RunCodeAnalysis>
-    <CodeAnalysisRuleSet>..\IDECodeAnalysis.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Lab.Debug|AnyCPU'">
     <DebugSymbols>true</DebugSymbols>
@@ -70,8 +68,8 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <Prefer32Bit>false</Prefer32Bit>
-    <RunCodeAnalysis>true</RunCodeAnalysis>
-    <CodeAnalysisRuleSet>..\IDECodeAnalysis.ruleset</CodeAnalysisRuleSet>
+    
+    
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>

--- a/src/SSHDebugPS/AD7/AD7Enums.cs
+++ b/src/SSHDebugPS/AD7/AD7Enums.cs
@@ -14,6 +14,8 @@ namespace Microsoft.SSHDebugPS
     #region Base Class
     internal class AD7Enum<T, I> where I : class
     {
+        private static readonly object _lock = new object();
+
         private readonly T[] _data;
         private uint _position;
 
@@ -42,7 +44,7 @@ namespace Microsoft.SSHDebugPS
 
         public int Reset()
         {
-            lock (this)
+            lock (_lock)
             {
                 _position = 0;
 
@@ -59,7 +61,7 @@ namespace Microsoft.SSHDebugPS
 
         private int Move(uint celt, T[] rgelt, out uint celtFetched)
         {
-            lock (this)
+            lock (_lock)
             {
                 int hr = HR.S_OK;
                 celtFetched = (uint)_data.Length - _position;

--- a/src/SSHDebugPS/AD7/AD7Port.cs
+++ b/src/SSHDebugPS/AD7/AD7Port.cs
@@ -166,7 +166,7 @@ namespace Microsoft.SSHDebugPS
             IDebugPortEvents2 eventCallback = sinkInterface as IDebugPortEvents2;
             if (eventCallback == null)
             {
-                throw new ArgumentOutOfRangeException("sinkIterface");
+                throw new ArgumentOutOfRangeException(nameof(sinkInterface));
             }
 
             lock (_lock)

--- a/src/SSHDebugPS/Docker/DockerHelper.cs
+++ b/src/SSHDebugPS/Docker/DockerHelper.cs
@@ -113,7 +113,7 @@ namespace Microsoft.SSHDebugPS.Docker
                     }
                 });
             }
-            catch (CommandFailedException _)
+            catch (CommandFailedException)
             {
                 // only care whether call to obtain LCOW succeeded
                 return false;
@@ -138,7 +138,7 @@ namespace Microsoft.SSHDebugPS.Docker
                     delegateServerOS = args;
                 });
             }
-            catch (CommandFailedException _)
+            catch (CommandFailedException)
             {
                 // only care whether call to obtain server OS succeeded
                 return false;
@@ -163,7 +163,7 @@ namespace Microsoft.SSHDebugPS.Docker
                     delegateContainerPlatform = args;
                 });
             }
-            catch (CommandFailedException _)
+            catch (CommandFailedException)
             {
                 // only care whether call to obtain container platform succeeded
                 return false;

--- a/src/SSHDebugPS/UI/ViewModels/ContainerPickerViewModel.cs
+++ b/src/SSHDebugPS/UI/ViewModels/ContainerPickerViewModel.cs
@@ -377,7 +377,7 @@ namespace Microsoft.SSHDebugPS.UI
                 return;
             }
 
-            if (!string.Equals(_statusMessage, statusMessage, StringComparison.CurrentCulture))
+            if (!string.Equals(_statusMessage, statusMessage, StringComparison.Ordinal))
             {
                 _statusMessage = statusMessage;
                 OnPropertyChanged(nameof(StatusMessage));

--- a/src/SSHDebugPS/UI/ViewModels/ContainerPickerViewModel.cs
+++ b/src/SSHDebugPS/UI/ViewModels/ContainerPickerViewModel.cs
@@ -217,7 +217,7 @@ namespace Microsoft.SSHDebugPS.UI
                 ContainerInstances = new ObservableCollection<IContainerViewModel>(containers.Select(item => new DockerContainerViewModel(item)).ToList());
                 OnPropertyChanged(nameof(ContainerInstances));
 
-                if (ContainerInstances.Count() > 0)
+                if (ContainerInstances.Count > 0)
                 {
 
                     if (selectedContainer != null)
@@ -239,16 +239,16 @@ namespace Microsoft.SSHDebugPS.UI
             }
             finally
             {
-                if (ContainerInstances.Count() > 0)
+                if (ContainerInstances.Count > 0)
                 {
-                    if (ContainerInstances.Count() < totalContainers)
+                    if (ContainerInstances.Count < totalContainers)
                     {
-                        UpdateStatusMessage(UIResources.ContainersNotAllParsedStatusText.FormatCurrentCultureWithArgs(totalContainers - ContainerInstances.Count()), isError: false);
-                        ContainersFoundText = UIResources.ContainersNotAllParsedText.FormatCurrentCultureWithArgs(ContainerInstances.Count(), totalContainers);
+                        UpdateStatusMessage(UIResources.ContainersNotAllParsedStatusText.FormatCurrentCultureWithArgs(totalContainers - ContainerInstances.Count), isError: false);
+                        ContainersFoundText = UIResources.ContainersNotAllParsedText.FormatCurrentCultureWithArgs(ContainerInstances.Count, totalContainers);
                     }
                     else
                     {
-                        ContainersFoundText = UIResources.ContainersFoundStatusText.FormatCurrentCultureWithArgs(ContainerInstances.Count());
+                        ContainersFoundText = UIResources.ContainersFoundStatusText.FormatCurrentCultureWithArgs(ContainerInstances.Count);
                     }
                 }
                 else

--- a/src/SSHDebugPS/UI/ViewModels/ContainerPickerViewModel.cs
+++ b/src/SSHDebugPS/UI/ViewModels/ContainerPickerViewModel.cs
@@ -165,7 +165,7 @@ namespace Microsoft.SSHDebugPS.UI
                     containers = DockerHelper.GetRemoteDockerContainers(connection, Hostname, out totalContainers);
                 }
 
-                if (containers.Count() > 0) 
+                if (containers.Any()) 
                 {
                     string serverOS;
 

--- a/src/WindowsDebugLauncher/Program.cs
+++ b/src/WindowsDebugLauncher/Program.cs
@@ -141,19 +141,19 @@ namespace WindowsDebugLauncher
                     switch (c)
                     {
                         case 'n':
-                            builder.Append("\n");
+                            builder.Append('\n');
                             break;
                         case 'r':
-                            builder.Append("\r");
+                            builder.Append('\r');
                             break;
                         case '\\':
-                            builder.Append("\\");
+                            builder.Append('\\');
                             break;
                         case '"':
-                            builder.Append("\"");
+                            builder.Append('\"');
                             break;
                         case ' ':
-                            builder.Append(" ");
+                            builder.Append(' ');
                             break;
                         default:
                             throw new ArgumentException(FormattableString.Invariant($"Invalid escape sequence: \\{c}"));

--- a/src/WindowsDebugLauncher/WindowsDebugLauncher.csproj
+++ b/src/WindowsDebugLauncher/WindowsDebugLauncher.csproj
@@ -39,8 +39,6 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <Externalconsole>true</Externalconsole>
-    <RunCodeAnalysis>true</RunCodeAnalysis>
-    <CodeAnalysisRuleSet>..\IDECodeAnalysis.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="System" />

--- a/src/prebuild/packages.config
+++ b/src/prebuild/packages.config
@@ -1,0 +1,8 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="Microsoft.CodeAnalysis.FxCopAnalyzers" version="3.3.0" targetFramework="net462" developmentDependency="true" />
+  <package id="Microsoft.CodeAnalysis.VersionCheckAnalyzer" version="3.3.0" targetFramework="net462" developmentDependency="true" />
+  <package id="Microsoft.CodeQuality.Analyzers" version="3.3.0" targetFramework="net462" developmentDependency="true" />
+  <package id="Microsoft.NetCore.Analyzers" version="3.3.0" targetFramework="net462" developmentDependency="true" />
+  <package id="Microsoft.NetFramework.Analyzers" version="3.3.0" targetFramework="net462" developmentDependency="true" />
+</packages>

--- a/src/prebuild/prebuild.csproj
+++ b/src/prebuild/prebuild.csproj
@@ -15,6 +15,7 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Desktop.Debug|AnyCPU'" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Desktop.Release|AnyCPU'" />
   <ItemGroup>
+    <None Include="packages.config" />
     <GenerateAssembly Include="$(ILDir)*.il">
       <Visible>false</Visible>
     </GenerateAssembly>


### PR DESCRIPTION
This PR disables the Legacy FxCop and uses FxCop Analyzers instead. 

Due to the upgrade, there are many issues that have been caught but are disabled in `IDECodeAnalysis.ruleset`. 
I have added the description of the rules we have disabled.

Let me know if there are ones I should fix instead of having them disabled for now.

Each commit is a fix for a rule except the first and last commit. 