### PR TITLE
Fix XUnit Test Analyzer Errors

### DIFF
--- a/src/MICoreUnitTests/AndroidLauncherTests.cs
+++ b/src/MICoreUnitTests/AndroidLauncherTests.cs
@@ -28,13 +28,13 @@ namespace MICoreUnitTests
                 "DeviceId=\"default\"/>");
 
             var options = CreateFromXml(content);
-            Assert.Equal(options.Package, "com.example.hellojni");
-            Assert.Equal(options.LaunchActivity, ".HelloJni");
-            Assert.Equal(options.TargetArchitecture, MICore.TargetArchitecture.ARM);
+            Assert.Equal("com.example.hellojni", options.Package);
+            Assert.Equal(".HelloJni", options.LaunchActivity);
+            Assert.Equal(MICore.TargetArchitecture.ARM, options.TargetArchitecture);
             Assert.Equal(options.IntermediateDirectory, temp);
-            Assert.Equal(options.AdditionalSOLibSearchPath, "c:\\example\\bin\\debug;c:\\someotherdir\\bin\\debug");
-            Assert.Equal(options.AbsolutePrefixSOLibSearchPath, "\"\"");
-            Assert.Equal(options.DeviceId, "default");
+            Assert.Equal("c:\\example\\bin\\debug;c:\\someotherdir\\bin\\debug", options.AdditionalSOLibSearchPath);
+            Assert.Equal("\"\"", options.AbsolutePrefixSOLibSearchPath);
+            Assert.Equal("default", options.DeviceId);
             Assert.False(options.IsAttach);
         }
 
@@ -59,7 +59,7 @@ namespace MICoreUnitTests
             }
             catch (MICore.InvalidLaunchOptionsException e)
             {
-                Assert.True(e.Message.Contains("LaunchActivity"));
+                Assert.Contains("LaunchActivity", e.Message, StringComparison.Ordinal);
             }
         }
 
@@ -105,14 +105,14 @@ namespace MICoreUnitTests
                 "Attach=\"true\"/>");
 
             var options = CreateFromXml(content);
-            Assert.Equal(options.Package, "com.example.hellojni");
-            Assert.Equal(null, options.LaunchActivity);
-            Assert.Equal(options.TargetArchitecture, MICore.TargetArchitecture.ARM);
+            Assert.Equal("com.example.hellojni", options.Package);
+            Assert.Null(options.LaunchActivity);
+            Assert.Equal(MICore.TargetArchitecture.ARM, options.TargetArchitecture);
             Assert.Equal(options.IntermediateDirectory, temp);
-            Assert.Equal(options.AdditionalSOLibSearchPath, "c:\\example\\bin\\debug;c:\\someotherdir\\bin\\debug");
-            Assert.Equal(options.AbsolutePrefixSOLibSearchPath, "\"\"");
-            Assert.Equal(options.DeviceId, "default");
-            Assert.Equal(options.IsAttach, true);
+            Assert.Equal("c:\\example\\bin\\debug;c:\\someotherdir\\bin\\debug", options.AdditionalSOLibSearchPath);
+            Assert.Equal("\"\"", options.AbsolutePrefixSOLibSearchPath);
+            Assert.Equal("default", options.DeviceId);
+            Assert.True(options.IsAttach);
         }
 
         [Fact]
@@ -137,7 +137,7 @@ namespace MICoreUnitTests
             }
             catch (MICore.InvalidLaunchOptionsException e)
             {
-                Assert.True(e.Message.Contains("BadValue"));
+                Assert.Contains("BadValue", e.Message, StringComparison.Ordinal);
             }
         }
 
@@ -157,59 +157,59 @@ namespace MICoreUnitTests
             string[] lines = GetFakeProcessListText1();
             TextColumn[] columns = TextColumn.TryParseHeader(lines[0]);
             Assert.True(columns != null && columns.Length == 8);
-            Assert.Equal(columns[0].Name, "USER");
-            Assert.Equal(columns[1].Name, "PID");
-            Assert.Equal(columns[2].Name, "PPID");
-            Assert.Equal(columns[3].Name, "VSIZE");
-            Assert.Equal(columns[4].Name, "RSS");
-            Assert.Equal(columns[5].Name, "WCHAN");
-            Assert.Equal(columns[6].Name, "PC");
-            Assert.Equal(columns[7].Name, "NAME");
+            Assert.Equal("USER", columns[0].Name);
+            Assert.Equal("PID", columns[1].Name);
+            Assert.Equal("PPID", columns[2].Name);
+            Assert.Equal("VSIZE", columns[3].Name);
+            Assert.Equal("RSS", columns[4].Name);
+            Assert.Equal("WCHAN", columns[5].Name);
+            Assert.Equal("PC", columns[6].Name);
+            Assert.Equal("NAME", columns[7].Name);
 
-            Assert.Equal(columns[0].ExtractCell(lines[1]), "root");
-            Assert.Equal(columns[1].ExtractCell(lines[1]), "1");
-            Assert.Equal(columns[2].ExtractCell(lines[1]), "0");
-            Assert.Equal(columns[3].ExtractCell(lines[1]), "640");
-            Assert.Equal(columns[4].ExtractCell(lines[1]), "496");
-            Assert.Equal(columns[5].ExtractCell(lines[1]), "c00bd520");
-            Assert.Equal(columns[6].ExtractCell(lines[1]), "00019fb8 S");
-            Assert.Equal(columns[7].ExtractCell(lines[1]), "/init");
+            Assert.Equal("root", columns[0].ExtractCell(lines[1]));
+            Assert.Equal("1", columns[1].ExtractCell(lines[1]));
+            Assert.Equal("0", columns[2].ExtractCell(lines[1]));
+            Assert.Equal("640", columns[3].ExtractCell(lines[1]));
+            Assert.Equal("496", columns[4].ExtractCell(lines[1]));
+            Assert.Equal("c00bd520", columns[5].ExtractCell(lines[1]));
+            Assert.Equal("00019fb8 S", columns[6].ExtractCell(lines[1]));
+            Assert.Equal("/init", columns[7].ExtractCell(lines[1]));
 
-            Assert.Equal(columns[0].ExtractCell(lines[2]), "root");
-            Assert.Equal(columns[1].ExtractCell(lines[2]), "2");
-            Assert.Equal(columns[2].ExtractCell(lines[2]), "0");
-            Assert.Equal(columns[3].ExtractCell(lines[2]), "0");
-            Assert.Equal(columns[4].ExtractCell(lines[2]), "0");
-            Assert.Equal(columns[5].ExtractCell(lines[2]), "c00335a0");
-            Assert.Equal(columns[6].ExtractCell(lines[2]), "00000000 S");
-            Assert.Equal(columns[7].ExtractCell(lines[2]), "fake_name");
+            Assert.Equal("root", columns[0].ExtractCell(lines[2]));
+            Assert.Equal("2", columns[1].ExtractCell(lines[2]));
+            Assert.Equal("0", columns[2].ExtractCell(lines[2]));
+            Assert.Equal("0", columns[3].ExtractCell(lines[2]));
+            Assert.Equal("0", columns[4].ExtractCell(lines[2]));
+            Assert.Equal("c00335a0", columns[5].ExtractCell(lines[2]));
+            Assert.Equal("00000000 S", columns[6].ExtractCell(lines[2]));
+            Assert.Equal("fake_name", columns[7].ExtractCell(lines[2]));
 
-            Assert.Equal(columns[0].ExtractCell(lines[3]), "root");
-            Assert.Equal(columns[1].ExtractCell(lines[3]), "3");
-            Assert.Equal(columns[2].ExtractCell(lines[3]), "2");
-            Assert.Equal(columns[3].ExtractCell(lines[3]), "0");
-            Assert.Equal(columns[4].ExtractCell(lines[3]), "0");
-            Assert.Equal(columns[5].ExtractCell(lines[3]), "c001e39c");
-            Assert.Equal(columns[6].ExtractCell(lines[3]), "00000000 S");
-            Assert.Equal(columns[7].ExtractCell(lines[3]), "fake_name");
+            Assert.Equal("root", columns[0].ExtractCell(lines[3]));
+            Assert.Equal("3", columns[1].ExtractCell(lines[3]));
+            Assert.Equal("2", columns[2].ExtractCell(lines[3]));
+            Assert.Equal("0", columns[3].ExtractCell(lines[3]));
+            Assert.Equal("0", columns[4].ExtractCell(lines[3]));
+            Assert.Equal("c001e39c", columns[5].ExtractCell(lines[3]));
+            Assert.Equal("00000000 S", columns[6].ExtractCell(lines[3]));
+            Assert.Equal("fake_name", columns[7].ExtractCell(lines[3]));
 
-            Assert.Equal(columns[0].ExtractCell(lines[4]), "u0_a56");
-            Assert.Equal(columns[1].ExtractCell(lines[4]), "1165");
-            Assert.Equal(columns[2].ExtractCell(lines[4]), "50");
-            Assert.Equal(columns[3].ExtractCell(lines[4]), "211416");
-            Assert.Equal(columns[4].ExtractCell(lines[4]), "16040");
-            Assert.Equal(columns[5].ExtractCell(lines[4]), "ffffffff");
-            Assert.Equal(columns[6].ExtractCell(lines[4]), "b6f46798 S");
-            Assert.Equal(columns[7].ExtractCell(lines[4]), "com.example.hellojni");
+            Assert.Equal("u0_a56", columns[0].ExtractCell(lines[4]));
+            Assert.Equal("1165", columns[1].ExtractCell(lines[4]));
+            Assert.Equal("50", columns[2].ExtractCell(lines[4]));
+            Assert.Equal("211416", columns[3].ExtractCell(lines[4]));
+            Assert.Equal("16040", columns[4].ExtractCell(lines[4]));
+            Assert.Equal("ffffffff", columns[5].ExtractCell(lines[4]));
+            Assert.Equal("b6f46798 S", columns[6].ExtractCell(lines[4]));
+            Assert.Equal("com.example.hellojni", columns[7].ExtractCell(lines[4]));
 
-            Assert.Equal(columns[0].ExtractCell(lines[5]), "root");
-            Assert.Equal(columns[1].ExtractCell(lines[5]), "1181");
-            Assert.Equal(columns[2].ExtractCell(lines[5]), "59");
-            Assert.Equal(columns[3].ExtractCell(lines[5]), "1236");
-            Assert.Equal(columns[4].ExtractCell(lines[5]), "460");
-            Assert.Equal(columns[5].ExtractCell(lines[5]), "00000000");
-            Assert.Equal(columns[6].ExtractCell(lines[5]), "b6f11158 R");
-            Assert.Equal(columns[7].ExtractCell(lines[5]), "ps");
+            Assert.Equal("root", columns[0].ExtractCell(lines[5]));
+            Assert.Equal("1181", columns[1].ExtractCell(lines[5]));
+            Assert.Equal("59", columns[2].ExtractCell(lines[5]));
+            Assert.Equal("1236", columns[3].ExtractCell(lines[5]));
+            Assert.Equal("460", columns[4].ExtractCell(lines[5]));
+            Assert.Equal("00000000", columns[5].ExtractCell(lines[5]));
+            Assert.Equal("b6f11158 R", columns[6].ExtractCell(lines[5]));
+            Assert.Equal("ps", columns[7].ExtractCell(lines[5]));
         }
 
         [Fact]
@@ -220,16 +220,16 @@ namespace MICoreUnitTests
             var processListParer = new ProcessListParser(GetFakeProcessListText1());
 
             result = processListParer.FindProcesses("hellojni");
-            Assert.Equal(result.Count, 0);
+            Assert.Empty(result);
 
             result = processListParer.FindProcesses("com.example.hellojni");
-            Assert.Equal(result.Count, 1);
-            Assert.Equal(result[0], 1165);
+            Assert.Single(result);
+            Assert.Equal(1165, result[0]);
 
             result = processListParer.FindProcesses("fake_name");
-            Assert.Equal(result.Count, 2);
-            Assert.Equal(result[0], 2);
-            Assert.Equal(result[1], 3);
+            Assert.Equal(2, result.Count);
+            Assert.Equal(2, result[0]);
+            Assert.Equal(3, result[1]);
         }
 
         [Fact]
@@ -240,15 +240,15 @@ namespace MICoreUnitTests
             var processListParer = new ProcessListParser(GetFakeProcessListText2());
 
             result = processListParer.FindProcesses("hellojni");
-            Assert.Equal(result.Count, 0);
+            Assert.Empty(result);
 
             result = processListParer.FindProcesses("com.example.hellojni");
-            Assert.Equal(result.Count, 1);
-            Assert.Equal(result[0], 7848);
+            Assert.Single(result);
+            Assert.Equal(7848, result[0]);
 
             result = processListParer.FindProcesses("com.example.memory_hog");
-            Assert.Equal(result.Count, 1);
-            Assert.Equal(result[0], 7915);
+            Assert.Single(result);
+            Assert.Equal(7915, result[0]);
         }
 
         private string[] GetFakeProcessListText1()
@@ -291,14 +291,14 @@ namespace MICoreUnitTests
         public void TestPwdOutputParser()
         {
             string result = PwdOutputParser.ExtractWorkingDirectory("/example/directory", "does-not-matter");
-            Assert.Equal(result, "/example/directory");
+            Assert.Equal("/example/directory", result);
 
             string outputWithDebugSpew = string.Concat(
                 "Function: selinux_compare_spd_ram , priority [2] , priority version is VE=SEPF_SM-G920I_5.0.2_0011\n",
                 "[DEBUG] get_category: variable seinfo: default sensitivity: NULL, cateogry: NULL\n",
                 "/data/data/com.Android53");
             result = PwdOutputParser.ExtractWorkingDirectory(outputWithDebugSpew, "com.Android53");
-            Assert.Equal(result, "/data/data/com.Android53");
+            Assert.Equal("/data/data/com.Android53", result);
 
             try
             {

--- a/src/MICoreUnitTests/BasicLaunchOptionsTests.cs
+++ b/src/MICoreUnitTests/BasicLaunchOptionsTests.cs
@@ -27,17 +27,17 @@ namespace MICoreUnitTests
                 "/>");
 
             var baseOptions = GetLaunchOptions(content);
-            Assert.IsAssignableFrom(typeof(LocalLaunchOptions), baseOptions);
+            Assert.IsAssignableFrom<LocalLaunchOptions>(baseOptions);
             var options = (LocalLaunchOptions)baseOptions;
 
             Assert.Equal(options.MIDebuggerPath, fakeFilePath);
-            Assert.Equal(options.MIDebuggerServerAddress, "myserverbox:345");
+            Assert.Equal("myserverbox:345", options.MIDebuggerServerAddress);
             Assert.Equal(options.ExePath, fakeFilePath);
-            Assert.Equal(options.TargetArchitecture, TargetArchitecture.ARM);
+            Assert.Equal(TargetArchitecture.ARM, options.TargetArchitecture);
             Assert.True(string.IsNullOrEmpty(options.AdditionalSOLibSearchPath));
             Assert.True(string.IsNullOrEmpty(options.AbsolutePrefixSOLibSearchPath));
-            Assert.Equal(options.DebuggerMIMode, MIMode.Gdb);
-            Assert.Equal(options.LaunchCompleteCommand, LaunchCompleteCommand.ExecRun);
+            Assert.Equal(MIMode.Gdb, options.DebuggerMIMode);
+            Assert.Equal(LaunchCompleteCommand.ExecRun, options.LaunchCompleteCommand);
             Assert.Null(options.CustomLaunchSetupCommands);
             Assert.True(options.SetupCommands != null && options.SetupCommands.Count == 0);
             Assert.True(String.IsNullOrEmpty(options.CoreDumpPath));
@@ -61,23 +61,23 @@ namespace MICoreUnitTests
                 "</PipeLaunchOptions>");
 
             var baseOptions = GetLaunchOptions(content);
-            Assert.IsAssignableFrom(typeof(PipeLaunchOptions), baseOptions);
+            Assert.IsAssignableFrom<PipeLaunchOptions>(baseOptions);
             var options = (PipeLaunchOptions)baseOptions;
 
             Assert.Equal(options.PipePath, fakeFilePath);
-            Assert.Equal(options.PipeCwd, null);
-            Assert.Equal(options.ExePath, "/home/user/myname/foo");
-            Assert.Equal(options.ExeArguments, "arg1 arg2");
-            Assert.Equal(options.TargetArchitecture, TargetArchitecture.X64);
+            Assert.Null(options.PipeCwd);
+            Assert.Equal("/home/user/myname/foo", options.ExePath);
+            Assert.Equal("arg1 arg2", options.ExeArguments);
+            Assert.Equal(TargetArchitecture.X64, options.TargetArchitecture);
             Assert.True(string.IsNullOrEmpty(options.AdditionalSOLibSearchPath));
             Assert.True(string.IsNullOrEmpty(options.AbsolutePrefixSOLibSearchPath));
-            Assert.Equal(options.DebuggerMIMode, MIMode.Gdb);
-            Assert.Equal(options.LaunchCompleteCommand, LaunchCompleteCommand.ExecRun);
+            Assert.Equal(MIMode.Gdb, options.DebuggerMIMode);
+            Assert.Equal(LaunchCompleteCommand.ExecRun, options.LaunchCompleteCommand);
             Assert.True(options.CustomLaunchSetupCommands == null);
             Assert.True(options.SetupCommands != null && options.SetupCommands.Count == 1);
             Assert.True(options.SetupCommands[0].IsMICommand);
-            Assert.Equal(options.SetupCommands[0].CommandText, "-gdb-set my-example-setting on");
-            Assert.True(options.SetupCommands[0].Description.Contains("gdb-set"));
+            Assert.Equal("-gdb-set my-example-setting on", options.SetupCommands[0].CommandText);
+            Assert.Contains("gdb-set", options.SetupCommands[0].Description, StringComparison.Ordinal);
             Assert.False(options.SetupCommands[0].IgnoreFailures);
             Assert.True(options.PipeEnvironment.Count == 0);
         }
@@ -109,28 +109,28 @@ namespace MICoreUnitTests
                 "</PipeLaunchOptions>");
 
             var baseOptions = GetLaunchOptions(content);
-            Assert.IsAssignableFrom(typeof(PipeLaunchOptions), baseOptions);
+            Assert.IsAssignableFrom<PipeLaunchOptions>(baseOptions);
             var options = (PipeLaunchOptions)baseOptions;
 
             Assert.Equal(options.PipePath, fakeFilePath);
-            Assert.Equal(options.PipeCwd, "/home/user/my program/src");
-            Assert.Equal(options.ExePath, "/home/user/myname/foo");
-            Assert.Equal(options.TargetArchitecture, TargetArchitecture.X64);
-            Assert.Equal(options.AbsolutePrefixSOLibSearchPath, "/system/bin");
+            Assert.Equal("/home/user/my program/src", options.PipeCwd);
+            Assert.Equal("/home/user/myname/foo", options.ExePath);
+            Assert.Equal(TargetArchitecture.X64, options.TargetArchitecture);
+            Assert.Equal("/system/bin", options.AbsolutePrefixSOLibSearchPath);
             string[] searchPaths = options.GetSOLibSearchPath().ToArray();
-            Assert.Equal(searchPaths.Length, 2);
-            Assert.Equal(searchPaths[0], "/home/user/myname");
-            Assert.Equal(searchPaths[1], "/a/b/c");
-            Assert.Equal(options.DebuggerMIMode, MIMode.Lldb);
+            Assert.Equal(2, searchPaths.Length);
+            Assert.Equal("/home/user/myname", searchPaths[0]);
+            Assert.Equal("/a/b/c", searchPaths[1]);
+            Assert.Equal(MIMode.Lldb, options.DebuggerMIMode);
             Assert.True(options.SetupCommands != null && options.SetupCommands.Count == 0);
             Assert.True(options.CustomLaunchSetupCommands != null && options.CustomLaunchSetupCommands.Count == 1);
             var command = options.CustomLaunchSetupCommands[0];
             Assert.False(command.IsMICommand);
-            Assert.Equal(command.CommandText, "Example command");
-            Assert.Equal(command.Description, "Example description");
-            Assert.Equal(options.LaunchCompleteCommand, LaunchCompleteCommand.None);
-            Assert.Equal(options.PipeEnvironment.First().Name, "PipeVar1");
-            Assert.Equal(options.PipeEnvironment.First().Value, "PipeValue1");
+            Assert.Equal("Example command", command.CommandText);
+            Assert.Equal("Example description", command.Description);
+            Assert.Equal(LaunchCompleteCommand.None, options.LaunchCompleteCommand);
+            Assert.Equal("PipeVar1", options.PipeEnvironment.First().Name);
+            Assert.Equal("PipeValue1", options.PipeEnvironment.First().Value);
         }
 
         // TODO this test is broken by a bug: the assembly binder only searches the unit test
@@ -156,19 +156,19 @@ namespace MICoreUnitTests
             </TcpLaunchOptions>";
 
             var baseOptions = GetLaunchOptions(content);
-            Assert.IsAssignableFrom(typeof(TcpLaunchOptions), baseOptions);
+            Assert.IsAssignableFrom<TcpLaunchOptions>(baseOptions);
             var options = (TcpLaunchOptions)baseOptions;
 
-            Assert.Equal(options.ExePath, "/a/b/c");
-            Assert.Equal(options.TargetArchitecture, TargetArchitecture.ARM);
-            Assert.Equal(options.DebuggerMIMode, MIMode.Gdb);
+            Assert.Equal("/a/b/c", options.ExePath);
+            Assert.Equal(TargetArchitecture.ARM, options.TargetArchitecture);
+            Assert.Equal(MIMode.Gdb, options.DebuggerMIMode);
             Assert.True(options.SetupCommands != null && options.SetupCommands.Count == 0);
             Assert.True(options.CustomLaunchSetupCommands != null && options.CustomLaunchSetupCommands.Count == 1);
             var command = options.CustomLaunchSetupCommands[0];
             Assert.True(command.IsMICommand);
-            Assert.Equal(command.CommandText, "-target-attach 1234");
-            Assert.Equal(command.Description, "Attaching to the 'foo' process");
-            Assert.Equal(options.LaunchCompleteCommand, LaunchCompleteCommand.ExecContinue);
+            Assert.Equal("-target-attach 1234", command.CommandText);
+            Assert.Equal("Attaching to the 'foo' process", command.Description);
+            Assert.Equal(LaunchCompleteCommand.ExecContinue, options.LaunchCompleteCommand);
         }
 
         [Fact]
@@ -187,7 +187,7 @@ namespace MICoreUnitTests
             }
             catch (InvalidLaunchOptionsException e)
             {
-                Assert.True(e.Message.Contains("Port"));
+                Assert.Contains("Port", e.Message, StringComparison.Ordinal);
             }
         }
 
@@ -204,7 +204,7 @@ namespace MICoreUnitTests
             }
             catch (InvalidLaunchOptionsException e)
             {
-                Assert.True(e.Message.StartsWith("Launch options", StringComparison.Ordinal));
+                Assert.StartsWith("Launch options", e.Message, StringComparison.Ordinal);
             }
         }
 
@@ -221,7 +221,7 @@ namespace MICoreUnitTests
             }
             catch (InvalidLaunchOptionsException e)
             {
-                Assert.True(e.Message.StartsWith("Launch options", StringComparison.Ordinal));
+                Assert.StartsWith("Launch options", e.Message, StringComparison.Ordinal);
             }
         }
 
@@ -245,7 +245,7 @@ namespace MICoreUnitTests
             }
             catch (InvalidLaunchOptionsException e)
             {
-                Assert.True(e.Message.StartsWith("Launch options", StringComparison.Ordinal));
+                Assert.StartsWith("Launch options", e.Message, StringComparison.Ordinal);
             }
         }
 
@@ -254,7 +254,7 @@ namespace MICoreUnitTests
         /// Verify that types relied upon by launcher extensions are exported by MIEngine in current build. 
         /// Don't change this test without checking with C++ team.
         /// </summary>
-        public void VerifyCoreApisPresent()
+        internal void VerifyCoreApisPresent()
         {
             LaunchOptions launchOptions = new LocalLaunchOptions("/usr/bin/gdb", "10.10.10.10:2345");
             launchOptions.ExePath = @"c:\users\me\myapp.out";

--- a/src/MICoreUnitTests/CommandLockTests.cs
+++ b/src/MICoreUnitTests/CommandLockTests.cs
@@ -202,7 +202,7 @@ namespace MICoreUnitTests
             foreach (Task t in pendingTasks)
             {
                 Assert.True(t.IsCompleted);
-                Assert.IsType(typeof(DebuggerDisposedException), t.Exception.InnerException);
+                Assert.IsType<DebuggerDisposedException>(t.Exception.InnerException);
                 Assert.Equal("CloseAbortsOperationsTest complete", t.Exception.InnerException.Message);
             }
         }

--- a/src/MICoreUnitTests/MIResultsTests.cs
+++ b/src/MICoreUnitTests/MIResultsTests.cs
@@ -68,7 +68,7 @@ namespace MICoreUnitTests
             string miString = @"name=""value"""; // name="value"
             Results results = r.ParseResultList(miString);
 
-            Assert.Equal(1, results.Content.Length);
+            Assert.Single(results.Content);
             Assert.Equal("name", results.Content[0].Name);
             Assert.True(results.Content[0].Value is ConstValue);
             Assert.Equal("value", (results.Content[0].Value as ConstValue).Content);

--- a/src/MICoreUnitTests/NdkVersionTests.cs
+++ b/src/MICoreUnitTests/NdkVersionTests.cs
@@ -15,10 +15,10 @@ namespace MICoreUnitTests
         {
             NdkToolVersion v;
             Assert.True(NdkToolVersion.TryParse("1.2.3.4.5", out v));
-            Assert.Equal(v.ToString(), "1.2.3.4.5");
+            Assert.Equal("1.2.3.4.5", v.ToString());
 
             Assert.True(NdkToolVersion.TryParse("6.7", out v));
-            Assert.Equal(v.ToString(), "6.7");
+            Assert.Equal("6.7", v.ToString());
 
             Assert.False(NdkToolVersion.TryParse("1", out v));
             Assert.False(NdkToolVersion.TryParse("1.0-beta", out v));
@@ -48,7 +48,7 @@ namespace MICoreUnitTests
             NdkToolVersion[] versions = { v1, v2, v3 };
             IEnumerable<string> versionStrings = versions.OrderByDescending((x) => x).Select((x) => x.ToString());
             string orderedResults = string.Join(", ", versionStrings);
-            Assert.Equal(orderedResults, "2.0, 1.2.3, 1.2");
+            Assert.Equal("2.0, 1.2.3, 1.2", orderedResults);
         }
 
         [Fact]
@@ -56,16 +56,16 @@ namespace MICoreUnitTests
         {
             NdkReleaseId r;
             Assert.True(NdkReleaseId.TryParse("r1", out r));
-            Assert.Equal(r.ToString(), "r1");
+            Assert.Equal("r1", r.ToString());
 
             Assert.True(NdkReleaseId.TryParse("r1a", out r));
-            Assert.Equal(r.ToString(), "r1");
+            Assert.Equal("r1", r.ToString());
 
             Assert.True(NdkReleaseId.TryParse("r10", out r));
-            Assert.Equal(r.ToString(), "r10");
+            Assert.Equal("r10", r.ToString());
 
             Assert.True(NdkReleaseId.TryParse("r10b (64-bit)", out r));
-            Assert.Equal(r.ToString(), "r10b");
+            Assert.Equal("r10b", r.ToString());
 
             Assert.False(NdkReleaseId.TryParse("100", out r));
             Assert.False(NdkReleaseId.TryParse("r", out r));
@@ -99,7 +99,7 @@ namespace MICoreUnitTests
             Assert.Equal("r1", r.ToString());
 
             Assert.True(NdkReleaseId.TryParseRevision("13.2.0", out r));
-            Assert.Equal(r.ToString(), "r13c");
+            Assert.Equal("r13c", r.ToString());
 
             Assert.False(NdkReleaseId.TryParseRevision("100", out r));
             Assert.False(NdkReleaseId.TryParseRevision("r11b", out r));


### PR DESCRIPTION
xUnit2000: The literal or constant value <..> should be passed as
the 'expected' argument in the call to 'Assert.Equal(expected, actual)'

xUnit2007: Do not use typeof(<Type>) expression to check the type.

xUnit2009: Do not use Assert.True() to check for substrings.

xUnit1013: Public method 'VerifyCoreApisPresent' on test class
'BasicLaunchOptionsTests' should be marked as a Fact.