### PR TITLE
Ensure filename is formatted for the host OS.

### DIFF
--- a/src/MIDebugEngine/Engine.Impl/MITextPosition.cs
+++ b/src/MIDebugEngine/Engine.Impl/MITextPosition.cs
@@ -39,6 +39,8 @@ namespace Microsoft.MIDebugEngine
             if (string.IsNullOrWhiteSpace(filename))
                 return null;
 
+            filename = PlatformUtilities.PathToHostOSPath(filename);
+
             uint? line = miTuple.TryFindUint("line");
             if (!line.HasValue || line.Value == 0)
                 return null;


### PR DESCRIPTION
In cross complie scenarios I have seen filename symbols in the .out file partially formatted in unix style and partially in Windows:

    <11>   DW_AT_name        : (indirect string, offset: 0x1709): ../../../hello_world.cpp
    <15>   DW_AT_comp_dir    : (indirect string, offset: 0x1922): C:\temp\raspi-toolchain\hello_world\out\build\x64-Debug

Which results in gdb returning file names like this:

    "C:\\temp\\raspi-toolchain\\hello_world\\out\\build\\x64-Debug/../../../hello_world.cpp"

VS doesn't understand names in this format so cannot find the source; replace the '/'s with '\\'.