### PR TITLE
Remove references to building with mono framework

### DIFF
--- a/build/miengine.settings.targets
+++ b/build/miengine.settings.targets
@@ -1,8 +1,12 @@
 <Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003"> 
-  
   <!--
   Settings file which is included by all the shipping code projects in the repo.
   -->
+
+  <!-- Validate OS -->
+  <Target Name="OSPlatformCheck" BeforeTargets="Build" Condition="!$([MSBuild]::IsOSPlatform('windows'))" >
+    <Error Text="'MIDebugEngine' does not build on non-windows platforms." />
+  </Target>
   
   <Import Project="all_projects.settings.targets"/>
   <Import Project="version.settings.targets" />
@@ -37,7 +41,6 @@
     <Otherwise>
       <PropertyGroup>
         <IsXPlat>false</IsXPlat>
-        <IsMonoRuntime>false</IsMonoRuntime>
       </PropertyGroup>
     </Otherwise>
   </Choose>

--- a/build/miengine.targets
+++ b/build/miengine.targets
@@ -13,41 +13,8 @@
     <BuildDependsOn>$(BuildDependsOn);GenerateMonoSymbols</BuildDependsOn>
   </PropertyGroup>
 
-  <UsingTask TaskName="GetRuntime" 
-             TaskFactory="CodeTaskFactory" 
-             AssemblyFile="$(MSBuildToolsPath)\Microsoft.Build.Tasks.v4.0.dll" >
-    <ParameterGroup>
-      <IsMonoRuntime ParameterType="System.Boolean" Output="true" />
-    </ParameterGroup>
-    <Task>
-      <Code Type="Fragment" Language="cs">
-        <![CDATA[
-        IsMonoRuntime = System.Type.GetType("Mono.Runtime") != null;
-        ]]>
-      </Code>
-    </Task>
-  </UsingTask>
-
-  <Target Name="DetermineCompilerBinary">
-    <GetRuntime>
-      <Output PropertyName="IsMonoRuntime" TaskParameter="IsMonoRuntime" />
-    </GetRuntime>
-
-    <Exec Condition="'$(IsMonoRuntime)' == 'true'"
-          ConsoleToMsBuild="true"
-          Command="dirname `which mcs`">
-      <Output TaskParameter="ConsoleOutput" PropertyName="McsPath" />
-    </Exec>
-
-    <PropertyGroup Condition="'$(IsMonoRuntime)' == 'true'">
-      <!-- If we're running on Mono, Roslyn will fail to sign the binaries, so use mcs instead -->      
-      <CscToolExe>mcs</CscToolExe>
-      <CscToolPath>$(McsPath)/</CscToolPath>
-    </PropertyGroup>
-  </Target>
-
   <Target Name="GenerateMonoSymbols"
-          Condition="'$(IsXPlat)' == 'true' AND '$(IsMonoRuntime)' == 'false' AND '$(ShouldGenerateMonoSymbols)' == 'true'">
+          Condition="'$(IsXPlat)' == 'true' AND '$(ShouldGenerateMonoSymbols)' == 'true'">
     <!-- If we're building the Desktop config on Windows, run pdb2mdb to generate Mono symbols as well -->
     <Exec Command="&quot;$(NugetPackagesDirectory)\Mono.Unofficial.pdb2mdb.4.2.3.4\tools\pdb2mdb.exe&quot; &quot;$(TargetPath)&quot;" />
   </Target>

--- a/build/miengine.targets
+++ b/build/miengine.targets
@@ -9,7 +9,6 @@
 
   <PropertyGroup>
     <CoreCompileDependsOn>GenerateAssemblyInfoFile;$(CoreCompileDependsOn)</CoreCompileDependsOn>
-    <BuildDependsOn Condition="'$(IsXPlat)' == 'true'">DetermineCompilerBinary;$(BuildDependsOn)</BuildDependsOn>
     <BuildDependsOn>$(BuildDependsOn);GenerateMonoSymbols</BuildDependsOn>
   </PropertyGroup>
 

--- a/src/DebugEngineHost.VSCode/DebugEngineHost.VSCode.csproj
+++ b/src/DebugEngineHost.VSCode/DebugEngineHost.VSCode.csproj
@@ -121,10 +121,9 @@
     <DropSignedFile Include="$(OutDir)\Microsoft.DebugEngineHost.dll" />
     <DropUnsignedFile Condition="'$(IsXPlat)' == 'true'" Include="$(OutDir)\Microsoft.DebugEngineHost.dll.mdb" />
   </ItemGroup>
-  <!-- Necessary because IsMonoRuntime isn't set until after DetermineCompilerBinary is run. -->
-  <Target Name="GetDropFiles" AfterTargets="DetermineCompilerBinary" BeforeTargets="DropFiles">
+  <Target Name="GetDropFiles" BeforeTargets="DropFiles">
     <ItemGroup>
-      <DropUnsignedFile Condition="'$(IsMonoRuntime)' == 'false'" Include="$(OutDir)\Microsoft.DebugEngineHost.pdb" />
+      <DropUnsignedFile Include="$(OutDir)\Microsoft.DebugEngineHost.pdb" />
     </ItemGroup>
   </Target>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />

--- a/src/MICore/GenerateXmlSerializersAssembly.targets
+++ b/src/MICore/GenerateXmlSerializersAssembly.targets
@@ -14,9 +14,7 @@
     <MakeDir Condition="!Exists('$(IntermediateOutputPath)')" Directories="$(IntermediateOutputPath)" />
     <PropertyGroup>
       <XsdParameters>LaunchOptions.xsd /classes /namespace:$(RootNamespace).Xml.LaunchOptions </XsdParameters>
-      <!-- Mono's XSD.exe uses /outputdir instead of /out -->
-      <XsdParameters Condition="'$(IsMonoRuntime)' == 'false'">$(XsdParameters) /out:"$(IntermediateOutputPath)."</XsdParameters>
-      <XsdParameters Condition="'$(IsMonoRuntime)' == 'true'">$(XsdParameters) /outputdir:"$(IntermediateOutputPath)."</XsdParameters>
+      <XsdParameters>$(XsdParameters) /out:"$(IntermediateOutputPath)."</XsdParameters>
       <XsdParameters Condition="'$(IsXPlat)' == 'false'">$(XsdParameters) /fields</XsdParameters>
 
       <XsdCandidateFile>$(IntermediateOutputPath)LaunchOptions.cs</XsdCandidateFile>
@@ -94,8 +92,7 @@
       <!-- Fix for VS 2019 -->
       <CompilerPath Condition="'$(CompilerPath)' == '' and Exists('$(RoslynTargetsPath)\csc.exe')">$(RoslynTargetsPath)\csc.exe</CompilerPath>
 
-      <RefPath Condition="'$(IsMonoRuntime)' == 'false'">$(MSBuildFrameworkToolsPath)</RefPath>
-      <RefPath Condition="'$(IsMonoRuntime)' == 'true'">$(SDK40ToolsPath)</RefPath>
+      <RefPath>$(MSBuildFrameworkToolsPath)</RefPath>
     </PropertyGroup>
 
     <Error Condition="'$(SDK40ToolsPath)'==''" Text="SDK40ToolsPath msbuild property is undefined." />

--- a/src/OpenDebugAD7/OpenDebugAD7.csproj
+++ b/src/OpenDebugAD7/OpenDebugAD7.csproj
@@ -182,10 +182,9 @@
     <DropUnsignedFile Include="$(OutputPath)\Microsoft.VisualStudio.Debugger.Interop.15.0.dll" />
     <DropUnsignedFile Include="$(OutputPath)\cppdbg.ad7Engine.json" />
   </ItemGroup>
-  <!-- Necessary because IsMonoRuntime isn't set until after DetermineCompilerBinary is run. -->
-  <Target Name="GetDropFiles" AfterTargets="DetermineCompilerBinary" BeforeTargets="DropFiles">
+  <Target Name="GetDropFiles" BeforeTargets="DropFiles">
     <ItemGroup>
-      <DropUnsignedFile Condition="'$(IsMonoRuntime)' == 'false'" Include="$(OutputPath)\OpenDebugAD7.pdb" />
+      <DropUnsignedFile Include="$(OutputPath)\OpenDebugAD7.pdb" />
     </ItemGroup>
   </Target>
   <ItemGroup>

--- a/src/WindowsDebugLauncher/WindowsDebugLauncher.csproj
+++ b/src/WindowsDebugLauncher/WindowsDebugLauncher.csproj
@@ -51,11 +51,10 @@
     <Compile Include="DebugLauncher.cs" />
     <Compile Include="Program.cs" />
   </ItemGroup>
-  <!-- Necessary because IsMonoRuntime isn't set until after DetermineCompilerBinary is run. -->
-  <Target Name="GetDropFiles" AfterTargets="DetermineCompilerBinary" BeforeTargets="DropFiles">
+  <Target Name="GetDropFiles" BeforeTargets="DropFiles">
     <ItemGroup>
       <DropSignedFile Include="$(OutputPath)\WindowsDebugLauncher.exe" />
-      <DropUnsignedFile Condition="'$(IsMonoRuntime)' == 'false'" Include="$(OutputPath)\WindowsDebugLauncher.pdb" />
+      <DropUnsignedFile Include="$(OutputPath)\WindowsDebugLauncher.pdb" />
     </ItemGroup>
   </Target>
   <Import Condition="'$(IsXPlat)' == 'true'" Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />

--- a/src/prebuild/prebuild.csproj
+++ b/src/prebuild/prebuild.csproj
@@ -21,12 +21,8 @@
     </GenerateAssembly>
   </ItemGroup>
   <Target Name="GenerateAssemblies" Condition="'@(GenerateAssembly)' != ''" Inputs="@(GenerateAssembly)" Outputs="@(GenerateAssembly->'$(GeneratedAssembliesDir)%(FileName).dll')" AfterTargets="Build">
-    <Exec Condition="'$(IsMonoRuntime)' == 'true'" ConsoleToMsBuild="true" Command="dirname `which ilasm`">
-      <Output TaskParameter="ConsoleOutput" PropertyName="IlAsmPath" />
-    </Exec>
     <PropertyGroup>
-      <IlAsmCommand Condition="'$(IsMonoRuntime)' == 'false'">"$(windir)\Microsoft.NET\Framework\v4.0.30319\ilasm.exe"</IlAsmCommand>
-      <IlAsmCommand Condition="'$(IsMonoRuntime)' == 'true'">$(IlAsmPath)/ilasm</IlAsmCommand>
+      <IlAsmCommand>"$(windir)\Microsoft.NET\Framework\v4.0.30319\ilasm.exe"</IlAsmCommand>
       <IlAsmFlags>$(IlAsmFlags) /DLL /quiet</IlAsmFlags>
     </PropertyGroup>
     <MakeDir Condition="!Exists('$(GeneratedAssembliesDir)')" Directories="$(GeneratedAssembliesDir)" />


### PR DESCRIPTION
This PR removes references on non-Windows platforms. We currently only
build with Visual Studio and on Windows.

This removes IsMonoFramework property and added an error check to see if
we are building on non-Windows.