### PR TITLE
Bug 1249829: Added externalConsole check for Visual Studio scenarios

### DIFF
--- a/src/OpenDebugAD7/AD7DebugSession.cs
+++ b/src/OpenDebugAD7/AD7DebugSession.cs
@@ -694,6 +694,8 @@ namespace OpenDebugAD7
             }
 
             // If the UI supports RunInTerminal, then register the callback.
+            // NOTE: Currently we don't support using the RunInTerminal request with VS or Windows Codespaces.
+            //       This is because: (1) they don't support 'Integrated' terminal, and (2) for MIEngine, we don't ship WindowsDebugLauncher.exe.
             if (!IsClientVS && arguments.SupportsRunInTerminalRequest.GetValueOrDefault(false))
             {
                 HostRunInTerminal.RegisterRunInTerminalCallback((title, cwd, useExternalConsole, commandArgs, env, success, error) =>

--- a/src/OpenDebugAD7/AD7DebugSession.cs
+++ b/src/OpenDebugAD7/AD7DebugSession.cs
@@ -305,6 +305,8 @@ namespace OpenDebugAD7
 
         private int GetMemoryContext(string memoryReference, int? offset, out IDebugMemoryContext2 memoryContext, out ulong address)
         {
+            memoryContext = null;
+
             if (memoryReference.StartsWith("0x", StringComparison.Ordinal))
             {
                 address = Convert.ToUInt64(memoryReference.Substring(2), 16);
@@ -326,7 +328,13 @@ namespace OpenDebugAD7
                 }
             }
 
-            int hr = ((IDebugMemoryBytesDAP)m_engine).CreateMemoryContext(address, out memoryContext);
+            int hr = HRConstants.E_NOTIMPL; // Engine does not support IDebugMemoryBytesDAP
+
+            if (m_engine is IDebugMemoryBytesDAP debugMemoryBytesDAPEngine)
+            {
+                hr = debugMemoryBytesDAPEngine.CreateMemoryContext(address, out memoryContext);
+            }
+
             return hr;
         }
 
@@ -726,7 +734,7 @@ namespace OpenDebugAD7
                 ExceptionBreakpointFilters = m_engineConfiguration.ExceptionSettings.ExceptionBreakpointFilters.Select(item => new ExceptionBreakpointsFilter() { Default = item.@default, Filter = item.filter, Label = item.label }).ToList(),
                 SupportsClipboardContext = m_engineConfiguration.ClipboardContext,
                 SupportsLogPoints = true,
-                SupportsReadMemoryRequest = true,
+                SupportsReadMemoryRequest = m_engine is IDebugMemoryBytesDAP, // TODO: Read from configuration or query engine for capabilities.
                 SupportsModulesRequest = true,
                 AdditionalModuleColumns = additionalModuleColumns,
                 SupportsDisassembleRequest = true

--- a/src/OpenDebugAD7/AD7DebugSession.cs
+++ b/src/OpenDebugAD7/AD7DebugSession.cs
@@ -780,14 +780,6 @@ namespace OpenDebugAD7
 
         protected override void HandleLaunchRequestAsync(IRequestResponder<LaunchArguments> responder)
         {
-            /*
-            if (IsClientVS && !responder.Arguments.ConfigurationProperties.GetValueAsBool("externalConsole").GetValueOrDefault(false))
-            {
-                responder.SetError(new ProtocolException("Integrated terminal is not supported in Visual Studio. To fix, set external console to true."));
-                return;
-            }
-            */
-
             const string telemetryEventName = DebuggerTelemetry.TelemetryLaunchEventName;
 
             int hr;

--- a/src/OpenDebugAD7/AD7DebugSession.cs
+++ b/src/OpenDebugAD7/AD7DebugSession.cs
@@ -687,20 +687,14 @@ namespace OpenDebugAD7
             }
 
             // If the UI supports RunInTerminal, then register the callback.
-            if (arguments.SupportsRunInTerminalRequest.GetValueOrDefault(false))
+            if (!IsClientVS && arguments.SupportsRunInTerminalRequest.GetValueOrDefault(false))
             {
                 HostRunInTerminal.RegisterRunInTerminalCallback((title, cwd, useExternalConsole, commandArgs, env, success, error) =>
                 {
-                    RunInTerminalArguments.KindValue kind = useExternalConsole ? RunInTerminalArguments.KindValue.External : RunInTerminalArguments.KindValue.Integrated;
-                    if (IsClientVS)
-                    {
-                        kind = RunInTerminalArguments.KindValue.External;
-                    }
-
                     RunInTerminalRequest request = new RunInTerminalRequest()
                     {
                         Arguments = commandArgs.ToList<string>(),
-                        Kind = kind,
+                        Kind = useExternalConsole ? RunInTerminalArguments.KindValue.External : RunInTerminalArguments.KindValue.Integrated,
                         Title = title,
                         Cwd = cwd,
                         Env = env


### PR DESCRIPTION
externalConsole must be true for Visual Studio scenarios. If externalConsole is false, however, this is the dialog customers would have seen before the fix:
![image](https://user-images.githubusercontent.com/60245970/100811929-ad718e00-33f0-11eb-837f-e42c63450a2e.png)

Here is what they should see after the fix:
![image](https://user-images.githubusercontent.com/60245970/100811910-a34f8f80-33f0-11eb-816c-4724253e142a.png)
