### PR TITLE
Use SIGTRAP to interrupt a process instead of SIGINT

### DIFF
--- a/src/MICore/CommandFactories/MICommandFactory.cs
+++ b/src/MICore/CommandFactories/MICommandFactory.cs
@@ -630,7 +630,8 @@ namespace MICore
 
             if (results.TryFindString("reason") == "signal-received")
             {
-                if (results.TryFindString("signal-name") == "SIGINT")
+                if (results.TryFindString("signal-name") == "SIGINT" || 
+                    results.TryFindString("signal-name") == "SIGTRAP")
                 {
                     isAsyncBreak = true;
                 }

--- a/src/MICore/Debugger.cs
+++ b/src/MICore/Debugger.cs
@@ -906,7 +906,7 @@ namespace MICore
 
         private Task<Results> CmdBreakUnix(int debugeePid, ResultClass expectedResultClass)
         {
-            // Send sigint to the debuggee process. This is the equivalent of hitting ctrl-c on the console.
+            // Send sigtrap to the debuggee process. This is the equivalent of hitting ctrl-c on the console.
             // This will cause gdb to async-break. This is necessary because gdb does not support async break
             // when attached.
             UnixUtilities.Interrupt(debugeePid);

--- a/src/MICore/Transports/PipeTransport.cs
+++ b/src/MICore/Transports/PipeTransport.cs
@@ -41,7 +41,7 @@ namespace MICore
                 return false;
             }
 
-            string killCmd = string.Format(CultureInfo.InvariantCulture, "kill -2 {0}", pid);
+            string killCmd = string.Format(CultureInfo.InvariantCulture, "kill -5 {0}", pid);
             return WrappedExecuteSyncCommand(MICoreResources.Info_KillingPipeProcess, killCmd, Timeout.Infinite) == 0;
         }
 

--- a/src/MICore/Transports/UnixShellPortTransport.cs
+++ b/src/MICore/Transports/UnixShellPortTransport.cs
@@ -141,7 +141,7 @@ namespace MICore
 
         public bool Interrupt(int pid)
         {
-            string killCmd = string.Format(CultureInfo.InvariantCulture, "kill -2 {0}", pid);
+            string killCmd = string.Format(CultureInfo.InvariantCulture, "kill -5 {0}", pid);
 
             try
             {

--- a/src/MICore/UnixUtilities.cs
+++ b/src/MICore/UnixUtilities.cs
@@ -253,7 +253,7 @@ namespace MICore
 
         internal static void Interrupt(int pid)
         {
-            Kill(pid, 2);
+            Kill(pid, 5);
         }
 
         private static void Kill(int pid, int signal)


### PR DESCRIPTION
Because of https://bugzilla.kernel.org/show_bug.cgi?id=9039, when
a program blocks a signal because it uses sigwait() or signalfd(),
GDB isn't notified of the signal via ptrace and cannot intercept it.

For MIEngine, this means that whenever MIEngine attaches to a process
using signalfd() or sigwait() to process SIGINT, any SIGINT signal
sent by MIEngine to interrupt gdb is delivered to the process instead
which usually handles the signal by exiting.

As a workaround, let's use SIGTRAP instead. SIGTRAP is explicitly
defined as a signal to inform the debugger that some condition has
occurred that it has requested to be informed of. As such, it is a
lot less likely to be blocked by programs compared to SIGINT. Because
it isn't blocked most of the time, gdb will be able to intercept it
and it won't be delivered to the program.

```
SIGTRAP
   ; The SIGTRAP signal is sent to a process when an exception (or trap) occurs: a condition that a debugger has requested to be informed of — for example, when a particular function is executed, or when a particular variable changes value.
```

Fixes https://github.com/microsoft/vscode-cpptools/issues/6704.