### PR TITLE
Set SetupCommands to be common for JSON parsing

### DIFF
--- a/src/MICore/JsonLaunchOptions.cs
+++ b/src/MICore/JsonLaunchOptions.cs
@@ -89,6 +89,12 @@ namespace MICore.Json.LaunchOptions
         /// </summary>
         [JsonProperty("symbolLoadInfo", DefaultValueHandling = DefaultValueHandling.Ignore)]
         public SymbolLoadInfo SymbolLoadInfo { get; set; }
+
+        /// <summary>
+        /// One or more GDB/LLDB commands to execute in order to setup the underlying debugger. Example: "setupCommands": [ { "text": "-enable-pretty-printing", "description": "Enable GDB pretty printing", "ignoreFailures": true }].
+        /// </summary>
+        [JsonProperty("setupCommands", DefaultValueHandling = DefaultValueHandling.Ignore)]
+        public List<SetupCommand> SetupCommands { get; protected set; }
     }
 
     public partial class AttachOptions : BaseOptions
@@ -219,12 +225,6 @@ namespace MICore.Json.LaunchOptions
         /// </summary>
         [JsonProperty("cwd", DefaultValueHandling = DefaultValueHandling.Ignore)]
         public string Cwd { get; set; }
-
-        /// <summary>
-        /// One or more GDB/LLDB commands to execute in order to setup the underlying debugger. Example: "setupCommands": [ { "text": "-enable-pretty-printing", "description": "Enable GDB pretty printing", "ignoreFailures": true }].
-        /// </summary>
-        [JsonProperty("setupCommands", DefaultValueHandling = DefaultValueHandling.Ignore)]
-        public List<SetupCommand> SetupCommands { get; private set; }
 
         /// <summary>
         /// If provided, this replaces the default commands used to launch a target with some other commands. For example, this can be "-target-attach" in order to attach to a target process. An empty command list replaces the launch commands with nothing, which can be useful if the debugger is being provided launch options as command line options. Example: "customLaunchSetupCommands": [ { "text": "target-run", "description": "run target", "ignoreFailures": false }].

--- a/src/MICore/LaunchOptions.cs
+++ b/src/MICore/LaunchOptions.cs
@@ -1711,6 +1711,8 @@ namespace MICore
                 }
             }
 
+            this.SetupCommands = LaunchCommand.CreateCollection(options.SetupCommands);
+
         }
 
         protected void InitializeCommonOptions(Xml.LaunchOptions.BaseLaunchOptions source)
@@ -1885,8 +1887,6 @@ namespace MICore
             this.WorkingDirectory = launch.Cwd ?? String.Empty;
 
             this.CoreDumpPath = launch.CoreDumpPath;
-
-            this.SetupCommands = LaunchCommand.CreateCollection(launch.SetupCommands);
 
             if (launch.CustomLaunchSetupCommands.Any())
             {


### PR DESCRIPTION
SetupCommands is used for both launch and attach. For JSON, it was only
set in launch. This PR fixes it so it does it for both launch and attach
by setting it as a common option.

https://github.com/microsoft/vscode-cpptools/issues/6417