### PR TITLE
Add SymbolLoadInfo for LaunchOptionJson

### DIFF
--- a/src/MICore/JsonLaunchOptions.cs
+++ b/src/MICore/JsonLaunchOptions.cs
@@ -191,7 +191,11 @@ namespace MICore.Json.LaunchOptions
 
         #region Constructors
 
-        public SymbolLoadInfo(bool? loadAll, string exceptionList)
+        public SymbolLoadInfo()
+        {
+        }
+
+        public SymbolLoadInfo(bool? loadAll = null, string exceptionList = null)
         {
             this.LoadAll = loadAll;
             this.ExceptionList = exceptionList;

--- a/src/MICore/JsonLaunchOptions.cs
+++ b/src/MICore/JsonLaunchOptions.cs
@@ -120,7 +120,8 @@ namespace MICore.Json.LaunchOptions
             string miDebuggerArgs = null,
             string miDebuggerServerAddress = null,
             Dictionary<string, object> sourceFileMap = null,
-            PipeTransport pipeTransport = null)
+            PipeTransport pipeTransport = null,
+            SymbolLoadInfo symbolLoadInfo = null)
         {
             this.Program = program;
             this.Type = type;
@@ -135,6 +136,7 @@ namespace MICore.Json.LaunchOptions
             this.ProcessId = processId;
             this.SourceFileMap = sourceFileMap;
             this.PipeTransport = pipeTransport;
+            this.SymbolLoadInfo = symbolLoadInfo;
         }
 
         #endregion
@@ -189,8 +191,10 @@ namespace MICore.Json.LaunchOptions
 
         #region Constructors
 
-        public SymbolLoadInfo()
+        public SymbolLoadInfo(bool? loadAll, string exceptionList)
         {
+            this.LoadAll = loadAll;
+            this.ExceptionList = exceptionList;
         }
 
         #endregion

--- a/src/MICore/JsonLaunchOptions.cs
+++ b/src/MICore/JsonLaunchOptions.cs
@@ -83,6 +83,12 @@ namespace MICore.Json.LaunchOptions
         /// </summary>
         [JsonProperty("pipeTransport", DefaultValueHandling = DefaultValueHandling.Ignore)]
         public PipeTransport PipeTransport { get; set; }
+
+        /// <summary>
+        /// Supports explcit control of symbol loading. The processing of Exceptions lists and symserver entries.
+        /// </summary>
+        [JsonProperty("symbolLoadInfo", DefaultValueHandling = DefaultValueHandling.Ignore)]
+        public SymbolLoadInfo SymbolLoadInfo { get; set; }
     }
 
     public partial class AttachOptions : BaseOptions
@@ -156,6 +162,35 @@ namespace MICore.Json.LaunchOptions
         {
             this.Name = name;
             this.Value = value;
+        }
+
+        #endregion
+    }
+
+    public partial class SymbolLoadInfo
+    {
+        #region Public Properties for Serialization
+
+        /// <summary>
+        /// If true, symbols for all libs will be loaded, otherwise no solib symbols will be loaded. Modified by ExceptionList. Default value is true.
+        /// </summary>
+        [JsonProperty("loadAll", DefaultValueHandling = DefaultValueHandling.Ignore)]
+        public bool? LoadAll { get; set; }
+
+        /// <summary>
+        /// List of filenames (wildcards allowed). Modifies behavior of LoadAll. 
+        /// If LoadAll is true then don't load symbols for libs that match any name in the list. 
+        /// Otherwise only load symbols for libs that match.
+        /// </summary>
+        [JsonProperty("exceptionList", DefaultValueHandling = DefaultValueHandling.Ignore)]
+        public string ExceptionList { get; set; }
+
+        #endregion
+
+        #region Constructors
+
+        public SymbolLoadInfo()
+        {
         }
 
         #endregion

--- a/src/MICore/LaunchOptions.cs
+++ b/src/MICore/LaunchOptions.cs
@@ -1795,21 +1795,21 @@ namespace MICore
 
             if (options.SymbolLoadInfo != null)
             {
-                this.WaitDynamicLibLoad = !String.IsNullOrWhiteSpace(options.SymbolLoadInfo.ExceptionList) || options.SymbolLoadInfo.LoadAll.HasValue;
-
                 SymbolInfoLoadAll = options.SymbolLoadInfo.LoadAll.GetValueOrDefault(true);
 
-                if (DebuggerMIMode == MIMode.Lldb && !string.IsNullOrWhiteSpace(options.SymbolLoadInfo.ExceptionList))
+                if (!string.IsNullOrWhiteSpace(options.SymbolLoadInfo.ExceptionList))
                 {
-                    throw new InvalidLaunchOptionsException(String.Format(CultureInfo.InvariantCulture, MICoreResources.Error_OptionNotSupported, nameof(options.SymbolLoadInfo.ExceptionList), nameof(MIMode.Lldb)));
+                    if (DebuggerMIMode == MIMode.Lldb)
+                    {
+                        throw new InvalidLaunchOptionsException(String.Format(CultureInfo.InvariantCulture, MICoreResources.Error_OptionNotSupported, nameof(options.SymbolLoadInfo.ExceptionList), nameof(MIMode.Lldb)));
+                    }
+
+                    this.WaitDynamicLibLoad = true;
+                    SymbolInfoExceptionList.SetTo(options.SymbolLoadInfo.ExceptionList.Split(';'));
                 }
-
-                SymbolInfoExceptionList.SetTo(options.SymbolLoadInfo.ExceptionList == null ? new string[0] : options.SymbolLoadInfo.ExceptionList.Split(';'));
-
-                // Ensure that symbol loading options are consistent
-                if (!WaitDynamicLibLoad && !SymbolInfoExceptionList.IsEmpty)
+                else
                 {
-                    throw new InvalidLaunchOptionsException(MICoreResources.Error_InvalidSymbolInfo);
+                    SymbolInfoExceptionList.SetTo(new string[0]);
                 }
             }
 

--- a/src/MICore/LaunchOptions.cs
+++ b/src/MICore/LaunchOptions.cs
@@ -1792,6 +1792,27 @@ namespace MICore
             this.WaitDynamicLibLoad = false;
 
             this.SourceMap = SourceMapEntry.CreateCollection(options.SourceFileMap);
+
+            if (options.SymbolLoadInfo != null)
+            {
+                this.WaitDynamicLibLoad = !String.IsNullOrWhiteSpace(options.SymbolLoadInfo.ExceptionList) || options.SymbolLoadInfo.LoadAll.HasValue;
+
+                SymbolInfoLoadAll = options.SymbolLoadInfo.LoadAll.GetValueOrDefault(true);
+
+                if (DebuggerMIMode == MIMode.Lldb && !string.IsNullOrWhiteSpace(options.SymbolLoadInfo.ExceptionList))
+                {
+                    throw new InvalidLaunchOptionsException(String.Format(CultureInfo.InvariantCulture, MICoreResources.Error_OptionNotSupported, nameof(options.SymbolLoadInfo.ExceptionList), nameof(MIMode.Lldb)));
+                }
+
+                SymbolInfoExceptionList.SetTo(options.SymbolLoadInfo.ExceptionList == null ? new string[0] : options.SymbolLoadInfo.ExceptionList.Split(';'));
+
+                // Ensure that symbol loading options are consistent
+                if (!WaitDynamicLibLoad && !SymbolInfoExceptionList.IsEmpty)
+                {
+                    throw new InvalidLaunchOptionsException(MICoreResources.Error_InvalidSymbolInfo);
+                }
+            }
+
         }
 
         protected void InitializeCommonOptions(Xml.LaunchOptions.BaseLaunchOptions source)


### PR DESCRIPTION
To keep the JSON parsing in OpenDebugAD7 and MIEngine in sync, this PR adds the JSON parsing for SymbolLoadInfo if launch options come in as JSON to MIEngine.

The current support for SymbolLoadInfo is in OpenDebugAD7, but it converts it to XML.

Support for reading JSON for SymbolLoadInfo : 
https://github.com/microsoft/MIEngine/blob/ec52d600d5d4a5d9a2517aa392e0c1767ad49e55/src/OpenDebugAD7/MILaunchOptions.cs#L625-L636

We set WaitDynamicLibLoad here:
https://github.com/microsoft/MIEngine/blob/ec52d600d5d4a5d9a2517aa392e0c1767ad49e55/src/OpenDebugAD7/MILaunchOptions.cs#L532-L540

Here is the XML parsing implementation for SymbolLoadInfo:
https://github.com/microsoft/MIEngine/blob/9be1a0f01c8a0183be22708bbefbfc0ad32427bc/src/MICore/LaunchOptions.cs#L1868-L1884