### PR TITLE
Remove entry breakpoint after stopping without reason

### DIFF
--- a/src/MIDebugEngine/Engine.Impl/DebuggedProcess.cs
+++ b/src/MIDebugEngine/Engine.Impl/DebuggedProcess.cs
@@ -1109,11 +1109,13 @@ namespace Microsoft.MIDebugEngine
                     if (frame.Contains("file"))
                     {
                         this.EntrypointHit = true;
+                        await this.OnEntrypointHit();
                     }
                 }
                 else
                 {
                     this.EntrypointHit = true;
+                    await this.OnEntrypointHit();
                 }
 
                 CmdContinueAsync();


### PR DESCRIPTION
Attempting to launch a debug configuration in VS Code using OpenOCD targeting an ARM microcontroller throws a spurious exception on entry.

What's happening is MIEngine adds a breakpoint on `main` with `-break-insert -f main`, then connects to the remote target. The target immediately responds with `*stopped,` which triggers the code path edited in this PR and sets `EntrypointHit` to `true`. However, the breakpoint on `main` is still set. Shortly, OpenOCD sends a `breakpoint-hit` event, but the entry breakpoint does not exist in the `_breakpointManager`, only in `_entryPointBreakpoint`, so it's treated as an exception instead.

The fix calls `OnEntrypointHit()` after changing the value of `EntrypointHit` to ensure that the breakpoint is removed before continuing execution.

cc @aleun

![image](https://user-images.githubusercontent.com/6981284/109362785-9a7c2780-7840-11eb-9991-02c7eceb1cf7.png)

Relevant portion of the log:

```
1: (500) <-1010-break-insert -f main
1: (500) ->&"\n"
1: (500) ->^done
1: (500) ->(gdb)
1: (500) ->1010^done,bkpt={number="1",type="breakpoint",disp="keep",enabled="y",addr="0x08000e66",func="main",file="../main.c",fullname="D:\\repos\\embedded\\examples\\blinky\\AZ3166\\main.c",line="7",thread-groups=["i1"],times="0",original-location="main"}
1: (500) ->(gdb)
1: (500) ->&"\n"
1: (500) ->^done
1: (500) ->(gdb)
1: (504) 1010: elapsed time 4
1: (505) <-1011-target-select remote localhost:3333
1: (2606) ->=thread-group-started,id="i1",pid="42000"
1: (2606) ->=thread-created,id="1",group-id="i1"
1: (2613) <-1012-thread-info 1
1: (2615) ->~"Reset_Handler () at D:/repos/embedded/examples/official-azure-rtos-samples/MXChip/AZ3166/lib/stm32cubef4/Drivers/CMSIS/Device/ST/STM32F4xx/Source/Templates/gcc\\startup_stm32f412rx.s:62\n"
1: (2615) ->~"62\t  ldr   sp, =_estack       /* set stack pointer */\n"
1: (2615) ->*stopped,frame={addr="0x08000e0c",func="Reset_Handler",args=[],file="D:/repos/embedded/examples/official-azure-rtos-samples/MXChip/AZ3166/lib/stm32cubef4/Drivers/CMSIS/Device/ST/STM32F4xx/Source/Templates/gcc\\startup_stm32f412rx.s",fullname="D:\\repos\\embedded\\examples\\official-azure-rtos-samples\\MXChip\\AZ3166\\lib\\stm32cubef4\\Drivers\\CMSIS\\Device\\ST\\STM32F4xx\\Source\\Templates\\gcc\\startup_stm32f412rx.s",line="62",arch="armv7e-m"},thread-id="1",stopped-threads="all"
1: (2615) ->1011^connected
1: (2615) ->(gdb)
1: (2615) ->&"\n"
1: (2615) ->^done
1: (2615) ->(gdb)
1: (2615) ->1012^done,threads=[{id="1",target-id="Remote target",frame={level="0",addr="0x08000e0c",func="Reset_Handler",args=[],file="D:/repos/embedded/examples/official-azure-rtos-samples/MXChip/AZ3166/lib/stm32cubef4/Drivers/CMSIS/Device/ST/STM32F4xx/Source/Templates/gcc\\startup_stm32f412rx.s",fullname="D:\\repos\\embedded\\examples\\official-azure-rtos-samples\\MXChip\\AZ3166\\lib\\stm32cubef4\\Drivers\\CMSIS\\Device\\ST\\STM32F4xx\\Source\\Templates\\gcc\\startup_stm32f412rx.s",line="62",arch="armv7e-m"},state="stopped"}]
1: (2615) ->(gdb)
1: (2616) ->&"\n"
1: (2616) ->^done
1: (2616) ->(gdb)
1: (2619) 1011: elapsed time 2113
1: (2619) 1012: elapsed time 5
1: (2623) Send Event AD7EngineCreateEvent
1: (2625) Send Event AD7ProgramCreateEvent
1: (2653) Send Event AD7LoadCompleteEvent
openocd: Open On-Chip Debugger 0.10.0 (2020-12-28) [https://github.com/sysprogs/openocd]
openocd: Licensed under GNU GPL v2
openocd: libusb1 09e75e98b4d9ea7909e8837b7a3f00dda4589dc3
openocd: For bug reports, read
openocd: 	http://openocd.org/doc/doxygen/bugs.html
openocd: Info : The selected transport took over low-level target control. The results might differ compared to plain JTAG/SWD
openocd: srst_only separate srst_nogate srst_open_drain connect_deassert_srst
openocd: 
openocd: Info : Listening on port 6666 for tcl connections
openocd: Info : Listening on port 4444 for telnet connections
openocd: Info : clock speed 2000 kHz
openocd: Error: libusb_open() failed with LIBUSB_ERROR_NOT_SUPPORTED
openocd: Info : STLINK V2J28M17 (API v2) VID:PID 0483:374B
openocd: Info : Target voltage: 3.293136
openocd: Info : stm32f4x.cpu: hardware has 6 breakpoints, 4 watchpoints
openocd: Info : starting gdb server for stm32f4x.cpu on 3333
openocd: Info : Listening on port 3333 for gdb connections
=thread-group-added,id="i1"
GNU gdb (GNU Arm Embedded Toolchain 9-2020-q2-update) 8.3.1.20191211-git
Copyright (C) 2019 Free Software Foundation, Inc.
License GPLv3+: GNU GPL version 3 or later <http://gnu.org/licenses/gpl.html>
This is free software: you are free to change and redistribute it.
There is NO WARRANTY, to the extent permitted by law.
Type "show copying" and "show warranty" for details.
This GDB was configured as "--host=i686-w64-mingw32 --target=arm-none-eabi".
Type "show configuration" for configuration details.
For bug reporting instructions, please see:
<http://www.gnu.org/software/gdb/bugs/>.
Find the GDB manual and other documentation resources online at:
    <http://www.gnu.org/software/gdb/documentation/>.

For help, type "help".
Type "apropos word" to search for commands related to "word".
Warning: Debuggee TargetArchitecture not detected, assuming x86_64.
=cmd-param-changed,param="pagination",value="off"
openocd: Info : accepting 'gdb' connection on tcp/3333
openocd: Info : device id = 0x30006441
openocd: Info : flash size = 1024 kbytes
openocd: Info : flash size = 512 bytes
openocd: Warn : Prefer GDB command "target extended-remote 3333" instead of "target remote 3333"
Reset_Handler () at D:/repos/embedded/examples/official-azure-rtos-samples/MXChip/AZ3166/lib/stm32cubef4/Drivers/CMSIS/Device/ST/STM32F4xx/Source/Templates/gcc\startup_stm32f412rx.s:62
62	  ldr   sp, =_estack       /* set stack pointer */
1: (2666) <-1013-thread-info
1: (2667) ->1013^done,threads=[{id="1",target-id="Remote target",frame={level="0",addr="0x08000e0c",func="Reset_Handler",args=[],file="D:/repos/embedded/examples/official-azure-rtos-samples/MXChip/AZ3166/lib/stm32cubef4/Drivers/CMSIS/Device/ST/STM32F4xx/Source/Templates/gcc\\startup_stm32f412rx.s",fullname="D:\\repos\\embedded\\examples\\official-azure-rtos-samples\\MXChip\\AZ3166\\lib\\stm32cubef4\\Drivers\\CMSIS\\Device\\ST\\STM32F4xx\\Source\\Templates\\gcc\\startup_stm32f412rx.s",line="62",arch="armv7e-m"},state="stopped"}],current-thread-id="1"
1: (2667) ->(gdb)
1: (2667) ->&"\n"
1: (2667) ->^done
1: (2667) ->(gdb)
1: (2668) 1013: elapsed time 1
1: (2677) <-1014-stack-list-frames 0 1000
1: (2682) ->1014^done,stack=[frame={level="0",addr="0x08000e0c",func="Reset_Handler",file="D:/repos/embedded/examples/official-azure-rtos-samples/MXChip/AZ3166/lib/stm32cubef4/Drivers/CMSIS/Device/ST/STM32F4xx/Source/Templates/gcc\\startup_stm32f412rx.s",fullname="D:\\repos\\embedded\\examples\\official-azure-rtos-samples\\MXChip\\AZ3166\\lib\\stm32cubef4\\Drivers\\CMSIS\\Device\\ST\\STM32F4xx\\Source\\Templates\\gcc\\startup_stm32f412rx.s",line="62",arch="armv7e-m"}]
1: (2682) ->(gdb)
1: (2682) ->&"\n"
1: (2682) ->^done
1: (2682) ->(gdb)
1: (2682) 1014: elapsed time 5
1: (2684) Send Event AD7ProcessInfoUpdatedEvent
1: (2691) Send Event AD7ThreadCreateEvent
1: (2697) <--exec-continue
1: (2698) ->^running
1: (2698) ->*running,thread-id="all"
1: (2698) ->~"Note: automatically using hardware breakpoints for read-only addresses.\n"
Note: automatically using hardware breakpoints for read-only addresses.
1: (2699) ->(gdb)
1: (2700) ->&"\n"
1: (2700) ->^done
1: (2700) ->(gdb)
1: (2838) ->=breakpoint-modified,bkpt={number="1",type="breakpoint",disp="keep",enabled="y",addr="0x08000e66",func="main",file="../main.c",fullname="D:\\repos\\embedded\\examples\\blinky\\AZ3166\\main.c",line="7",thread-groups=["i1"],times="1",original-location="main"}
1: (2840) ->~"\n"
1: (2840) ->~"Breakpoint 1, main () at ../main.c:7\n"
1: (2840) ->~"7\t    GPIO_TypeDef * const port = GPIOC;\n"
1: (2840) ->*stopped,reason="breakpoint-hit",disp="keep",bkptno="1",frame={addr="0x08000e66",func="main",args=[],file="../main.c",fullname="D:\\repos\\embedded\\examples\\blinky\\AZ3166\\main.c",line="7",arch="armv7e-m"},thread-id="1",stopped-threads="all"

Breakpoint 1, main () at ../main.c:7
7	    GPIO_TypeDef * const port = GPIOC;
1: (2841) <-1015-stack-list-frames 0 1000
1: (2853) ->1015^done,stack=[frame={level="0",addr="0x08000e66",func="main",file="../main.c",fullname="D:\\repos\\embedded\\examples\\blinky\\AZ3166\\main.c",line="7",arch="armv7e-m"}]
1: (2853) ->(gdb)
1: (2854) 1015: elapsed time 13
1: (2854) ->&"\n"
1: (2854) ->^done
1: (2854) ->(gdb)
1: (2864) Send Event AD7ExceptionEvent
```