### PR TITLE
Support Empty/Null strings in 'args' for json

### DIFF
--- a/src/MICore/LaunchOptions.cs
+++ b/src/MICore/LaunchOptions.cs
@@ -1819,6 +1819,12 @@ namespace MICore
                 {
                     foreach (string rawArgument in arguments)
                     {
+                        // Skip on null or blank arguments.
+                        if (string.IsNullOrWhiteSpace(rawArgument))
+                        {
+                            continue;
+                        }
+
                         string argument = rawArgument.TrimStart();
                         if (argument.TrimStart().StartsWith("2>", StringComparison.Ordinal))
                         {
@@ -2123,8 +2129,10 @@ namespace MICore
         private static char[] s_ARGUMENT_SEPARATORS = { ' ', '\t', '(', ')' };
         protected static string QuoteArgument(string arg)
         {
-            // If its not quoted and it has an argument separater, then quote it. 
-            if (arg[0] != '"' && arg.IndexOfAny(s_ARGUMENT_SEPARATORS) >= 0)
+            // Quote if:
+            // 1. string is null or empty and convert to a quoted empty string.
+            // 2. Its not quoted and it has an argument seperator. 
+            if (string.IsNullOrEmpty(arg) || (arg[0] != '"' && arg.IndexOfAny(s_ARGUMENT_SEPARATORS) >= 0))
             {
                 return '"' + arg + '"';
             }


### PR DESCRIPTION
This PR handle empty/null strings in the args field for the launch.json.
QuoteArgs will quote empty strings if requested and we will skip over
null strings since it is not possible to pass NULL into a program's
argument.

However, launch.json's 'args' array does support `null` so we are
handling it so it does not crash OpenDebugAD7.

Related: https://github.com/microsoft/vscode-cpptools/issues/6522