### PR TITLE
Add stopAtConnect option and improve entrypoint breakpoint handling

### DIFF
--- a/src/MICore/JsonLaunchOptions.cs
+++ b/src/MICore/JsonLaunchOptions.cs
@@ -95,6 +95,12 @@ namespace MICore.Json.LaunchOptions
         /// </summary>
         [JsonProperty("setupCommands", DefaultValueHandling = DefaultValueHandling.Ignore)]
         public List<SetupCommand> SetupCommands { get; protected set; }
+
+        /// <summary>
+        /// Optional parameter. If true, the debugger should stop after connecting to the target.
+        /// </summary>
+        [JsonProperty("stopAtConnect", DefaultValueHandling = DefaultValueHandling.Ignore)]
+        public bool? StopAtConnect { get; set; }
     }
 
     public partial class AttachOptions : BaseOptions
@@ -127,7 +133,8 @@ namespace MICore.Json.LaunchOptions
             string miDebuggerServerAddress = null,
             Dictionary<string, object> sourceFileMap = null,
             PipeTransport pipeTransport = null,
-            SymbolLoadInfo symbolLoadInfo = null)
+            SymbolLoadInfo symbolLoadInfo = null,
+            bool? stopAtConnect = null)
         {
             this.Program = program;
             this.Type = type;
@@ -143,6 +150,7 @@ namespace MICore.Json.LaunchOptions
             this.SourceFileMap = sourceFileMap;
             this.PipeTransport = pipeTransport;
             this.SymbolLoadInfo = symbolLoadInfo;
+            this.StopAtConnect = stopAtConnect;
         }
 
         #endregion
@@ -345,7 +353,8 @@ namespace MICore.Json.LaunchOptions
             string coreDumpPath = null,
             bool? externalConsole = null,
             Dictionary<string, object> sourceFileMap = null,
-            PipeTransport pipeTransport = null)
+            PipeTransport pipeTransport = null,
+            bool? stopAtConnect = null)
         {
             this.Program = program;
             this.Args = args;
@@ -374,6 +383,7 @@ namespace MICore.Json.LaunchOptions
             this.ExternalConsole = externalConsole;
             this.SourceFileMap = sourceFileMap;
             this.PipeTransport = pipeTransport;
+            this.StopAtConnect = stopAtConnect;
         }
 
         #endregion

--- a/src/MICore/JsonLaunchOptions.cs
+++ b/src/MICore/JsonLaunchOptions.cs
@@ -95,12 +95,6 @@ namespace MICore.Json.LaunchOptions
         /// </summary>
         [JsonProperty("setupCommands", DefaultValueHandling = DefaultValueHandling.Ignore)]
         public List<SetupCommand> SetupCommands { get; protected set; }
-
-        /// <summary>
-        /// Optional parameter. If true, the debugger should stop after connecting to the target.
-        /// </summary>
-        [JsonProperty("stopAtConnect", DefaultValueHandling = DefaultValueHandling.Ignore)]
-        public bool? StopAtConnect { get; set; }
     }
 
     public partial class AttachOptions : BaseOptions
@@ -133,8 +127,7 @@ namespace MICore.Json.LaunchOptions
             string miDebuggerServerAddress = null,
             Dictionary<string, object> sourceFileMap = null,
             PipeTransport pipeTransport = null,
-            SymbolLoadInfo symbolLoadInfo = null,
-            bool? stopAtConnect = null)
+            SymbolLoadInfo symbolLoadInfo = null)
         {
             this.Program = program;
             this.Type = type;
@@ -150,7 +143,6 @@ namespace MICore.Json.LaunchOptions
             this.SourceFileMap = sourceFileMap;
             this.PipeTransport = pipeTransport;
             this.SymbolLoadInfo = symbolLoadInfo;
-            this.StopAtConnect = stopAtConnect;
         }
 
         #endregion
@@ -312,6 +304,12 @@ namespace MICore.Json.LaunchOptions
         /// </summary>
         [JsonProperty("avoidWindowsConsoleRedirection", DefaultValueHandling = DefaultValueHandling.Ignore)]
         public bool? AvoidWindowsConsoleRedirection { get; set; }
+
+        /// <summary>
+        /// Optional parameter. If true, the debugger should stop after connecting to the target.
+        /// </summary>
+        [JsonProperty("stopAtConnect", DefaultValueHandling = DefaultValueHandling.Ignore)]
+        public bool? StopAtConnect { get; set; }
 
         #endregion
 

--- a/src/MICore/LaunchOptions.cs
+++ b/src/MICore/LaunchOptions.cs
@@ -1126,6 +1126,21 @@ namespace MICore
             }
         }
 
+        private bool _stopAtConnect;
+
+        /// <summary>
+        /// Optional parameter. If true, the debugger should stop after connecting to the target.
+        /// </summary>
+        public bool StopAtConnect
+        {
+            get { return _stopAtConnect; }
+            set
+            {
+                VerifyCanModifyProperty(nameof(StopAtConnect));
+                _stopAtConnect = value;
+            }
+        }
+
         public string GetOptionsString()
         {
             try
@@ -1714,7 +1729,7 @@ namespace MICore
             }
 
             this.SetupCommands = LaunchCommand.CreateCollection(options.SetupCommands);
-
+            this.StopAtConnect = options.StopAtConnect ?? false;
         }
 
         protected void InitializeCommonOptions(Xml.LaunchOptions.BaseLaunchOptions source)

--- a/src/MICore/LaunchOptions.cs
+++ b/src/MICore/LaunchOptions.cs
@@ -1729,7 +1729,7 @@ namespace MICore
             }
 
             this.SetupCommands = LaunchCommand.CreateCollection(options.SetupCommands);
-            this.StopAtConnect = options.StopAtConnect ?? false;
+
         }
 
         protected void InitializeCommonOptions(Xml.LaunchOptions.BaseLaunchOptions source)
@@ -1922,6 +1922,7 @@ namespace MICore
             }
 
             this.Environment = new ReadOnlyCollection<EnvironmentEntry>(GetEnvironmentEntries(launch.Environment));
+            this.StopAtConnect = launch.StopAtConnect ?? false;
         }
 
         public void InitializeAttachOptions(Json.LaunchOptions.AttachOptions attach)

--- a/src/MIDebugEngine/Engine.Impl/DebuggedProcess.cs
+++ b/src/MIDebugEngine/Engine.Impl/DebuggedProcess.cs
@@ -1103,24 +1103,41 @@ namespace Microsoft.MIDebugEngine
             if (String.IsNullOrWhiteSpace(reason) && !this.EntrypointHit)
             {
                 breakRequest = BreakRequest.None;   // don't let stopping interfere with launch processing
+                bool shouldContinue = true;
 
+                if (_launchOptions.StopAtConnect)
+                {
+                    this.EntrypointHit = true;
+                    await this.ClearEntrypointBreakpoint();
+
+                    // Send a breakpoint event to force the client to stop (entry point may not stop depending on how the user started debugging)
+                    _callback.OnBreakpoint(thread, new ReadOnlyCollection<object>(new AD7BoundBreakpoint[] { }));
+                    shouldContinue = false;
+                }
                 // MinGW sends a stopped event on attach. gdb<->gdbserver also sends a stopped event when first attached.
                 // If this is a gdb<->gdbserver connection, ignore this as the entryPoint
-                if (IsLocalLaunchUsingServer())
+                else if (IsLocalLaunchUsingServer())
                 {
                     // If the stopped event occurs on gdbserver, ignore it unless it contains a filename.
                     TupleValue frame = results.Results.TryFind<TupleValue>("frame");
                     if (frame.Contains("file"))
                     {
                         this.EntrypointHit = true;
+                        await this.ClearEntrypointBreakpoint();
+                        _callback.OnEntryPoint(thread);
+                        shouldContinue = false;
                     }
                 }
                 else
                 {
                     this.EntrypointHit = true;
+                    await this.ClearEntrypointBreakpoint();
                 }
 
-                CmdContinueAsync();
+                if (shouldContinue)
+                {
+                    CmdContinueAsync();
+                }
                 FireDeviceAppLauncherResume();
             }
             else if (reason == "entry-point-hit")
@@ -1315,6 +1332,14 @@ namespace Microsoft.MIDebugEngine
                 await ConsoleCmdAsync("process handle --pass true --stop false --notify false SIGHUP", allowWhileRunning: false, ignoreFailures: true);
             }
 
+            await this.ClearEntrypointBreakpoint();
+        }
+
+        /// <summary>
+        /// Attempts to remove the breakpoint automatically set at the entrypoint of the application.
+        /// </summary>
+        private async Task ClearEntrypointBreakpoint()
+        {
             if (this._deleteEntryPointBreakpoint && !String.IsNullOrWhiteSpace(this._entryPointBreakpoint))
             {
                 // Try and delete the entrypoint breakpoint. We only try this once but in some cases this won't succeed

--- a/src/MIDebugPackage/OpenFolderSchema.json
+++ b/src/MIDebugPackage/OpenFolderSchema.json
@@ -170,6 +170,10 @@
               },
               "pipeTransport": {
                 "$ref": "#/definitions/cpp_schema/definitions/pipeTransportOptions"
+              },
+              "stopAtConnect": {
+                "type": "boolean",
+                "description": "If true, the debugger should stop after connecting to the target. If false, the debugger will continue after connecting. \nDefaults to false."
               }
             },
             "definitions": {


### PR DESCRIPTION
I was running into issues debugging an embedded device with OpenOCD where the `stopAtEntry` setting in `launch.json` was ignored and the debugger always threw an exception with "Unknown breakpoint" when entering main.

The problem was that `_callback.OnEntryPoint(thread)` wasn't called after setting `EntrypointHit`, so none of the `stopAtEntry` logic in OpenDebugAD7 had a chance to run, and that the entrypoint breakpoint inserted on `main` by MIEngine was never removed by `this.OnEntrypointHit()`. However, even with that added, there was another problem because `CmdContinueAsync()` runs unconditionally.

The fix adds a new option, `stopAtConnect` that will always treat unexpected stopped events when connecting as if an entrypoint has been hit and stop. The fix also makes sure that the entrypoint breakpoint inserted on `main` is always cleaned up to avoid "Unknown breakpoint" exceptions.

With these changes, an embedded device debugging session will correctly respond to `stopAtEntry` and `stopAtConnect`, and will no longer throw spurious exceptions.

cc @aleun