### PR TITLE
Fixing Cygwin PathMapping with SourceFileMap

### DIFF
--- a/src/MIDebugEngine/AD7.Impl/AD7DocumentContext.cs
+++ b/src/MIDebugEngine/AD7.Impl/AD7DocumentContext.cs
@@ -15,14 +15,12 @@ namespace Microsoft.MIDebugEngine
     {
         private readonly MITextPosition _textPosition;
         private AD7MemoryAddress _codeContext;
-        private readonly DebuggedProcess _debuggedProcess;
 
 
-        public AD7DocumentContext(MITextPosition textPosition, AD7MemoryAddress codeContext, DebuggedProcess debuggedProcess)
+        public AD7DocumentContext(MITextPosition textPosition, AD7MemoryAddress codeContext)
         {
             _textPosition = textPosition;
             _codeContext = codeContext;
-            _debuggedProcess = debuggedProcess;
         }
 
 #region IDebugDocumentContext2 Members
@@ -97,14 +95,7 @@ namespace Microsoft.MIDebugEngine
         // Gets the displayable name of the document that contains this document context.
         int IDebugDocumentContext2.GetName(enum_GETNAME_TYPE gnType, out string pbstrFileName)
         {
-            if (_debuggedProcess.IsCygwin)
-            {
-                pbstrFileName = _debuggedProcess.CygwinFilePathMapper.MapCygwinToWindows(_textPosition.FileName);
-            }
-            else
-            {
-                pbstrFileName = _textPosition.FileName;
-            }
+            pbstrFileName = _textPosition.FileName;
 
             return Constants.S_OK;
         }

--- a/src/MIDebugEngine/AD7.Impl/AD7Engine.cs
+++ b/src/MIDebugEngine/AD7.Impl/AD7Engine.cs
@@ -842,7 +842,7 @@ namespace Microsoft.MIDebugEngine
                     pos.dwLine = line;
                     pos.dwColumn = 0;
                     MITextPosition textPosition = new MITextPosition(documentName, pos, pos);
-                    codeCxt.SetDocumentContext(new AD7DocumentContext(textPosition, codeCxt, this.DebuggedProcess));
+                    codeCxt.SetDocumentContext(new AD7DocumentContext(textPosition, codeCxt));
                     codeContexts.Add(codeCxt);
                 }
                 if (codeContexts.Count > 0)

--- a/src/MIDebugEngine/AD7.Impl/AD7PendingBreakpoint.cs
+++ b/src/MIDebugEngine/AD7.Impl/AD7PendingBreakpoint.cs
@@ -128,7 +128,7 @@ namespace Microsoft.MIDebugEngine
             {
                 AD7MemoryAddress codeContext = new AD7MemoryAddress(_engine, address, functionName);
 
-                return new AD7DocumentContext(new MITextPosition(_documentName, _startPosition[0], _startPosition[0]), codeContext, _engine.DebuggedProcess);
+                return new AD7DocumentContext(new MITextPosition(_documentName, _startPosition[0], _startPosition[0]), codeContext);
             }
             else
             {

--- a/src/MIDebugEngine/AD7.Impl/AD7StackFrame.cs
+++ b/src/MIDebugEngine/AD7.Impl/AD7StackFrame.cs
@@ -52,7 +52,7 @@ namespace Microsoft.MIDebugEngine
 
             if (_textPosition != null)
             {
-                _documentCxt = new AD7DocumentContext(_textPosition, _codeCxt, this.Engine.DebuggedProcess);
+                _documentCxt = new AD7DocumentContext(_textPosition, _codeCxt);
 
                 if (_codeCxt != null)
                 {

--- a/src/MIDebugEngine/Engine.Impl/Breakpoints.cs
+++ b/src/MIDebugEngine/Engine.Impl/Breakpoints.cs
@@ -408,7 +408,7 @@ namespace Microsoft.MIDebugEngine
                 return _parent.AD7breakpoint.GetDocumentContext(this.Addr, this.FunctionName);
             }
 
-            return new AD7DocumentContext(_textPosition, new AD7MemoryAddress(engine, Addr, this.FunctionName), engine.DebuggedProcess);
+            return new AD7DocumentContext(_textPosition, new AD7MemoryAddress(engine, Addr, this.FunctionName));
         }
 
         /// <summary>

--- a/src/MIDebugEngine/Engine.Impl/DebuggedProcess.cs
+++ b/src/MIDebugEngine/Engine.Impl/DebuggedProcess.cs
@@ -2265,6 +2265,10 @@ namespace Microsoft.MIDebugEngine
             string currentName = string.Empty;
             if (!string.IsNullOrEmpty(file))
             {
+                if (IsCygwin)
+                {
+                    file = CygwinFilePathMapper.MapCygwinToWindows(file);
+                }
                 MapCompileTimeSrcToCurrentSrc(file, out currentName);
             }
             return currentName;


### PR DESCRIPTION
When migrating sourceFileMap to MIDebugEngine in the XML Conversion PR,
we are now doing the call to 'cygpath' after we attempt to do the source
file mapping.

This PR moves this call before we do the source file map for frame's
files.

This also removes the DebuggedProcess in AD7DocumentContext and cleans
up the constructors and those who initalize the AD7DocumentContext.