### PR TITLE
Support GetProcessArchitecture and read ps flags

### DIFF
--- a/src/Microsoft.VisualStudio.Debugger.Interop.UnixPortSupplier/Microsoft.VisualStudio.Debugger.Interop.UnixPortSupplier.cs
+++ b/src/Microsoft.VisualStudio.Debugger.Interop.UnixPortSupplier/Microsoft.VisualStudio.Debugger.Interop.UnixPortSupplier.cs
@@ -164,7 +164,7 @@ namespace Microsoft.VisualStudio.Debugger.Interop.UnixPortSupplier
         /// <summary>
         /// Gets the architecture unix process.
         /// </summary>
-        /// <returns>the string representation of the process's architecture</returns>
+        /// <returns>The string representation of the process's architecture. The format of this is architecture-specific and will match that returned by uname -m. Example: 'x86_64'</returns>
         string GetProcessArchitecture();
     };
 }

--- a/src/Microsoft.VisualStudio.Debugger.Interop.UnixPortSupplier/Microsoft.VisualStudio.Debugger.Interop.UnixPortSupplier.cs
+++ b/src/Microsoft.VisualStudio.Debugger.Interop.UnixPortSupplier/Microsoft.VisualStudio.Debugger.Interop.UnixPortSupplier.cs
@@ -151,4 +151,20 @@ namespace Microsoft.VisualStudio.Debugger.Interop.UnixPortSupplier
         /// <param name="exitCode">The exit code of the command, assuming one was printed.</param>
         void OnExit(string exitCode);
     };
+
+    /// <summary>
+    /// Interface to query unix process architecture information.
+    /// </summary>
+    [ComImport()]
+    [ComVisible(true)]
+    [InterfaceType(ComInterfaceType.InterfaceIsIUnknown)]
+    [Guid("61D4C2C4-7CA8-4472-8446-7B1DF5C9D16D")]
+    public interface IDebugUnixProcess
+    {
+        /// <summary>
+        /// Gets the architecture unix process.
+        /// </summary>
+        /// <returns>the string representation of the process's architecture</returns>
+        string GetProcessArchitecture();
+    };
 }

--- a/src/SSHDebugPS/AD7/AD7Process.cs
+++ b/src/SSHDebugPS/AD7/AD7Process.cs
@@ -16,12 +16,16 @@ namespace Microsoft.SSHDebugPS
         private readonly AD7Port _port;
         private readonly uint _processId;
         private readonly string _systemArch;
-        private readonly uint _flags;
         private readonly string _commandLine;
         private readonly string _userName;
         private readonly bool _isSameUser;
         private readonly Lazy<Guid> _uniqueId = new Lazy<Guid>(() => Guid.NewGuid(), LazyThreadSafetyMode.ExecutionAndPublication);
         private IDebugProgram2 _program;
+
+        /// <summary>
+        /// Flags are only used in ps command scenarios. It will be set to 0 for others.
+        /// </summary>
+        private readonly uint _flags;
 
         /// <summary>
         /// Returns true if _commandLine appears to hold a real file name + args rather than just a description
@@ -35,8 +39,9 @@ namespace Microsoft.SSHDebugPS
             _commandLine = psProcess.CommandLine;
             _userName = psProcess.UserName;
             _isSameUser = psProcess.IsSameUser;
-            _flags = psProcess.Flags;
             _systemArch = psProcess.SystemArch;
+
+            _flags = psProcess.Flags;
         }
 
         public int Attach(IDebugEventCallback2 pCallback, Guid[] rgguidSpecificEngines, uint celtSpecificEngines, int[] rghrEngineAttach)

--- a/src/SSHDebugPS/IConnection.cs
+++ b/src/SSHDebugPS/IConnection.cs
@@ -53,16 +53,32 @@ namespace Microsoft.SSHDebugPS
     public class Process
     {
         public uint Id { get; private set; }
+        public uint Flags { get; private set; }
+        public string SystemArch { get; private set; }
         public string CommandLine { get; private set; }
         public string UserName { get; private set; }
         public bool IsSameUser { get; private set; }
 
-        public Process(uint id, string userName, string commandLine, bool isSameUser)
+        public Process(uint id, string arch, uint flags, string userName, string commandLine, bool isSameUser)
         {
             this.Id = id;
+            this.Flags = flags;
             this.UserName = userName;
             this.CommandLine = commandLine;
             this.IsSameUser = isSameUser;
+            this.SystemArch = arch;
+        }
+    }
+
+    public class SystemInformation
+    {
+        public string UserName { get; private set; }
+        public string Architecture { get; private set; }
+
+        public SystemInformation(string username, string architecture)
+        {
+            this.UserName = username;
+            this.Architecture = architecture;
         }
     }
 }

--- a/src/SSHDebugPS/IConnection.cs
+++ b/src/SSHDebugPS/IConnection.cs
@@ -53,6 +53,9 @@ namespace Microsoft.SSHDebugPS
     public class Process
     {
         public uint Id { get; private set; }
+        /// <summary>
+        /// Only used by the PSOutputParser
+        /// </summary>
         public uint Flags { get; private set; }
         public string SystemArch { get; private set; }
         public string CommandLine { get; private set; }
@@ -70,7 +73,7 @@ namespace Microsoft.SSHDebugPS
         }
     }
 
-    public class SystemInformation
+    internal class SystemInformation
     {
         public string UserName { get; private set; }
         public string Architecture { get; private set; }

--- a/src/SSHDebugPS/PipeConnection.cs
+++ b/src/SSHDebugPS/PipeConnection.cs
@@ -108,17 +108,19 @@ namespace Microsoft.SSHDebugPS
             return commandOutput.StartsWith("Linux", StringComparison.OrdinalIgnoreCase);
         }
 
-        public bool TryGetSystemInformation(out SystemInformation systemInformation)
+        /// <summary>
+        /// Retrieves system information such as username and architecture
+        /// </summary>
+        /// <returns>SystemInformation containing username and architecture. If it was unable to obtain any of these, the value will be set to string.Empty.</returns>
+        public SystemInformation GetSystemInformation()
         {
-            systemInformation = null;
+            string commandOutput;
+            string errorMessage;
 
             string username = string.Empty;
             string command = "id -u -n";
-            string commandOutput;
-            string errorMessage;
             if (ExecuteCommand(command, Timeout.Infinite, throwOnFailure: false, commandOutput: out commandOutput, errorMessage: out errorMessage))
             {
-
                 username = commandOutput;
             }
 
@@ -126,23 +128,15 @@ namespace Microsoft.SSHDebugPS
             command = "uname -m";
             if (ExecuteCommand(command, Timeout.Infinite, throwOnFailure: false, commandOutput: out commandOutput, errorMessage: out errorMessage))
             {
-
                 architecture = commandOutput;
             }
 
-            if (string.IsNullOrWhiteSpace(username) || string.IsNullOrWhiteSpace(architecture))
-            {
-                return false;
-            }
-
-            systemInformation = new SystemInformation(username, architecture);
-            return true;
+            return new SystemInformation(username, architecture);
         }
 
         public override List<Process> ListProcesses()
         {
-            SystemInformation systemInformation;
-            TryGetSystemInformation(out systemInformation);
+            SystemInformation systemInformation = GetSystemInformation();
 
             List<Process> processes;
             string psErrorMessage;

--- a/src/SSHDebugPS/ProcFSOutputParser.cs
+++ b/src/SSHDebugPS/ProcFSOutputParser.cs
@@ -21,7 +21,7 @@ namespace Microsoft.SSHDebugPS
         private List<Process> _processList = new List<Process>();
         private uint _shellProcess = uint.MaxValue;
 
-        public static List<Process> Parse(string output, SystemInformation systemInformation)
+        internal static List<Process> Parse(string output, SystemInformation systemInformation)
         {
             return new ProcFSOutputParser().ParseInternal(output, systemInformation);
         }
@@ -104,8 +104,7 @@ namespace Microsoft.SSHDebugPS
 
             // Note:
             //    For Flags, will need to parse /proc/[pid]/stat flags.
-            //    But at this commit, flags are unused for Linux scenarios.
-            Process process = new Process(processId, systemInformation.Architecture, /* TODO: Flags */ 0, procUsername, commandLine, isSameUser);
+            Process process = new Process(processId, systemInformation.Architecture, /* Flags */ 0, procUsername, commandLine, isSameUser);
             _processList.Add(process);
         }
     }

--- a/src/SSHDebugPS/SSH/SSHConnection.cs
+++ b/src/SSHDebugPS/SSH/SSHConnection.cs
@@ -51,13 +51,22 @@ namespace Microsoft.SSHDebugPS.SSH
                 username = usernameCommand.Output.TrimEnd('\n', '\r'); // trim line endings because 'id' command ends with a newline
             }
 
+            string architecture = string.Empty;
+            var architectureCommand = _remoteSystem.Shell.ExecuteCommand("uname -m");
+            if (architectureCommand.ExitCode == 0)
+            {
+                architecture = architectureCommand.Output.TrimEnd('\n', '\r'); // trim line endings because 'uname -m' command ends with a newline
+            }
+
+            SystemInformation systemInformation = new SystemInformation(username, architecture);
+
             var command = _remoteSystem.Shell.ExecuteCommand(PSOutputParser.PSCommandLine);
             if (command.ExitCode != 0)
             {
                 throw new CommandFailedException(StringResources.Error_PSFailed);
             }
 
-            return PSOutputParser.Parse(command.Output, username);
+            return PSOutputParser.Parse(command.Output, systemInformation);
         }
 
         public override void BeginExecuteAsyncCommand(string commandText, bool runInShell, IDebugUnixShellCommandCallback callback, out IDebugUnixShellAsyncCommand asyncCommand)

--- a/src/SSHDebugTests/PSOutputParserTests.cs
+++ b/src/SSHDebugTests/PSOutputParserTests.cs
@@ -15,6 +15,7 @@ namespace SSHDebugTests
         public void PSOutputParser_Ubuntu14()
         {
             const string username = "greggm";
+            const string architecture = "x86_64";
             // example output from ps on a real Ubuntu 14 machine (with many processes removed):
             const string input =
                 "pppppppppp rrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrr COMMAND\n" +
@@ -25,7 +26,7 @@ namespace SSHDebugTests
                 "      2580 root                             /sbin/dhclient -d -sf /usr/lib/NetworkManager/nm-dhcp-client.action -pf /run/sendsigs.omit.d/network-manager.dhclient-eth0.pid -lf /var/lib/NetworkManager/dhclient-d08a482b-ff90-4007-9b13-6500eb94b673-eth0.lease -cf /var/lib/NetworkManager/dhclient-eth0.conf eth0\n" +
                 "      2913 greggm                           ps -axww -o pid=pppppppppp -o ruser=rrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrr -o args\n";
 
-            List<Process> r = PSOutputParser.Parse(input, username);
+            List<Process> r = PSOutputParser.Parse(input, new SystemInformation(username, architecture));
             Assert.AreEqual(5, r.Count);
 
             uint[] pids = { 1, 2, 720, 2389, 2580 };
@@ -45,12 +46,13 @@ namespace SSHDebugTests
         public void PSOutputParser_SmallCol()
         {
             const string username = "greggm";
+            const string architecture = "x86_64";
             // made up output for what could happen if the fields were all just 1 character in size
             const string input =
                 "A B C\n" +
                 "9 r /sbin/init";
 
-            List<Process> r = PSOutputParser.Parse(input, username);
+            List<Process> r = PSOutputParser.Parse(input, new SystemInformation(username, architecture));
             Assert.AreEqual(1, r.Count);
             Assert.AreEqual<uint>(9, r[0].Id);
             Assert.AreEqual("r", r[0].UserName);
@@ -62,13 +64,14 @@ namespace SSHDebugTests
         {
             // Made up ps output from a system where $USER wasn't a thing
             const string username = "";
+            const string architecture = "";
             const string input =
                 "pppppppppp rrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrr COMMAND\n" +
                 "         1 root                             /sbin/init\n" +
                 "       720                                  dbus-daemon --system --fork\n" +
                 "      2389 greggm                           -bash\n";
 
-            List<Process> r = PSOutputParser.Parse(input, username);
+            List<Process> r = PSOutputParser.Parse(input, new SystemInformation(username, architecture));
             Assert.AreEqual(3, r.Count);
 
             uint[] pids = { 1, 720, 2389 };


### PR DESCRIPTION
This PR adds GetProcessArchitecture in IDebugUnixProcess for SSHDebugPS
and obtains the flags in ps.

For most processes, it will be the same as the system architecture from
'uname -m'.

However, on Apple M1 Machines. we need to determine if the process is being
emulated or not. We determine this by checking if P_TRANSLATED (0x20000) on OSX ARM64
is enabled on the process, it is under x86_64 emulation.