### PR TITLE
Add support for debugging macOS app bundles

### DIFF
--- a/src/OpenDebugAD7/AD7DebugSession.cs
+++ b/src/OpenDebugAD7/AD7DebugSession.cs
@@ -174,7 +174,7 @@ namespace OpenDebugAD7
                 // On macOS, check to see if we are trying to debug an app bundle (.app).
                 // 'app bundles' contain various resources and executables in a folder.
                 // LLDB understands how to target these bundles.
-                if (Utilities.IsOSX() && program.EndsWith(".app", StringComparison.OrdinalIgnoreCase) && miMode.Equals("lldb", StringComparison.OrdinalIgnoreCase))
+                if (Utilities.IsOSX() && program.EndsWith(".app", StringComparison.OrdinalIgnoreCase) && miMode?.Equals("lldb", StringComparison.OrdinalIgnoreCase) == true)
                 {
                     return Directory.Exists(program);
                 }

--- a/src/OpenDebugAD7/OpenDebug/Utilities.cs
+++ b/src/OpenDebugAD7/OpenDebug/Utilities.cs
@@ -47,17 +47,19 @@ namespace OpenDebug
 
         private static RuntimePlatform CalculateRuntimePlatform()
         {
-            switch (Environment.OSVersion.Platform)
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
             {
-                case PlatformID.Win32NT:
-                    return RuntimePlatform.Windows;
-                case PlatformID.Unix:
-                    return RuntimePlatform.Unix;
-                case PlatformID.MacOSX:
-                    return RuntimePlatform.MacOSX;
-                default:
-                    return RuntimePlatform.Unknown;
+                return RuntimePlatform.Windows;
             }
+            else if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
+            {
+                return RuntimePlatform.MacOSX;
+            }
+            else if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
+            {
+                return RuntimePlatform.Unix;
+            }
+            return RuntimePlatform.Unknown;
         }
 
         /*

--- a/test/CppTests/TestConfigurations/config_lldb.xml
+++ b/test/CppTests/TestConfigurations/config_lldb.xml
@@ -5,12 +5,20 @@
       Compiler="Clang"
       DebuggeeArchitecture="x64"
       Debugger="Lldb" />
+    <TestConfiguration
+        Compiler="xcoderun"
+        DebuggeeArchitecture="x64"
+        Debugger="Lldb" />
   </TestConfigurations>
   <Compilers>
     <Compiler
       Name="Clang"
       Type="ClangPlusPlus"
       Path="/usr/bin/clang++" />
+    <Compiler
+      Name="xcoderun"
+      Type="XCodeBuild"
+      Path="/usr/bin/xcodebuild" />
   </Compilers>
   <Debuggers>
     <!-- By not specifying the Path, LLDB that ships with the extension will be used. -->

--- a/test/CppTests/Tests/MacOSAppTests.cs
+++ b/test/CppTests/Tests/MacOSAppTests.cs
@@ -1,0 +1,82 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net;
+using System.Threading;
+using DebuggerTesting;
+using DebuggerTesting.Compilation;
+using DebuggerTesting.OpenDebug;
+using DebuggerTesting.OpenDebug.Commands;
+using DebuggerTesting.OpenDebug.CrossPlatCpp;
+using DebuggerTesting.OpenDebug.Events;
+using DebuggerTesting.OpenDebug.Extensions;
+using DebuggerTesting.Ordering;
+using DebuggerTesting.Utilities;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace CppTests.Tests
+{
+    [TestCaseOrderer(DependencyTestOrderer.TypeName, DependencyTestOrderer.AssemblyName)]
+    public class MacOSAppTests : TestBase
+    {
+        #region Constructor
+
+        public MacOSAppTests(ITestOutputHelper outputHelper) : base(outputHelper)
+        {
+        }
+
+        #endregion
+
+        #region Methods
+
+        [Theory]
+        [RequiresTestSettings]
+        [SupportedCompiler(SupportedCompiler.XCodeBuild, SupportedArchitecture.x64)]
+        public void CompileMacOSAppForTests(ITestSettings settings)
+        {
+            this.TestPurpose("Compile MacOSApp debuggee for tests.");
+            this.WriteSettings(settings);
+
+            IDebuggee debuggee = Debuggee.Create(this, settings.CompilerSettings, "MacOSApp", 1, "TestApp.app", CompilerOutputType.MacOSApp);
+            
+            debuggee.AddSourceFiles("TestApp.xcodeproj");
+
+            debuggee.Compile();
+        }
+
+        [Theory]
+        [DependsOnTest(nameof(CompileMacOSAppForTests))]
+        [RequiresTestSettings]
+        [SupportedCompiler(SupportedCompiler.XCodeBuild, SupportedArchitecture.x64)]
+        public void MacOSAppBasic(ITestSettings settings)
+        {
+            IDebuggee debuggee = Debuggee.Open(this, settings.CompilerSettings, "MacOSApp", 1, "TestApp.app", CompilerOutputType.MacOSApp);
+
+            using (IDebuggerRunner runner = CreateDebugAdapterRunner(settings))
+            {
+                this.Comment("Configure launch.");
+                runner.Launch(settings.DebuggerSettings, debuggee, null);
+
+                SourceBreakpoints mainBreakpoints = debuggee.Breakpoints(SinkHelper.Main, 14);
+                runner.SetBreakpoints(mainBreakpoints);
+
+                this.Comment("Launch and run until first breakpoint");
+                runner.Expects.HitBreakpointEvent(SinkHelper.Main, 14)
+                              .AfterConfigurationDone();
+
+                this.Comment("Continue until end");
+                    runner.Expects.ExitedEvent()
+                                .TerminatedEvent()
+                                .AfterContinue();
+
+                    runner.DisconnectAndVerify();
+            }
+        }
+
+        #endregion
+    }
+}

--- a/test/CppTests/debuggees/MacOSApp/src/Shared/Assets.xcassets/AccentColor.colorset/Contents.json
+++ b/test/CppTests/debuggees/MacOSApp/src/Shared/Assets.xcassets/AccentColor.colorset/Contents.json
@@ -1,0 +1,11 @@
+{
+  "colors" : [
+    {
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/test/CppTests/debuggees/MacOSApp/src/Shared/Assets.xcassets/AppIcon.appiconset/Contents.json
+++ b/test/CppTests/debuggees/MacOSApp/src/Shared/Assets.xcassets/AppIcon.appiconset/Contents.json
@@ -1,0 +1,148 @@
+{
+  "images" : [
+    {
+      "idiom" : "iphone",
+      "scale" : "2x",
+      "size" : "20x20"
+    },
+    {
+      "idiom" : "iphone",
+      "scale" : "3x",
+      "size" : "20x20"
+    },
+    {
+      "idiom" : "iphone",
+      "scale" : "2x",
+      "size" : "29x29"
+    },
+    {
+      "idiom" : "iphone",
+      "scale" : "3x",
+      "size" : "29x29"
+    },
+    {
+      "idiom" : "iphone",
+      "scale" : "2x",
+      "size" : "40x40"
+    },
+    {
+      "idiom" : "iphone",
+      "scale" : "3x",
+      "size" : "40x40"
+    },
+    {
+      "idiom" : "iphone",
+      "scale" : "2x",
+      "size" : "60x60"
+    },
+    {
+      "idiom" : "iphone",
+      "scale" : "3x",
+      "size" : "60x60"
+    },
+    {
+      "idiom" : "ipad",
+      "scale" : "1x",
+      "size" : "20x20"
+    },
+    {
+      "idiom" : "ipad",
+      "scale" : "2x",
+      "size" : "20x20"
+    },
+    {
+      "idiom" : "ipad",
+      "scale" : "1x",
+      "size" : "29x29"
+    },
+    {
+      "idiom" : "ipad",
+      "scale" : "2x",
+      "size" : "29x29"
+    },
+    {
+      "idiom" : "ipad",
+      "scale" : "1x",
+      "size" : "40x40"
+    },
+    {
+      "idiom" : "ipad",
+      "scale" : "2x",
+      "size" : "40x40"
+    },
+    {
+      "idiom" : "ipad",
+      "scale" : "1x",
+      "size" : "76x76"
+    },
+    {
+      "idiom" : "ipad",
+      "scale" : "2x",
+      "size" : "76x76"
+    },
+    {
+      "idiom" : "ipad",
+      "scale" : "2x",
+      "size" : "83.5x83.5"
+    },
+    {
+      "idiom" : "ios-marketing",
+      "scale" : "1x",
+      "size" : "1024x1024"
+    },
+    {
+      "idiom" : "mac",
+      "scale" : "1x",
+      "size" : "16x16"
+    },
+    {
+      "idiom" : "mac",
+      "scale" : "2x",
+      "size" : "16x16"
+    },
+    {
+      "idiom" : "mac",
+      "scale" : "1x",
+      "size" : "32x32"
+    },
+    {
+      "idiom" : "mac",
+      "scale" : "2x",
+      "size" : "32x32"
+    },
+    {
+      "idiom" : "mac",
+      "scale" : "1x",
+      "size" : "128x128"
+    },
+    {
+      "idiom" : "mac",
+      "scale" : "2x",
+      "size" : "128x128"
+    },
+    {
+      "idiom" : "mac",
+      "scale" : "1x",
+      "size" : "256x256"
+    },
+    {
+      "idiom" : "mac",
+      "scale" : "2x",
+      "size" : "256x256"
+    },
+    {
+      "idiom" : "mac",
+      "scale" : "1x",
+      "size" : "512x512"
+    },
+    {
+      "idiom" : "mac",
+      "scale" : "2x",
+      "size" : "512x512"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/test/CppTests/debuggees/MacOSApp/src/Shared/Assets.xcassets/Contents.json
+++ b/test/CppTests/debuggees/MacOSApp/src/Shared/Assets.xcassets/Contents.json
@@ -1,0 +1,6 @@
+{
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/test/CppTests/debuggees/MacOSApp/src/Shared/main.cpp
+++ b/test/CppTests/debuggees/MacOSApp/src/Shared/main.cpp
@@ -1,0 +1,21 @@
+//
+//  main.cpp
+//  TestApp
+//
+//  Created by Andrew Wang on 8/31/21.
+//
+
+#include "main.hpp"
+
+int main(int argc, char **argv)
+{
+    int i = 0;
+
+    printf("Hello from XCodeBuild\n");
+
+    i = i + 1;
+
+    printf("Goodbye from XCodeBuild");
+
+    return 0;
+}

--- a/test/CppTests/debuggees/MacOSApp/src/Shared/main.hpp
+++ b/test/CppTests/debuggees/MacOSApp/src/Shared/main.hpp
@@ -1,0 +1,13 @@
+//
+//  main.hpp
+//  TestApp
+//
+//  Created by Andrew Wang on 8/31/21.
+//
+
+#ifndef main_hpp
+#define main_hpp
+
+#include <stdio.h>
+
+#endif /* main_hpp */

--- a/test/CppTests/debuggees/MacOSApp/src/TestApp.xcodeproj/project.pbxproj
+++ b/test/CppTests/debuggees/MacOSApp/src/TestApp.xcodeproj/project.pbxproj
@@ -1,0 +1,313 @@
+// !$*UTF8*$!
+{
+	archiveVersion = 1;
+	classes = {
+	};
+	objectVersion = 50;
+	objects = {
+
+/* Begin PBXBuildFile section */
+		90383F7326DF005800AECE94 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 90383F5D26DF005800AECE94 /* Assets.xcassets */; };
+		90383F7F26DF009800AECE94 /* main.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 90383F7C26DF009800AECE94 /* main.cpp */; };
+/* End PBXBuildFile section */
+
+/* Begin PBXFileReference section */
+		90383F5D26DF005800AECE94 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
+		90383F6A26DF005800AECE94 /* TestApp.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = TestApp.app; sourceTree = BUILT_PRODUCTS_DIR; };
+		90383F6C26DF005800AECE94 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		90383F6D26DF005800AECE94 /* macOS.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = macOS.entitlements; sourceTree = "<group>"; };
+		90383F7C26DF009800AECE94 /* main.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = main.cpp; sourceTree = "<group>"; };
+		90383F7D26DF009800AECE94 /* main.hpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.h; path = main.hpp; sourceTree = "<group>"; };
+/* End PBXFileReference section */
+
+/* Begin PBXGroup section */
+		90383F5526DF005600AECE94 = {
+			isa = PBXGroup;
+			children = (
+				90383F5A26DF005600AECE94 /* Shared */,
+				90383F6B26DF005800AECE94 /* macOS */,
+				90383F6326DF005800AECE94 /* Products */,
+			);
+			sourceTree = "<group>";
+		};
+		90383F5A26DF005600AECE94 /* Shared */ = {
+			isa = PBXGroup;
+			children = (
+				90383F5D26DF005800AECE94 /* Assets.xcassets */,
+				90383F7C26DF009800AECE94 /* main.cpp */,
+				90383F7D26DF009800AECE94 /* main.hpp */,
+			);
+			path = Shared;
+			sourceTree = "<group>";
+		};
+		90383F6326DF005800AECE94 /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				90383F6A26DF005800AECE94 /* TestApp.app */,
+			);
+			name = Products;
+			sourceTree = "<group>";
+		};
+		90383F6B26DF005800AECE94 /* macOS */ = {
+			isa = PBXGroup;
+			children = (
+				90383F6C26DF005800AECE94 /* Info.plist */,
+				90383F6D26DF005800AECE94 /* macOS.entitlements */,
+			);
+			path = macOS;
+			sourceTree = "<group>";
+		};
+/* End PBXGroup section */
+
+/* Begin PBXNativeTarget section */
+		90383F6926DF005800AECE94 /* TestApp (macOS) */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 90383F7926DF005800AECE94 /* Build configuration list for PBXNativeTarget "TestApp (macOS)" */;
+			buildPhases = (
+				90383F6626DF005800AECE94 /* Sources */,
+				90383F6826DF005800AECE94 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = "TestApp (macOS)";
+			productName = "TestApp (macOS)";
+			productReference = 90383F6A26DF005800AECE94 /* TestApp.app */;
+			productType = "com.apple.product-type.application";
+		};
+/* End PBXNativeTarget section */
+
+/* Begin PBXProject section */
+		90383F5626DF005600AECE94 /* Project object */ = {
+			isa = PBXProject;
+			attributes = {
+				LastSwiftUpdateCheck = 1250;
+				LastUpgradeCheck = 1250;
+				TargetAttributes = {
+					90383F6926DF005800AECE94 = {
+						CreatedOnToolsVersion = 12.5.1;
+					};
+				};
+			};
+			buildConfigurationList = 90383F5926DF005600AECE94 /* Build configuration list for PBXProject "TestApp" */;
+			compatibilityVersion = "Xcode 9.3";
+			developmentRegion = en;
+			hasScannedForEncodings = 0;
+			knownRegions = (
+				en,
+				Base,
+			);
+			mainGroup = 90383F5526DF005600AECE94;
+			productRefGroup = 90383F6326DF005800AECE94 /* Products */;
+			projectDirPath = "";
+			projectRoot = "";
+			targets = (
+				90383F6926DF005800AECE94 /* TestApp (macOS) */,
+			);
+		};
+/* End PBXProject section */
+
+/* Begin PBXResourcesBuildPhase section */
+		90383F6826DF005800AECE94 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				90383F7326DF005800AECE94 /* Assets.xcassets in Resources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXResourcesBuildPhase section */
+
+/* Begin PBXSourcesBuildPhase section */
+		90383F6626DF005800AECE94 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				90383F7F26DF009800AECE94 /* main.cpp in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXSourcesBuildPhase section */
+
+/* Begin XCBuildConfiguration section */
+		90383F7426DF005800AECE94 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++14";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = dwarf;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_TESTABILITY = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu11;
+				GCC_DYNAMIC_NO_PIC = NO;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"DEBUG=1",
+					"$(inherited)",
+				);
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
+				MTL_FAST_MATH = YES;
+				ONLY_ACTIVE_ARCH = YES;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+			};
+			name = Debug;
+		};
+		90383F7526DF005800AECE94 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++14";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				ENABLE_NS_ASSERTIONS = NO;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu11;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				MTL_ENABLE_DEBUG_INFO = NO;
+				MTL_FAST_MATH = YES;
+				SWIFT_COMPILATION_MODE = wholemodule;
+				SWIFT_OPTIMIZATION_LEVEL = "-O";
+			};
+			name = Release;
+		};
+		90383F7A26DF005800AECE94 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				CODE_SIGN_ENTITLEMENTS = macOS/macOS.entitlements;
+				CODE_SIGN_STYLE = Automatic;
+				COMBINE_HIDPI_IMAGES = YES;
+				ENABLE_PREVIEWS = YES;
+				INFOPLIST_FILE = macOS/Info.plist;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/../Frameworks",
+				);
+				MACOSX_DEPLOYMENT_TARGET = 11.0;
+				PRODUCT_BUNDLE_IDENTIFIER = com.microsoft.TestApp;
+				PRODUCT_NAME = TestApp;
+				SDKROOT = macosx;
+				SWIFT_VERSION = 5.0;
+			};
+			name = Debug;
+		};
+		90383F7B26DF005800AECE94 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				CODE_SIGN_ENTITLEMENTS = macOS/macOS.entitlements;
+				CODE_SIGN_STYLE = Automatic;
+				COMBINE_HIDPI_IMAGES = YES;
+				ENABLE_PREVIEWS = YES;
+				INFOPLIST_FILE = macOS/Info.plist;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/../Frameworks",
+				);
+				MACOSX_DEPLOYMENT_TARGET = 11.0;
+				PRODUCT_BUNDLE_IDENTIFIER = com.microsoft.TestApp;
+				PRODUCT_NAME = TestApp;
+				SDKROOT = macosx;
+				SWIFT_VERSION = 5.0;
+			};
+			name = Release;
+		};
+/* End XCBuildConfiguration section */
+
+/* Begin XCConfigurationList section */
+		90383F5926DF005600AECE94 /* Build configuration list for PBXProject "TestApp" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				90383F7426DF005800AECE94 /* Debug */,
+				90383F7526DF005800AECE94 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		90383F7926DF005800AECE94 /* Build configuration list for PBXNativeTarget "TestApp (macOS)" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				90383F7A26DF005800AECE94 /* Debug */,
+				90383F7B26DF005800AECE94 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+/* End XCConfigurationList section */
+	};
+	rootObject = 90383F5626DF005600AECE94 /* Project object */;
+}

--- a/test/CppTests/debuggees/MacOSApp/src/TestApp.xcodeproj/project.xcworkspace/contents.xcworkspacedata
+++ b/test/CppTests/debuggees/MacOSApp/src/TestApp.xcodeproj/project.xcworkspace/contents.xcworkspacedata
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Workspace
+   version = "1.0">
+   <FileRef
+      location = "self:">
+   </FileRef>
+</Workspace>

--- a/test/CppTests/debuggees/MacOSApp/src/TestApp.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
+++ b/test/CppTests/debuggees/MacOSApp/src/TestApp.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>IDEDidComputeMac32BitWarning</key>
+	<true/>
+</dict>
+</plist>

--- a/test/CppTests/debuggees/MacOSApp/src/macOS/Info.plist
+++ b/test/CppTests/debuggees/MacOSApp/src/macOS/Info.plist
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>$(DEVELOPMENT_LANGUAGE)</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIconFile</key>
+	<string></string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleVersion</key>
+	<string>1</string>
+	<key>LSMinimumSystemVersion</key>
+	<string>$(MACOSX_DEPLOYMENT_TARGET)</string>
+</dict>
+</plist>

--- a/test/CppTests/debuggees/MacOSApp/src/macOS/macOS.entitlements
+++ b/test/CppTests/debuggees/MacOSApp/src/macOS/macOS.entitlements
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>com.apple.security.app-sandbox</key>
+    <true/>
+    <key>com.apple.security.files.user-selected.read-only</key>
+    <true/>
+</dict>
+</plist>

--- a/test/DebuggerTesting/Attribution/TestSettingsHelper.cs
+++ b/test/DebuggerTesting/Attribution/TestSettingsHelper.cs
@@ -36,11 +36,25 @@ namespace DebuggerTesting
             IReadOnlyCollection<SupportedDebuggerAttribute> supportedDebuggers = methodInfo.GetCustomAttributes<SupportedDebuggerAttribute>().ToArray();
             IReadOnlyCollection<UnsupportedDebuggerAttribute> unsupportedDebuggers = methodInfo.GetCustomAttributes<UnsupportedDebuggerAttribute>().ToArray();
 
+            // Remove XCodeBuild from default list of SupportedCompilers since its special cased for .xcodeproj.
+            if (supportedCompilers.Count == 0)
+            {
+                supportedCompilers = new List<SupportedCompilerAttribute>()
+                {
+                    new SupportedCompilerAttribute(SupportedCompiler.GPlusPlus, SupportedArchitecture.x86),
+                    new SupportedCompilerAttribute(SupportedCompiler.GPlusPlus, SupportedArchitecture.x64),
+                    new SupportedCompilerAttribute(SupportedCompiler.ClangPlusPlus, SupportedArchitecture.x86),
+                    new SupportedCompilerAttribute(SupportedCompiler.ClangPlusPlus, SupportedArchitecture.x64),
+                    new SupportedCompilerAttribute(SupportedCompiler.VisualCPlusPlus, SupportedArchitecture.x86),
+                    new SupportedCompilerAttribute(SupportedCompiler.VisualCPlusPlus, SupportedArchitecture.x64)
+                };
+            }
+
             // Get the subset of test settings that match the requirements of the test.
             // The test will be run for each test setting in the set. If an empty set is returned,
             // the test is not run.
             return settings.Where(s =>
-                (supportedCompilers.Count == 0 || supportedCompilers.Matches(s.CompilerSettings)) &&
+                supportedCompilers.Matches(s.CompilerSettings) &&
                 (supportedDebuggers.Count == 0 || supportedDebuggers.Matches(s.DebuggerSettings)) &&
                 !unsupportedDebuggers.Matches(s.DebuggerSettings))
                 .Select(x => TestSettings.CloneWithName(x, methodInfo.Name))

--- a/test/DebuggerTesting/Compilation/CompilerBase.cs
+++ b/test/DebuggerTesting/Compilation/CompilerBase.cs
@@ -53,7 +53,15 @@ namespace DebuggerTesting.Compilation
             Assert.True(result, "The compilation failed.");
 
             // If the output file was not created, then error
-            Assert.True(File.Exists(targetFilePath), "The compiler did not create the expected output. " + targetFilePath);
+            if (outputType == CompilerOutputType.MacOSApp)
+            {
+                // .app on macOS is a special folder
+                Assert.True(Directory.Exists(targetFilePath), "The compiler did not create the expected output. " + targetFilePath);
+            }
+            else
+            {
+                Assert.True(File.Exists(targetFilePath), "The compiler did not create the expected output. " + targetFilePath);
+            }
         }
 
         #endregion

--- a/test/DebuggerTesting/Compilation/CompilerOutputType.cs
+++ b/test/DebuggerTesting/Compilation/CompilerOutputType.cs
@@ -8,6 +8,7 @@ namespace DebuggerTesting.Compilation
         Unspecified = 0,
         ObjectFile,
         SharedLibrary,
-        Executable
+        Executable,
+        MacOSApp
     }
 }

--- a/test/DebuggerTesting/Compilation/Debuggee.cs
+++ b/test/DebuggerTesting/Compilation/Debuggee.cs
@@ -170,6 +170,8 @@ namespace DebuggerTesting.Compilation
                     return new ClangCompiler(logger, settings);
                 case SupportedCompiler.VisualCPlusPlus:
                     return new VisualCPlusPlusCompiler(logger, settings);
+                case SupportedCompiler.XCodeBuild:
+                    return new XCodeCompiler(logger, settings);
                 default:
                     throw new ArgumentOutOfRangeException(nameof(settings.CompilerType), "Unhandled compiler toolset: " + settings.CompilerType);
             }
@@ -209,6 +211,8 @@ namespace DebuggerTesting.Compilation
                         return Path.ChangeExtension(outputName, "dll");
                     else
                         return Path.ChangeExtension(outputName, "so");
+                case CompilerOutputType.MacOSApp:
+                        return Path.ChangeExtension(outputName, "app");
                 default:
                     throw new NotSupportedException("Support for output type '{0}' has not been implemented.".FormatInvariantWithArgs(outputType));
             }

--- a/test/DebuggerTesting/Compilation/XCodeRunCompiler.cs
+++ b/test/DebuggerTesting/Compilation/XCodeRunCompiler.cs
@@ -1,0 +1,65 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.IO;
+using System.Collections.Generic;
+using DebuggerTesting.Utilities;
+
+namespace DebuggerTesting.Compilation
+{
+    internal sealed class XCodeCompiler :
+        CompilerBase
+    {
+        #region Constructor
+
+        public XCodeCompiler(ILoggingComponent logger, ICompilerSettings settings)
+            : base(logger, settings, false)
+        {
+        }
+
+        #endregion
+
+        #region Methods
+
+        protected override bool CompileCore(
+            CompilerOutputType outputType,
+            SupportedArchitecture architecture,
+            IEnumerable<string> libraries,
+            IEnumerable<string> sourceFilePaths,
+            string targetFilePath,
+            CompilerOption options,
+            IDictionary<string, string> defineConstants)
+        {
+            if (outputType != CompilerOutputType.MacOSApp)
+            {
+                throw new InvalidOperationException("Output type is: " + outputType);
+            }
+
+            //xcodebuild -project TestApp.xcodeproj -configuration Debug -scheme "TestApp (macOS)" CONFIGURATION_BUILD_DIR="./out/xcoderun/x64/"
+
+            string project = string.Empty;
+            foreach (string sourceFile in sourceFilePaths)
+            {
+                if (sourceFile.EndsWith(".xcodeproj"))
+                {
+                    project = sourceFile;
+                }
+            }
+
+            if (string.IsNullOrWhiteSpace(project))
+            {
+                throw new InvalidOperationException(".xcodeproj is missing");
+            }
+
+            ArgumentBuilder builder = new ArgumentBuilder("-", " ");
+            builder.AppendNamedArgument("project", project);
+            builder.AppendNamedArgument("configuration", "Debug");
+            builder.AppendNamedArgumentQuoted("scheme", "TestApp (macOS)");
+
+            return 0 == this.RunCompiler(builder.ToString() + " CONFIGURATION_BUILD_DIR=\"" + Path.GetDirectoryName(targetFilePath) + "\"", targetFilePath);
+        }
+
+        #endregion
+    }
+}

--- a/test/DebuggerTesting/SupportedCompiler.cs
+++ b/test/DebuggerTesting/SupportedCompiler.cs
@@ -11,5 +11,6 @@ namespace DebuggerTesting
         ClangPlusPlus = 0x1,
         GPlusPlus = 0x2,
         VisualCPlusPlus = 0x4,
+        XCodeBuild = 0x8
     }
 }


### PR DESCRIPTION
This PR adds support for debugging app bundles on macOS.

LLDB understands how to handle app bundles when provided to
-file-exec-and-symbols.

Reference:
./lldb-mi
(gdb)
-file-exec-and-symbols /Applications/VLC.app
^done
(gdb)
=library-loaded,id="/Applications/VLC.app/Contents/MacOS/VLC",target-name="/Applications/VLC.app/Contents/MacOS/VLC",host-name="/Applications/VLC.app/Contents/MacOS/VLC",symbols-loaded="0",loaded_addr="-",size="20480"

Added MacOSApp Test to CppTests. 