### PR TITLE
Support "format" field on "stackTrace" request

### DIFF
--- a/src/MIDebugEngine/AD7.Impl/AD7Thread.cs
+++ b/src/MIDebugEngine/AD7.Impl/AD7Thread.cs
@@ -112,6 +112,15 @@ namespace Microsoft.MIDebugEngine
             enumObject = null;
             try
             {
+                uint radix = _engine.CurrentRadix();
+                if (radix != _engine.DebuggedProcess.MICommandFactory.Radix)
+                {
+                    _engine.DebuggedProcess.WorkerThread.RunOperation(async () =>
+                    {
+                        await _engine.UpdateRadixAsync(radix);
+                    });
+                }
+
                 // get the thread's stack frames
                 System.Collections.Generic.List<ThreadContext> stackFrames = null;
                 _engine.DebuggedProcess.WorkerThread.RunOperation(async () => stackFrames = await _engine.DebuggedProcess.ThreadCache.StackFrames(_debuggedThread));

--- a/src/OpenDebugAD7/AD7Resources.Designer.cs
+++ b/src/OpenDebugAD7/AD7Resources.Designer.cs
@@ -299,6 +299,15 @@ namespace OpenDebugAD7 {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Unable to retrieve stack trace. {0}.
+        /// </summary>
+        internal static string Error_Scenario_StackTrace {
+            get {
+                return ResourceManager.GetString("Error_Scenario_StackTrace", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Unable to step in. {0}.
         /// </summary>
         internal static string Error_Scenario_Step_In {

--- a/src/OpenDebugAD7/AD7Resources.Designer.cs
+++ b/src/OpenDebugAD7/AD7Resources.Designer.cs
@@ -227,6 +227,15 @@ namespace OpenDebugAD7 {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to {0}: property &apos;{1}&apos; is invalid..
+        /// </summary>
+        internal static string Error_PropertyInvalid {
+            get {
+                return ResourceManager.GetString("Error_PropertyInvalid", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to {0}: property &apos;{1}&apos; is missing, null, or empty.
         /// </summary>
         internal static string Error_PropertyMissing {

--- a/src/OpenDebugAD7/AD7Resources.resx
+++ b/src/OpenDebugAD7/AD7Resources.resx
@@ -288,4 +288,8 @@
   <data name="Error_Scenario_Disassemble" xml:space="preserve">
     <value>Unable to disassemble. {0}</value>
   </data>
+  <data name="Error_PropertyInvalid" xml:space="preserve">
+    <value>{0}: property '{1}' is invalid.</value>
+    <comment>{0} is the name of the command, {1} is the name of the property</comment>
+  </data>
 </root>

--- a/src/OpenDebugAD7/AD7Resources.resx
+++ b/src/OpenDebugAD7/AD7Resources.resx
@@ -292,4 +292,7 @@
     <value>{0}: property '{1}' is invalid.</value>
     <comment>{0} is the name of the command, {1} is the name of the property</comment>
   </data>
+  <data name="Error_Scenario_StackTrace" xml:space="preserve">
+    <value>Unable to retrieve stack trace. {0}</value>
+  </data>
 </root>


### PR DESCRIPTION
Adds support for the "value formatting" feature of DAP, which allows flags to be passed to control formatting of stack frames, as well as variables and evaluation results.

Note that while this commit wires up the DAP formatting flags to the relevant AD7 calls, MIEngine currently doesn't make use of the radix value passed, so the flag to control hex vs decimal formatting doesn't work.