### PR TITLE
Add hardware breakpoint support

### DIFF
--- a/src/MICore/CommandFactories/MICommandFactory.cs
+++ b/src/MICore/CommandFactories/MICommandFactory.cs
@@ -427,6 +427,10 @@ namespace MICore
             {
                 cmd.Append("-d ");
             }
+            if (_debugger.LaunchOptions.RequireHardwareBreakpoints)
+            {
+                cmd.Append("-h ");
+            }
             return Task<StringBuilder>.FromResult(cmd);
         }
 

--- a/src/MICore/JsonLaunchOptions.cs
+++ b/src/MICore/JsonLaunchOptions.cs
@@ -97,7 +97,7 @@ namespace MICore.Json.LaunchOptions
         public List<SetupCommand> SetupCommands { get; protected set; }
 
         /// <summary>
-        /// Force all breakpoints to be hardware breakpoints. Enforce an optional limit if specified. Example: "hardwareBreakpoint": { "require": true, "limit": 5 }.
+        /// Explicitly control whether hardware breakpoints are used. If an optional limit is provided, additionally restrict the number of hardware breakpoints for remote targets. Example: "hardwareBreakpoints": { "require": true, "limit": 5 }.
         /// </summary>
         [JsonProperty("hardwareBreakpoints", DefaultValueHandling = DefaultValueHandling.Ignore)]
         public HardwareBreakpointInfo HardwareBreakpointInfo { get; set; }
@@ -229,7 +229,7 @@ namespace MICore.Json.LaunchOptions
         public bool Require { get; set; }
 
         /// <summary>
-        /// If provided, limit the number of hardware breakpoints to the given number. Default is 0, in which case there is no limit. This setting is only enforced with remote GDB targets.
+        /// When <see cref="Require"/> is true, restrict the number of available hardware breakpoints. Default is 0, in which case there is no limit. This setting is only enforced with remote GDB targets.
         /// </summary>
         [JsonProperty("limit", DefaultValueHandling = DefaultValueHandling.Ignore)]
         public int? Limit { get; set; }

--- a/src/MICore/JsonLaunchOptions.cs
+++ b/src/MICore/JsonLaunchOptions.cs
@@ -97,7 +97,7 @@ namespace MICore.Json.LaunchOptions
         public List<SetupCommand> SetupCommands { get; protected set; }
 
         /// <summary>
-        /// Force all breakpoints to be hardware breakpoints. Enforce an optional limit if specified. Example: "hardwareBreakpoint": { "enable": true, "limit": 5 }.
+        /// Force all breakpoints to be hardware breakpoints. Enforce an optional limit if specified. Example: "hardwareBreakpoint": { "require": true, "limit": 5 }.
         /// </summary>
         [JsonProperty("hardwareBreakpoints", DefaultValueHandling = DefaultValueHandling.Ignore)]
         public HardwareBreakpointInfo HardwareBreakpointInfo { get; set; }
@@ -225,8 +225,8 @@ namespace MICore.Json.LaunchOptions
         /// <summary>
         /// If true, always use hardware breakpoints. Default value is false.
         /// </summary>
-        [JsonProperty("enable")]
-        public bool Enable { get; set; }
+        [JsonProperty("require")]
+        public bool Require { get; set; }
 
         /// <summary>
         /// If provided, limit the number of hardware breakpoints to the given number. Default is 0, in which case there is no limit. This setting is only enforced with remote GDB targets.
@@ -242,9 +242,9 @@ namespace MICore.Json.LaunchOptions
         {
         }
 
-        public HardwareBreakpointInfo(bool enable = false, int? limit = null)
+        public HardwareBreakpointInfo(bool require = false, int? limit = null)
         {
-            this.Enable = enable;
+            this.Require = require;
             this.Limit = limit;
         }
 

--- a/src/MICore/JsonLaunchOptions.cs
+++ b/src/MICore/JsonLaunchOptions.cs
@@ -95,6 +95,12 @@ namespace MICore.Json.LaunchOptions
         /// </summary>
         [JsonProperty("setupCommands", DefaultValueHandling = DefaultValueHandling.Ignore)]
         public List<SetupCommand> SetupCommands { get; protected set; }
+
+        /// <summary>
+        /// If true, always use hardware breakpoints.
+        /// </summary>
+        [JsonProperty("requireHardwareBreakpoints", DefaultValueHandling = DefaultValueHandling.Ignore)]
+        public bool? RequireHardwareBreakpoints { get; protected set; }
     }
 
     public partial class AttachOptions : BaseOptions
@@ -125,6 +131,7 @@ namespace MICore.Json.LaunchOptions
             string miDebuggerPath = null,
             string miDebuggerArgs = null,
             string miDebuggerServerAddress = null,
+            bool? requireHardwareBreakpoints = null,
             Dictionary<string, object> sourceFileMap = null,
             PipeTransport pipeTransport = null,
             SymbolLoadInfo symbolLoadInfo = null)
@@ -140,6 +147,7 @@ namespace MICore.Json.LaunchOptions
             this.MiDebuggerArgs = miDebuggerArgs;
             this.MiDebuggerServerAddress = miDebuggerServerAddress;
             this.ProcessId = processId;
+            this.RequireHardwareBreakpoints = requireHardwareBreakpoints;
             this.SourceFileMap = sourceFileMap;
             this.PipeTransport = pipeTransport;
             this.SymbolLoadInfo = symbolLoadInfo;
@@ -344,6 +352,7 @@ namespace MICore.Json.LaunchOptions
             int? serverLaunchTimeout = null,
             string coreDumpPath = null,
             bool? externalConsole = null,
+            bool? requireHardwareBreakpoints = null,
             Dictionary<string, object> sourceFileMap = null,
             PipeTransport pipeTransport = null)
         {
@@ -372,6 +381,7 @@ namespace MICore.Json.LaunchOptions
             this.ServerLaunchTimeout = serverLaunchTimeout;
             this.CoreDumpPath = coreDumpPath;
             this.ExternalConsole = externalConsole;
+            this.RequireHardwareBreakpoints = requireHardwareBreakpoints;
             this.SourceFileMap = sourceFileMap;
             this.PipeTransport = pipeTransport;
         }

--- a/src/MICore/JsonLaunchOptions.cs
+++ b/src/MICore/JsonLaunchOptions.cs
@@ -97,10 +97,10 @@ namespace MICore.Json.LaunchOptions
         public List<SetupCommand> SetupCommands { get; protected set; }
 
         /// <summary>
-        /// If true, always use hardware breakpoints.
+        /// Force all breakpoints to be hardware breakpoints. Enforce an optional limit if specified. Example: "hardwareBreakpoint": { "enable": true, "limit": 5 }.
         /// </summary>
-        [JsonProperty("requireHardwareBreakpoints", DefaultValueHandling = DefaultValueHandling.Ignore)]
-        public bool? RequireHardwareBreakpoints { get; protected set; }
+        [JsonProperty("hardwareBreakpoints", DefaultValueHandling = DefaultValueHandling.Ignore)]
+        public HardwareBreakpointInfo HardwareBreakpointInfo { get; set; }
     }
 
     public partial class AttachOptions : BaseOptions
@@ -131,7 +131,7 @@ namespace MICore.Json.LaunchOptions
             string miDebuggerPath = null,
             string miDebuggerArgs = null,
             string miDebuggerServerAddress = null,
-            bool? requireHardwareBreakpoints = null,
+            HardwareBreakpointInfo hardwareBreakpointInfo = null,
             Dictionary<string, object> sourceFileMap = null,
             PipeTransport pipeTransport = null,
             SymbolLoadInfo symbolLoadInfo = null)
@@ -147,7 +147,7 @@ namespace MICore.Json.LaunchOptions
             this.MiDebuggerArgs = miDebuggerArgs;
             this.MiDebuggerServerAddress = miDebuggerServerAddress;
             this.ProcessId = processId;
-            this.RequireHardwareBreakpoints = requireHardwareBreakpoints;
+            this.HardwareBreakpointInfo = hardwareBreakpointInfo;
             this.SourceFileMap = sourceFileMap;
             this.PipeTransport = pipeTransport;
             this.SymbolLoadInfo = symbolLoadInfo;
@@ -213,6 +213,39 @@ namespace MICore.Json.LaunchOptions
         {
             this.LoadAll = loadAll;
             this.ExceptionList = exceptionList;
+        }
+
+        #endregion
+    }
+
+    public partial class HardwareBreakpointInfo
+    {
+        #region Public Properties for Serialization
+
+        /// <summary>
+        /// If true, always use hardware breakpoints. Default value is false.
+        /// </summary>
+        [JsonProperty("enable")]
+        public bool Enable { get; set; }
+
+        /// <summary>
+        /// If provided, limit the number of hardware breakpoints to the given number. Default is 0, in which case there is no limit. This setting is only enforced with remote GDB targets.
+        /// </summary>
+        [JsonProperty("limit", DefaultValueHandling = DefaultValueHandling.Ignore)]
+        public int? Limit { get; set; }
+
+        #endregion
+
+        #region Constructors
+
+        public HardwareBreakpointInfo()
+        {
+        }
+
+        public HardwareBreakpointInfo(bool enable = false, int? limit = null)
+        {
+            this.Enable = enable;
+            this.Limit = limit;
         }
 
         #endregion
@@ -352,7 +385,7 @@ namespace MICore.Json.LaunchOptions
             int? serverLaunchTimeout = null,
             string coreDumpPath = null,
             bool? externalConsole = null,
-            bool? requireHardwareBreakpoints = null,
+            HardwareBreakpointInfo hardwareBreakpointInfo = null,
             Dictionary<string, object> sourceFileMap = null,
             PipeTransport pipeTransport = null)
         {
@@ -381,7 +414,7 @@ namespace MICore.Json.LaunchOptions
             this.ServerLaunchTimeout = serverLaunchTimeout;
             this.CoreDumpPath = coreDumpPath;
             this.ExternalConsole = externalConsole;
-            this.RequireHardwareBreakpoints = requireHardwareBreakpoints;
+            this.HardwareBreakpointInfo = hardwareBreakpointInfo;
             this.SourceFileMap = sourceFileMap;
             this.PipeTransport = pipeTransport;
         }

--- a/src/MICore/LaunchOptions.cs
+++ b/src/MICore/LaunchOptions.cs
@@ -1742,9 +1742,9 @@ namespace MICore
             this.RequireHardwareBreakpoints = options.HardwareBreakpointInfo?.Require ?? false;
             this.HardwareBreakpointLimit = options.HardwareBreakpointInfo?.Limit ?? 0;
 
-            if (this.HardwareBreakpointLimit > 0 && DebuggerMIMode == MIMode.Lldb)
+            if (this.RequireHardwareBreakpoints && DebuggerMIMode == MIMode.Lldb)
             {
-                throw new InvalidLaunchOptionsException(String.Format(CultureInfo.InvariantCulture, MICoreResources.Error_OptionNotSupported, nameof(options.HardwareBreakpointInfo.Limit), nameof(MIMode.Lldb)));
+                throw new InvalidLaunchOptionsException(String.Format(CultureInfo.InvariantCulture, MICoreResources.Error_OptionNotSupported, nameof(options.HardwareBreakpointInfo.Require), nameof(MIMode.Lldb)));
             }
         }
 

--- a/src/MICore/LaunchOptions.cs
+++ b/src/MICore/LaunchOptions.cs
@@ -1138,6 +1138,18 @@ namespace MICore
             }
         }
 
+        private int _hardwareBreakpointLimit;
+
+        public int HardwareBreakpointLimit
+        {
+            get { return _hardwareBreakpointLimit; }
+            set
+            {
+                VerifyCanModifyProperty(nameof(HardwareBreakpointLimit));
+                _hardwareBreakpointLimit = value;
+            }
+        }
+
         public string GetOptionsString()
         {
             try
@@ -1727,7 +1739,13 @@ namespace MICore
 
             this.SetupCommands = LaunchCommand.CreateCollection(options.SetupCommands);
 
-            this.RequireHardwareBreakpoints = options.RequireHardwareBreakpoints.GetValueOrDefault(false);
+            this.RequireHardwareBreakpoints = options.HardwareBreakpointInfo?.Enable ?? false;
+            this.HardwareBreakpointLimit = options.HardwareBreakpointInfo?.Limit ?? 0;
+
+            if (this.RequireHardwareBreakpoints && DebuggerMIMode == MIMode.Lldb)
+            {
+                throw new InvalidLaunchOptionsException(String.Format(CultureInfo.InvariantCulture, MICoreResources.Error_OptionNotSupported, nameof(options.HardwareBreakpointInfo.Limit), nameof(MIMode.Lldb)));
+            }
         }
 
         protected void InitializeCommonOptions(Xml.LaunchOptions.BaseLaunchOptions source)

--- a/src/MICore/LaunchOptions.cs
+++ b/src/MICore/LaunchOptions.cs
@@ -1742,7 +1742,7 @@ namespace MICore
             this.RequireHardwareBreakpoints = options.HardwareBreakpointInfo?.Enable ?? false;
             this.HardwareBreakpointLimit = options.HardwareBreakpointInfo?.Limit ?? 0;
 
-            if (this.RequireHardwareBreakpoints && DebuggerMIMode == MIMode.Lldb)
+            if (this.HardwareBreakpointLimit > 0 && DebuggerMIMode == MIMode.Lldb)
             {
                 throw new InvalidLaunchOptionsException(String.Format(CultureInfo.InvariantCulture, MICoreResources.Error_OptionNotSupported, nameof(options.HardwareBreakpointInfo.Limit), nameof(MIMode.Lldb)));
             }

--- a/src/MICore/LaunchOptions.cs
+++ b/src/MICore/LaunchOptions.cs
@@ -1739,7 +1739,7 @@ namespace MICore
 
             this.SetupCommands = LaunchCommand.CreateCollection(options.SetupCommands);
 
-            this.RequireHardwareBreakpoints = options.HardwareBreakpointInfo?.Enable ?? false;
+            this.RequireHardwareBreakpoints = options.HardwareBreakpointInfo?.Require ?? false;
             this.HardwareBreakpointLimit = options.HardwareBreakpointInfo?.Limit ?? 0;
 
             if (this.HardwareBreakpointLimit > 0 && DebuggerMIMode == MIMode.Lldb)

--- a/src/MICore/LaunchOptions.cs
+++ b/src/MICore/LaunchOptions.cs
@@ -1126,6 +1126,18 @@ namespace MICore
             }
         }
 
+        private bool _requireHardwareBreakpoints = false;
+
+        public bool RequireHardwareBreakpoints
+        {
+            get { return _requireHardwareBreakpoints;  }
+            set
+            {
+                VerifyCanModifyProperty(nameof(RequireHardwareBreakpoints));
+                _requireHardwareBreakpoints = value;
+            }
+        }
+
         public string GetOptionsString()
         {
             try
@@ -1715,6 +1727,7 @@ namespace MICore
 
             this.SetupCommands = LaunchCommand.CreateCollection(options.SetupCommands);
 
+            this.RequireHardwareBreakpoints = options.RequireHardwareBreakpoints.GetValueOrDefault(false);
         }
 
         protected void InitializeCommonOptions(Xml.LaunchOptions.BaseLaunchOptions source)

--- a/src/MIDebugEngine/AD7.Impl/AD7Engine.cs
+++ b/src/MIDebugEngine/AD7.Impl/AD7Engine.cs
@@ -393,6 +393,8 @@ namespace Microsoft.MIDebugEngine
             return s_bpLongBindTimeout;
         }
 
+        public int GetBPLongEnableTimeout() => GetBPLongBindTimeout();
+
         // Informs a DE that the program specified has been atypically terminated and that the DE should
         // clean up all references to the program and send a program destroy event.
         public int DestroyProgram(IDebugProgram2 pProgram)

--- a/src/MIDebugEngine/AD7.Impl/AD7PendingBreakpoint.cs
+++ b/src/MIDebugEngine/AD7.Impl/AD7PendingBreakpoint.cs
@@ -360,7 +360,7 @@ namespace Microsoft.MIDebugEngine
                     }
                     if (bindResult.BoundBreakpoints == null || bindResult.BoundBreakpoints.Count == 0)
                     {
-                        this.SetError(new AD7ErrorBreakpoint(this, bindResult.ErrorMessage), true);
+                        this.SetError(new AD7ErrorBreakpoint(this, bindResult.ErrorMessage, enum_BP_ERROR_TYPE.BPET_GENERAL_ERROR), true);
                     }
                     else
                     {

--- a/src/MIDebugEngine/AD7.Impl/AD7PendingBreakpoint.cs
+++ b/src/MIDebugEngine/AD7.Impl/AD7PendingBreakpoint.cs
@@ -481,7 +481,15 @@ namespace Microsoft.MIDebugEngine
                     _engine.DebuggedProcess.WorkerThread.RunOperation(() =>
                     {
                         _engine.DebuggedProcess.AddInternalBreakAction(
-                            () => bp.EnableAsync(_enabled, _engine.DebuggedProcess)
+                            async () => {
+                                try
+                                {
+                                    await bp.EnableAsync(_enabled, _engine.DebuggedProcess);
+                                } catch (UnexpectedMIResultException exc)
+                                {
+                                    this.SetError(new AD7ErrorBreakpoint(this, exc.MIError, enum_BP_ERROR_TYPE.BPET_GENERAL_ERROR), true);
+                                }
+                            }
                         );
                     });
                 }

--- a/src/MIDebugEngine/AD7.Impl/AD7PendingBreakpoint.cs
+++ b/src/MIDebugEngine/AD7.Impl/AD7PendingBreakpoint.cs
@@ -428,7 +428,7 @@ namespace Microsoft.MIDebugEngine
                 _deleted = true;
                 if (_engine.DebuggedProcess.ProcessState != ProcessState.Stopped && !_engine.DebuggedProcess.MICommandFactory.AllowCommandsWhileRunning())
                 {
-                    if (_engine.DebuggedProcess.LaunchOptions.RequireHardwareBreakpoints)
+                    if (_engine.DebuggedProcess.LaunchOptions.RequireHardwareBreakpoints && _bp != null)
                     {
                         // Hardware breakpoint deletion should not be deferred
                         // because the debugger needs to keep an accurate count
@@ -436,7 +436,7 @@ namespace Microsoft.MIDebugEngine
                         _engine.DebuggedProcess.WorkerThread.RunOperation(() =>
                         {
                             _engine.DebuggedProcess.AddInternalBreakAction(
-                                () => _bp?.DeleteAsync(_engine.DebuggedProcess));
+                                () => _bp.DeleteAsync(_engine.DebuggedProcess));
                         });
                     } else
                     {

--- a/src/MIDebugEngine/Engine.Impl/Breakpoints.cs
+++ b/src/MIDebugEngine/Engine.Impl/Breakpoints.cs
@@ -160,7 +160,10 @@ namespace Microsoft.MIDebugEngine
                 // (the error is sent via an "&" string and hence lost)
                 return new BindResult(errormsg);
             }
-            Debug.Assert(bkpt.FindString("type") == "breakpoint");
+            string bkptType = bkpt.FindString("type");
+
+            // gdb reports breakpoint type "hw breakpoint" for `-break-insert -h` command
+            Debug.Assert(bkptType == "breakpoint" || bkptType == "hw breakpoint");
 
             string number = bkpt.FindString("number");
             string warning = bkpt.TryFindString("warning");

--- a/src/MIDebugEngine/Engine.Impl/DebuggedProcess.cs
+++ b/src/MIDebugEngine/Engine.Impl/DebuggedProcess.cs
@@ -825,7 +825,7 @@ namespace Microsoft.MIDebugEngine
                         {
                             commands.Add(new LaunchCommand("-target-select remote " + destination, string.Format(CultureInfo.CurrentCulture, ResourceStrings.ConnectingMessage, destination)));
 
-                            if (localLaunchOptions.HardwareBreakpointLimit > 0) {
+                            if (localLaunchOptions.RequireHardwareBreakpoints && localLaunchOptions.HardwareBreakpointLimit > 0) {
                                 commands.Add(new LaunchCommand(string.Format(CultureInfo.InvariantCulture, "-interpreter-exec console \"set remote hardware-breakpoint-limit {0}\"", localLaunchOptions.HardwareBreakpointLimit.ToString(CultureInfo.InvariantCulture))));
                             }
                         }

--- a/src/MIDebugEngine/Engine.Impl/DebuggedProcess.cs
+++ b/src/MIDebugEngine/Engine.Impl/DebuggedProcess.cs
@@ -824,6 +824,10 @@ namespace Microsoft.MIDebugEngine
                         if (!string.IsNullOrWhiteSpace(destination))
                         {
                             commands.Add(new LaunchCommand("-target-select remote " + destination, string.Format(CultureInfo.CurrentCulture, ResourceStrings.ConnectingMessage, destination)));
+
+                            if (localLaunchOptions.HardwareBreakpointLimit > 0) {
+                                commands.Add(new LaunchCommand(string.Format(CultureInfo.InvariantCulture, "-interpreter-exec console \"set remote hardware-breakpoint-limit {0}\"", localLaunchOptions.HardwareBreakpointLimit.ToString(CultureInfo.InvariantCulture))));
+                            }
                         }
 
                     }

--- a/src/MIDebugEngine/ResourceStrings.Designer.cs
+++ b/src/MIDebugEngine/ResourceStrings.Designer.cs
@@ -238,6 +238,15 @@ namespace Microsoft.MIDebugEngine {
                 return ResourceManager.GetString("LongBind", resourceCulture);
             }
         }
+
+        /// <summary>
+        ///   Looks up a localized string similar to Attempting to enable the breakpoint.....
+        /// </summary>
+        internal static string LongEnable {
+            get {
+                return ResourceManager.GetString("LongEnable", resourceCulture);
+            }
+        }
         
         /// <summary>
         ///   Looks up a localized string similar to Failed to find thread {0} for break event.

--- a/src/MIDebugEngine/ResourceStrings.resx
+++ b/src/MIDebugEngine/ResourceStrings.resx
@@ -168,6 +168,9 @@
   <data name="LongBind" xml:space="preserve">
     <value>Attempting to bind the breakpoint....</value>
   </data>
+  <data name="LongEnable" xml:space="preserve">
+    <value>Attempting to enable the breakpoint....</value>
+  </data>
   <data name="NoSideEffectsVisualizerMessage" xml:space="preserve">
     <value>Explicit refresh required for visualized expressions</value>
   </data>

--- a/src/OpenDebugAD7/AD7DebugSession.cs
+++ b/src/OpenDebugAD7/AD7DebugSession.cs
@@ -2876,14 +2876,16 @@ namespace OpenDebugAD7
                     if (pendingBreakpoint.GetBreakpointRequest(out breakpointRequest) == 0)
                     {
                         string errorMsg = string.Empty;
+                        enum_BP_ERROR_TYPE errorType = enum_BP_ERROR_TYPE.BPET_NONE;
 
                         IDebugErrorBreakpointResolution2 errorBreakpointResolution;
                         if (errorBreakpoint.GetBreakpointResolution(out errorBreakpointResolution) == 0)
                         {
                             BP_ERROR_RESOLUTION_INFO[] bpInfo = new BP_ERROR_RESOLUTION_INFO[1];
-                            if (errorBreakpointResolution.GetResolutionInfo(enum_BPERESI_FIELDS.BPERESI_MESSAGE, bpInfo) == 0)
+                            if (errorBreakpointResolution.GetResolutionInfo(enum_BPERESI_FIELDS.BPERESI_MESSAGE | enum_BPERESI_FIELDS.BPERESI_TYPE, bpInfo) == 0)
                             {
                                 errorMsg = bpInfo[0].bstrMessage;
+                                errorType = bpInfo[0].dwType;
                             }
                         }
 
@@ -2930,7 +2932,7 @@ namespace OpenDebugAD7
                             outputMessage = string.Format(CultureInfo.CurrentCulture, AD7Resources.Error_FunctionBreakpoint, ad7BPRequest.FunctionPosition.Name, errorMsg);
                         }
 
-                        if (!string.IsNullOrEmpty(outputMessage))
+                        if (!string.IsNullOrEmpty(outputMessage) && ((errorType & enum_BP_ERROR_TYPE.BPET_SEV_MASK) > enum_BP_ERROR_TYPE.BPET_SEV_LOW))
                         {
                             SendMessageEvent(MessagePrefix.Error, outputMessage);
                         }

--- a/src/OpenDebugAD7/AD7DebugSession.cs
+++ b/src/OpenDebugAD7/AD7DebugSession.cs
@@ -2932,7 +2932,7 @@ namespace OpenDebugAD7
                             outputMessage = string.Format(CultureInfo.CurrentCulture, AD7Resources.Error_FunctionBreakpoint, ad7BPRequest.FunctionPosition.Name, errorMsg);
                         }
 
-                        if (!string.IsNullOrEmpty(outputMessage) && ((errorType & enum_BP_ERROR_TYPE.BPET_SEV_MASK) > enum_BP_ERROR_TYPE.BPET_SEV_LOW))
+                        if (!string.IsNullOrEmpty(outputMessage) && ((errorType & enum_BP_ERROR_TYPE.BPET_TYPE_ERROR) != 0))
                         {
                             SendMessageEvent(MessagePrefix.Error, outputMessage);
                         }

--- a/src/OpenDebugAD7/AD7DebugSession.cs
+++ b/src/OpenDebugAD7/AD7DebugSession.cs
@@ -2887,6 +2887,7 @@ namespace OpenDebugAD7
                             }
                         }
 
+                        string outputMessage; // output message to be written to debug console
                         AD7BreakPointRequest ad7BPRequest = (AD7BreakPointRequest)breakpointRequest;
                         Breakpoint bp = null;
                         if (ad7BPRequest.DocumentPosition != null)
@@ -2900,15 +2901,18 @@ namespace OpenDebugAD7
                                     Line = m_pathConverter.ConvertDebuggerLineToClient(ad7BPRequest.DocumentPosition.Line),
                                     Message = errorMsg
                                 };
+
+                                outputMessage = errorMsg;
                             }
                             else
                             {
+                                outputMessage = string.Format(CultureInfo.CurrentCulture, AD7Resources.Error_ConditionBreakpoint, ad7BPRequest.Condition, errorMsg);
                                 bp = new Breakpoint()
                                 {
                                     Verified = false,
                                     Id = (int)ad7BPRequest.Id,
                                     Line = m_pathConverter.ConvertDebuggerLineToClient(ad7BPRequest.DocumentPosition.Line),
-                                    Message = string.Format(CultureInfo.CurrentCulture, AD7Resources.Error_ConditionBreakpoint, ad7BPRequest.Condition, errorMsg)
+                                    Message = outputMessage
                                 };
                             }
                         }
@@ -2923,10 +2927,13 @@ namespace OpenDebugAD7
                             };
 
                             // TODO: currently VSCode will ignore the error message from "breakpoint" event, the workaround is to log the error to output window
-                            string outputMsg = string.Format(CultureInfo.CurrentCulture, AD7Resources.Error_FunctionBreakpoint, ad7BPRequest.FunctionPosition.Name, errorMsg);
-                            m_logger.WriteLine(LoggingCategory.DebuggerError, outputMsg);
+                            outputMessage = string.Format(CultureInfo.CurrentCulture, AD7Resources.Error_FunctionBreakpoint, ad7BPRequest.FunctionPosition.Name, errorMsg);
                         }
 
+                        if (!string.IsNullOrEmpty(outputMessage))
+                        {
+                            SendMessageEvent(MessagePrefix.Error, outputMessage);
+                        }
                         ad7BPRequest.BindResult = bp;
                         Protocol.SendEvent(new BreakpointEvent(BreakpointEvent.ReasonValue.Changed, bp));
                     }


### PR DESCRIPTION
This PR adds a `hardwareBreakpoints` setting for toggling hardware breakpoint behavior.

Example: `"hardwareBreakpoints": { "require": true, "limit": 5 }`

1. `require` forces all breakpoints to be hardware breakpoints via the `-break-insert -h` option.
2. `limit` restricts the number of remote hardware breakpoints via GDB's `set remote hardware-breakpoint-limit` command. It is optional. Any breakpoints past the limit do not bind and instead show an error message (screenshots below).

## In VSCode

Screenshot:
![vscode_screen](https://user-images.githubusercontent.com/34582775/111682278-65307d00-87e1-11eb-8921-7366c6b7eb1c.png)

Note that the error message comes directly from GDB.

The relevant excerpt of the debug console log:

```
1: (47954) <-1024-break-insert -f -h main.c:18
1: (47957) ->1024^done,bkpt={number="3",type="hw breakpoint",disp="keep",enabled="y",addr="0x08000fd8",func="main",file="../main.c",fullname="C:\\proj\\embedded\\examples\\blinky\\STM32L4\\main.c",line="18",thread-groups=["i1"],times="0",original-location="main.c:18"}
1: (47957) ->(gdb)
1: (47957) 1024: elapsed time 3
1: (47957) Send Event AD7BreakpointBoundEvent
1: (47957) ->&"\n"
1: (47958) ->^done
1: (47958) ->(gdb)
1: (49596) <-1025-break-insert -f -h main.c:19
1: (49601) ->1025^error,msg="Hardware breakpoints used exceeds limit."
1: (49601) ->(gdb)
1: (49601) 1025: elapsed time 4
1: (49602) ->&"\n"
1: (49602) ->^done
1: (49602) ->(gdb)
1: (49602) Send Event AD7BreakpointErrorEvent
ERROR: Hardware breakpoints used exceeds limit.
```

## In VS 2019

Screenshot:
![vs_screen](https://user-images.githubusercontent.com/34582775/111682316-71b4d580-87e1-11eb-9a6c-92bca6cfd790.png)

Relevant log excerpt:

```
1: (247977) <-1020-break-insert -f -h main.c:99
1: (247986) ->1020^done,bkpt={number="3",type="hw breakpoint",disp="keep",enabled="y",addr="0x0800017a",func="main",file="../Core/Src/main.c",fullname="C:\\Users\\alleu\\STM32CubeIDE\\workspace_1.5.0\\nucleo-f103rb-blinky\\Core\\Src\\main.c",line="99",thread-groups=["i1"],times="0",original-location="main.c:99"}
1: (247989) ->(gdb)
1: (247989) 1020: elapsed time 11
1: (247995) Send Event AD7BreakpointBoundEvent
1: (247998) ->&"\n"
1: (248009) ->^done
1: (248011) ->(gdb)
1: (251233) <-1021-break-insert -f -h main.c:88
1: (251237) ->1021^error,msg="Hardware breakpoints used exceeds limit."
1: (251239) ->(gdb)
1: (251239) 1021: elapsed time 6
1: (251247) ->&"\n"
1: (251250) ->^done
1: (251250) Send Event AD7BreakpointErrorEvent
1: (251253) ->(gdb)
```

## Implementation Notes

- Between VS and VSCode, there is a difference in behavior when enabling/disabling breakpoints past the limit. Illustrative scenario: suppose the user has just gone above the breakpoint limit, causing their latest breakpoint to remain unbound. They then disable some previous breakpoints, and attempt rebinding the offending breakpoint. The user needs to do slightly different things in VS and VSCode. This is due to the difference between the two in the way user gestures for enabling/disabling breakpoints are interpreted:
  - In VSCode, toggling enables always translates into `-break-insert` and `-break-delete` GDB commands, even if the breakpoints are unbound, so toggling the enable state can "revive" a previously unbound breakpoint.
  - In VS, toggling enables translate into `-break-enable` and `-break-disable` GDB commands, but they are not fired in the case of an unbound breakpoint (because there is nothing for GDB to enable). This means the only way to "revive" the breakpoint in the UI is by deleting and adding it again.
- Tested with OpenOCD on Windows with VS and VSCode.
