### PR TITLE
Pull in correct Newtonsoft.Json for Mono Runtime

### DIFF
--- a/src/DebugEngineHost.VSCode/DebugEngineHost.VSCode.csproj
+++ b/src/DebugEngineHost.VSCode/DebugEngineHost.VSCode.csproj
@@ -88,7 +88,15 @@
 
   <ItemGroup Label="NuGet Packages">
     <PackageReference Include="Microsoft.VisualStudio.Debugger.Interop.Portable" Version="$(Microsoft_VisualStudio_Debugger_Interop_Portable_Version)" />
-    <PackageReference Include="Newtonsoft.Json" Version="$(Newtonsoft_Json_VSCode_Version)" />
+    <!-- This will pull in the net45 newtonsoft.json, we want the portable-net45+wp80+win8+wpa81 version. Use this to get the install path.  -->
+    <PackageReference Include="Newtonsoft.Json" Version="$(Newtonsoft_Json_VSCode_Version)" GeneratePathProperty="true">
+      <IncludeAssets>none</IncludeAssets>
+      <ExcludeAssets>all</ExcludeAssets>
+      <PrivateAssets>none</PrivateAssets>
+    </PackageReference>
+    <Reference Include="Newtonsoft.Json">
+      <HintPath>$(PkgNewtonsoft_Json)\lib\portable-net45+wp80+win8+wpa81\Newtonsoft.Json.dll</HintPath>
+    </Reference>
     <PackageReference Include="Microsoft.VisualStudioEng.MicroBuild.Core" Version="$(Microsoft_VisualStudioEng_MicroBuild_Core_Version)" GeneratePathProperty="true"/>
   </ItemGroup>
 

--- a/src/OpenDebugAD7/OpenDebugAD7.csproj
+++ b/src/OpenDebugAD7/OpenDebugAD7.csproj
@@ -94,8 +94,16 @@
     <PackageReference Include="Microsoft.VisualStudio.Debugger.Interop.15.0" Version="$(Microsoft_VisualStudio_Debugger_Interop_15_0_Version)" />
     <PackageReference Include="Microsoft.VisualStudio.Debugger.Interop.16.0" Version="$(Microsoft_VisualStudio_Debugger_Interop_16_0_Version)" />
     <PackageReference Include="Microsoft.VisualStudio.Shared.VSCodeDebugProtocol" Version="$(Microsoft_VisualStudio_Shared_VSCodeDebugProtocol_Version)" />
-    <PackageReference Include="Newtonsoft.Json" Version="$(Newtonsoft_Json_VSCode_Version)" />
-    <PackageReference Include="Microsoft.VisualStudioEng.MicroBuild.Core" Version="$(Microsoft_VisualStudioEng_MicroBuild_Core_Version)" GeneratePathProperty="true"/>
+    <!-- This will pull in the net45 newtonsoft.json, we want the portable-net45+wp80+win8+wpa81 version. Use this to get the install path.  -->
+    <PackageReference Include="Newtonsoft.Json" Version="$(Newtonsoft_Json_VSCode_Version)" GeneratePathProperty="true">
+      <IncludeAssets>none</IncludeAssets>
+      <ExcludeAssets>all</ExcludeAssets>
+      <PrivateAssets>none</PrivateAssets>
+    </PackageReference>
+    <Reference Include="Newtonsoft.Json">
+      <HintPath>$(PkgNewtonsoft_Json)\lib\portable-net45+wp80+win8+wpa81\Newtonsoft.Json.dll</HintPath>
+    </Reference>
+    <PackageReference Include="Microsoft.VisualStudioEng.MicroBuild.Core" Version="$(Microsoft_VisualStudioEng_MicroBuild_Core_Version)" GeneratePathProperty="true" />
   </ItemGroup>
   
   <ItemGroup Label="Project References">


### PR DESCRIPTION
When converting to SDK and using PackageReference, nuget pulls in
\lib\net45\Newtonsoft.Json.dll

For mono, we need lib\portable-net45+wp80+win8+wpa81\Newtonsoft.Json.dll

This PR adds in the PackageRefernce that will download the package and
export the property to the path to the NewtonsoftPackage, and uses a
Reference to refer to that binary.

FYI @aleun 