### PR TITLE
Fix SourceFileMap in MICore

### DIFF
--- a/src/MICore/CommandFactories/MICommandFactory.cs
+++ b/src/MICore/CommandFactories/MICommandFactory.cs
@@ -436,7 +436,7 @@ namespace MICore
             path = path.Trim();
             if (useUnixFormat)  // convert directory separators
             {
-                path = path.Replace('\\', '/');
+                path = PlatformUtilities.WindowsPathToUnixPath(path);
             }
             if (path.IndexOf(' ') != -1)    // path contains spaces. Convert to c-string format
             {

--- a/src/MICore/LaunchOptions.cs
+++ b/src/MICore/LaunchOptions.cs
@@ -379,20 +379,27 @@ namespace MICore
                 {
                     editorPath = value;
                 }
-                else if (item.Value is JObject)
+                else if (item.Value is JObject jObject)
                 {
-                    Json.LaunchOptions.SourceFileMapOptions sourceMapItem =
-                        ((JObject)item.Value).ToObject<Json.LaunchOptions.SourceFileMapOptions>();
+                    try
+                    {
+                        Json.LaunchOptions.SourceFileMapOptions sourceMapItem =
+                        jObject.ToObject<Json.LaunchOptions.SourceFileMapOptions>();
 
-                    editorPath = sourceMapItem.EditorPath;
-                    useForBreakpoints = sourceMapItem.UseForBreakpoints.GetValueOrDefault(true);
+                        editorPath = sourceMapItem.EditorPath;
+                        useForBreakpoints = sourceMapItem.UseForBreakpoints.GetValueOrDefault(true);
+                    }
+                    catch (JsonReaderException)
+                    {
+                        throw new InvalidLaunchOptionsException(String.Format(CultureInfo.CurrentCulture, MICoreResources.Error_SourceFileMapFormat, compileTimePath));
+                    }
                 }
                 else
                 {
-                    throw new InvalidLaunchOptionsException(String.Format(CultureInfo.CurrentCulture, MICoreResources.Error_SourceFileMapFormat, item.Key));
+                    throw new InvalidLaunchOptionsException(String.Format(CultureInfo.CurrentCulture, MICoreResources.Error_SourceFileMapFormat, compileTimePath));
                 }
 
-                if (!string.IsNullOrEmpty(compileTimePath) && !string.IsNullOrEmpty(editorPath))
+                if (!string.IsNullOrEmpty(editorPath))
                 {
                     sourceMaps.Add(new SourceMapEntry()
                     {
@@ -400,6 +407,10 @@ namespace MICore
                         EditorPath = PlatformUtilities.PathToHostOSPath(editorPath),
                         UseForBreakpoints = useForBreakpoints
                     });
+                }
+                else
+                {
+                    throw new InvalidLaunchOptionsException(String.Format(CultureInfo.CurrentCulture, MICoreResources.Error_SourceFileMapInvalidEditorPath));
                 }
             }
             return new ReadOnlyCollection<SourceMapEntry>(sourceMaps);

--- a/src/MICore/LaunchOptions.cs
+++ b/src/MICore/LaunchOptions.cs
@@ -310,14 +310,14 @@ namespace MICore
 
     public sealed class SourceMapEntry
     {
-        public SourceMapEntry() // used by launchers 
+        public SourceMapEntry() // used by launchers
         {
         }
 
         public SourceMapEntry(Xml.LaunchOptions.SourceMapEntry xmlEntry)
         {
-            this.EditorPath = xmlEntry.EditorPath;
-            this.CompileTimePath = xmlEntry.CompileTimePath;
+            this.EditorPath = PlatformUtilities.NormalizeClientPath(xmlEntry.EditorPath);
+            this.CompileTimePath = PlatformUtilities.NormalizeClientPath(xmlEntry.CompileTimePath);
             this.UseForBreakpoints = xmlEntry.UseForBreakpoints;
         }
 
@@ -356,6 +356,7 @@ namespace MICore
         public static ReadOnlyCollection<SourceMapEntry> CreateCollection(Xml.LaunchOptions.SourceMapEntry[] source)
         {
             SourceMapEntry[] pathArray = source?.Select(x => new SourceMapEntry(x)).ToArray();
+
             if (pathArray == null)
             {
                 pathArray = new SourceMapEntry[0];
@@ -370,29 +371,35 @@ namespace MICore
 
             foreach (var item in source)
             {
-                if (item.Value is String)
+                string compileTimePath = item.Key;
+                string editorPath = null;
+                bool useForBreakpoints = true;
+
+                if (item.Value is string value)
                 {
-                    sourceMaps.Add(new SourceMapEntry()
-                    {
-                        CompileTimePath = item.Key,
-                        EditorPath = (String)item.Value,
-                        UseForBreakpoints = true
-                    });
+                    editorPath = value;
                 }
                 else if (item.Value is JObject)
                 {
                     Json.LaunchOptions.SourceFileMapOptions sourceMapItem =
                         ((JObject)item.Value).ToObject<Json.LaunchOptions.SourceFileMapOptions>();
-                    sourceMaps.Add(new SourceMapEntry()
-                    {
-                        CompileTimePath = item.Key,
-                        EditorPath = sourceMapItem.EditorPath,
-                        UseForBreakpoints = sourceMapItem.UseForBreakpoints.GetValueOrDefault(true)
-                    });
+
+                    editorPath = sourceMapItem.EditorPath;
+                    useForBreakpoints = sourceMapItem.UseForBreakpoints.GetValueOrDefault(true);
                 }
                 else
                 {
                     throw new InvalidLaunchOptionsException(String.Format(CultureInfo.CurrentCulture, MICoreResources.Error_SourceFileMapFormat, item.Key));
+                }
+
+                if (!string.IsNullOrEmpty(compileTimePath) && !string.IsNullOrEmpty(editorPath))
+                {
+                    sourceMaps.Add(new SourceMapEntry()
+                    {
+                        CompileTimePath = PlatformUtilities.NormalizeClientPath(compileTimePath),
+                        EditorPath = PlatformUtilities.NormalizeClientPath(editorPath),
+                        UseForBreakpoints = useForBreakpoints
+                    });
                 }
             }
             return new ReadOnlyCollection<SourceMapEntry>(sourceMaps);

--- a/src/MICore/LaunchOptions.cs
+++ b/src/MICore/LaunchOptions.cs
@@ -316,8 +316,8 @@ namespace MICore
 
         public SourceMapEntry(Xml.LaunchOptions.SourceMapEntry xmlEntry)
         {
-            this.EditorPath = PlatformUtilities.NormalizeClientPath(xmlEntry.EditorPath);
-            this.CompileTimePath = PlatformUtilities.NormalizeClientPath(xmlEntry.CompileTimePath);
+            this.EditorPath = PlatformUtilities.PathToHostOSPath(xmlEntry.EditorPath);
+            this.CompileTimePath = PlatformUtilities.PathToHostOSPath(xmlEntry.CompileTimePath);
             this.UseForBreakpoints = xmlEntry.UseForBreakpoints;
         }
 
@@ -396,8 +396,8 @@ namespace MICore
                 {
                     sourceMaps.Add(new SourceMapEntry()
                     {
-                        CompileTimePath = PlatformUtilities.NormalizeClientPath(compileTimePath),
-                        EditorPath = PlatformUtilities.NormalizeClientPath(editorPath),
+                        CompileTimePath = PlatformUtilities.PathToHostOSPath(compileTimePath),
+                        EditorPath = PlatformUtilities.PathToHostOSPath(editorPath),
                         UseForBreakpoints = useForBreakpoints
                     });
                 }

--- a/src/MICore/MICoreResources.Designer.cs
+++ b/src/MICore/MICoreResources.Designer.cs
@@ -429,6 +429,15 @@ namespace MICore {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to &apos;editorPath&apos; can not be null or empty.
+        /// </summary>
+        public static string Error_SourceFileMapInvalidEditorPath {
+            get {
+                return ResourceManager.GetString("Error_SourceFileMapInvalidEditorPath", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to This string is null or empty..
         /// </summary>
         public static string Error_StringIsNullOrEmpty {

--- a/src/MICore/MICoreResources.resx
+++ b/src/MICore/MICoreResources.resx
@@ -323,4 +323,7 @@ Error: {1}</value>
   <data name="Error_UnknownError" xml:space="preserve">
     <value>&lt;Unknown Error&gt;</value>
   </data>
+  <data name="Error_SourceFileMapInvalidEditorPath" xml:space="preserve">
+    <value>'editorPath' can not be null or empty</value>
+  </data>
 </root>

--- a/src/MICore/PlatformUtilities.cs
+++ b/src/MICore/PlatformUtilities.cs
@@ -142,7 +142,7 @@ namespace MICore
             return windowsPath.Replace('\\', '/');
         }
 
-        public static string NormalizeClientPath(string path)
+        public static string PathToHostOSPath(string path)
         {
             if (string.IsNullOrWhiteSpace(path))
             {
@@ -151,11 +151,11 @@ namespace MICore
 
             if (IsWindows())
             {
-                return WindowsPathToUnixPath(path);
+                return UnixPathToWindowsPath(path);
             }
             else
             {
-                return UnixPathToWindowsPath(path);
+                return WindowsPathToUnixPath(path);
             }
         }
     }

--- a/src/MICore/PlatformUtilities.cs
+++ b/src/MICore/PlatformUtilities.cs
@@ -131,6 +131,33 @@ namespace MICore
 #endif
             return null;
         }
+
+        public static string UnixPathToWindowsPath(string unixPath)
+        {
+            return unixPath.Replace('/', '\\');
+        }
+
+        public static string WindowsPathToUnixPath(string windowsPath)
+        {
+            return windowsPath.Replace('\\', '/');
+        }
+
+        public static string NormalizeClientPath(string path)
+        {
+            if (string.IsNullOrWhiteSpace(path))
+            {
+                return path;
+            }
+
+            if (IsWindows())
+            {
+                return WindowsPathToUnixPath(path);
+            }
+            else
+            {
+                return UnixPathToWindowsPath(path);
+            }
+        }
     }
 }
 

--- a/src/MIDebugEngine/Engine.Impl/CygwinFileMapper.cs
+++ b/src/MIDebugEngine/Engine.Impl/CygwinFileMapper.cs
@@ -31,7 +31,7 @@ namespace Microsoft.MIDebugEngine
 
             LocalLaunchOptions localLaunchOptions = (LocalLaunchOptions)_debuggedProcess.LaunchOptions;
 
-            string cygwinPath = origCygwinPath.Replace('\\', '/');
+            string cygwinPath = PlatformUtilities.WindowsPathToUnixPath(origCygwinPath);
 
             string windowsPath = cygwinPath;
 

--- a/src/MIDebugEngine/Engine.Impl/DebuggedProcess.cs
+++ b/src/MIDebugEngine/Engine.Impl/DebuggedProcess.cs
@@ -2214,7 +2214,7 @@ namespace Microsoft.MIDebugEngine
             if (_launchOptions.SourceMap != null)
             {
                 // Convert to Client source paths
-                compilerSrc = PlatformUtilities.PathToHostOSPath(compilerSrc);
+                string hostOSCompilerSrc = PlatformUtilities.PathToHostOSPath(compilerSrc);
 
                 StringComparison comp = _launchOptions.UseUnixSymbolPaths ? StringComparison.Ordinal : StringComparison.OrdinalIgnoreCase;
                 foreach (var e in _launchOptions.SourceMap)
@@ -2223,9 +2223,9 @@ namespace Microsoft.MIDebugEngine
                     {
                         continue;   // don't try to map back if path has an empty compiler src tree
                     }
-                    if (compilerSrc.StartsWith(e.CompileTimePath, comp))
+                    if (hostOSCompilerSrc.StartsWith(e.CompileTimePath, comp))
                     {
-                        var file = compilerSrc.Substring(e.CompileTimePath.Length);
+                        var file = hostOSCompilerSrc.Substring(e.CompileTimePath.Length);
                         if (string.IsNullOrEmpty(file)) // matched the whole directory string
                         {
                             break;  // use default

--- a/src/MIDebugEngine/Engine.Impl/DebuggedProcess.cs
+++ b/src/MIDebugEngine/Engine.Impl/DebuggedProcess.cs
@@ -1385,7 +1385,7 @@ namespace Microsoft.MIDebugEngine
         {
             if (this.UseUnixPathSeparators)
             {
-                path = path.Replace('\\', '/');
+                path = PlatformUtilities.WindowsPathToUnixPath(path);
             }
             else
             {
@@ -1408,7 +1408,7 @@ namespace Microsoft.MIDebugEngine
         {
             if (this.UseUnixSymbolPaths)
             {
-                path = path.Replace('\\', '/');
+                path = PlatformUtilities.WindowsPathToUnixPath(path);
             }
             else
             {
@@ -1444,11 +1444,6 @@ namespace Microsoft.MIDebugEngine
         }
 
         internal bool UseUnixSymbolPaths { get { return _launchOptions.UseUnixSymbolPaths; } }
-
-        internal static string UnixPathToWindowsPath(string unixPath)
-        {
-            return unixPath.Replace('/', '\\');
-        }
 
         internal void LoadSymbols(DebuggedModule module)
         {
@@ -2204,7 +2199,7 @@ namespace Microsoft.MIDebugEngine
                         compilerSrc = Path.Combine(e.CompileTimePath, file);    // map to the compiled location
                         if (compilerSrc.IndexOf('\\') > 0)
                         {
-                            compilerSrc = compilerSrc.Replace('\\', '/'); // use Unix notation for the compiled path
+                            compilerSrc = PlatformUtilities.WindowsPathToUnixPath(compilerSrc); // use Unix notation for the compiled path
                         }
                         return true;
                     }
@@ -2218,6 +2213,9 @@ namespace Microsoft.MIDebugEngine
         {
             if (_launchOptions.SourceMap != null)
             {
+                // Convert to Client source paths
+                compilerSrc = PlatformUtilities.NormalizeClientPath(compilerSrc);
+
                 StringComparison comp = _launchOptions.UseUnixSymbolPaths ? StringComparison.Ordinal : StringComparison.OrdinalIgnoreCase;
                 foreach (var e in _launchOptions.SourceMap)
                 {

--- a/src/MIDebugEngine/Engine.Impl/DebuggedProcess.cs
+++ b/src/MIDebugEngine/Engine.Impl/DebuggedProcess.cs
@@ -2214,7 +2214,7 @@ namespace Microsoft.MIDebugEngine
             if (_launchOptions.SourceMap != null)
             {
                 // Convert to Client source paths
-                compilerSrc = PlatformUtilities.NormalizeClientPath(compilerSrc);
+                compilerSrc = PlatformUtilities.PathToHostOSPath(compilerSrc);
 
                 StringComparison comp = _launchOptions.UseUnixSymbolPaths ? StringComparison.Ordinal : StringComparison.OrdinalIgnoreCase;
                 foreach (var e in _launchOptions.SourceMap)

--- a/src/MIDebugEngine/Engine.Impl/MITextPosition.cs
+++ b/src/MIDebugEngine/Engine.Impl/MITextPosition.cs
@@ -35,10 +35,6 @@ namespace Microsoft.MIDebugEngine
         public static MITextPosition TryParse(DebuggedProcess process, TupleValue miTuple)
         {
             string filename = process.GetMappedFileFromTuple(miTuple);
-            if (!string.IsNullOrEmpty(filename))
-            {
-                filename = DebuggedProcess.UnixPathToWindowsPath(filename);
-            }
 
             if (string.IsNullOrWhiteSpace(filename))
                 return null;


### PR DESCRIPTION
Added PathNormalization methods in PlatformUtilities that is both used
in MICore and MIDebugEngine.

This change will ensure all paths created for sourceFileMap are
normalized to the client. E.g. Windows '\' if on Windows and '/' if on
macOS or Unix.

When submitting for breakpoints in MIEngine, it will normalize compiler
sources to use Unix styled paths for GDB.

This also fixes the issue that we do not correctly normalize the compilerSrcPath before checking it with sourceFileMappings for MITextPositions.