### PR TITLE
Fix DebugServerPath for JSON parsing

### DIFF
--- a/src/MICore/LaunchOptions.cs
+++ b/src/MICore/LaunchOptions.cs
@@ -443,7 +443,7 @@ namespace MICore
 
         private void InitializeServerOptions(Json.LaunchOptions.LaunchOptions launchOptions)
         {
-            if (!String.IsNullOrWhiteSpace(launchOptions.MiDebuggerServerAddress))
+            if (!String.IsNullOrWhiteSpace(launchOptions.DebugServerPath))
             {
                 this.DebugServer = launchOptions.DebugServerPath;
                 this.DebugServerArgs = launchOptions.DebugServerArgs;


### PR DESCRIPTION
The XML creation for InitializeServerOptions checks for DebugServerPath
being null or whitespace. Making JSON's InitializeServerOptions the
same.

See: 
https://github.com/microsoft/MIEngine/blob/728f403c563c2c50c46542e9b44271a7f8d5895b/src/MICore/LaunchOptions.cs#L461-L476