### PR TITLE
Fix NPE for memoryContext on null variable value

### DIFF
--- a/src/MIDebugEngine/AD7.Impl/AD7Property.cs
+++ b/src/MIDebugEngine/AD7.Impl/AD7Property.cs
@@ -163,11 +163,11 @@ namespace Microsoft.MIDebugEngine
                 return AD7_HRESULT.S_GETMEMORYCONTEXT_NO_MEMORY_CONTEXT;
             // try to interpret the result as an address
             string v = _variableInformation.Value;
-            v = v.Trim();
-            if (v.Length == 0)
+            if (string.IsNullOrWhiteSpace(v))
             {
                 return AD7_HRESULT.S_GETMEMORYCONTEXT_NO_MEMORY_CONTEXT;
             }
+            v = v.Trim();
             if (v[0] == '{')
             {
                 // strip type name and trailing spaces


### PR DESCRIPTION
This fixes a crash when GDB returns a map of object and we have no
value for it. We then try to do a string.trim on a null string.

Did a null or whitespace check then trimmed the string.