### PR TITLE
Fixed ps call for Docker Linux containers

### DIFF
--- a/src/SSHDebugPS/PSOutputParser.cs
+++ b/src/SSHDebugPS/PSOutputParser.cs
@@ -65,7 +65,7 @@ namespace Microsoft.SSHDebugPS
         private ColumnDef _ruserCol;
         private ColumnDef _argsCol;
 
-        public static string PSCommandLine = PSCommandLineFormat.FormatInvariantWithArgs(" -axww ");
+        public static string PSCommandLine = PSCommandLineFormat.FormatInvariantWithArgs(" axww ");
         public static string AltPSCommandLine = PSCommandLineFormat.FormatInvariantWithArgs(" ");
 
         public static List<Process> Parse(string output, string username)


### PR DESCRIPTION
Fix for Bug 1152117: Attach to process doesn't work on alpine based Linux containers. Verified on images listed [here](https://hub.docker.com/search?q=&type=image&operating_system=linux&category=base).

Before:
![image](https://user-images.githubusercontent.com/60245970/93152986-01ec5380-f6b5-11ea-9fbd-b91579ddf36e.png)

After:
![image](https://user-images.githubusercontent.com/60245970/93153052-23e5d600-f6b5-11ea-8417-471a44d4afdd.png)