### PR TITLE
Add support for MSYS2

### DIFF
--- a/src/MIDebugEngine/Engine.Impl/DebuggedProcess.cs
+++ b/src/MIDebugEngine/Engine.Impl/DebuggedProcess.cs
@@ -845,7 +845,7 @@ namespace Microsoft.MIDebugEngine
                 // mingw will not implement this command, but to be safe, also check if the results contains the string cygwin.
                 LaunchCommand lc = new LaunchCommand("show configuration", null, true, null, (string resStr) =>
                 {
-                    if (resStr.Contains("cygwin"))
+                    if (resStr.Contains("cygwin") || resStr.Contains("msys"))
                     {
                         this.IsCygwin = true;
                         this.CygwinFilePathMapper = new CygwinFilePathMapper(this);

--- a/src/MIDebugEngine/Engine.Impl/DebuggedProcess.cs
+++ b/src/MIDebugEngine/Engine.Impl/DebuggedProcess.cs
@@ -13,6 +13,7 @@ using System.IO;
 using System.Linq;
 using System.Reflection;
 using System.Text;
+using System.Text.RegularExpressions;
 using System.Threading;
 using System.Threading.Tasks;
 using Logger = MICore.Logger;
@@ -845,7 +846,9 @@ namespace Microsoft.MIDebugEngine
                 // mingw will not implement this command, but to be safe, also check if the results contains the string cygwin.
                 LaunchCommand lc = new LaunchCommand("show configuration", null, true, null, (string resStr) =>
                 {
-                    if (resStr.Contains("cygwin") || resStr.Contains("msys"))
+                    // Look to see if configuration has "cywgin" within a word boundry.
+                    // Also look for "msys" since it is a modified version of Cygwin.
+                    if (Regex.IsMatch(resStr, "\\bcygwin\\b|\\bmsys\\b"))
                     {
                         this.IsCygwin = true;
                         this.CygwinFilePathMapper = new CygwinFilePathMapper(this);


### PR DESCRIPTION
From https://www.msys2.org/:
	MSYS2 is a collection of tools and libraries providing you with an
	easy-to-use environment for building, installing and running native
	Windows software.

	It consists of a command line terminal called mintty, bash, version
	control systems like git and subversion, tools like tar and awk and even
	build systems like autotools, all based on a modified version of Cygwin.

This PR enables MSYS2 to be similar to be Cygwin and enable Cygwin
PathMapping.

Similar to how we determine if we were running a `cygwin` GDB by running `show configuration`, 
we detect if we are `msys` if we see `msys` in the output.

<details>
<summary>
GDB Information
</summary>

```
GNU gdb (GDB) 9.2
Copyright (C) 2020 Free Software Foundation, Inc.
License GPLv3+: GNU GPL version 3 or later <http://gnu.org/licenses/gpl.html>
This is free software: you are free to change and redistribute it.
There is NO WARRANTY, to the extent permitted by law.
Type "show copying" and "show warranty" for details.
This GDB was configured as "x86_64-pc-msys".
Type "show configuration" for configuration details.
For bug reporting instructions, please see:
<http://www.gnu.org/software/gdb/bugs/>.
Find the GDB manual and other documentation resources online at:
    <http://www.gnu.org/software/gdb/documentation/>.

For help, type "help".
Type "apropos word" to search for commands related to "word".
(gdb) show configuration
This GDB was configured as follows:
   configure --host=x86_64-pc-msys --target=x86_64-pc-msys
             --with-auto-load-dir=$debugdir:$datadir/auto-load
             --with-auto-load-safe-path=$debugdir:$datadir/auto-load
             --with-expat
             --with-gdb-datadir=/usr/share/gdb (relocatable)
             --with-jit-reader-dir=/usr/lib/gdb (relocatable)
             --without-libunwind-ia64
             --with-lzma
             --without-babeltrace
                             --without-intel-pt
             --with-mpfr
             --without-xxhash
             --with-python=/usr (relocatable)
             --without-guile
             --disable-source-highlight
             --with-separate-debug-dir=/usr/lib/debug (relocatable)
             --with-system-gdbinit=/etc/gdbinit
```

</details>