### PR TITLE
Don't require the pipeCmd.

### DIFF
--- a/src/MICore/LaunchOptions.cs
+++ b/src/MICore/LaunchOptions.cs
@@ -139,7 +139,7 @@ namespace MICore
             PipeLaunchOptions pipeOptions = new PipeLaunchOptions(
                 pipePath: pipeProgram,
                 pipeArguments: EnsurePipeArguments(pipeArgs, debuggerPath, gdbPathDefault, quoteArgs),
-                pipeCommandArguments: ParseArguments(pipeCmd, quoteArgs),
+                pipeCommandArguments: ParseArguments(pipeCmd??pipeArgs, quoteArgs),
                 pipeCwd: pipeCwd,
                 pipeEnvironment: GetEnvironmentEntries(pipeEnv)
             );


### PR DESCRIPTION
Fixes null ref exception when pipeCmd is NOT present. Falls back to previous behavior - use the pipeArgs instead.