### PR TITLE
Fix file:line path for $FILEPOS

### DIFF
--- a/src/OpenDebugAD7/Tracepoint.cs
+++ b/src/OpenDebugAD7/Tracepoint.cs
@@ -162,7 +162,7 @@ namespace OpenDebugAD7
                                 hr = pDocumentContext.GetStatementRange(textPosBeg, textPosEnd);
                                 if (hr >= 0)
                                 {
-                                    return string.Format(CultureInfo.InvariantCulture, "{0}({1})", fileName, textPosBeg[0].dwLine + 1);
+                                    return string.Format(CultureInfo.InvariantCulture, "{0}:{1}", fileName, textPosBeg[0].dwLine + 1);
                                 }
                             }
                         }


### PR DESCRIPTION
From https://github.com/microsoft/vscode-cpptools/issues/7193

We are outputting `$FILEPOS` for tracepoints as `filepath(line)` which is not the format VSCode expects when you do a ctrl+click when you want to jump to a specific file and line. It only jumps to the file.

Switching it to `filepath:line` it will correctly jump to the file and the line.