### PR TITLE
Task 1274960: Add support for IDebugProperty160.GetDataBreakpointInfo160 in MIEngine (cont.)

### DIFF
--- a/src/MIDebugEngine/AD7.Impl/AD7BoundBreakpoint.cs
+++ b/src/MIDebugEngine/AD7.Impl/AD7BoundBreakpoint.cs
@@ -91,14 +91,17 @@ namespace Microsoft.MIDebugEngine
                 lock (_engine.DebuggedProcess.DataBreakpointVariables)
                 {
                     string addressId = _pendingBreakpoint.AddressId;
-                    bool InDataBreakpointVariables = _engine.DebuggedProcess.DataBreakpointVariables.Contains(addressId);
-                    if (Enabled && !InDataBreakpointVariables)
+                    if (addressId != null)
                     {
-                        _engine.DebuggedProcess.DataBreakpointVariables.Add(addressId);
-                    }
-                    else if (!Enabled && InDataBreakpointVariables)
-                    {
-                        _engine.DebuggedProcess.DataBreakpointVariables.Remove(addressId);
+                        bool InDataBreakpointVariables = _engine.DebuggedProcess.DataBreakpointVariables.Contains(addressId);
+                        if (Enabled && !InDataBreakpointVariables)
+                        {
+                            _engine.DebuggedProcess.DataBreakpointVariables.Add(addressId);
+                        }
+                        else if (!Enabled && InDataBreakpointVariables)
+                        {
+                            _engine.DebuggedProcess.DataBreakpointVariables.Remove(addressId);
+                        }
                     }
                 }
             }

--- a/src/MIDebugEngine/AD7.Impl/AD7PendingBreakpoint.cs
+++ b/src/MIDebugEngine/AD7.Impl/AD7PendingBreakpoint.cs
@@ -42,12 +42,12 @@ namespace Microsoft.MIDebugEngine
         private IEnumerable<Checksum> _checksums = null;
 
         public DebuggedProcess DebuggedProcess { get { return _engine.DebuggedProcess; } }
-        public BP_REQUEST_INFO BpRequestInfo { get { return _bpRequestInfo; } }
 
         internal string BreakpointId
         {
             get { return _bp == null ? string.Empty : _bp.Number; }
         }
+        internal string AddressId { get; private set; }
 
         internal bool Enabled { get { return _enabled; } }
         internal bool Deleted { get { return _deleted; } }
@@ -239,7 +239,17 @@ namespace Microsoft.MIDebugEngine
 
                                     break;
                                 case enum_BP_LOCATION_TYPE.BPLT_DATA_STRING:
-                                    _address = HostMarshal.GetDataBreakpointStringForIntPtr(_bpRequestInfo.bpLocation.unionmember3).Split(',')[0];
+                                    string address = HostMarshal.GetDataBreakpointStringForIntPtr(_bpRequestInfo.bpLocation.unionmember3);
+                                    if (address.Contains(","))
+                                    {
+                                        this.AddressId = address;
+                                        _address = address.Split(',')[0];
+                                    }
+                                    else
+                                    {
+                                        this.AddressId = null;
+                                        _address = address;
+                                    }
                                     _size = (uint)_bpRequestInfo.bpLocation.unionmember4;
                                     if (_condition != null)
                                     {

--- a/src/MIDebugEngine/AD7.Impl/AD7PendingBreakpoint.cs
+++ b/src/MIDebugEngine/AD7.Impl/AD7PendingBreakpoint.cs
@@ -1,17 +1,14 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
-using Microsoft.VisualStudio.Debugger.Interop;
-using System.Collections;
-using System.Collections.Generic;
-using System.Text;
-using System.Threading.Tasks;
 using MICore;
-using System.Diagnostics;
 using Microsoft.DebugEngineHost;
-using System.Globalization;
+using Microsoft.VisualStudio.Debugger.Interop;
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
 using System.Linq;
+using System.Threading.Tasks;
 
 namespace Microsoft.MIDebugEngine
 {
@@ -45,6 +42,7 @@ namespace Microsoft.MIDebugEngine
         private IEnumerable<Checksum> _checksums = null;
 
         public DebuggedProcess DebuggedProcess { get { return _engine.DebuggedProcess; } }
+        public string Address { get { return _address; } }
 
         internal string BreakpointId
         {
@@ -273,6 +271,14 @@ namespace Microsoft.MIDebugEngine
                     }
                     else
                     {
+                        // test -- need to delete; insert something here
+                        lock (_engine.DebuggedProcess.DataBreakpointVariables)
+                        {
+                            if (!_engine.DebuggedProcess.DataBreakpointVariables.Contains(_address)) // might need to expand condition
+                            {
+                                _engine.DebuggedProcess.DataBreakpointVariables.Add(_address);
+                            }
+                        }
                         return Constants.S_OK;
                     }
                 }

--- a/src/MIDebugEngine/AD7.Impl/AD7PendingBreakpoint.cs
+++ b/src/MIDebugEngine/AD7.Impl/AD7PendingBreakpoint.cs
@@ -42,7 +42,7 @@ namespace Microsoft.MIDebugEngine
         private IEnumerable<Checksum> _checksums = null;
 
         public DebuggedProcess DebuggedProcess { get { return _engine.DebuggedProcess; } }
-        public string Address { get { return _address; } }
+        public BP_REQUEST_INFO BpRequestInfo { get { return _bpRequestInfo; } }
 
         internal string BreakpointId
         {
@@ -239,7 +239,7 @@ namespace Microsoft.MIDebugEngine
 
                                     break;
                                 case enum_BP_LOCATION_TYPE.BPLT_DATA_STRING:
-                                    _address = HostMarshal.GetDataBreakpointStringForIntPtr(_bpRequestInfo.bpLocation.unionmember3);
+                                    _address = HostMarshal.GetDataBreakpointStringForIntPtr(_bpRequestInfo.bpLocation.unionmember3).Split(',')[0];
                                     _size = (uint)_bpRequestInfo.bpLocation.unionmember4;
                                     if (_condition != null)
                                     {
@@ -271,12 +271,15 @@ namespace Microsoft.MIDebugEngine
                     }
                     else
                     {
-                        // test -- need to delete; insert something here
-                        lock (_engine.DebuggedProcess.DataBreakpointVariables)
+                        if ((enum_BP_LOCATION_TYPE)_bpRequestInfo.bpLocation.bpLocationType == enum_BP_LOCATION_TYPE.BPLT_DATA_STRING)
                         {
-                            if (!_engine.DebuggedProcess.DataBreakpointVariables.Contains(_address)) // might need to expand condition
+                            lock (_engine.DebuggedProcess.DataBreakpointVariables)
                             {
-                                _engine.DebuggedProcess.DataBreakpointVariables.Add(_address);
+                                string addressName = HostMarshal.GetDataBreakpointStringForIntPtr(_bpRequestInfo.bpLocation.unionmember3);
+                                if (!_engine.DebuggedProcess.DataBreakpointVariables.Contains(addressName)) // might need to expand condition
+                                {
+                                    _engine.DebuggedProcess.DataBreakpointVariables.Add(addressName);
+                                }
                             }
                         }
                         return Constants.S_OK;

--- a/src/MIDebugEngine/AD7.Impl/AD7Property.cs
+++ b/src/MIDebugEngine/AD7.Impl/AD7Property.cs
@@ -88,7 +88,7 @@ namespace Microsoft.MIDebugEngine
                         {
                             propertyInfo.dwAttrib |= (enum_DBG_ATTRIB_FLAGS)DBG_ATTRIB_HAS_DATA_BREAKPOINT;
                         }
-                    } catch (MICore.UnexpectedMIResultException e)
+                    } catch (Exception e)
                     {
                         // do something here
                     }

--- a/src/MIDebugEngine/AD7.Impl/AD7Property.cs
+++ b/src/MIDebugEngine/AD7.Impl/AD7Property.cs
@@ -446,7 +446,7 @@ namespace Microsoft.MIDebugEngine
             {
                 pbstrAddress = _variableInformation.Address() + "," + _variableInformation.FullName();
                 pSize = _variableInformation.Size();
-                pbstrDisplayName = _variableInformation.Name;
+                pbstrDisplayName = _variableInformation.FullName();
                 pbstrError = "";
                 return Constants.S_OK;
             }

--- a/src/MIDebugEngine/Engine.Impl/DebuggedProcess.cs
+++ b/src/MIDebugEngine/Engine.Impl/DebuggedProcess.cs
@@ -11,7 +11,6 @@ using System.Diagnostics;
 using System.Globalization;
 using System.IO;
 using System.Linq;
-using System.Reflection;
 using System.Text;
 using System.Text.RegularExpressions;
 using System.Threading;
@@ -27,7 +26,6 @@ namespace Microsoft.MIDebugEngine
         public List<string> VariablesToDelete { get; private set; }
         public List<string> DataBreakpointVariables { get; private set; }
         public List<IVariableInformation> ActiveVariables { get; private set; }
-        public HashSet<string> VariableNameAddressMap { get; private set; }
         public VariableInformation ReturnValue { get; private set; }
         public SourceLineCache SourceLineCache { get; private set; }
         public ThreadCache ThreadCache { get; private set; }
@@ -86,7 +84,6 @@ namespace Microsoft.MIDebugEngine
             VariablesToDelete = new List<string>();
             DataBreakpointVariables = new List<string>();
             this.ActiveVariables = new List<IVariableInformation>();
-            VariableNameAddressMap = new HashSet<string>();
             _fileTimestampWarnings = new HashSet<Tuple<string, string>>();
 
             OutputStringEvent += delegate (object o, string message)

--- a/src/MIDebugEngine/Engine.Impl/Variables.cs
+++ b/src/MIDebugEngine/Engine.Impl/Variables.cs
@@ -1,15 +1,15 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using MICore;
+using Microsoft.VisualStudio.Debugger.Interop;
+using Microsoft.VisualStudio.Debugger.Interop.DAP;
 using System;
 using System.Collections.Generic;
-using Microsoft.VisualStudio.Debugger.Interop;
 using System.Diagnostics;
-using MICore;
-using System.Threading.Tasks;
-using System.Text.RegularExpressions;
 using System.Globalization;
-using Microsoft.VisualStudio.Debugger.Interop.DAP;
+using System.Text.RegularExpressions;
+using System.Threading.Tasks;
 
 namespace Microsoft.MIDebugEngine
 {

--- a/src/MIDebugEngine/Engine.Impl/Variables.cs
+++ b/src/MIDebugEngine/Engine.Impl/Variables.cs
@@ -89,22 +89,17 @@ namespace Microsoft.MIDebugEngine
         private string DisplayHint { get; set; }
         public bool IsPreformatted { get; set; }
 
-        private static readonly string[] s_validAddressFormats = new string[] {
-            @"^0x[0-9a-fA-F]+$",
-            @"^(0x[0-9a-fA-F]+)\b"
-        };
+        static readonly Lazy<Regex> s_addressPattern = new Lazy<Regex>(() => new Regex(@"^(0x[0-9a-fA-F]+)\b"));
 
         public string Address()
         {
             // ask GDB to evaluate "&expression"
             string command = "&("+FullName()+")";
             var result = EvalDependentExpression(command);
-            for (int i = 0; i < s_validAddressFormats.Length; i++)
+            Match m = s_addressPattern.Value.Match(result);
+            if (m.Success)
             {
-                if (Regex.IsMatch(result, s_validAddressFormats[i]))
-                {
-                    return result;
-                }
+                return m.Captures[0].ToString();
             }
             string errorMessage = String.Format(CultureInfo.InvariantCulture, "Unexpected result {0} from evaluating {1}", result, command);
             throw new UnexpectedMIResultException(_debuggedProcess.MICommandFactory.Name, "-data-evaluate-expression", errorMessage);

--- a/src/MIDebugEngine/Natvis.Impl/Natvis.cs
+++ b/src/MIDebugEngine/Natvis.Impl/Natvis.cs
@@ -1,21 +1,19 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using MICore;
+using Microsoft.DebugEngineHost;
+using Microsoft.VisualStudio.Debugger.Interop;
+using Microsoft.VisualStudio.Debugger.Interop.DAP;
 using System;
 using System.Collections.Generic;
-using System.Text;
 using System.Globalization;
-using Microsoft.VisualStudio.Debugger.Interop;
-using MICore;
-using System.Text.RegularExpressions;
-using System.Xml.Serialization;
-using System.Xml;
 using System.IO;
-using Microsoft.DebugEngineHost;
 using System.Reflection;
-using Logger = MICore.Logger;
-using Microsoft.VisualStudio.Debugger.Interop.DAP;
-using System.Threading.Tasks;
+using System.Text;
+using System.Text.RegularExpressions;
+using System.Xml;
+using System.Xml.Serialization;
 
 namespace Microsoft.MIDebugEngine.Natvis
 {

--- a/src/MIDebugPackage/OpenFolderSchema.json
+++ b/src/MIDebugPackage/OpenFolderSchema.json
@@ -61,10 +61,14 @@
                 "type": "object",
                 "description": "Optional source file mappings passed to the debug engine. Format: '{ \"<Compiler source location>\": \"<Editor source location>\" }' OR '{ \"<Compiler source location>\": { \"editorPath\": \"<Editor source location>\", \"useForBreakpoints\": true } }'. \nExample: '{ \"/home/user/foo\": \"C:\\foo\" }' OR '{ \"/home/user/foo\": { \"editorPath\": \"c:\\foo\", \"useForBreakpoints\": true } }'.",
                 "additionalProperties": {
-                  "anyOf": {
-                    "type": "string",
-                    "$ref": "#/definitions/cpp_schema/definitions/sourceFileMapOptions"
-                  }
+                  "anyOf": [
+                    {
+                      "type": "string"
+                    },
+                    {
+                      "$ref": "#/definitions/cpp_schema/definitions/sourceFileMapOptions"
+                    }
+                  ]
                 }
               },
               "MIMode": {


### PR DESCRIPTION
I addressed the following PR comments:
1.	You don’t want to add/remove from DataBreakpointVariables/VariableNameAddressMap when GetDataBreakpointInfo160 is called, as this is before the UI has actually us to set the data breakpoint. Instead this should be done when the data breakpoint is created/disabled/deleted.
2.	To support [1], I believe you will need to change the ‘pbstrAddress’ to be some sort of encoding of the full name and the address. You can then parse the two back apart when handling the create/delete/disable data breakpoint. Maybe: ‘<address>,<full-name>’
3.	On AD7Property.cs line 88, you need a try/catch around variable.Address() since that can throw
4.	It’s possible to add the same variable multiple times with different addresses, so I think I would suggest changing DataBreakpointVariables and VariableNameAddressMap to a siengle list with both the pair that contains both the variable name and its address

Remaining PR comments to address:
1.	I should have noticed this earlier, but on AD7Proces.cs line 435, I think you actually want the display name to be the full name.
2.	In Variable.cs line 106 – if the regex your checking is the first regex in your list: returning the result is fine. But if it is your second Regex then you need to return the value of the capture rather than ‘result’. I guess really you could just check the second regex since anything that matches the first regex would also match the second.

@gregg-miskelly, I have questions about the remaining PR comments:
1.	What should the display name be - Name or FullName(), and why? (This is a good learning opportunity for me to understand why one over the other and gives me insight as to the decision process.)
2.	What is meant by "the value of the capture"? Is this `result` with the opening and closing parentheses removed (in the case of the second regex)?

Thank you!