### PR TITLE
Set lldb mode on the attach initialization path. Enable pipeCmd args.

### DIFF
--- a/src/MICore/JsonLaunchOptions.cs
+++ b/src/MICore/JsonLaunchOptions.cs
@@ -487,7 +487,7 @@ namespace MICore.Json.LaunchOptions
         public List<string> PipeArgs { get; private set; }
 
         /// <summary>
-        /// Command line arguments passed to the pipe program to execute a reote command.
+        /// Command line arguments passed to the pipe program to execute a remote command.
         /// </summary>
         [JsonProperty("pipeCmd", DefaultValueHandling = DefaultValueHandling.Ignore)]
         public List<string> PipeCmd { get; private set; }

--- a/src/MICore/JsonLaunchOptions.cs
+++ b/src/MICore/JsonLaunchOptions.cs
@@ -487,6 +487,12 @@ namespace MICore.Json.LaunchOptions
         public List<string> PipeArgs { get; private set; }
 
         /// <summary>
+        /// Command line arguments passed to the pipe program to execute a reote command.
+        /// </summary>
+        [JsonProperty("pipeCmd", DefaultValueHandling = DefaultValueHandling.Ignore)]
+        public List<string> PipeCmd { get; private set; }
+
+        /// <summary>
         /// The full path to the debugger on the target machine, for example /usr/bin/gdb.
         /// </summary>
         [JsonProperty("debuggerPath", DefaultValueHandling = DefaultValueHandling.Ignore)]

--- a/src/MICore/LaunchOptions.cs
+++ b/src/MICore/LaunchOptions.cs
@@ -106,6 +106,7 @@ namespace MICore
             string pipeCwd = pipeTransport.PipeCwd;
             string pipeProgram = pipeTransport.PipeProgram;
             List<string> pipeArgs = pipeTransport.PipeArgs;
+            List<string> pipeCmd = pipeTransport.PipeCmd;
             string debuggerPath = pipeTransport.DebuggerPath;
             bool quoteArgs = pipeTransport.QuoteArgs.GetValueOrDefault(true);
             Dictionary<string, string> pipeEnv = pipeTransport.PipeEnv;
@@ -128,6 +129,7 @@ namespace MICore
             {
                 pipeProgram = platformSpecificTransportOptions.PipeProgram ?? pipeProgram;
                 pipeArgs = platformSpecificTransportOptions.PipeArgs ?? pipeArgs;
+                pipeCmd = platformSpecificTransportOptions.PipeCmd ?? pipeCmd;
                 pipeCwd = platformSpecificTransportOptions.PipeCwd ?? pipeCwd;
                 pipeEnv = platformSpecificTransportOptions.PipeEnv ?? pipeEnv;
                 debuggerPath = platformSpecificTransportOptions.DebuggerPath ?? pipeTransport.DebuggerPath;
@@ -137,7 +139,7 @@ namespace MICore
             PipeLaunchOptions pipeOptions = new PipeLaunchOptions(
                 pipePath: pipeProgram,
                 pipeArguments: EnsurePipeArguments(pipeArgs, debuggerPath, gdbPathDefault, quoteArgs),
-                pipeCommandArguments: ParseArguments(pipeArgs, quoteArgs),
+                pipeCommandArguments: ParseArguments(pipeCmd, quoteArgs),
                 pipeCwd: pipeCwd,
                 pipeEnvironment: GetEnvironmentEntries(pipeEnv)
             );
@@ -1909,6 +1911,7 @@ namespace MICore
 
         public void InitializeAttachOptions(Json.LaunchOptions.AttachOptions attach)
         {
+            this.DebuggerMIMode = ConvertMIModeString(RequireAttribute(attach.MIMode, nameof(attach.MIMode)));
             this.ProcessId = attach.ProcessId;
         }
 

--- a/src/MIDebugPackage/OpenFolderSchema.json
+++ b/src/MIDebugPackage/OpenFolderSchema.json
@@ -207,7 +207,7 @@
                   },
                   "pipeCmd": {
                     "type": "array",
-                    "description": "Command line arguments passed to the pipe program to execute commands.",
+                    "description": "Arguments passed to the pipe executable to run a remote Unix (ex: bash or similar) shell command. This is used for running 'kill' on the remote system, or other commands that the debugger may need. If not specified, the debugger will do its best without the shell. But some features, such as setting breakpoints in run mode, may not work. This string should contain the string '{0}' which will be replaced with the command to execute.",
                     "items": {
                       "type": "string"
                     }

--- a/src/MIDebugPackage/OpenFolderSchema.json
+++ b/src/MIDebugPackage/OpenFolderSchema.json
@@ -205,6 +205,13 @@
                       "type": "string"
                     }
                   },
+                  "pipeCmd": {
+                    "type": "array",
+                    "description": "Command line arguments passed to the pipe program to execute commands.",
+                    "items": {
+                      "type": "string"
+                    }
+                  },
                   "debuggerPath": {
                     "type": "string",
                     "description": "The full path to the debugger on the target machine, for example /usr/bin/gdb."


### PR DESCRIPTION
Ran across a few issues in trying to attach to process on a mac. 
1. The json launch configuration didn't allow specification of the pipeCMd string.
2. MIMode was not propagated to the launch options when attaching.