### PR TITLE
Fix output buffering with IDebugUnixShellPort.BeginExecuteAsyncCommand

### DIFF
--- a/src/MICore/Transports/UnixShellPortTransport.cs
+++ b/src/MICore/Transports/UnixShellPortTransport.cs
@@ -141,7 +141,7 @@ namespace MICore
 
         public bool Interrupt(int pid)
         {
-            string killCmd = string.Format(CultureInfo.InvariantCulture, "kill -5 {0}", pid);
+            string killCmd = string.Format(CultureInfo.InvariantCulture, "/bin/sh -c \"kill -5 {0}\"", pid);
 
             try
             {

--- a/src/MICore/Transports/UnixShellPortTransport.cs
+++ b/src/MICore/Transports/UnixShellPortTransport.cs
@@ -27,17 +27,17 @@ namespace MICore
 
         private const string ErrorPrefix = "Error:";
 
-        private class UnixShellAsyncCommandCallback: IDebugUnixShellCommandCallback
+        private class KillCommandCallback: IDebugUnixShellCommandCallback
         {
-            UnixShellPortTransport _parent;
-            public UnixShellAsyncCommandCallback(UnixShellPortTransport parent)
+            private readonly Logger _logger;
+            public KillCommandCallback(Logger logger)
             {
-                this._parent = parent;
+                this._logger = logger;
             }
 
             public void OnOutputLine(string line)
             {
-                ((IDebugUnixShellCommandCallback)_parent).OnOutputLine(line);
+                _logger?.WriteLine("[kill] ->" + line);
             }
 
             public void OnExit(string exitCode)
@@ -57,7 +57,7 @@ namespace MICore
             _startRemoteDebuggerCommand = _launchOptions.StartRemoteDebuggerCommand;
 
             _callback.AppendToInitializationLog(string.Format(CultureInfo.CurrentCulture, MICoreResources.Info_StartingUnixCommand, _startRemoteDebuggerCommand));
-            _launchOptions.UnixPort.BeginExecuteAsyncCommand(_startRemoteDebuggerCommand, true, this, out _asyncCommand);
+            _launchOptions.UnixPort.BeginExecuteAsyncCommand(_startRemoteDebuggerCommand, runInShell: true, this, out _asyncCommand);
         }
 
         public void Close()
@@ -146,8 +146,8 @@ namespace MICore
             try
             {
                 IDebugUnixShellAsyncCommand asyncCommand;
-                UnixShellAsyncCommandCallback callbacks = new UnixShellAsyncCommandCallback(this);
-                _launchOptions.UnixPort.BeginExecuteAsyncCommand(killCmd, false, callbacks, out asyncCommand);
+                KillCommandCallback callbacks = new KillCommandCallback(_logger);
+                _launchOptions.UnixPort.BeginExecuteAsyncCommand(killCmd, runInShell: true, callbacks, out asyncCommand);
             }
             catch (Exception e)
             {

--- a/src/Microsoft.VisualStudio.Debugger.Interop.UnixPortSupplier/Microsoft.VisualStudio.Debugger.Interop.UnixPortSupplier.cs
+++ b/src/Microsoft.VisualStudio.Debugger.Interop.UnixPortSupplier/Microsoft.VisualStudio.Debugger.Interop.UnixPortSupplier.cs
@@ -36,7 +36,10 @@ namespace Microsoft.VisualStudio.Debugger.Interop.UnixPortSupplier
         /// it.
         /// </summary>
         /// <param name="commandText">Text of the command to execut</param>
-        /// <param name="runInShell">True if a PTY should be allocated and a shell started before executing the command.</param>
+        /// <param name="runInShell">True if the command should be executed in a shell and PTY. It is important to note that callers should pass
+        /// True unless their callback implementation is capable of handling raw output text, as <see cref="IDebugUnixShellCommandCallback.OnOutputLine(string)"/>
+        /// will be sent unbuffered output when this is false, so the implementation must be able to handle partial lines or multiple lines in
+        /// one call to OnOutputLine.</param>
         /// <param name="callback">Callback which will receive the output and events 
         /// from the command</param>
         /// <param name="asyncCommand">Returned command object</param>
@@ -141,8 +144,17 @@ namespace Microsoft.VisualStudio.Debugger.Interop.UnixPortSupplier
     public interface IDebugUnixShellCommandCallback
     {
         /// <summary>
-        /// Fired when a line of text is sent by the command
+        /// Notification fired when the command has output available
         /// </summary>
+        /// <param name="line">Text that the executing command wrote to standard out or error.
+        /// <para>If `false` is passed for `runInShell` when <see cref="IDebugUnixShellPort.BeginExecuteAsyncCommand(string, bool, IDebugUnixShellCommandCallback, out IDebugUnixShellAsyncCommand)"/>
+        /// was called then this text will NOT be buffered, so either partial lines or multiple lines are possible, and this text will include new line
+        /// characters.
+        /// </para>
+        /// <para>
+        /// If `true` is passed for `runInShell` then this will be a single line of output with new line characters removed.
+        /// </para>
+        /// </param>
         void OnOutputLine(string line);
 
         /// <summary>

--- a/src/SSHDebugPS/CommandRunner.cs
+++ b/src/SSHDebugPS/CommandRunner.cs
@@ -46,11 +46,10 @@ namespace Microsoft.SSHDebugPS
     /// </summary>
     internal class LocalCommandRunner : ICommandRunner
     {
-        public static int BUFMAX = 4096;
+        protected const int BUFMAX = 4096;
 
-        private ProcessStartInfo _processStartInfo;
+        protected ProcessStartInfo ProcessStartInfo { get; }
         private System.Diagnostics.Process _process;
-        private CancellationTokenSource _cancellationSource = new CancellationTokenSource();
         private System.Threading.Tasks.Task _outputReadLoopTask;
         private System.Threading.Tasks.Task _errorReadLoopTask;
         private bool _hasExited = false;
@@ -59,11 +58,13 @@ namespace Microsoft.SSHDebugPS
         private StreamReader _stdOutReader;
         private StreamReader _stdErrReader;
 
-        protected object _lock = new object();
+        private readonly object _lock = new object();
 
         public event EventHandler<string> OutputReceived;
         public event EventHandler<int> Closed;
         public event EventHandler<ErrorOccuredEventArgs> ErrorOccured;
+
+        protected bool IsDisposeStarted => _process == null;
 
         public LocalCommandRunner(IPipeTransportSettings settings)
             : this(settings.Command, settings.CommandArgs)
@@ -71,28 +72,41 @@ namespace Microsoft.SSHDebugPS
 
         public LocalCommandRunner(string command, string commandArgs)
         {
-            _processStartInfo = new ProcessStartInfo(command, commandArgs);
+            ProcessStartInfo = new ProcessStartInfo(command, commandArgs);
 
-            _processStartInfo.RedirectStandardError = true;
-            _processStartInfo.RedirectStandardInput = true;
-            _processStartInfo.RedirectStandardOutput = true;
+            ProcessStartInfo.RedirectStandardError = true;
+            ProcessStartInfo.RedirectStandardInput = true;
+            ProcessStartInfo.RedirectStandardOutput = true;
 
-            _processStartInfo.UseShellExecute = false;
-            _processStartInfo.CreateNoWindow = true;
+            ProcessStartInfo.UseShellExecute = false;
+            ProcessStartInfo.CreateNoWindow = true;
+        }
+
+        public static LocalCommandRunner CreateInstance(bool handleRawOutput, IPipeTransportSettings settings)
+        {
+            return CreateInstance(handleRawOutput, settings.Command, settings.CommandArgs);
+        }
+
+        public static LocalCommandRunner CreateInstance(bool handleRawOutput, string command, string args)
+        {
+            if (handleRawOutput)
+            {
+                return new RawLocalCommandRunner(command, args);
+            }
+            else
+            {
+                return new LocalCommandRunner(command, args);
+            }
         }
 
         public void Start()
         {
             ThrowIfDisposed();
-            if (_processStartInfo == null)
-            {
-                throw new InvalidOperationException("Unable to create process. Process start info does not exist");
-            }
 
             lock (_lock)
             {
                 _process = new System.Diagnostics.Process();
-                _process.StartInfo = _processStartInfo;
+                _process.StartInfo = this.ProcessStartInfo;
 
                 _process.Exited += OnProcessExited;
                 _process.EnableRaisingEvents = true;
@@ -103,8 +117,8 @@ namespace Microsoft.SSHDebugPS
                 _stdOutReader = new StreamReader(_process.StandardOutput.BaseStream, new UTF8Encoding(encoderShouldEmitUTF8Identifier: false), false, BUFMAX);
                 _stdErrReader = new StreamReader(_process.StandardError.BaseStream, new UTF8Encoding(encoderShouldEmitUTF8Identifier: false), false, BUFMAX);
 
-                _outputReadLoopTask = System.Threading.Tasks.Task.Run(() => ReadLoop(_stdOutReader, _cancellationSource.Token, true, OnOutputReceived));
-                _errorReadLoopTask = System.Threading.Tasks.Task.Run(() => ReadLoop(_stdErrReader, _cancellationSource.Token, false, OnErrorReceived));
+                _outputReadLoopTask = ReadStdOutAsync(_stdOutReader);
+                _errorReadLoopTask = ReadLoopAsync(_stdErrReader, false, OnErrorReceived);
             }
         }
 
@@ -136,11 +150,11 @@ namespace Microsoft.SSHDebugPS
             ErrorOccured?.Invoke(this, new ErrorOccuredEventArgs(ex));
         }
 
-        protected virtual void OnProcessExited(object sender, EventArgs args)
+        private void OnProcessExited(object sender, EventArgs args)
         {
             lock (_lock)
             {
-                // Make sure that all output has been written before exiting.
+                // Make sure that all output has been read before exiting.
                 if (!_hasExited && _outputReadLoopTask.IsCompleted)
                 {
                     _hasExited = true;
@@ -154,21 +168,31 @@ namespace Microsoft.SSHDebugPS
             ErrorOccured?.Invoke(this, new ErrorOccuredEventArgs(error));
         }
 
-        protected virtual void OnOutputReceived(string line)
+        protected virtual Task ReadStdOutAsync(StreamReader stdOutReader)
+        {
+            return ReadLoopAsync(stdOutReader, checkForExitedProcess: true, OnOutputReceived);
+        }
+
+        protected void OnOutputReceived(string line)
         {
             OutputReceived?.Invoke(this, line);
         }
 
-        protected virtual void ReadLoop(StreamReader reader, CancellationToken token, bool checkForExitedProcess, Action<string> action)
+        private async Task ReadLoopAsync(StreamReader reader, bool checkForExitedProcess, Action<string> action)
         {
             try
             {
-                while (!token.IsCancellationRequested)
+                while (!this.IsDisposeStarted)
                 {
-                    Task<string> task = reader.ReadLineAsync();
-                    task.Wait(token);
+                    string line = await reader.ReadLineAsync();
 
-                    if (task.Result == null || token.IsCancellationRequested)
+                    if (this.IsDisposeStarted)
+                    {
+                        // Dispose was called
+                        return;
+                    }
+
+                    if (line == null)
                     {
                         if (checkForExitedProcess)
                         {
@@ -177,13 +201,16 @@ namespace Microsoft.SSHDebugPS
                         return; // end of stream
                     }
 
-                    action(task.Result);
+                    action(line);
                 }
             }
             catch (Exception e)
             {
-                ReportException(e);
-                Dispose();
+                if (this.IsDisposeStarted) // ignore exceptions if we are disposing
+                {
+                    ReportException(e);
+                    Dispose();
+                }
             }
         }
 
@@ -206,7 +233,7 @@ namespace Microsoft.SSHDebugPS
 
         }
 
-        protected void EnsureRunning()
+        private void EnsureRunning()
         {
             if (_process == null || _process.HasExited)
             {
@@ -214,27 +241,31 @@ namespace Microsoft.SSHDebugPS
             }
         }
 
-        protected void CleanUpProcess()
+        private void CleanUpProcess()
         {
             if (_process != null)
             {
                 lock (_lock)
                 {
-                    if (_process != null)
+                    System.Diagnostics.Process process = _process;
+                    if (process != null)
                     {
-                        if (!_process.HasExited)
+                        _process = null;
+
+                        if (!process.HasExited)
                         {
-                            _process.Kill();
+                            try
+                            {
+                                process.Kill();
+                            }
+                            catch (Exception)
+                            {
+                                // Process may already be dead
+                            }
                         }
 
                         // clean up event handlers.
-                        _process.Exited -= OnProcessExited;
-                        _process = null;
-
-                        _cancellationSource.Cancel();
-
-                        _outputReadLoopTask = null;
-                        _errorReadLoopTask = null;
+                        process.Exited -= OnProcessExited;
 
                         _stdInWriter.Close();
                         _stdInWriter = null;
@@ -244,6 +275,8 @@ namespace Microsoft.SSHDebugPS
 
                         _stdErrReader.Close();
                         _stdErrReader = null;
+
+                        process.Close();
                     }
                 }
             }
@@ -282,54 +315,68 @@ namespace Microsoft.SSHDebugPS
     }
 
     /// <summary>
-    /// Launches a local command where the output is read in a buffer.
+    /// Launches a local command where the OutputReceived event is fired with the raw line ending characters
     /// </summary>
     internal class RawLocalCommandRunner : LocalCommandRunner
     {
         public RawLocalCommandRunner(string command, string args) : base(command, args) { }
 
-        public RawLocalCommandRunner(IPipeTransportSettings settings) : base(settings) { }
+        protected override Task ReadStdOutAsync(StreamReader stdOutReader)
+        {
+            // Async reads against the stream aren't completing even though data is available, possibly because PineZorro
+            // is using `.Result` on an I/O object. So use a dedicated thread instead.
+            TaskCompletionSource<object> tcs = new TaskCompletionSource<object>();
 
-        protected override void ReadLoop(StreamReader reader, CancellationToken token, bool checkForExitedProcess, Action<string> action)
+            // We shouldn't need a full stack for this thread, so reduce the stack size to 256KB
+            const int stackSize = 256 * 1024;
+            var thread = new Thread(() =>
+                {
+                    SyncReadStdOut(stdOutReader);
+                    tcs.SetResult(null);
+                },
+                stackSize);
+
+            thread.Name = string.Concat("SSHDebugPS: ", Path.GetFileNameWithoutExtension(this.ProcessStartInfo.FileName), " stdout reader");
+            thread.Start();
+
+            return tcs.Task;
+        }
+
+        private void SyncReadStdOut(StreamReader stdOutReader)
         {
             try
             {
-                string result = string.Empty;
-                while (!token.IsCancellationRequested)
+                char[] buffer = new char[BUFMAX];
+                while (!this.IsDisposeStarted)
                 {
-                    char[] buffer = new char[BUFMAX];
-                    Task<int> task = reader.ReadAsync(buffer, 0, buffer.Length);
-                    task.Wait(token);
+                    int bytesRead = stdOutReader.Read(buffer, 0, buffer.Length);
 
-                    if (task.Result > 0)
+                    if (bytesRead > 0)
                     {
-                        result += new string(buffer, 0, task.Result);
-                        if (task.Result < BUFMAX)
-                        {
-                            action(result);
-                            result = string.Empty;
-                        }
+                        string result = new string(buffer, 0, bytesRead);
+                        OnOutputReceived(result);
                     }
                     else
                     {
-                        if (!string.IsNullOrEmpty(result))
-                        {
-                            action(result);
-                            result = string.Empty;
-                        }
-                        if (checkForExitedProcess)
-                        {
-                            VerifyProcessExitedAndNotify();
-                        }
+                        VerifyProcessExitedAndNotify();
                         return;
                     }
                 }
             }
             catch (Exception ex)
             {
-                ReportException(ex);
-                Dispose();
+                if (!this.IsDisposeStarted)
+                {
+                    ReportException(ex);
+                    Dispose();
+                }
             }
+        }
+
+        protected override void OnErrorReceived(string error)
+        {
+            // stderr doesn't need to be read using raw I/O, but the call back does expect new line characters, so add them
+            base.OnErrorReceived(error + Environment.NewLine);
         }
     }
 
@@ -338,24 +385,26 @@ namespace Microsoft.SSHDebugPS
     /// </summary>
     internal class RemoteCommandRunner : ICommandRunner, IDebugUnixShellCommandCallback
     {
+        private readonly string _commandText;
+        private readonly Connection _remoteConnection;
         private IDebugUnixShellAsyncCommand _asyncCommand;
         private bool _isRunning;
-        private string _commandText;
-        private Connection _remoteConnection;
+        private readonly bool _handleRawOutput;
 
-        public RemoteCommandRunner(IPipeTransportSettings settings, Connection remoteConnection)
-            : this(settings.Command, settings.CommandArgs, remoteConnection)
+        public RemoteCommandRunner(IPipeTransportSettings settings, Connection remoteConnection, bool handleRawOutput)
+            : this(settings.Command, settings.CommandArgs, remoteConnection, handleRawOutput)
         { }
 
-        public RemoteCommandRunner(string command, string arguments, Connection remoteConnection)
+        public RemoteCommandRunner(string command, string arguments, Connection remoteConnection, bool handleRawOutput)
         {
             _remoteConnection = remoteConnection;
             _commandText = string.Concat(command, " ", arguments);
+            _handleRawOutput = handleRawOutput;
         }
 
         public void Start()
         {
-            _remoteConnection.BeginExecuteAsyncCommand(_commandText, runInShell: false, callback: this, asyncCommand: out _asyncCommand);
+            _remoteConnection.BeginExecuteAsyncCommand(_commandText, runInShell: _handleRawOutput == false, callback: this, asyncCommand: out _asyncCommand);
             _isRunning = true;
         }
 

--- a/src/SSHDebugPS/Docker/DockerAsyncCommand.cs
+++ b/src/SSHDebugPS/Docker/DockerAsyncCommand.cs
@@ -3,6 +3,7 @@
 
 using System.Globalization;
 using System.Text;
+using System.Threading;
 using Microsoft.VisualStudio.Debugger.Interop.UnixPortSupplier;
 
 namespace Microsoft.SSHDebugPS.Docker
@@ -60,13 +61,14 @@ namespace Microsoft.SSHDebugPS.Docker
 
         public void Close()
         {
-            if (_runner != null)
+            // If Close is called more than once, make subsequent calls a nop
+            ICommandRunner runner = Interlocked.Exchange(ref _runner, null);
+            if (runner != null)
             {
-                _runner.Dispose();
-                _runner.OutputReceived -= OnOutputReceived;
-                _runner.ErrorOccured -= OnErrorOccured;
-                _runner.Closed -= OnClose;
-                _runner = null;
+                runner.Dispose();
+                runner.OutputReceived -= OnOutputReceived;
+                runner.ErrorOccured -= OnErrorOccured;
+                runner.Closed -= OnClose;
             }
             _callback = null;
         }

--- a/src/SSHDebugPS/Docker/DockerExecutionManager.cs
+++ b/src/SSHDebugPS/Docker/DockerExecutionManager.cs
@@ -70,7 +70,9 @@ namespace Microsoft.SSHDebugPS.Docker
                 return new LocalCommandRunner(execSettings);
             }
             else
-                return new RemoteCommandRunner(execSettings.Command, execSettings.CommandArgs, _outerConnection);
+            {
+                return new RemoteCommandRunner(execSettings, _outerConnection, handleRawOutput: false);
+            }
         }
 
         public int ExecuteCommand(string commandText, int timeout, out string commandOutput, out string errorMessage, bool runInShell = true, bool makeInteractive = true)

--- a/src/SSHDebugPS/IConnection.cs
+++ b/src/SSHDebugPS/IConnection.cs
@@ -14,8 +14,6 @@ namespace Microsoft.SSHDebugPS
 
         void Close();
 
-        void BeginExecuteAsyncCommand(string commandText, bool runInShell, IDebugUnixShellCommandCallback callback, out IDebugUnixShellAsyncCommand asyncCommand);
-
         int ExecuteCommand(string commandText, int timeout, out string commandOutput, out string errorMessage);
 
         List<Process> ListProcesses();

--- a/src/SSHDebugPS/SSH/SSHConnection.cs
+++ b/src/SSHDebugPS/SSH/SSHConnection.cs
@@ -69,6 +69,7 @@ namespace Microsoft.SSHDebugPS.SSH
             return PSOutputParser.Parse(command.Output, systemInformation);
         }
 
+        /// <inheritdoc/>
         public override void BeginExecuteAsyncCommand(string commandText, bool runInShell, IDebugUnixShellCommandCallback callback, out IDebugUnixShellAsyncCommand asyncCommand)
         {
             if (runInShell)


### PR DESCRIPTION
### Summary

This PR addresses a fairly wide ranging issue that this code base had with [IDebugUnixShellPort.BeginExecuteAsyncCommand](https://github.com/microsoft/MIEngine/blob/70bf82b1f42094e4f7d534a1f4cf8b65beb3ab82/src/Microsoft.VisualStudio.Debugger.Interop.UnixPortSupplier/Microsoft.VisualStudio.Debugger.Interop.UnixPortSupplier.cs#L43) and output buffering. The way things were supposed to work was that if `runInShell` was set to `true` then output would always be delivered one line at a time and without newline characters and if it was false then output characters would be delivered whenever the pipe decided to flush and raw characters would be given. However, this isn't how things really were -- we had some places specify `false` for `runInShell` even though they didn't actually handle non-line-based output, and we also had code paths were the raw output would be used even though the caller specified `true` for `runInShell`.

### Fixes along the way

* UnixShellPortTransport.cs: 
    * Stop dumping the output from `kill` into the stdout stream and instead of just adding it to the log
    * `kill` isn't available as a command without starting a shell in Docker
* CommandRunner.cs:
    * Stop using 'raw' output reading for stderr
    * Stop abusing the thread pool by using Task.Run for a very long running operation
    * Stop using Task.Wait to wait for I/O to be ready
    * Dispose the process
    * Don't null out `_outputReadLoopTask`/`_errorReadLoopTask` as that causes null derefs in `OnProcessExited`
    * Fix hang from calling `Process.HasExited` under a lock. This is not a trivial method and could deadlock with the reader thread
    * Wait for stderr to complete as well (we were just waiting for stdout)
* DockerAsyncCommand.cs: Fix crash that I saw when Close was called more than once

### Testing

- [X] WSL: .NET debugging: tested attach, break, inspection, detach, reattach and run-to-completion
- [X] WSL: GDB debugging: tested attach, break, inspection, detach, reattach and run-to-completion
- [x] Docker Local: .NET debugging: tested attach, break, inspection, detach, reattach and run-to-completion
- [x] Docker Local: GDB debugging: tested attach, break, inspection, detach, reattach and run-to-completion
- [x] Docker Remote: .NET debugging: tested attach, break, inspection, detach, reattach and run-to-completion
- [x] Docker Remote: GDB debugging: tested attach, break, inspection, detach, reattach and run-to-completion