### PR TITLE
Add Setup script for OpenDebugAD7

### DIFF
--- a/tools/Setup.cmd
+++ b/tools/Setup.cmd
@@ -1,0 +1,20 @@
+@echo off
+setlocal enabledelayedexpansion
+
+where dotnet >nul 2>nul
+
+if NOT "%ERRORLEVEL%"=="0" (
+    echo dotnet needs to be installed. https://dotnet.microsoft.com/download/dotnet-core
+    exit /b -1
+)
+
+dotnet script -v >nul 2>nul
+
+if NOT "%ERRORLEVEL%"=="0" (
+    echo dotnet script needs to be installed. Run 'dotnet tool install -g dotnet-script'.
+    echo More Information: https://github.com/filipw/dotnet-script#net-core-global-tool
+    exit /b -1
+)
+
+dotnet script %~dp0\Setup.csx %*
+exit /b %ERRORLEVEL%

--- a/tools/Setup.csx
+++ b/tools/Setup.csx
@@ -1,0 +1,228 @@
+#!/usr/bin/env dotnet-script
+// To run dotnet-scripts. Install dotnet at https://dotnet.microsoft.com/download and then run 'dotnet tool install -g dotnet-script'
+
+/*
+    This setup script is to install OpenDebugAD7/MIEngine bits for VS Code C++ Extension or for the VS CodeSpaces CMake Debug scenario.
+*/
+
+using System.Runtime.CompilerServices;
+using System.IO;
+
+enum Client {
+    None,
+    VS,
+    VSCode
+};
+
+enum Configuration {
+    Debug,
+    Release
+};
+
+class Setup {
+    Client Client { get; set;  }
+
+    Configuration Configuration { get; set;  }
+
+    string TargetPath { get; set; }
+
+    // Work-around helper method to get the source file location.
+    public static string GetSourceFile([CallerFilePath] string file = "") => file;
+
+    public Setup()
+    {
+        Client = Client.None;
+        Configuration = Configuration.Debug;
+    }
+
+    private void PrintHelp()
+    {
+        Console.WriteLine("USAGE: dotnet script Setup.csx -- <Target-Path> [-vs|-vscode] [-debug|-release]");
+        Console.WriteLine("");
+        Console.WriteLine("\t<Target-Path> is the path to the VS Code C/C++ Extension or root path of Visual Studio.");
+        Console.WriteLine("\tFor Example:");
+        Console.WriteLine("\t\tC:\\Program Files (x86)\\Microsoft Visual Studio\\2019\\Preview");
+        Console.WriteLine("\t\tC:\\Users\\<USERNAME>\\.vscode\\extensions\\ms-vscode.cpptools-1.0.0");
+
+        System.Environment.Exit(1);
+    }
+
+    public void ParseArguments(IList<string> args)
+    {
+        if (args.Count == 0)
+        {
+            PrintHelp();
+        }
+
+        foreach (string arg in args)
+        {
+            if (arg.StartsWith("-") || arg.StartsWith("/"))
+            {
+                switch(arg.Substring(1).ToLower())
+                {
+                    case "help":
+                    case "?":
+                        PrintHelp();
+                        break;
+                    case "vs":
+                        Client = Client.VS;
+                        break;
+                    case "vscode":
+                        Client = Client.VSCode;
+                        break;
+                    case "debug":
+                        Configuration = Configuration.Debug;
+                        break;
+                    case "release":
+                        Configuration = Configuration.Release;
+                        break;
+                    default:
+                        Console.WriteLine(string.Format("Unknown flag {0}", arg));
+                        break;
+                }
+            }
+            else
+            {
+                TargetPath = arg;
+            }
+        }
+
+        if (string.IsNullOrWhiteSpace(TargetPath))
+        {
+            throw new ArgumentNullException(nameof(TargetPath));
+        }
+    }
+
+    private class ListFileFormat
+    {
+        public string FileName { get; }
+        public string SourceRoot { get; }
+        public string SourceDir { get; }
+        public string InstallDir { get; }
+
+        public ListFileFormat(
+            string fileName,
+            string sourceRoot,
+            string sourceDir,
+            string installDir
+        )
+        {
+            FileName = fileName;
+            SourceRoot = sourceRoot;
+            SourceDir = sourceDir;
+            InstallDir = installDir;
+        }
+    }
+
+    private IList<ListFileFormat> ParseListFiles(string filePath)
+    {
+        List<ListFileFormat> fileFormats = new List<ListFileFormat>();
+
+        using (StreamReader fs = new StreamReader(filePath))
+        {
+            string line;
+
+            while((line = fs.ReadLine()) != null)  
+            {
+                line = line.Trim();
+
+                // Skip blank or commented out lines
+                if (string.IsNullOrWhiteSpace(line) || line.StartsWith("#"))
+                {
+                    continue;
+                }
+
+                string[] data = line.Split(',');
+                if (data.Length < 4)
+                {
+                    Console.Error.WriteLine(string.Format("Invalid line in {0}: '{1}'", filePath, line));
+                    continue;
+                }
+
+                ListFileFormat listFile = new ListFileFormat(
+                    data[0],
+                    data[1],
+                    data[2],
+                    data[3]
+                );
+                
+                fileFormats.Add(listFile);
+            }  
+        }
+
+        return fileFormats;
+    }
+
+    public void Run()
+    {
+        string scriptDirectoryPath = Path.GetDirectoryName(GetSourceFile());
+        string srcDirectoryPath = Path.GetFullPath(Path.Join(scriptDirectoryPath, "..", "src"));
+        string binDirectoryPath = Path.GetFullPath(Path.Join(scriptDirectoryPath, "..", "bin"));
+
+        // No client flag provided, try to auto detect.
+        if (Client == Client.None)
+        {
+            string devenvPath = Path.Join(TargetPath, "Common7", "IDE", "devenv.exe");
+            string packageJsonPath = Path.Join(TargetPath, "package.json");
+
+            if (File.Exists(devenvPath))
+            {
+                Client = Client.VS;
+                Console.WriteLine("Detected VS Client");
+            }
+            else if (File.Exists(packageJsonPath))
+            {
+                Client = Client.VSCode;
+                Console.WriteLine("Detected VS Code Client");
+            }
+            else
+            {
+                throw new ArgumentNullException(nameof(Client));
+            }
+        }
+
+        string listFilePath = string.Empty;
+
+        if (Client == Client.VS)
+        {
+            listFilePath = Path.Join(scriptDirectoryPath, "VS.CodeSpaces.list");
+            binDirectoryPath = Path.Join(binDirectoryPath, Configuration.ToString());
+        }
+        else if (Client == Client.VSCode)
+        {
+            listFilePath = Path.Join(scriptDirectoryPath, "VSCode.list");
+            binDirectoryPath = Path.Join(binDirectoryPath, "Desktop." + Configuration.ToString());
+        }
+
+        if (!File.Exists(binDirectoryPath))
+        {
+            string configurationToUse = Client == Client.VS ? Configuration.ToString() : "Desktop." + Configuration.ToString();
+            throw new InvalidOperationException(string.Format("'{0}' does not exist. Did you build {1}?", binDirectoryPath, configurationToUse));
+        }
+
+        IList<ListFileFormat> lffList = this.ParseListFiles(listFilePath);
+
+        foreach (ListFileFormat lff in lffList)
+        {
+            string srcPath = string.Empty;
+            if (lff.SourceRoot == "src")
+            {
+                srcPath = Path.Join(srcDirectoryPath, lff.SourceDir, lff.FileName);
+            }
+            else
+            {
+                srcPath = Path.Join(binDirectoryPath, lff.SourceDir, lff.FileName);
+            }
+            string destPath = Path.Join(TargetPath, lff.InstallDir, lff.FileName);
+
+            Console.WriteLine(string.Format("Copying {0} to {1}.", srcPath, destPath));
+
+            File.Copy(srcPath, destPath, overwrite: true);
+        }
+    }
+
+} 
+
+Setup setup = new Setup();
+setup.ParseArguments(Args);
+setup.Run();

--- a/tools/Setup.csx
+++ b/tools/Setup.csx
@@ -215,7 +215,7 @@ class Setup {
             binDirectoryPath = Path.Join(binDirectoryPath, "Desktop." + Configuration.ToString());
         }
 
-        if (!File.Exists(binDirectoryPath))
+        if (!Directory.Exists(binDirectoryPath))
         {
             string configurationToUse = Client == Client.VS ? Configuration.ToString() : "Desktop." + Configuration.ToString();
             throw new InvalidOperationException(string.Format("'{0}' does not exist. Did you build {1}?", binDirectoryPath, configurationToUse));

--- a/tools/Setup.csx
+++ b/tools/Setup.csx
@@ -6,6 +6,7 @@
 */
 
 using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
 using System.IO;
 using System.Collections;
 
@@ -244,6 +245,11 @@ class Setup {
     }
 
 } 
+
+if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+{
+    throw new InvalidOperationException("This script is only supported for Windows.");
+}
 
 Setup setup = new Setup();
 setup.ParseArguments(Args);

--- a/tools/VS.CodeSpaces.list
+++ b/tools/VS.CodeSpaces.list
@@ -1,0 +1,8 @@
+# filename,source-root,source-dir,install-dir
+# Where 'source-root' is either 'src', or 'bin'
+Microsoft.MICore.dll,bin,,\Common7\IDE\CommonExtensions\Microsoft\MDD\Debugger
+Microsoft.MICore.XmlSerializers.dll,bin,,\Common7\IDE\CommonExtensions\Microsoft\MDD\Debugger
+Microsoft.MIDebugEngine.dll,bin,,\Common7\IDE\CommonExtensions\Microsoft\MDD\Debugger
+OpenDebugAD7.exe,bin,vscode,\Common7\IDE\CommonExtensions\Microsoft\MDD\Debugger\vscode
+Microsoft.DebugEngineHost.dll,bin,vscode,\Common7\IDE\CommonExtensions\Microsoft\MDD\Debugger\vscode
+Microsoft.VisualStudio.Shared.VSCodeDebugProtocol.dll,bin,vscode,\Common7\IDE\CommonExtensions\Microsoft\MDD\Debugger\vscode

--- a/tools/VS.CodeSpaces.list
+++ b/tools/VS.CodeSpaces.list
@@ -6,3 +6,4 @@ Microsoft.MIDebugEngine.dll,bin,,\Common7\IDE\CommonExtensions\Microsoft\MDD\Deb
 OpenDebugAD7.exe,bin,vscode,\Common7\IDE\CommonExtensions\Microsoft\MDD\Debugger\vscode
 Microsoft.DebugEngineHost.dll,bin,vscode,\Common7\IDE\CommonExtensions\Microsoft\MDD\Debugger\vscode
 Microsoft.VisualStudio.Shared.VSCodeDebugProtocol.dll,bin,vscode,\Common7\IDE\CommonExtensions\Microsoft\MDD\Debugger\vscode
+cppdbg.ad7Engine.json,src,OpenDebugAD7,\Common7\IDE\CommonExtensions\Microsoft\MDD\Debugger\vscode

--- a/tools/VSCode.list
+++ b/tools/VSCode.list
@@ -6,3 +6,4 @@ Microsoft.MIDebugEngine.dll,bin,,debugAdapters\bin
 OpenDebugAD7.exe,bin,vscode,debugAdapters\bin
 Microsoft.DebugEngineHost.dll,bin,vscode,debugAdapters\bin
 Microsoft.VisualStudio.Shared.VSCodeDebugProtocol.dll,bin,vscode,debugAdapters\bin
+cppdbg.ad7Engine.json,src,OpenDebugAD7,debugAdapters\bin

--- a/tools/VSCode.list
+++ b/tools/VSCode.list
@@ -1,0 +1,8 @@
+# filename,source-root,source-dir,install-dir
+# Where 'source-root' is either 'src', or 'bin'
+Microsoft.MICore.dll,bin,,debugAdapters\bin
+Microsoft.MICore.XmlSerializers.dll,bin,,debugAdapters\bin
+Microsoft.MIDebugEngine.dll,bin,,debugAdapters\bin
+OpenDebugAD7.exe,bin,vscode,debugAdapters\bin
+Microsoft.DebugEngineHost.dll,bin,vscode,debugAdapters\bin
+Microsoft.VisualStudio.Shared.VSCodeDebugProtocol.dll,bin,vscode,debugAdapters\bin


### PR DESCRIPTION
This PR adds a Setup script and List files for scenarios that launch OpenDebugAD7.exe.
The scenarios are VS Code C++ extension or VS CodeSpaces CMake Debug.

This script simplifies the process of patching the files.