### PR TITLE
Support non-IDebugMemoryBytesDAP engines

### DIFF
--- a/src/OpenDebugAD7/AD7DebugSession.cs
+++ b/src/OpenDebugAD7/AD7DebugSession.cs
@@ -305,6 +305,8 @@ namespace OpenDebugAD7
 
         private int GetMemoryContext(string memoryReference, int? offset, out IDebugMemoryContext2 memoryContext, out ulong address)
         {
+            memoryContext = null;
+
             if (memoryReference.StartsWith("0x", StringComparison.Ordinal))
             {
                 address = Convert.ToUInt64(memoryReference.Substring(2), 16);
@@ -326,7 +328,13 @@ namespace OpenDebugAD7
                 }
             }
 
-            int hr = ((IDebugMemoryBytesDAP)m_engine).CreateMemoryContext(address, out memoryContext);
+            int hr = HRConstants.E_NOTIMPL; // Engine does not support IDebugMemoryBytesDAP
+
+            if (m_engine is IDebugMemoryBytesDAP debugMemoryBytesDAPEngine)
+            {
+                hr = debugMemoryBytesDAPEngine.CreateMemoryContext(address, out memoryContext);
+            }
+
             return hr;
         }
 

--- a/src/OpenDebugAD7/AD7DebugSession.cs
+++ b/src/OpenDebugAD7/AD7DebugSession.cs
@@ -734,7 +734,7 @@ namespace OpenDebugAD7
                 ExceptionBreakpointFilters = m_engineConfiguration.ExceptionSettings.ExceptionBreakpointFilters.Select(item => new ExceptionBreakpointsFilter() { Default = item.@default, Filter = item.filter, Label = item.label }).ToList(),
                 SupportsClipboardContext = m_engineConfiguration.ClipboardContext,
                 SupportsLogPoints = true,
-                SupportsReadMemoryRequest = true,
+                SupportsReadMemoryRequest = m_engine is IDebugMemoryBytesDAP, // TODO: Read from configuration or query engine for capabilities.
                 SupportsModulesRequest = true,
                 AdditionalModuleColumns = additionalModuleColumns,
                 SupportsDisassembleRequest = true


### PR DESCRIPTION
There can be cases where the engine loaded is not the latest AD7Engine or the Microsoft.MIDebugEngine. 
In GetMemoryContext, we do a hard cast to IDebugMemoryBytesDAP. This
will error with "Specified cast is not valid" if the engine does not
implement IDebugMemoryBytesDAP and the engine is not the latest
Microsoft.MIDebugEngine.

This PR converts the hard cast to be a `is` check. If the engine is not
IDebugMemoryBytesDAP, it will return E_NOTIMPL.

Related: https://github.com/microsoft/MIEngine/issues/1081