### PR TITLE
Add Cppdbg Tests to MIDebugEngine.sln

### DIFF
--- a/build/debuggertesting.settings.targets
+++ b/build/debuggertesting.settings.targets
@@ -5,6 +5,7 @@
   <Import Project="all_projects.settings.targets"/>
   <Import Project="package_versions.settings.targets" />
   <Import Project="version.settings.targets" />
+  <Import Project="source_link.targets" />
 
   <PropertyGroup>
     <OutputPath>$(MIEngineRoot)bin\DebugAdapterProtocolTests\$(Configuration)</OutputPath>

--- a/build/debuggertesting.settings.targets
+++ b/build/debuggertesting.settings.targets
@@ -1,0 +1,19 @@
+<Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003"> 
+  <!--
+  Settings file which is used by the debugger testing projects.
+  -->  
+  <Import Project="all_projects.settings.targets"/>
+  <Import Project="package_versions.settings.targets" />
+  <Import Project="version.settings.targets" />
+
+  <PropertyGroup>
+    <OutputPath>$(MIEngineRoot)bin\DebugAdapterProtocolTests\$(Configuration)</OutputPath>
+    <DropDir>$(MIEngineRoot)bin\DebugAdapterProtocolTests\$(Configuration)\drop</DropDir>
+    <DropRootDir>$(DropDir)</DropRootDir>
+
+     <!-- SDK Project Variables -->
+    <Configurations>Debug;Release</Configurations>
+    <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
+    <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
+  </PropertyGroup>
+</Project>

--- a/build/miengine.targets
+++ b/build/miengine.targets
@@ -6,6 +6,7 @@
   </PropertyGroup>
 
   <Import Project=".\Analyzers.targets" />
+  <Import Project=".\source_link.targets" />
 
   <PropertyGroup>
     <CoreCompileDependsOn>GenerateAssemblyInfoFile;$(CoreCompileDependsOn)</CoreCompileDependsOn>
@@ -67,31 +68,6 @@
       <Output TaskParameter="OutputFile" ItemName="Compile" />
       <Output TaskParameter="OutputFile" ItemName="FileWrites" />
     </WriteCodeFragment>
-  </Target>
-  
-  <!-- Source Link -->
-  <PropertyGroup Condition="'$(EnableSourceLink)' == 'true' and '$(BUILD_SOURCEVERSION)' != ''">
-    <SourceLink>$(IntermediateOutputPath)SourceLink.json</SourceLink>
-  </PropertyGroup>
-  
-  <Target Name="CreateSourceLinkJson"
-          Condition="'$(SourceLink)' != ''"
-          BeforeTargets="CoreCompile">
-    <PropertyGroup>
-      <EscapedRepositoryRoot>$(MIEngineRoot.Replace("\", "\\"))</EscapedRepositoryRoot>
-      <SourceLinkDir>$([System.IO.Path]::GetDirectoryName('$(SourceLink)'))</SourceLinkDir>
-      
-      <JsonString>
-{
-  "documents": {
-    "$(EscapedRepositoryRoot)*": "https://raw.githubusercontent.com/Microsoft/MIEngine/$(BUILD_SOURCEVERSION)/*"
-  }
-}
-      </JsonString>
-    </PropertyGroup>
-
-    <MakeDir Condition="!Exists('$(SourceLinkDir)')" Directories="$(SourceLinkDir)"/>
-    <WriteLinesToFile File="$(SourceLink)" Lines="$(JsonString)" Overwrite="true"/>
   </Target>
 
   <!-- ResolveProjectReferences allows us to generate the dll from il before adding them as a reference -->

--- a/build/source_link.targets
+++ b/build/source_link.targets
@@ -1,0 +1,28 @@
+<Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+
+  <!-- Source Link -->
+  <PropertyGroup Condition="'$(EnableSourceLink)' == 'true' and '$(BUILD_SOURCEVERSION)' != ''">
+    <SourceLink>$(IntermediateOutputPath)SourceLink.json</SourceLink>
+  </PropertyGroup>
+  
+  <Target Name="CreateSourceLinkJson"
+          Condition="'$(SourceLink)' != ''"
+          BeforeTargets="CoreCompile">
+    <PropertyGroup>
+      <EscapedRepositoryRoot>$(MIEngineRoot.Replace("\", "\\"))</EscapedRepositoryRoot>
+      <SourceLinkDir>$([System.IO.Path]::GetDirectoryName('$(SourceLink)'))</SourceLinkDir>
+      
+      <JsonString>
+{
+  "documents": {
+    "$(EscapedRepositoryRoot)*": "https://raw.githubusercontent.com/Microsoft/MIEngine/$(BUILD_SOURCEVERSION)/*"
+  }
+}
+      </JsonString>
+    </PropertyGroup>
+
+    <MakeDir Condition="!Exists('$(SourceLinkDir)')" Directories="$(SourceLinkDir)"/>
+    <WriteLinesToFile File="$(SourceLink)" Lines="$(JsonString)" Overwrite="true"/>
+  </Target>
+
+</Project>

--- a/src/MIDebugEngine.sln
+++ b/src/MIDebugEngine.sln
@@ -63,6 +63,27 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "MIDebugPackage", "MIDebugPa
 		{15BCBEF4-1C2B-412B-925B-34A049097E62} = {15BCBEF4-1C2B-412B-925B-34A049097E62}
 	EndProjectSection
 EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "DebugAdapterProtocolTests", "DebugAdapterProtocolTests", "{9D97EF1A-BCD5-4932-BBCC-98194CF8A841}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "CppTests", "..\test\CppTests\CppTests.csproj", "{FCE5D242-33FC-4570-88F3-A3DDE8C27643}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "DebugAdapterRunner", "..\test\DebugAdapterRunner\DebugAdapterRunner.csproj", "{A65FA6DE-D455-4662-9593-8EBBE61BA134}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "DebuggerTesting", "..\test\DebuggerTesting\DebuggerTesting.csproj", "{6B26CBAE-38A1-47E6-BFF1-F4A626C9A5B5}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "build", "build", "{4F96DA84-CCBA-4ADE-8D7D-BC15D566A329}"
+	ProjectSection(SolutionItems) = preProject
+		..\build\all_projects.settings.targets = ..\build\all_projects.settings.targets
+		..\build\Analyzers.targets = ..\build\Analyzers.targets
+		..\build\debuggertesting.settings.targets = ..\build\debuggertesting.settings.targets
+		..\build\DropFiles.targets = ..\build\DropFiles.targets
+		..\build\miengine.csharp.localization.targets = ..\build\miengine.csharp.localization.targets
+		..\build\miengine.settings.targets = ..\build\miengine.settings.targets
+		..\build\miengine.targets = ..\build\miengine.targets
+		..\build\package_versions.settings.targets = ..\build\package_versions.settings.targets
+		..\build\version.settings.targets = ..\build\version.settings.targets
+	EndProjectSection
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -265,6 +286,42 @@ Global
 		{A8D8E02F-4258-4F2E-88B6-A50FEBD5AD8C}.Lab.Release|Any CPU.Build.0 = Lab.Release|Any CPU
 		{A8D8E02F-4258-4F2E-88B6-A50FEBD5AD8C}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{A8D8E02F-4258-4F2E-88B6-A50FEBD5AD8C}.Release|Any CPU.Build.0 = Release|Any CPU
+		{FCE5D242-33FC-4570-88F3-A3DDE8C27643}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{FCE5D242-33FC-4570-88F3-A3DDE8C27643}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{FCE5D242-33FC-4570-88F3-A3DDE8C27643}.Desktop.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{FCE5D242-33FC-4570-88F3-A3DDE8C27643}.Desktop.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{FCE5D242-33FC-4570-88F3-A3DDE8C27643}.Desktop.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{FCE5D242-33FC-4570-88F3-A3DDE8C27643}.Desktop.Release|Any CPU.Build.0 = Release|Any CPU
+		{FCE5D242-33FC-4570-88F3-A3DDE8C27643}.Lab.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{FCE5D242-33FC-4570-88F3-A3DDE8C27643}.Lab.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{FCE5D242-33FC-4570-88F3-A3DDE8C27643}.Lab.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{FCE5D242-33FC-4570-88F3-A3DDE8C27643}.Lab.Release|Any CPU.Build.0 = Release|Any CPU
+		{FCE5D242-33FC-4570-88F3-A3DDE8C27643}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{FCE5D242-33FC-4570-88F3-A3DDE8C27643}.Release|Any CPU.Build.0 = Release|Any CPU
+		{A65FA6DE-D455-4662-9593-8EBBE61BA134}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{A65FA6DE-D455-4662-9593-8EBBE61BA134}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{A65FA6DE-D455-4662-9593-8EBBE61BA134}.Desktop.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{A65FA6DE-D455-4662-9593-8EBBE61BA134}.Desktop.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{A65FA6DE-D455-4662-9593-8EBBE61BA134}.Desktop.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{A65FA6DE-D455-4662-9593-8EBBE61BA134}.Desktop.Release|Any CPU.Build.0 = Release|Any CPU
+		{A65FA6DE-D455-4662-9593-8EBBE61BA134}.Lab.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{A65FA6DE-D455-4662-9593-8EBBE61BA134}.Lab.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{A65FA6DE-D455-4662-9593-8EBBE61BA134}.Lab.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{A65FA6DE-D455-4662-9593-8EBBE61BA134}.Lab.Release|Any CPU.Build.0 = Release|Any CPU
+		{A65FA6DE-D455-4662-9593-8EBBE61BA134}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{A65FA6DE-D455-4662-9593-8EBBE61BA134}.Release|Any CPU.Build.0 = Release|Any CPU
+		{6B26CBAE-38A1-47E6-BFF1-F4A626C9A5B5}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{6B26CBAE-38A1-47E6-BFF1-F4A626C9A5B5}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{6B26CBAE-38A1-47E6-BFF1-F4A626C9A5B5}.Desktop.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{6B26CBAE-38A1-47E6-BFF1-F4A626C9A5B5}.Desktop.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{6B26CBAE-38A1-47E6-BFF1-F4A626C9A5B5}.Desktop.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{6B26CBAE-38A1-47E6-BFF1-F4A626C9A5B5}.Desktop.Release|Any CPU.Build.0 = Release|Any CPU
+		{6B26CBAE-38A1-47E6-BFF1-F4A626C9A5B5}.Lab.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{6B26CBAE-38A1-47E6-BFF1-F4A626C9A5B5}.Lab.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{6B26CBAE-38A1-47E6-BFF1-F4A626C9A5B5}.Lab.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{6B26CBAE-38A1-47E6-BFF1-F4A626C9A5B5}.Lab.Release|Any CPU.Build.0 = Release|Any CPU
+		{6B26CBAE-38A1-47E6-BFF1-F4A626C9A5B5}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{6B26CBAE-38A1-47E6-BFF1-F4A626C9A5B5}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -276,6 +333,10 @@ Global
 		{207FD4CC-116B-466D-8893-F9565248A085} = {2865BFC4-770D-4219-945A-75670F98A6A6}
 		{D2A11674-F677-4B11-9989-2F6099A6F0A2} = {B864C337-1AA8-42B3-BF01-90901F55DE70}
 		{AE7F97CA-DFD2-41BC-B581-98C91C83065C} = {B864C337-1AA8-42B3-BF01-90901F55DE70}
+		{FCE5D242-33FC-4570-88F3-A3DDE8C27643} = {9D97EF1A-BCD5-4932-BBCC-98194CF8A841}
+		{A65FA6DE-D455-4662-9593-8EBBE61BA134} = {9D97EF1A-BCD5-4932-BBCC-98194CF8A841}
+		{6B26CBAE-38A1-47E6-BFF1-F4A626C9A5B5} = {9D97EF1A-BCD5-4932-BBCC-98194CF8A841}
+		{4F96DA84-CCBA-4ADE-8D7D-BC15D566A329} = {CF02407C-BF37-4D51-83F4-845A7F36C101}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {6099AC71-DA1D-4578-A8A3-376EB3C602E6}

--- a/test/CppTests/CppTestSettingsProvider.cs
+++ b/test/CppTests/CppTestSettingsProvider.cs
@@ -1,0 +1,43 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Collections.Generic;
+using System.Reflection;
+using System.Threading;
+using DebuggerTesting;
+using DebuggerTesting.Settings;
+using DebuggerTesting.TestFramework;
+
+namespace CppTests
+{
+    public sealed class CppTestSettingsProvider :
+        ITestSettingsProvider
+    {
+        #region ITestSettingsProvider Member
+
+        IEnumerable<ITestSettings> ITestSettingsProvider.GetSettings(MethodInfo testMethod)
+        {
+            return this.settingsLazy.Value;
+        }
+
+        #endregion
+
+        #region Methods
+
+        private static IEnumerable<ITestSettings> GetSettings()
+        {
+            return TestSettingsHelper.LoadSettingsFromConfig(PathSettings.TestConfigurationFilePath);
+        }
+
+        #endregion
+
+        #region Fields
+
+        private Lazy<IEnumerable<ITestSettings>> settingsLazy = new Lazy<IEnumerable<ITestSettings>>(
+            CppTestSettingsProvider.GetSettings,
+            LazyThreadSafetyMode.ExecutionAndPublication);
+
+        #endregion
+    }
+}

--- a/test/CppTests/CppTests.csproj
+++ b/test/CppTests/CppTests.csproj
@@ -1,0 +1,50 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+  <Import Project="..\..\build\debuggertesting.settings.targets" />
+
+  <PropertyGroup>
+    <TargetFramework>net5.0</TargetFramework>
+
+    <IsPackable>false</IsPackable>
+
+    <OutputPath>$(OutputPath)\CppTests</OutputPath>
+  </PropertyGroup>
+  
+  <ItemGroup Label="Package References">
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="$(Microsoft_NET_Test_Sdk_Version)" />
+    <PackageReference Include="xunit" Version="$(xunit_Version)" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="$(xunit_runner_visualstudio_Version)">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+  </ItemGroup>
+
+  <ItemGroup Label="Additional Files">
+    <None Include="debuggees\**" CopyToOutputDirectory="PreserveNewest" />
+    <None Include="TestConfigurations\**" CopyToOutputDirectory="PreserveNewest" />
+
+    <ContentFiles Include="debuggees\**" />
+    <ContentFiles Include="TestConfigurations\**" />
+  </ItemGroup>
+
+  <ItemGroup Label="Project References">
+    <ProjectReference Include="..\DebugAdapterRunner\DebugAdapterRunner.csproj" />
+    <ProjectReference Include="..\DebuggerTesting\DebuggerTesting.csproj" />
+  </ItemGroup>
+
+  <Target Name="Copy Config and Debuggees" BeforeTargets="DropFiles">
+    <Copy
+        SourceFiles="@(ContentFiles)"
+        DestinationFolder="$(DropDir)\contentFiles\%(RecursiveDir)"
+    />
+  </Target>
+
+  <ItemGroup>
+    <DropSignedFile Include="$(OutputPath)CppTests.dll" />
+    <DropUnsignedFile Include="$(OutputPath)CppTests.pdb" />
+    <DropSignedFile Include="$(OutputPath)DebuggerTesting.dll" />
+    <DropUnsignedFile Include="$(OutputPath)DebuggerTesting.pdb" />
+  </ItemGroup>
+
+  <Import Project="..\..\build\DropFiles.targets" />
+
+</Project>

--- a/test/CppTests/CppTests.nuspec
+++ b/test/CppTests/CppTests.nuspec
@@ -1,0 +1,23 @@
+<?xml version="1.0"?>
+<package xmlns="http://schemas.microsoft.com/packaging/2011/08/nuspec.xsd">
+  <metadata>
+    <id>Microsoft.VisualStudio.DebuggerTesting.CppTests</id>
+    <version>$version$</version>
+    <title>Microsoft.VisualStudio.DebuggerTesting.CppTests</title>
+    <authors>Microsoft</authors>
+    <owners>Microsoft</owners>
+    <licenseUrl>https://aka.ms/pexunj</licenseUrl>
+    <projectUrl>https://aka.ms/vsextensibility</projectUrl>
+    <iconUrl>https://aka.ms/vsextensibilityicon</iconUrl>
+    <requireLicenseAcceptance>true</requireLicenseAcceptance>
+    <description>Contains C++ Tests and Debuggees used for testing C++ Debug Adapters. This package should only be used for testing owned by the Microsoft Visual Studio Diagnostics team and isn't supported for other purposes.</description>
+    <copyright>© Microsoft Corporation. All rights reserved.</copyright>
+  </metadata>
+  <files>
+    <file src="$binRoot$CppTests.dll" target="lib\net5.0" />
+    <file src="$binRoot$CppTests.pdb" target="lib\net5.0" />
+    <file src="$binRoot$DebuggerTesting.dll" target="lib\net5.0" />
+    <file src="$binRoot$DebuggerTesting.pdb" target="lib\net5.0" />
+    <file src="$binRoot$contentFiles\**\*" target="contentFiles" />
+  </files>
+</package>

--- a/test/CppTests/OpenDebug/CrossPlatCpp/AttachCommand.cs
+++ b/test/CppTests/OpenDebug/CrossPlatCpp/AttachCommand.cs
@@ -1,0 +1,58 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using DebuggerTesting.OpenDebug.Commands;
+using DebuggerTesting.Utilities;
+using Newtonsoft.Json;
+
+namespace DebuggerTesting.OpenDebug.CrossPlatCpp
+{
+    public class AttachCommand : AttachCommand<CppLaunchCommandArgs>
+    {
+
+        public AttachCommand(IDebuggerSettings settings, Process process)
+        {
+            this.Timeout = TimeSpan.FromSeconds(15);
+
+            this.Args.processId = process.Id;
+            this.Args.name = CreateName(settings);
+            this.Args.program = process.StartInfo.FileName;
+            this.Args.args = new string[] { };
+            this.Args.request = "attach";
+            this.Args.environment = new EnvironmentEntry[] { };
+            this.Args.launchOptionType = "Local";
+            this.Args.sourceFileMap = new Dictionary<string, string>();
+
+            if (settings.DebuggerType == SupportedDebugger.VsDbg)
+            {
+                this.Args.type = "cppvsdbg";
+            }
+            else
+            {
+                this.Args.stopAtEntry = false;
+                this.Args.cwd = Path.GetDirectoryName(process.StartInfo.FileName);
+                this.Args.type = "cppdbg";
+                this.Args.miDebuggerPath = settings.DebuggerPath;
+                this.Args.targetArchitecture = settings.DebuggeeArchitecture.ToArchitectureString();
+                this.Args.noDebug = false;
+                this.Args.coreDumpPath = null;
+                this.Args.MIMode = settings.MIMode;
+            }
+        }
+
+        private string CreateName(IDebuggerSettings settings)
+        {
+            string debuggerName = Enum.GetName(typeof(SupportedDebugger), settings.DebuggerType);
+            return "C++ ({0})".FormatInvariantWithArgs(debuggerName);
+        }
+
+        public override string ToString()
+        {
+            return "{0} ({1})".FormatInvariantWithArgs(base.ToString(), this.Args.program);
+        }
+    }
+}

--- a/test/CppTests/OpenDebug/CrossPlatCpp/DebuggerRunner.cs
+++ b/test/CppTests/OpenDebug/CrossPlatCpp/DebuggerRunner.cs
@@ -1,0 +1,340 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Globalization;
+using System.IO;
+using System.Text.RegularExpressions;
+using System.Threading;
+using DebugAdapterRunner;
+using DebuggerTesting.OpenDebug.Commands;
+using DebuggerTesting.Settings;
+using DebuggerTesting.Utilities;
+using Xunit;
+using Xunit.Abstractions;
+using DarRunner = DebugAdapterRunner.DebugAdapterRunner;
+
+namespace DebuggerTesting.OpenDebug.CrossPlatCpp
+{
+    /// <summary>
+    /// Provides a wrapper to initialize and close a debug adapter.
+    /// The constructur will initiate the connection to the debug adapter.
+    /// Disposing this wrapper will close the connection.
+    /// </summary>
+    public class DebuggerRunner : DisposableObject, IDebuggerRunner
+    {
+#if DEBUG
+        private IDebugFailUI savedDebugFailUI;
+#endif
+
+        private string engineLogPath;
+        private static Regex _engineLogRegEx;
+
+        #region Constructor/Create/Dispose
+
+        private DebuggerRunner(ILoggingComponent logger, ITestSettings testSettings, IEnumerable<Tuple<string, CallbackRequestHandler>> callbackHandlers)
+        {
+            Parameter.ThrowIfNull(testSettings, nameof(testSettings));
+            this.OutputHelper = logger.OutputHelper;
+            this.DebuggerSettings = testSettings.DebuggerSettings;
+#if DEBUG
+            this.savedDebugFailUI = UDebug.DebugFailUI;
+            UDebug.DebugFailUI = new XUnitDefaultDebugFailUI(this.OutputHelper);
+#endif
+
+            this.WriteLine("Creating Debug Adapter Runner.");
+            string adapterId = (this.DebuggerSettings.DebuggerType == SupportedDebugger.VsDbg) ? "cppvsdbg" : "cppdbg";
+            string debugAdapterRelativePath = this.DebuggerSettings.DebuggerAdapterPath ?? "OpenDebugAD7";
+            string debugAdapterFullPath = Path.Combine(PathSettings.DebugAdaptersPath, debugAdapterRelativePath);
+
+            Assert.True(Directory.Exists(Path.GetDirectoryName(debugAdapterFullPath)), "Debug Adapter Path {0} does not exist.".FormatInvariantWithArgs(debugAdapterFullPath));
+
+            // Output engine log to temp folder if requested.
+            this.engineLogPath = Path.Combine(PathSettings.TempPath, "EngineLog-{0}-{1}-{2}.log".FormatInvariantWithArgs(testSettings.Name, testSettings.DebuggerSettings.DebuggeeArchitecture.ToString(), testSettings.DebuggerSettings.DebuggerType.ToString()));
+            this.WriteLine("Logging engine to: {0}", this.engineLogPath);
+
+            this.DarRunner = new DarRunner(
+                adapterPath: debugAdapterFullPath,
+                traceDebugAdapterOutput: DiagnosticsSettings.LogDebugAdapter ? DebugAdapterRunner.TraceDebugAdapterMode.Memory : DebugAdapterRunner.TraceDebugAdapterMode.None,
+                engineLogPath: this.engineLogPath,
+                pauseForDebugger: false,
+                isVsDbg: this.DebuggerSettings.DebuggerType == SupportedDebugger.VsDbg,
+                isNative: true,
+                responseTimeout: 5000);
+
+            if (callbackHandlers != null)
+            {
+                foreach (Tuple<string, CallbackRequestHandler> handlerPair in callbackHandlers)
+                {
+                    this.DarRunner.AddCallbackRequestHandler(handlerPair.Item1, handlerPair.Item2);
+                }
+            }
+
+            this.WriteLine("Initializing debugger.");
+            this.initializeResponse = this.RunCommand(new InitializeCommand(adapterId));
+        }
+
+        public static IDebuggerRunner Create(ILoggingComponent logger, ITestSettings testSettings, IEnumerable<Tuple<string, CallbackRequestHandler>> callbackHandlers)
+        {
+            return new DebuggerRunner(logger, testSettings, callbackHandlers);
+        }
+
+        protected override void Dispose(bool isDisposing)
+        {
+            // If we disposed is called and the adapter is still running, send
+            // a disconnect command.
+            if (isDisposing)
+            {
+#if DEBUG
+                UDebug.DebugFailUI = this.savedDebugFailUI;
+#endif
+
+                this.DisconnectDebugAdapter(throwOnFailure: false);
+            }
+            else
+            {
+                try
+                {
+                    // If in the finalizer, just try to kill the process
+                    if (this.DarRunner?.DebugAdapter?.HasExited == false)
+                    {
+                        ProcessHelper.KillProcess(this.DarRunner.DebugAdapter, recurse: true);
+                    }
+                }
+                catch (InvalidOperationException e)
+                { 
+                    // If the process has exited but is already cleaned up, it will throw an InvalidOperationException with the message "Process has not been started"
+                    this.WriteLine("InvalidOperationException: {0}. /n StackTrace: {1}", e.Message, e.StackTrace);
+                }
+            }
+
+            base.Dispose(isDisposing);
+        }
+
+        /// <summary>
+        /// Call this to close the debug adapter. If child processes still exist
+        /// this will throw.
+        /// </summary>
+        public void DisconnectAndVerify()
+        {
+            this.DisconnectDebugAdapter(throwOnFailure: true);
+        }
+
+        private void DisconnectDebugAdapter(bool throwOnFailure)
+        {
+            if (this.DarRunner?.DebugAdapter?.HasExited == false)
+            {
+                this.Comment("Disconnecting Debug Adapter Runner.");
+                this.RunCommand(new DisconnectCommand());
+
+                // Wait 60 seconds for the adapter to close
+                int attempts = 0;
+                int maxAttempts = 10 * 60; // 60 seconds
+                while (this.DarRunner.DebugAdapter.HasExited == false &&
+                       attempts < maxAttempts)
+                {
+                    Thread.Sleep(100);
+                    attempts++;
+                }
+            }
+
+            // If the adapter is still running, forcibly stop it
+            if (this.DarRunner?.DebugAdapter?.HasExited == false)
+            {
+                this.Comment("Killing Debug Adapter Runner.");
+                int killCount = ProcessHelper.KillProcess(this.DarRunner.DebugAdapter, recurse: true);
+                this.WriteLine("Killed {0} process(es).", killCount);
+
+                // At this point the test is likely throwing a failure exception. 
+                // Failing the test due to failed cleanup will probably mask the error.
+                // Just log the output to the test log.
+                this.WriteLine("ERROR: Debug adapter was still running. Found and killed extra processes.");
+                Assert.False(throwOnFailure, "ERROR: Debug adapter still running. Processes not cleaned up properly.");
+            }
+
+            if (!throwOnFailure && DiagnosticsSettings.LogDebugAdapter)
+            {
+                this.Comment("Debug Adapter Log");
+                this.WriteLine(this.DarRunner.DebugAdapterOutput);
+            }
+
+            // Check for any abandoned debugger files or processes
+            this.CheckDebuggerArtifacts(throwOnFailure);
+        }
+
+        private static Regex EngineLogRegEx
+        {
+            get
+            {
+                const string engineLogArtifacts = @".*TempFile=(?<tempFile>.+)|" +
+                                                  @".*ShellPid=(?<shellPid>\d+)|" +
+                                                  @".*DebuggerPid=(?<debuggerPid>\d+)";
+
+                if (_engineLogRegEx == null)
+                    _engineLogRegEx = new Regex(engineLogArtifacts, RegexOptions.Compiled | RegexOptions.Multiline);
+                return _engineLogRegEx;
+            }
+        }
+
+        /// <summary>
+        /// Check for abandoned files or processes
+        /// </summary>
+        /// <param name="throwOnFailure">Fail the test if abandoned artifacts found</param>
+        private void CheckDebuggerArtifacts(bool throwOnFailure)
+        {
+            try
+            {
+                if (string.IsNullOrEmpty(this.engineLogPath) || !File.Exists(this.engineLogPath))
+                    return;
+
+                string engineLogContent = File.ReadAllText(this.engineLogPath);
+
+                // Add the MIEngine log to the test log (if it is enabled)
+                if (!throwOnFailure && DiagnosticsSettings.LogMIEngine)
+                {
+                    this.Comment("Engine Log");
+                    this.WriteLine(engineLogContent);
+                }
+
+                // Parse the mi engine's log to find associated temp files and debugger pids
+                // This only checks for any process ids or files logged by the mi engine
+                // and may not be a complete list.
+                List<string> tempFiles = new List<string>(3);
+                List<int> associatedPids = new List<int>(2);
+                foreach (Match match in EngineLogRegEx.Matches(engineLogContent))
+                {
+                    string tempFile = match.Groups?["tempFile"]?.Value;
+                    string shellPid = match.Groups?["shellPid"]?.Value;
+                    string debuggerPid = match.Groups?["debuggerPid"]?.Value;
+
+                    if (!string.IsNullOrEmpty(tempFile))
+                        tempFiles.Add(tempFile);
+                    else if (!string.IsNullOrEmpty(shellPid))
+                        associatedPids.Add(int.Parse(shellPid, CultureInfo.InvariantCulture));
+                    else if (!string.IsNullOrEmpty(debuggerPid))
+                        associatedPids.Add(int.Parse(debuggerPid, CultureInfo.InvariantCulture));
+                }
+
+                // Check for abandoned temp files
+                foreach (string tempFile in tempFiles)
+                {
+                    if (File.Exists(tempFile))
+                    {
+                        this.WriteLine("ERROR: Debug Adapter abandoned temp file: " + tempFile);
+                        TryDeleteFile(tempFile);
+                        Assert.False(throwOnFailure, "ERROR: Debug Adapter abandoned temp file: " + tempFile);
+                    }
+                }
+
+                // Check for abandoned processes
+                foreach (int associatedPid in associatedPids)
+                {
+                    if (ProcessHelper.IsProcessRunning(associatedPid))
+                    {
+                        this.WriteLine("ERROR: Debug Adapter abandoned process: " + associatedPid.ToString(CultureInfo.InvariantCulture));
+                        ProcessHelper.KillProcess(associatedPid, recurse: true);
+                        Assert.False(throwOnFailure, "ERROR: Debug Adapter abandoned process: " + associatedPid.ToString(CultureInfo.InvariantCulture));
+                    }
+                }
+            }
+            catch (Exception ex)
+            {
+                this.WriteLine("Error checking engine log. {0}", UDebug.ExceptionToString(ex));
+            }
+        }
+
+        private static void TryDeleteFile(string tempFile)
+        {
+            // This is already in cleanup code, ignore exceptions
+            try
+            {
+                File.Delete(tempFile);
+            }
+            catch (IOException)
+            { }
+        }
+
+        #endregion
+
+        #region ILoggingComponent Members
+
+        public ITestOutputHelper OutputHelper { get; private set; }
+
+        #endregion
+
+        #region IDebuggerRunner Members
+
+        public IDebuggerSettings DebuggerSettings { get; private set; }
+
+        private InitializeResponseValue initializeResponse { get; set; }
+        InitializeResponseValue IDebuggerRunner.InitializeResponse
+        {
+            get
+            {
+                return this.initializeResponse;
+            }
+        }
+
+        public bool ErrorEncountered { get; set; }
+
+        public DarRunner DarRunner { get; private set; }
+
+        public R RunCommand<R>(ICommandWithResponse<R> command, params IEvent[] expectedEvents)
+        {
+            return command.Run(this, expectedEvents);
+        }
+
+        public void RunCommand(ICommand command, params IEvent[] expectedEvents)
+        {
+            command.Run(this, expectedEvents);
+        }
+
+        /// <summary>
+        /// This gets populated when a stopped event occurs. It has the thread
+        /// id of the stopped thread.
+        /// </summary>
+        public int StoppedThreadId
+        {
+            get
+            {
+                return this.DarRunner.CurrentThreadId;
+            }
+        }
+
+        public IRunBuilder Expects
+        {
+            get { return new RunBuilder(this); }
+        }
+
+        #endregion
+
+        #region XUnitDefaultDebugFailUI
+
+#if DEBUG
+        /// <summary>
+        /// Implements the Debug Fail UI for the UDebug class
+        /// </summary>
+        internal class XUnitDefaultDebugFailUI : IDebugFailUI
+        {
+            private ITestOutputHelper outputHelper;
+
+            public XUnitDefaultDebugFailUI(ITestOutputHelper outputHelper)
+            {
+                this.outputHelper = outputHelper;
+            }
+
+            DebugUIResult IDebugFailUI.ShowFailure(string message, string callLocation, string exception, string callStack)
+            {
+                string header = exception + ": " + message;
+                this.outputHelper.WriteLine(header + Environment.NewLine + callStack);
+                Debug.Fail(header, callStack);
+                return DebugUIResult.Ignore;
+            }
+        }
+#endif //DEBUG
+
+        #endregion
+    }
+}

--- a/test/CppTests/OpenDebug/CrossPlatCpp/DebuggerRunnerExtensions.cs
+++ b/test/CppTests/OpenDebug/CrossPlatCpp/DebuggerRunnerExtensions.cs
@@ -1,0 +1,36 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Diagnostics;
+using DebuggerTesting.Compilation;
+
+namespace DebuggerTesting.OpenDebug.CrossPlatCpp
+{
+    public static class DebuggerRunnerExtensions
+    {
+        public static void Launch(this IDebuggerRunner runner, IDebuggerSettings settings, bool stopAtEntry, string program, params string[] args)
+        {
+            runner.RunCommand(new LaunchCommand(settings, program, false, args) { StopAtEntry = stopAtEntry });
+        }
+
+        public static void Launch(this IDebuggerRunner runner, IDebuggerSettings settings, bool stopAtEntry, IDebuggee debuggee, params string[] args)
+        {
+            runner.Launch(settings, stopAtEntry, debuggee.OutputPath, args);
+        }
+
+        public static void Launch(this IDebuggerRunner runner, IDebuggerSettings settings, IDebuggee debuggee, params string[] args)
+        {
+            runner.Launch(settings, false, debuggee.OutputPath, args);
+        }
+
+        public static void Attach(this IDebuggerRunner runner, IDebuggerSettings settings, Process process)
+        {
+            runner.RunCommand(new AttachCommand(settings, process));
+        }
+
+        public static void LaunchCoreDump(this IDebuggerRunner runner, IDebuggerSettings settings, IDebuggee debuggee, string coreDumpPath)
+        {
+            runner.RunCommand(new LaunchCommand(settings, debuggee.OutputPath, coreDumpPath));
+        }
+    }
+}

--- a/test/CppTests/OpenDebug/CrossPlatCpp/InspectorValueExtensions.cs
+++ b/test/CppTests/OpenDebug/CrossPlatCpp/InspectorValueExtensions.cs
@@ -1,0 +1,468 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using DebuggerTesting;
+using DebuggerTesting.OpenDebug.Commands;
+using DebuggerTesting.OpenDebug.Extensions;
+using System;
+using System.Globalization;
+using System.Text;
+using Xunit;
+
+namespace DebuggerTesting.OpenDebug.CrossPlatCpp
+{
+    /// <summary>
+    /// Provides helpers to give value types that are returned in different formats by different debugggers
+    /// </summary>
+    internal static class InspectorValueExtensions
+    {
+        #region Double
+
+        public static void AssertValueAsDouble(this IVariableInspector valueInspector, double expectedValue)
+        {
+            AssertDoubleValue(valueInspector.DebuggerRunner.DebuggerSettings, valueInspector.Value, expectedValue);
+        }
+
+        public static void AssertEvaluateAsDouble(this IFrameInspector frameInspector, string expression, EvaluateContext context, double expectedValue)
+        {
+            string actualValue = frameInspector.Evaluate(expression, context);
+            AssertDoubleValue(frameInspector.DebuggerRunner.DebuggerSettings, actualValue, expectedValue);
+        }
+
+        private static void AssertDoubleValue(IDebuggerSettings debuggerSettings, string actualValue, double expectedValue)
+        {
+            Assert.StartsWith(InspectorValueExtensions.GetDoubleValue(debuggerSettings, expectedValue), actualValue, StringComparison.Ordinal);
+        }
+
+        private static string GetDoubleValue(IDebuggerSettings debuggerSettings, double value)
+        {
+            if (double.IsPositiveInfinity(value))
+            {
+                switch (debuggerSettings.DebuggerType)
+                {
+                    case SupportedDebugger.Gdb_Gnu:
+                    case SupportedDebugger.Gdb_Cygwin:
+                    case SupportedDebugger.Gdb_MinGW:
+                    case SupportedDebugger.VsDbg:
+                        return "inf";
+                    case SupportedDebugger.Lldb:
+                        return "+Inf";
+                    default:
+                        Assert.True(false, "Debugger type doesn't have a specification for double value");
+                        return null;
+                }
+            }
+
+            switch (debuggerSettings.DebuggerType)
+            {
+                case SupportedDebugger.Gdb_Gnu:
+                case SupportedDebugger.Gdb_Cygwin:
+                case SupportedDebugger.Gdb_MinGW:
+                case SupportedDebugger.Lldb:
+                    //10.1
+                    //0
+                    return value.ToString("R", CultureInfo.InvariantCulture);
+                case SupportedDebugger.VsDbg:
+                    //10.100000000000000
+                    //0.00000000000000000
+                    return value.ToString("G10", CultureInfo.InvariantCulture);
+                default:
+                    Assert.True(false, "Debugger type doesn't have a specification for double value");
+                    return null;
+            }
+        }
+
+        #endregion
+
+        #region Float
+
+        public static void AssertValueAsFloat(this IVariableInspector valueInspector, float expectedValue)
+        {
+            AssertFloatValue(valueInspector.DebuggerRunner.DebuggerSettings, valueInspector.Value, expectedValue);
+        }
+
+        public static void AssertEvaluateAsFloat(this IFrameInspector frameInspector, string expression, EvaluateContext context, float expectedValue)
+        {
+            string actualValue = frameInspector.Evaluate(expression, context);
+            AssertFloatValue(frameInspector.DebuggerRunner.DebuggerSettings, actualValue, expectedValue);
+        }
+
+        private static void AssertFloatValue(IDebuggerSettings debuggerSettings, string actualValue, float expectedValue)
+        {
+            Assert.StartsWith(InspectorValueExtensions.GetFloatValue(debuggerSettings, expectedValue), actualValue, StringComparison.Ordinal);
+        }
+
+        private static string GetFloatValue(IDebuggerSettings debuggerSettings, float value)
+        {
+            if (float.IsPositiveInfinity(value))
+            {
+                switch (debuggerSettings.DebuggerType)
+                {
+                    case SupportedDebugger.Gdb_Gnu:
+                    case SupportedDebugger.Gdb_Cygwin:
+                    case SupportedDebugger.Gdb_MinGW:
+                    case SupportedDebugger.VsDbg:
+                        return "inf";
+                    case SupportedDebugger.Lldb:
+                        return "+Inf";
+                    default:
+                        Assert.True(false, "Debugger type doesn't have a specification for float value");
+                        return null;
+                }
+            }
+
+            switch (debuggerSettings.DebuggerType)
+            {
+                case SupportedDebugger.Gdb_Gnu:
+                case SupportedDebugger.Gdb_Cygwin:
+                case SupportedDebugger.Gdb_MinGW:
+                case SupportedDebugger.Lldb:
+                    return value.ToString("R", CultureInfo.InvariantCulture);
+                case SupportedDebugger.VsDbg:
+                    return value.ToString("G5", CultureInfo.InvariantCulture);
+                default:
+                    Assert.True(false, "Debugger type doesn't have a specification for float value");
+                    return null;
+            }
+        }
+
+        #endregion
+
+        #region Char
+
+        public static void AssertValueAsChar(this IVariableInspector valueInspector, char expectedValue)
+        {
+            AssertCharValue(valueInspector.DebuggerRunner.DebuggerSettings, valueInspector.Value, expectedValue);
+        }
+
+        public static void AssertEvaluateAsChar(this IFrameInspector frameInspector, string expression, EvaluateContext context, char expectedValue)
+        {
+            string actualValue = frameInspector.Evaluate(expression, context);
+            AssertCharValue(frameInspector.DebuggerRunner.DebuggerSettings, actualValue, expectedValue);
+        }
+
+        private static void AssertCharValue(IDebuggerSettings debuggerSettings, string actualValue, char expectedValue)
+        {
+            Assert.Equal(InspectorValueExtensions.GetCharValue(debuggerSettings, expectedValue), actualValue);
+        }
+
+        private static string GetCharValue(IDebuggerSettings debuggerSettings, char value)
+        {
+            // Non-printable chars
+            if (value < ' ')
+            {
+                switch (debuggerSettings.DebuggerType)
+                {
+                    case SupportedDebugger.Gdb_Gnu:
+                    case SupportedDebugger.Gdb_Cygwin:
+                    case SupportedDebugger.Gdb_MinGW:
+                        // 0 '\000'
+                        return @"{0} '\{0:D3}'".FormatInvariantWithArgs((int)value);
+                    case SupportedDebugger.Lldb:
+                    case SupportedDebugger.VsDbg:
+                        // 0 '\0'
+                        return @"{0} '\{0}'".FormatInvariantWithArgs((int)value);
+                    default:
+                        Assert.True(false, "Debugger type doesn't have a specification for char value");
+                        return null;
+                }
+            }
+
+            // Printable chars
+            switch (debuggerSettings.DebuggerType)
+            {
+                case SupportedDebugger.Gdb_Gnu:
+                case SupportedDebugger.Gdb_Cygwin:
+                case SupportedDebugger.Gdb_MinGW:
+                    return EscapeIfNeeded(c => c == '\'', value);
+                case SupportedDebugger.VsDbg:
+                    return EscapeIfNeeded(c => c == '"', value);
+                case SupportedDebugger.Lldb:
+                    return "{0} '{1}'".FormatInvariantWithArgs((int)value, value);
+                default:
+                    Assert.True(false, "Debugger type doesn't have a specification for char value");
+                    return null;
+            }
+        }
+
+        private static string EscapeIfNeeded(Func<char, bool> shouldEscape, char value)
+        {
+            string valueAsString = shouldEscape(value)
+                ? "\\{0}".FormatInvariantWithArgs(value)
+                : "{0}".FormatInvariantWithArgs(value);
+            return "{0} '{1}'".FormatInvariantWithArgs((int)value, valueAsString);
+        }
+
+        #endregion
+
+        #region WChar
+
+        public static void AssertValueAsWChar(this IVariableInspector valueInspector, char expectedValue)
+        {
+            AssertWCharValue(valueInspector.DebuggerRunner.DebuggerSettings, valueInspector.Value, expectedValue);
+        }
+
+        public static void AssertEvaluateAsWChar(this IFrameInspector frameInspector, string expression, EvaluateContext context, char expectedValue)
+        {
+            string actualValue = frameInspector.Evaluate(expression, context);
+            AssertWCharValue(frameInspector.DebuggerRunner.DebuggerSettings, actualValue, expectedValue);
+        }
+
+        private static void AssertWCharValue(IDebuggerSettings debuggerSettings, string actualValue, char expectedValue)
+        {
+            Assert.Equal(InspectorValueExtensions.GetWCharValue(debuggerSettings, expectedValue), actualValue);
+        }
+
+        private static string GetWCharValue(IDebuggerSettings debuggerSettings, char value)
+        {
+            switch (debuggerSettings.DebuggerType)
+            {
+                case SupportedDebugger.Gdb_Gnu:
+                case SupportedDebugger.Gdb_Cygwin:
+                case SupportedDebugger.Gdb_MinGW:
+                    return "{0} L'{1}'".FormatInvariantWithArgs((int)value, value);
+                case SupportedDebugger.Lldb:
+                    return "L'{0}'".FormatInvariantWithArgs(value);
+                case SupportedDebugger.VsDbg:
+                    return "{0} '{1}'".FormatInvariantWithArgs((int)value, value);
+                default:
+                    Assert.True(false, "Debugger type doesn't have a specification for wchar value");
+                    return null;
+            }
+        }
+
+        #endregion
+
+        #region Undefined Variable
+
+        public static void AssertEvaluateAsError(this IFrameInspector frameInspector, string variableName, EvaluateContext context)
+        {
+            string actualErrorMessage = frameInspector.Evaluate(variableName, context);
+            string expectedErrorMessage = GetUndefinedError(frameInspector.DebuggerRunner.DebuggerSettings, variableName);
+            Assert.Contains(expectedErrorMessage, actualErrorMessage, StringComparison.OrdinalIgnoreCase);
+        }
+
+        private static string GetUndefinedError(IDebuggerSettings debuggerSettings, string variableName)
+        {
+            switch (debuggerSettings.DebuggerType)
+            {
+                case SupportedDebugger.Gdb_Gnu:
+                case SupportedDebugger.Gdb_Cygwin:
+                case SupportedDebugger.Gdb_MinGW:
+                    return "-var-create: unable to create variable object";
+                case SupportedDebugger.Lldb:
+                    return "error: error: use of undeclared identifier '{0}'".FormatInvariantWithArgs(variableName);
+                case SupportedDebugger.VsDbg:
+                    return @"identifier ""{0}"" is undefined".FormatInvariantWithArgs(variableName);
+                default:
+                    Assert.True(false, "This debugger type doesn't have a error message test.");
+                    return null;
+            }
+        }
+
+        #endregion
+
+        #region Vector
+
+        public static void AssertValueAsVector(this IVariableInspector valueInspector, int vectorCount)
+        {
+            AssertVectorValue(valueInspector.DebuggerRunner.DebuggerSettings, valueInspector.Value, vectorCount);
+        }
+
+        public static void AssertEvaluateAsVector(this IFrameInspector frameInspector, string expression, EvaluateContext context, int vectorCount)
+        {
+            string actualValue = frameInspector.Evaluate(expression, context);
+            AssertVectorValue(frameInspector.DebuggerRunner.DebuggerSettings, actualValue, vectorCount);
+        }
+
+        private static void AssertVectorValue(IDebuggerSettings debuggerSettings, string actualValue, int vectorCount)
+        {
+            Assert.Equal(InspectorValueExtensions.GetVectorValue(debuggerSettings, vectorCount), actualValue);
+        }
+
+        private static string GetVectorValue(IDebuggerSettings debuggerSettings, int vectorCount)
+        {
+            switch (debuggerSettings.DebuggerType)
+            {
+                case SupportedDebugger.Gdb_Gnu:
+                case SupportedDebugger.Gdb_Cygwin:
+                case SupportedDebugger.Gdb_MinGW:
+                    return "{...}";
+                case SupportedDebugger.VsDbg:
+                    return "{{ size={0} }}".FormatInvariantWithArgs(vectorCount);
+                case SupportedDebugger.Lldb:
+                    return "size={0}".FormatInvariantWithArgs(vectorCount);
+                default:
+                    Assert.True(false, "This debugger type doesn't have a vector format.");
+                    return null;
+            }
+        }
+
+        #endregion
+
+        #region Object
+
+        public static void AssertValueAsObject(this IVariableInspector valueInspector, params string[] expectedObjectProperties)
+        {
+            AssertObjectValue(valueInspector.DebuggerRunner.DebuggerSettings, valueInspector.Value, expectedObjectProperties);
+        }
+
+        public static void AssertEvaluateAsObject(this IFrameInspector frameInspector, string expression, EvaluateContext context, params string[] expectedObjectProperties)
+        {
+            string actualValue = frameInspector.Evaluate(expression, context);
+            AssertObjectValue(frameInspector.DebuggerRunner.DebuggerSettings, actualValue, expectedObjectProperties);
+        }
+
+        private static void AssertObjectValue(IDebuggerSettings debuggerSettings, string actualValue, params string[] expectedObjectProperties)
+        {
+            Assert.Equal(InspectorValueExtensions.GetObjectValue(debuggerSettings, expectedObjectProperties), actualValue);
+        }
+
+        private static string GetObjectValue(IDebuggerSettings debuggerSettings, params string[] properties)
+        {
+            if (properties.Length % 2 != 0)
+            {
+                throw new ArgumentException("Missing a property!");
+            }
+
+            switch (debuggerSettings.DebuggerType)
+            {
+                case SupportedDebugger.Gdb_Gnu:
+                case SupportedDebugger.Gdb_Cygwin:
+                case SupportedDebugger.Gdb_MinGW:
+                case SupportedDebugger.Lldb:
+                    return "{...}";
+                case SupportedDebugger.VsDbg:
+                    StringBuilder sb = new StringBuilder("{");
+
+                    for (int i = 0; i < properties.Length; i += 2)
+                    {
+                        string name = properties[i];
+                        string value = properties[i + 1];
+                        sb.Append(name);
+                        sb.Append("=");
+                        sb.Append(value);
+                        sb.Append(" ");
+                    }
+                    sb.Append("}");
+                    return sb.ToString();
+                default:
+                    Assert.True(false, "This debugger type doesn't have an object format.");
+                    return null;
+            }
+        }
+
+        #endregion
+
+        #region IntArray
+
+        public static void AssertValueAsIntArray(this IVariableInspector valueInspector, params int[] expectedValue)
+        {
+            AssertIntArrayValue(valueInspector.DebuggerRunner.DebuggerSettings, valueInspector.Value, expectedValue);
+        }
+
+        public static void AssertEvaluateAsIntArray(this IFrameInspector frameInspector, string expression, EvaluateContext context, params int[] expectedValue)
+        {
+            string actualValue = frameInspector.Evaluate(expression, context);
+            AssertIntArrayValue(frameInspector.DebuggerRunner.DebuggerSettings, actualValue, expectedValue);
+        }
+
+
+        private static void AssertIntArrayValue(IDebuggerSettings debuggerSettings, string actualValue, params int[] expectedValue)
+        {
+            Assert.Contains(GetIntArray(debuggerSettings, expectedValue), actualValue, StringComparison.Ordinal);
+        }
+
+        private static string GetIntArray(IDebuggerSettings debuggerSettings, params int[] value)
+        {
+            switch (debuggerSettings.DebuggerType)
+            {
+                case SupportedDebugger.Gdb_Gnu:
+                case SupportedDebugger.Gdb_Cygwin:
+                case SupportedDebugger.Gdb_MinGW:
+                case SupportedDebugger.Lldb:
+                    return "[{0}]".FormatInvariantWithArgs(value.Length);
+                case SupportedDebugger.VsDbg:
+                    StringBuilder sb = new StringBuilder("{");
+                    for (int i = 0; i < value.Length; i++)
+                    {
+                        if (i != 0)
+                            sb.Append(", ");
+                        sb.Append(value[i]);
+                    }
+                    sb.Append("}");
+                    return sb.ToString();
+                default:
+                    Assert.True(false, "This debugger type doesn't have an object format.");
+                    return null;
+            }
+
+        }
+
+        #endregion
+
+        #region String / char*
+
+        /// <summary>
+        /// This method has only been used for const char* so far.
+        /// If required to work with other string-like types, please test it and
+        /// expand this method to support those types.
+        /// </summary>
+        /// <param name="frameInspector"></param>
+        /// <param name="expression"></param>
+        /// <param name="context"></param>
+        /// <param name="expectedValue"></param>
+        public static void AssertEvaluateAsString(
+            this IFrameInspector frameInspector,
+            string expression,
+            EvaluateContext context,
+            string expectedValue)
+        {
+            if (expectedValue == null)
+            {
+                AssertEvaluateAsNull(frameInspector, expression, context);
+                return;
+            }
+
+            for (int i = 0; i <= expectedValue.Length; i++)
+            {
+                string actualValue = frameInspector.Evaluate(
+                    string.Format(CultureInfo.InvariantCulture, "{0}[{1}]", expression, i), context);
+                char expectedChar; ;
+                if (i == expectedValue.Length)
+                {
+                    expectedChar = '\0';
+                }
+                else
+                {
+                    expectedChar = expectedValue[i];
+                }
+
+                AssertCharValue(frameInspector.DebuggerRunner.DebuggerSettings, actualValue, expectedChar);
+            }
+        }
+
+        #endregion
+
+        #region Pointer
+
+        /// <summary>
+        /// Checks whether a pointer value is null.
+        /// This function will return incorrect results if not called with an expression of type pointer.
+        /// </summary>
+        /// <param name="frameInspector"></param>
+        /// <param name="expression"></param>
+        /// <param name="context"></param>
+        public static void AssertEvaluateAsNull(
+            this IFrameInspector frameInspector,
+            string expression,
+            EvaluateContext context)
+        {
+            string actualValue = frameInspector.Evaluate(
+                string.Format(CultureInfo.InvariantCulture, "{0}==0", expression), context);
+            Assert.Equal("true", actualValue);
+        }
+
+        #endregion
+    }
+}

--- a/test/CppTests/OpenDebug/CrossPlatCpp/LaunchCommand.cs
+++ b/test/CppTests/OpenDebug/CrossPlatCpp/LaunchCommand.cs
@@ -1,0 +1,97 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using DebuggerTesting.OpenDebug.Commands;
+using DebuggerTesting.Utilities;
+using Newtonsoft.Json;
+
+namespace DebuggerTesting.OpenDebug.CrossPlatCpp
+{
+    #region LaunchCommandArgs
+
+    public sealed class CppLaunchCommandArgs : LaunchCommandArgs
+    {
+        public string launchOptionType;
+        public string miDebuggerPath;
+        public string targetArchitecture;
+
+        [JsonProperty(DefaultValueHandling = DefaultValueHandling.Ignore)]
+        public string symbolSearchPath;
+
+        [JsonProperty(DefaultValueHandling = DefaultValueHandling.Ignore)]
+        public string coreDumpPath;
+
+        [JsonProperty(DefaultValueHandling = DefaultValueHandling.Ignore)]
+        public int? processId;
+
+        [JsonProperty(DefaultValueHandling = DefaultValueHandling.Ignore)]
+        public bool? externalConsole;
+
+        [JsonProperty(DefaultValueHandling = DefaultValueHandling.Ignore)]
+        public string MIMode;
+    }
+
+    #endregion
+
+    public class LaunchCommand : LaunchCommand<CppLaunchCommandArgs>
+    {
+        /// <summary>
+        /// Launches a new process and attaches to it
+        /// </summary>
+        /// <param name="program">The full path to the program to launch</param>
+        /// <param name="architecture">The architecture of the program</param>
+        /// <param name="args">[OPTIONAL] Args to pass to the program</param>
+        public LaunchCommand(IDebuggerSettings settings, string program, bool isAttach = false, params string[] args)
+        {
+            this.Timeout = TimeSpan.FromSeconds(15);
+
+            this.Args.name = CreateName(settings);
+            this.Args.program = program;
+            this.Args.args = args ?? new string[] { };
+            this.Args.request = "launch";
+            this.Args.cwd = Path.GetDirectoryName(program);
+            this.Args.environment = new EnvironmentEntry[] { };
+            this.Args.launchOptionType = "Local";
+            this.Args.symbolSearchPath = String.Empty;
+            this.Args.sourceFileMap = new Dictionary<string, string>();
+
+            if (settings.DebuggerType == SupportedDebugger.VsDbg)
+            {
+                this.Args.type = "cppvsdbg";
+            }
+            else
+            {
+                this.Args.type = "cppdbg";
+                this.Args.miDebuggerPath = settings.DebuggerPath;
+                this.Args.targetArchitecture = settings.DebuggeeArchitecture.ToArchitectureString();
+                this.Args.MIMode = settings.MIMode;
+            }
+        }
+
+        /// <summary>
+        /// Launch a core dump
+        /// </summary>
+        /// <param name="settings"></param>
+        /// <param name="program"></param>
+        /// <param name="coreDumpPath"></param>
+        public LaunchCommand(IDebuggerSettings settings, string program, string coreDumpPath)
+            : this(settings, program)
+        {
+            this.Args.coreDumpPath = coreDumpPath;
+        }
+
+        private string CreateName(IDebuggerSettings settings)
+        {
+            string debuggerName = Enum.GetName(typeof(SupportedDebugger), settings.DebuggerType);
+            return "C++ ({0})".FormatInvariantWithArgs(debuggerName);
+        }
+
+        public override string ToString()
+        {
+            return "{0} ({1})".FormatInvariantWithArgs(base.ToString(), this.Args.program);
+        }
+    }
+}

--- a/test/CppTests/Properties/AssemblyInfo.cs
+++ b/test/CppTests/Properties/AssemblyInfo.cs
@@ -1,0 +1,22 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Reflection;
+using System.Runtime.InteropServices;
+using CppTests;
+using DebuggerTesting.Attribution;
+using Xunit;
+
+// Setting ComVisible to false makes the types in this assembly not visible 
+// to COM components.  If you need to access a type in this assembly from 
+// COM, set the ComVisible attribute to true on that type.
+[assembly: ComVisible(false)]
+
+// The following GUID is for the ID of the typelib if this project is exposed to COM
+[assembly: Guid("ae286353-4fc0-4fb3-bf6a-2677252b96b2")]
+
+// Turn off parallel threads, xunit didn't seem to be handling this correctly
+[assembly: CollectionBehavior(DisableTestParallelization = true)]
+
+// This is located by the test settings resolver and specifies the settings provider for C++ tests
+[assembly: TestSettingsProvider(typeof(CppTestSettingsProvider))]

--- a/test/CppTests/TestBase.cs
+++ b/test/CppTests/TestBase.cs
@@ -1,0 +1,37 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using DebugAdapterRunner;
+using DebuggerTesting;
+using DebuggerTesting.OpenDebug;
+using DebuggerTesting.OpenDebug.CrossPlatCpp;
+using System;
+using System.Collections.Generic;
+using Xunit.Abstractions;
+
+namespace CppTests
+{
+    public abstract class TestBase : ILoggingComponent
+    {
+        #region ILoggingComponent Members
+
+        public ITestOutputHelper OutputHelper { get; }
+
+        #endregion
+
+        protected TestBase(ITestOutputHelper outputHelper)
+        {
+            this.OutputHelper = outputHelper;
+        }
+
+        protected IDebuggerRunner CreateDebugAdapterRunner(ITestSettings settings)
+        {
+            return DebuggerRunner.Create(this, settings, GetCallbackHandlers());
+        }
+
+        protected virtual IEnumerable<Tuple<string, CallbackRequestHandler>> GetCallbackHandlers()
+        {
+            return null;
+        }
+    }
+}

--- a/test/CppTests/TestConfigurations/config_gdb.xml
+++ b/test/CppTests/TestConfigurations/config_gdb.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<TestMachineConfiguration>
+  <TestConfigurations>
+    <TestConfiguration
+      Compiler="Gpp"
+      DebuggeeArchitecture="x64"
+      Debugger="Gdb" />
+  </TestConfigurations>
+  <Compilers>
+    <Compiler
+      Name="Gpp"
+      Type="GPlusPlus"
+      Path="/usr/bin/g++"/>
+  </Compilers>
+  <Debuggers>
+    <Debugger
+      Name="Gdb"
+      Type="Gdb_Gnu"
+      Path="/usr/bin/gdb"/>
+  </Debuggers>
+</TestMachineConfiguration>

--- a/test/CppTests/TestConfigurations/config_vsdbg.xml
+++ b/test/CppTests/TestConfigurations/config_vsdbg.xml
@@ -1,0 +1,57 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<TestMachineConfiguration>
+  <TestConfigurations>
+    <TestConfiguration
+      Compiler="VisualCPlusPlusCompiler_x86"
+      DebuggeeArchitecture="x86"
+      Debugger="VsDebugger" />
+    <TestConfiguration
+      Compiler="VisualCPlusPlusCompiler_x64"
+      DebuggeeArchitecture="x64"
+      Debugger="VsDebugger" />
+  </TestConfigurations>
+  <Compilers>
+    <Compiler
+      Name="VisualCPlusPlusCompiler_x86"
+      Type="VisualCPlusPlus"
+      Path="%PROGRAMFILES(X86)%\Microsoft Visual Studio 14.0\VC\bin\cl.exe">
+      <Properties>
+        <Property Name="Include">
+          %PROGRAMFILES(X86)%\Microsoft Visual Studio 14.0\VC\include;
+          %PROGRAMFILES(X86)%\Windows Kits\10\Include\10.0.10240.0\ucrt;
+          %PROGRAMFILES(X86)%\Windows Kits\10\Include\10.0.10240.0\um;
+          %PROGRAMFILES(X86)%\Windows Kits\10\Include\10.0.10240.0\shared
+        </Property>
+        <Property Name="Lib">
+          %PROGRAMFILES(X86)%\Microsoft Visual Studio 14.0\VC\lib;
+          %PROGRAMFILES(X86)%\Windows Kits\10\Lib\10.0.10240.0\um\x86;
+          %PROGRAMFILES(X86)%\Windows Kits\10\Lib\10.0.10240.0\ucrt\x86
+        </Property>
+      </Properties>
+    </Compiler>
+    <Compiler
+      Name="VisualCPlusPlusCompiler_x64"
+      Type="VisualCPlusPlus"
+      Path="%PROGRAMFILES(X86)%\Microsoft Visual Studio 14.0\VC\bin\amd64\cl.exe">
+      <Properties>
+        <Property Name="Include">
+          %PROGRAMFILES(X86)%\Microsoft Visual Studio 14.0\VC\include;
+          %PROGRAMFILES(X86)%\Windows Kits\10\Include\10.0.10240.0\ucrt;
+          %PROGRAMFILES(X86)%\Windows Kits\10\Include\10.0.10240.0\um;
+          %PROGRAMFILES(X86)%\Windows Kits\10\Include\10.0.10240.0\shared
+        </Property>
+        <Property Name="Lib">
+          %PROGRAMFILES(X86)%\Microsoft Visual Studio 14.0\VC\lib\amd64;
+          %PROGRAMFILES(X86)%\Windows Kits\10\Lib\10.0.10240.0\um\x64;
+          %PROGRAMFILES(X86)%\Windows Kits\10\Lib\10.0.10240.0\ucrt\x64
+        </Property>
+      </Properties>
+    </Compiler>
+  </Compilers>
+  <Debuggers>
+    <Debugger
+      Name="VsDebugger"
+      Type="VsDbg"
+      AdapterPath="vsdbg\bin\vsdbg.exe" />
+  </Debuggers>
+</TestMachineConfiguration>

--- a/test/CppTests/Tests/AttachTests.cs
+++ b/test/CppTests/Tests/AttachTests.cs
@@ -1,0 +1,140 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Diagnostics;
+using System.Linq;
+using DebuggerTesting;
+using DebuggerTesting.Compilation;
+using DebuggerTesting.OpenDebug;
+using DebuggerTesting.OpenDebug.CrossPlatCpp;
+using DebuggerTesting.OpenDebug.Events;
+using DebuggerTesting.OpenDebug.Extensions;
+using DebuggerTesting.Ordering;
+using DebuggerTesting.Utilities;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace CppTests.Tests
+{
+    [TestCaseOrderer(DependencyTestOrderer.TypeName, DependencyTestOrderer.AssemblyName)]
+    public class AttachTests : TestBase
+    {
+        #region Constructor
+
+        public AttachTests(ITestOutputHelper outputHelper) : base(outputHelper)
+        {
+        }
+
+        #endregion
+
+        [Theory]
+        [RequiresTestSettings]
+        public void CompileKitchenSinkForAttach(ITestSettings settings)
+        {
+            this.TestPurpose("Compiles the kitchen sink debuggee for attach.");
+            this.WriteSettings(settings);
+
+            IDebuggee debuggee = SinkHelper.OpenAndCompile(this, settings.CompilerSettings, DebuggeeMonikers.KitchenSink.Attach);
+        }
+
+        [Theory]
+        [DependsOnTest(nameof(CompileKitchenSinkForAttach))]
+        [RequiresTestSettings]
+        // TODO: Re-enable for vsdbg
+        [UnsupportedDebugger(SupportedDebugger.Gdb_Cygwin | SupportedDebugger.Gdb_MinGW | SupportedDebugger.Lldb | SupportedDebugger.VsDbg, SupportedArchitecture.x64 | SupportedArchitecture.x86)]
+        public void AttachAsyncBreak(ITestSettings settings)
+        {
+            this.TestPurpose("Verifies attach and that breakpoints can be set from break mode.");
+            this.WriteSettings(settings);
+
+            IDebuggee debuggee = SinkHelper.Open(this, settings.CompilerSettings, DebuggeeMonikers.KitchenSink.Attach);
+            Process debuggeeProcess = debuggee.Launch("-fNonTerminating", "-fCalling");
+
+            using (ProcessHelper.ProcessCleanup(this, debuggeeProcess))
+            using (IDebuggerRunner runner = CreateDebugAdapterRunner(settings))
+            {
+                this.Comment("Attach to debuggee");
+                runner.Attach(settings.DebuggerSettings, debuggeeProcess);
+                runner.ConfigurationDone();
+
+                this.Comment("Attempt to break all");
+                StoppedEvent breakAllEvent = new StoppedEvent(StoppedReason.Pause);
+                runner.Expects.Event(breakAllEvent)
+                              .AfterAsyncBreak();
+
+                this.WriteLine("Break all stopped on:");
+                this.WriteLine(breakAllEvent.ActualEvent.ToString());
+
+                this.Comment("Set breakpoint while breaking code.");
+                runner.SetBreakpoints(debuggee.Breakpoints(SinkHelper.NonTerminating, 28));
+
+                this.Comment("Start running after the async break (since we have no idea where we are) and then hit the breakpoint");
+                runner.Expects.HitBreakpointEvent(SinkHelper.NonTerminating, 28)
+                              .AfterContinue();
+
+                this.Comment("Evaluate the shouldExit member to true to stop the infinite loop.");
+                using (IThreadInspector threadInspector = runner.GetThreadInspector())
+                {
+                    IFrameInspector firstFrame = threadInspector.Stack.First();
+                    this.WriteLine(firstFrame.ToString());
+                    firstFrame.GetVariable("shouldExitLocal").Value = "true";
+                }
+
+                this.Comment("Continue until debuggee exists");
+                runner.Expects.ExitedEvent(exitCode: 0).TerminatedEvent().AfterContinue();
+
+                this.Comment("Verify debugger and debuggee closed");
+                runner.DisconnectAndVerify();
+                Assert.True(debuggeeProcess.HasExited, "Debuggee still running.");
+            }
+        }
+
+        [Theory]
+        [DependsOnTest(nameof(CompileKitchenSinkForAttach))]
+        [RequiresTestSettings]
+        // TODO: Re-enable for vsdbg
+        [UnsupportedDebugger(SupportedDebugger.Gdb_Cygwin | SupportedDebugger.Gdb_MinGW | SupportedDebugger.Lldb | SupportedDebugger.VsDbg, SupportedArchitecture.x64 | SupportedArchitecture.x86)]
+        public void Detach(ITestSettings settings)
+        {
+            this.TestPurpose("Verify debugger can detach and reattach to a debuggee.");
+            this.WriteSettings(settings);
+
+            this.Comment("Starting debuggee");
+            IDebuggee debuggee = SinkHelper.Open(this, settings.CompilerSettings, DebuggeeMonikers.KitchenSink.Attach);
+            Process debuggeeProcess = debuggee.Launch("-fNonTerminating", "-fCalling");
+
+            using (ProcessHelper.ProcessCleanup(this, debuggeeProcess))
+            {
+                using (IDebuggerRunner runner = CreateDebugAdapterRunner(settings))
+                {
+                    this.Comment("Attaching first time");
+                    runner.Attach(settings.DebuggerSettings, debuggeeProcess);
+                    runner.ConfigurationDone();
+
+                    this.Comment("Attempt to break all");
+                    StoppedEvent breakAllEvent = new StoppedEvent(StoppedReason.Pause);
+                    runner.Expects.Event(breakAllEvent)
+                                  .AfterAsyncBreak();
+
+                    this.WriteLine("Break all stopped on:");
+                    this.WriteLine(breakAllEvent.ActualEvent.ToString());
+
+                    this.Comment("Detach then verify debugger closed");
+                    runner.DisconnectAndVerify();
+                }
+
+                Assert.False(debuggeeProcess.HasExited, "Debuggee should still be running.");
+
+                using (IDebuggerRunner runner = CreateDebugAdapterRunner(settings))
+                {
+                    this.Comment("Attaching second time");
+                    runner.Attach(settings.DebuggerSettings, debuggeeProcess);
+                    runner.ConfigurationDone();
+
+                    this.Comment("Detach then verify debugger closed");
+                    runner.DisconnectAndVerify();
+                }
+            }
+        }
+    }
+}

--- a/test/CppTests/Tests/BreakpointTests.cs
+++ b/test/CppTests/Tests/BreakpointTests.cs
@@ -1,0 +1,375 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Linq;
+using System.Threading;
+using DebuggerTesting;
+using DebuggerTesting.Compilation;
+using DebuggerTesting.OpenDebug;
+using DebuggerTesting.OpenDebug.Commands;
+using DebuggerTesting.OpenDebug.CrossPlatCpp;
+using DebuggerTesting.OpenDebug.Events;
+using DebuggerTesting.OpenDebug.Extensions;
+using DebuggerTesting.Ordering;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace CppTests.Tests
+{
+    [TestCaseOrderer(DependencyTestOrderer.TypeName, DependencyTestOrderer.AssemblyName)]
+    public class BreakpointTests : TestBase
+    {
+        #region Constructor
+
+        public BreakpointTests(ITestOutputHelper outputHelper) : base(outputHelper)
+        {
+        }
+
+        #endregion
+
+        #region Methods
+
+        [Theory]
+        [RequiresTestSettings]
+        public void CompileKitchenSinkForBreakpointTests(ITestSettings settings)
+        {
+            this.TestPurpose("Compiles the kitchen sink debuggee.");
+            this.WriteSettings(settings);
+
+            IDebuggee debuggee = SinkHelper.OpenAndCompile(this, settings.CompilerSettings, DebuggeeMonikers.KitchenSink.Breakpoint);
+        }
+
+        [Theory]
+        [DependsOnTest(nameof(CompileKitchenSinkForBreakpointTests))]
+        [RequiresTestSettings]
+        public void LineBreakpointsBasic(ITestSettings settings)
+        {
+            this.TestPurpose("Tests basic operation of line breakpoints");
+            this.WriteSettings(settings);
+
+            IDebuggee debuggee = SinkHelper.Open(this, settings.CompilerSettings, DebuggeeMonikers.KitchenSink.Breakpoint);
+
+            using (IDebuggerRunner runner = CreateDebugAdapterRunner(settings))
+            {
+                this.Comment("Configure launch");
+                runner.Launch(settings.DebuggerSettings, debuggee, "-fCalling");
+
+                // These keep track of all the breakpoints in a source file
+                SourceBreakpoints argumentsBreakpoints = debuggee.Breakpoints(SinkHelper.Arguments, 23);
+                SourceBreakpoints mainBreakpoints = debuggee.Breakpoints(SinkHelper.Main, 33);
+
+                SourceBreakpoints callingBreakpoints = debuggee.Breakpoints(SinkHelper.Calling, 48);
+
+                // A bug in clang causes several breakpoint hits in a constructor
+                // See: https://llvm.org/bugs/show_bug.cgi?id=30620
+                if (settings.CompilerSettings.CompilerType != SupportedCompiler.ClangPlusPlus)
+                {
+                    callingBreakpoints.Add(6);
+                }
+
+                this.Comment("Set initial breakpoints");
+                runner.SetBreakpoints(argumentsBreakpoints);
+                runner.SetBreakpoints(mainBreakpoints);
+                runner.SetBreakpoints(callingBreakpoints);
+
+                this.Comment("Launch and run until first breakpoint");
+                runner.Expects.HitBreakpointEvent(SinkHelper.Arguments, 23)
+                              .AfterConfigurationDone();
+
+                // A bug in clang causes several breakpoint hits in a constructor
+                // See: https://llvm.org/bugs/show_bug.cgi?id=30620
+                if (settings.CompilerSettings.CompilerType != SupportedCompiler.ClangPlusPlus)
+                {
+                    this.Comment("Continue until second initial breakpoint");
+                    runner.Expects.HitBreakpointEvent(SinkHelper.Calling, 6).AfterContinue();
+                }
+
+                this.Comment("Disable third initial breakpoint");
+                mainBreakpoints.Remove(33);
+                runner.SetBreakpoints(mainBreakpoints);
+
+                this.Comment("Continue, hit fourth initial breakpoint");
+                runner.Expects.HitBreakpointEvent(SinkHelper.Calling, 48).AfterContinue();
+
+                this.Comment("Set a breakpoint while in break mode");
+                callingBreakpoints.Add(52);
+                runner.SetBreakpoints(callingBreakpoints);
+
+                this.Comment("Continue until newly-added breakpoint");
+                runner.Expects.HitBreakpointEvent(SinkHelper.Calling, 52)
+                              .AfterContinue();
+
+                this.Comment("Continue until end");
+                runner.Expects.ExitedEvent()
+                              .TerminatedEvent()
+                              .AfterContinue();
+
+                runner.DisconnectAndVerify();
+            }
+        }
+
+        [Theory]
+        [DependsOnTest(nameof(CompileKitchenSinkForBreakpointTests))]
+        [RequiresTestSettings]
+        public void FunctionBreakpointsBasic(ITestSettings settings)
+        {
+            this.TestPurpose("Tests basic operation of function breakpoints");
+            this.WriteSettings(settings);
+
+            IDebuggee debuggee = SinkHelper.Open(this, settings.CompilerSettings, DebuggeeMonikers.KitchenSink.Breakpoint);
+
+            using (IDebuggerRunner runner = CreateDebugAdapterRunner(settings))
+            {
+                this.Comment("Configure launch");
+                runner.Launch(settings.DebuggerSettings, debuggee, "-fCalling");
+
+                this.Comment("Set initial function breakpoints");
+                FunctionBreakpoints functionBreakpoints = new FunctionBreakpoints("Arguments::CoreRun", "Calling::CoreRun", "a()");
+                runner.SetFunctionBreakpoints(functionBreakpoints);
+
+                this.Comment("Launch and run until first initial breakpoint");
+                runner.ExpectBreakpointAndStepToTarget(SinkHelper.Arguments, startLine: 9, targetLine: 10)
+                              .AfterConfigurationDone();
+
+                this.Comment("Continue until second initial breakpoint");
+                runner.ExpectBreakpointAndStepToTarget(SinkHelper.Calling, startLine: 47, targetLine: 48)
+                              .AfterContinue();
+
+                this.Comment("Remove and replace third initial function breakpoint while in break mode");
+                functionBreakpoints.Remove("a()");
+                functionBreakpoints.Add("b()");
+                runner.SetFunctionBreakpoints(functionBreakpoints);
+
+                this.Comment("Continue until newly-added function breakpoint");
+                runner.ExpectBreakpointAndStepToTarget(SinkHelper.Calling, startLine: 37, targetLine: 38)
+                              .AfterContinue();
+
+                this.Comment("Continue until end");
+                runner.Expects.ExitedEvent()
+                              .TerminatedEvent()
+                              .AfterContinue();
+
+                runner.DisconnectAndVerify();
+            }
+        }
+
+        [Theory]
+        [DependsOnTest(nameof(CompileKitchenSinkForBreakpointTests))]
+        [RequiresTestSettings]
+        [UnsupportedDebugger(SupportedDebugger.Gdb_Cygwin | SupportedDebugger.Gdb_MinGW, SupportedArchitecture.x64 | SupportedArchitecture.x86)]
+        public void RunModeBreakpoints(ITestSettings settings)
+        {
+            this.TestPurpose("Tests setting breakpoints while in run mode");
+            this.WriteSettings(settings);
+
+            IDebuggee debuggee = SinkHelper.Open(this, settings.CompilerSettings, DebuggeeMonikers.KitchenSink.Breakpoint);
+
+            using (IDebuggerRunner runner = CreateDebugAdapterRunner(settings))
+            {
+                this.Comment("Configure launch");
+                runner.Launch(settings.DebuggerSettings, debuggee, "-fNonTerminating");
+                runner.ConfigurationDone();
+
+                // Wait a second to ensure the debuggee has entered run mode, then try to set a breakpoint
+                Thread.Sleep(TimeSpan.FromSeconds(1));
+                this.Comment("Set a function breakpoint while in run mode");
+                FunctionBreakpoints functionBreakpoints = new FunctionBreakpoints("NonTerminating::DoSleep");
+                runner.ExpectBreakpointAndStepToTarget(SinkHelper.NonTerminating, startLine: 37, targetLine: 38)
+                              .AfterSetFunctionBreakpoints(functionBreakpoints);
+
+                this.Comment("Remove function breakpoint");
+                functionBreakpoints.Remove("NonTerminating::DoSleep");
+                runner.SetFunctionBreakpoints(functionBreakpoints);
+
+                this.Comment("Continue, set a line breakpoint while in run mode");
+                runner.Continue();
+
+                // Wait a second to ensure the debuggee has entered run mode, then try to set a breakpoint
+                Thread.Sleep(TimeSpan.FromSeconds(1));
+                runner.Expects.HitBreakpointEvent(SinkHelper.NonTerminating, 28)
+                              .AfterSetBreakpoints(debuggee.Breakpoints(SinkHelper.NonTerminating, 28));
+
+                this.Comment("Escape loop");
+                using (IThreadInspector threadInspector = runner.GetThreadInspector())
+                {
+                    IFrameInspector firstFrame = threadInspector.Stack.First();
+                    this.WriteLine(firstFrame.ToString());
+                    firstFrame.GetVariable("this", "shouldExit").Value = "1";
+                }
+
+                this.Comment("Continue until end");
+                runner.Expects.ExitedEvent()
+                              .TerminatedEvent()
+                              .AfterContinue();
+
+                runner.DisconnectAndVerify();
+            }
+        }
+
+        [Theory]
+        [DependsOnTest(nameof(CompileKitchenSinkForBreakpointTests))]
+        [RequiresTestSettings]
+        public void BreakpointBinding(ITestSettings settings)
+        {
+            this.TestPurpose("Tests that breakpoints are bound to the correct locations");
+            this.WriteSettings(settings);
+
+            IDebuggee debuggee = SinkHelper.Open(this, settings.CompilerSettings, DebuggeeMonikers.KitchenSink.Breakpoint);
+
+            using (IDebuggerRunner runner = CreateDebugAdapterRunner(settings))
+            {
+                this.Comment("Configure launch");
+                runner.Launch(settings.DebuggerSettings, debuggee);
+
+                SourceBreakpoints callingBreakpoints = debuggee.Breakpoints(SinkHelper.Calling, 11);
+                FunctionBreakpoints functionBreakpoints = new FunctionBreakpoints("Calling::CoreRun");
+
+                // VsDbg does not fire Breakpoint Change events when breakpoints are set.
+                // Instead it sends a new breakpoint event when it is bound (after configuration done).
+                bool bindsLate = (settings.DebuggerSettings.DebuggerType == SupportedDebugger.VsDbg);
+
+                this.Comment("Set a breakpoint at a location that has no executable code, expect it to be moved to the next line");
+                runner.Expects.ConditionalEvent(!bindsLate, x => x.BreakpointChangedEvent(BreakpointReason.Changed, 12))
+                              .AfterSetBreakpoints(callingBreakpoints);
+
+                this.Comment("Set a function breakpoint in a class member, expect it to be placed at the opening bracket");
+                runner.Expects.ConditionalEvent(!bindsLate, x => x.FunctionBreakpointChangedEvent(BreakpointReason.Changed, startLine: 47, endLine: 48))
+                              .AfterSetFunctionBreakpoints(functionBreakpoints);
+
+                this.Comment("Set a function breakpoint in a non-member, expect it to be placed on the first line of code");
+                functionBreakpoints.Add("a()");
+                runner.Expects.ConditionalEvent(!bindsLate, x => x.FunctionBreakpointChangedEvent(BreakpointReason.Changed, startLine: 42, endLine: 43))
+                              .AfterSetFunctionBreakpoints(functionBreakpoints);
+
+
+                runner.Expects.ConditionalEvent(bindsLate, x => x.BreakpointChangedEvent(BreakpointReason.Changed, 12)
+                                  .FunctionBreakpointChangedEvent(BreakpointReason.Changed, startLine: 47, endLine: 48)
+                                  .FunctionBreakpointChangedEvent(BreakpointReason.Changed, startLine: 42, endLine: 43))
+                              .ExitedEvent()
+                              .TerminatedEvent()
+                              .AfterConfigurationDone();
+
+                runner.DisconnectAndVerify();
+            }
+        }
+
+        [Theory]
+        [DependsOnTest(nameof(CompileKitchenSinkForBreakpointTests))]
+        [RequiresTestSettings]
+        public void DuplicateBreakpoints(ITestSettings settings)
+        {
+            this.TestPurpose("Tests that duplicate breakpoints are only hit once");
+            this.WriteSettings(settings);
+
+            IDebuggee debuggee = SinkHelper.Open(this, settings.CompilerSettings, DebuggeeMonikers.KitchenSink.Breakpoint);
+
+            using (IDebuggerRunner runner = CreateDebugAdapterRunner(settings))
+            {
+                this.Comment("Configure launch");
+                runner.Launch(settings.DebuggerSettings, debuggee, "-fCalling");
+
+                // These two breakpoints should resolve to the same line - setting two breakpoints on the same
+                //  line directly will throw an exception.
+                SourceBreakpoints callingBreakpoints = debuggee.Breakpoints(SinkHelper.Calling, 11, 12);
+
+                this.Comment("Set two line breakpoints that resolve to the same source location");
+                runner.SetBreakpoints(callingBreakpoints);
+
+                this.Comment("Set duplicate function breakpoints");
+                FunctionBreakpoints functionBreakpoints = new FunctionBreakpoints("Arguments::CoreRun", "Arguments::CoreRun");
+                runner.SetFunctionBreakpoints(functionBreakpoints);
+
+                this.Comment("Run to first breakpoint");
+                runner.ExpectBreakpointAndStepToTarget(SinkHelper.Arguments, startLine: 9, targetLine: 10)
+                              .AfterConfigurationDone();
+
+                this.Comment("Run to second breakpoint");
+                runner.Expects.HitBreakpointEvent(SinkHelper.Calling, 12)
+                              .AfterContinue();
+
+                this.Comment("Run to completion");
+                runner.Expects.ExitedEvent()
+                              .TerminatedEvent()
+                              .AfterContinue();
+
+                runner.DisconnectAndVerify();
+            }
+        }
+
+        [Theory]
+        [DependsOnTest(nameof(CompileKitchenSinkForBreakpointTests))]
+        [RequiresTestSettings]
+        public void ConditionalBreakpoints(ITestSettings settings)
+        {
+            this.TestPurpose("Tests that conditional breakpoints work");
+            this.WriteSettings(settings);
+
+            IDebuggee debuggee = SinkHelper.Open(this, settings.CompilerSettings, DebuggeeMonikers.KitchenSink.Breakpoint);
+
+            using (IDebuggerRunner runner = CreateDebugAdapterRunner(settings))
+            {
+                this.Comment("Configure launch");
+                runner.Launch(settings.DebuggerSettings, debuggee, "-fCalling");
+
+                this.Comment("Set a conditional line breakpoint");
+                SourceBreakpoints callingBreakpoints = new SourceBreakpoints(debuggee, SinkHelper.Calling);
+                callingBreakpoints.Add(17, "i == 5");
+                runner.SetBreakpoints(callingBreakpoints);
+
+                // The schema also supports conditions on function breakpoints, but MIEngine or GDB doesn't seem
+                //  to support that.  Plus, there's no way to do it through the VSCode UI anyway.
+
+                this.Comment("Run to breakpoint");
+                runner.Expects.HitBreakpointEvent(SinkHelper.Calling, 17)
+                              .AfterConfigurationDone();
+
+                this.Comment("Verify breakpoint condition is met");
+                using (IThreadInspector inspector = runner.GetThreadInspector())
+                {
+                    IFrameInspector mainFrame = inspector.Stack.First();
+                    mainFrame.AssertVariables("i", "5");
+                }
+
+                this.Comment("Run to completion");
+                runner.Expects.ExitedEvent()
+                              .TerminatedEvent()
+                              .AfterContinue();
+
+                runner.DisconnectAndVerify();
+            }
+        }
+
+        [Theory]
+        [DependsOnTest(nameof(CompileKitchenSinkForBreakpointTests))]
+        [RequiresTestSettings]
+        public void BreakpointSettingsVerification(ITestSettings settings)
+        {
+            this.TestPurpose("Tests supported breakpoint settings");
+            this.WriteSettings(settings);
+
+            IDebuggee debuggee = SinkHelper.Open(this, settings.CompilerSettings, DebuggeeMonikers.KitchenSink.Breakpoint);
+
+            using (IDebuggerRunner runner = CreateDebugAdapterRunner(settings))
+            {
+                this.Comment("Configure launch");
+                runner.Launch(settings.DebuggerSettings, debuggee);
+
+                Assert.True(runner.InitializeResponse.body.supportsConditionalBreakpoints.HasValue
+                    && runner.InitializeResponse.body.supportsConditionalBreakpoints.Value == true, "Conditional breakpoints should be supported");
+
+                Assert.True(runner.InitializeResponse.body.supportsFunctionBreakpoints.HasValue
+                    && runner.InitializeResponse.body.supportsFunctionBreakpoints.Value == true, "Function breakpoints should be supported");
+
+                this.Comment("Run to completion");
+                runner.Expects.ExitedEvent()
+                              .TerminatedEvent()
+                              .AfterConfigurationDone();
+
+                runner.DisconnectAndVerify();
+            }
+        }
+
+        #endregion
+    }
+}

--- a/test/CppTests/Tests/CoreDumpTests.cs
+++ b/test/CppTests/Tests/CoreDumpTests.cs
@@ -1,0 +1,295 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Collections.Generic;
+using System.Globalization;
+using System.IO;
+using System.Linq;
+using System.Threading;
+using DebuggerTesting;
+using DebuggerTesting.Compilation;
+using DebuggerTesting.OpenDebug;
+using DebuggerTesting.OpenDebug.Commands;
+using DebuggerTesting.OpenDebug.Commands.Responses;
+using DebuggerTesting.OpenDebug.CrossPlatCpp;
+using DebuggerTesting.OpenDebug.Events;
+using DebuggerTesting.OpenDebug.Extensions;
+using DebuggerTesting.Ordering;
+using DebuggerTesting.Utilities;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace CppTests.Tests
+{
+    [TestCaseOrderer(DependencyTestOrderer.TypeName, DependencyTestOrderer.AssemblyName)]
+    public class CoreDumpTests : TestBase
+    {
+        #region Constructor
+
+        public CoreDumpTests(ITestOutputHelper outputHelper) : base(outputHelper)
+        {
+        }
+
+        #endregion
+
+        #region Fields
+
+        private const string srcAppName = "main.cpp";
+        private const string srcClassName = "exception.cpp";
+        private const string outAppName = "myapp";
+        private const string outCoreName = "core";
+        private const string debuggeeName = "exception";
+        private const string evalError = "not available";
+        private const string stepError = "Unable to {0}. This operation is not supported when debugging dump files";
+        private const string bpError = "Error setting breakpoint. This operation is not supported when debugging dump files";
+        private static object syncObject = new object();
+
+        #endregion
+
+        #region Methods
+
+        [Theory]
+        [RequiresTestSettings]
+        [SupportedPlatform(SupportedPlatform.Linux, SupportedArchitecture.x64 | SupportedArchitecture.x86)]
+        [SupportedDebugger(SupportedDebugger.Gdb_Gnu, SupportedArchitecture.x64 | SupportedArchitecture.x86)]
+        public void CoreDumpBasic(ITestSettings settings)
+        {
+            this.TestPurpose("This test checks to see if core dump can be launched successfully");
+            this.WriteSettings(settings);
+
+            this.Comment("Compile the application");
+            CompileApp(this, settings, DebuggeeMonikers.CoreDump.Default);
+
+            this.Comment("Run core dump basic debugging scenarios");
+            RunCoreDumpBasic(settings, DebuggeeMonikers.CoreDump.Default);
+        }
+
+        [Theory]
+        [RequiresTestSettings]
+        [SupportedPlatform(SupportedPlatform.Linux, SupportedArchitecture.x64 | SupportedArchitecture.x86)]
+        [SupportedDebugger(SupportedDebugger.Gdb_Gnu, SupportedArchitecture.x64 | SupportedArchitecture.x86)]
+        public void CoreDumpBasicMismatchedSourceAndSymbols(ITestSettings settings)
+        {
+            this.TestPurpose("This test checks to see if core dump can be launched successfully with mismathed source code.");
+            this.WriteSettings(settings);
+
+            this.Comment("Compile the application");
+            CompileApp(this, settings, DebuggeeMonikers.CoreDump.MismatchedSource);
+
+            this.TestPurpose("Apply changes in the source code after compile the debuggee");
+            ApplyChangesInSource(settings, DebuggeeMonikers.CoreDump.MismatchedSource);
+
+            this.Comment("Run core dump basic debugging scenarios with mismatched source file");
+            RunCoreDumpBasic(settings, DebuggeeMonikers.CoreDump.MismatchedSource);
+        }
+
+        [Theory]
+        [RequiresTestSettings]
+        [SupportedPlatform(SupportedPlatform.Linux, SupportedArchitecture.x64 | SupportedArchitecture.x86)]
+        [SupportedDebugger(SupportedDebugger.Gdb_Gnu, SupportedArchitecture.x64 | SupportedArchitecture.x86)]
+        public void CoreDumpVerifyActions(ITestSettings settings)
+        {
+            this.TestPurpose("This test checks to see the behavior when do actions during core dump debugging.");
+            this.WriteSettings(settings);
+
+            this.Comment("Compile the application");
+            CompileApp(this, settings, DebuggeeMonikers.CoreDump.Action);
+
+            this.Comment("Set initial debuggee for application");
+            IDebuggee debuggee = OpenDebuggee(this, settings, DebuggeeMonikers.CoreDump.Action);
+
+            this.Comment("Launch the application to hit an exception and generate core dump");
+            string coreDumpPath = GenerateCoreDump(settings, DebuggeeMonikers.CoreDump.Action, debuggee);
+
+            using (IDebuggerRunner runner = CreateDebugAdapterRunner(settings))
+            {
+                this.Comment("Configure the core dump before start debugging");
+                runner.LaunchCoreDump(settings.DebuggerSettings, debuggee, coreDumpPath);
+
+                this.Comment("Start debugging to hit the exception and verify it should stop at correct source file and line");
+                runner.Expects.StoppedEvent(StoppedReason.Exception, srcClassName, 8).AfterConfigurationDone();
+
+                this.Comment("Verify the error message for relevant actions during core dump debugging");
+                using (IThreadInspector threadInspector = runner.GetThreadInspector())
+                {
+                    this.Comment("Get current frame object");
+                    IFrameInspector currentFrame = threadInspector.Stack.First();
+
+                    this.Comment("Verify current frame when stop at the exception");
+                    threadInspector.AssertStackFrameNames(true, "myException::RaisedUnhandledException.*");
+
+                    this.Comment("Try to evaluate a expression and verify the results");
+
+                    string varEvalResult = currentFrame.Evaluate("result + 1");
+                    Assert.Equal("11", varEvalResult);
+
+                    this.Comment("Try to evaluate a function and verify the error message");
+                    EvaluateResponseValue evalResponse = runner.RunCommand(new EvaluateCommand("EvalFunc(100, 100)", currentFrame.Id));
+                    // TODO: From VSCode IDE with the latest cpptools, the error message after evaluate function is "not availabe", but evalResponse.message is null, is it expected ?
+                    // Currently just simply verify the result is empty as a workaround, need to revisit this once get more information from logged bug #242418
+                    this.Comment(string.Format(CultureInfo.InvariantCulture, "Actual evaluated result: {0}", evalResponse.body.result));
+                    Assert.True(evalResponse.body.result.Equals(string.Empty));
+
+                    this.Comment(string.Format(CultureInfo.InvariantCulture, "Actual evaluated respone message: {0}", evalResponse.message));
+                    //Assert.True(evalResponse.message.Contains(evalError));
+                }
+
+                this.Comment("Try to step in and verify the error message");
+                StepInCommand stepInCommand = new StepInCommand(runner.DarRunner.CurrentThreadId);
+                runner.RunCommandExpectFailure(stepInCommand);
+                this.WriteLine(string.Format(CultureInfo.InvariantCulture, "Actual respone message: {0}", stepInCommand.Message));
+                Assert.Contains(stepInCommand.Message, string.Format(CultureInfo.InvariantCulture, stepError, "step in"));
+
+                this.Comment("Try to step over and verify the error message");
+                StepOverCommand stepOverCommand = new StepOverCommand(runner.DarRunner.CurrentThreadId);
+                runner.RunCommandExpectFailure(stepOverCommand);
+                this.WriteLine(string.Format(CultureInfo.InvariantCulture, "Actual respone message: {0}", stepOverCommand.Message));
+                Assert.Contains(stepOverCommand.Message, string.Format(CultureInfo.InvariantCulture, stepError, "step next"));
+
+                this.Comment("Try to step out and verify the error message");
+                StepOutCommand stepOutCommand = new StepOutCommand(runner.DarRunner.CurrentThreadId);
+                runner.RunCommandExpectFailure(stepOutCommand);
+                this.WriteLine(string.Format(CultureInfo.InvariantCulture, "Actual respone message: {0}", stepOutCommand.Message));
+                Assert.Contains(stepOutCommand.Message, string.Format(CultureInfo.InvariantCulture, stepError, "step out"));
+
+                this.Comment("Try to continue and verify the error message");
+                ContinueCommand continueCommand = new ContinueCommand(runner.DarRunner.CurrentThreadId);
+                runner.RunCommandExpectFailure(continueCommand);
+                this.WriteLine(string.Format(CultureInfo.InvariantCulture, "Actual respone message: {0}", continueCommand.Message));
+                Assert.Contains(continueCommand.Message, string.Format(CultureInfo.InvariantCulture, stepError, "continue"));
+
+                this.Comment("Try to set a breakpoint and verify the error message");
+                SourceBreakpoints bp = debuggee.Breakpoints(srcAppName, 16);
+                SetBreakpointsResponseValue setBpResponse = runner.SetBreakpoints(bp);
+                Assert.False(setBpResponse.body.breakpoints[0].verified);
+                this.WriteLine(string.Format(CultureInfo.InvariantCulture, "Actual respone message: {0}", setBpResponse.body.breakpoints[0].message));
+                Assert.Contains(setBpResponse.body.breakpoints[0].message, bpError);
+
+                this.Comment("Stop core dump debugging");
+                runner.DisconnectAndVerify();
+            }
+        }
+
+        #endregion
+
+        #region Function Helper
+
+        /// <summary>
+        /// Create the debuggee and compile the application
+        /// </summary>
+        private static IDebuggee CompileApp(ILoggingComponent logger, ITestSettings settings, int debuggeeMoniker)
+        {
+            lock (syncObject)
+            {
+                IDebuggee debuggee = Debuggee.Create(logger, settings.CompilerSettings, debuggeeName, debuggeeMoniker, outAppName);
+                debuggee.AddSourceFiles(srcClassName, srcAppName);
+                debuggee.Compile();
+                return debuggee;
+            }
+        }
+
+        /// <summary>
+        /// Open existing debuggee
+        /// </summary>
+        private static IDebuggee OpenDebuggee(ILoggingComponent logger, ITestSettings settings, int debuggeeMoniker)
+        {
+            lock (syncObject)
+            {
+                IDebuggee debuggee = Debuggee.Open(logger, settings.CompilerSettings, debuggeeName, debuggeeMoniker, outAppName);
+                Assert.True(File.Exists(debuggee.OutputPath), "The debuggee was not compiled. Missing " + debuggee.OutputPath);
+                return debuggee;
+            }
+        }
+
+        /// <summary>
+        /// Launch the application and generate the core dump
+        /// </summary>
+        private string GenerateCoreDump(ITestSettings settings, int debuggeeMoniker, IDebuggee debuggee)
+        {
+            lock (syncObject)
+            {
+                string dumpPath = debuggee.OutputPath.Replace(outAppName, outCoreName);
+                this.Comment("Expecting core dump to be generated at '{0}'.".FormatInvariantWithArgs(dumpPath));
+
+                debuggee.Launch("-CallRaisedUnhandledException").WaitForExit(2000);
+
+                // Sometimes need take more time to generate core dump on virtual machine
+                int maxAttempts = 10;
+                for (int attempt = 0; attempt < maxAttempts && !File.Exists(dumpPath); attempt++)
+                {
+                    this.Comment("Waiting for core dump to be generated ({0}/{1}).".FormatInvariantWithArgs(attempt + 1, maxAttempts));
+                    Thread.Sleep(3000);
+                }
+
+                Assert.True(File.Exists(dumpPath), "Core dump was not generated at '{0}'.".FormatInvariantWithArgs(dumpPath));
+
+                return dumpPath;
+            }
+        }
+
+        /// <summary>
+        /// Apply changes in the source file so that the source and symbols is not matached anymore
+        /// </summary>
+        private void ApplyChangesInSource(ITestSettings settings, int debuggeeMoniker)
+        {
+            IDebuggee debuggee = OpenDebuggee(this, settings, debuggeeMoniker);
+            string srcAppNamePath = string.Format(CultureInfo.InvariantCulture, Path.Combine(debuggee.SourceRoot, srcAppName));
+            Assert.True(File.Exists(srcAppNamePath), string.Format(CultureInfo.InvariantCulture, "ERROR: Didn't find the source file:{0} under {1}", srcAppName, debuggee.SourceRoot));
+            try
+            {
+                using (StreamWriter writer = File.AppendText(srcAppNamePath))
+                {
+                    //TODO: I just simply added a new line to make the symbols mismatch after compile the application
+                    writer.WriteLine(System.Environment.NewLine);
+                }
+            }
+            catch
+            {
+                this.Comment("ERROR: Didn't apply the changes in source file successfully.");
+                throw;
+            }
+        }
+
+        /// <summary>
+        /// Run core dump basic debugging scenarios
+        /// </summary>
+        void RunCoreDumpBasic(ITestSettings settings, int debuggeeMoniker)
+        {
+            this.Comment("Set initial debuggee for application");
+            IDebuggee debuggee = OpenDebuggee(this, settings, debuggeeMoniker);
+
+            this.Comment("Launch the application to hit an exception and generate core dump");
+            string coreDumpPath = GenerateCoreDump(settings, debuggeeMoniker, debuggee);
+
+            using (IDebuggerRunner runner = CreateDebugAdapterRunner(settings))
+            {
+                this.Comment("Configure the core dump before start debugging");
+                runner.LaunchCoreDump(settings.DebuggerSettings, debuggee, coreDumpPath);
+
+                this.Comment("Start debugging to hit the exception and verify it should stop at correct source file and line");
+                runner.Expects.StoppedEvent(StoppedReason.Exception, srcClassName, 8).AfterConfigurationDone();
+
+                this.Comment("Verify the callstack and variables");
+                using (IThreadInspector threadInspector = runner.GetThreadInspector())
+                {
+                    this.Comment("Get current frame object");
+                    IFrameInspector currentFrame = threadInspector.Stack.First();
+
+                    this.WriteLine("current frame: {0}", currentFrame);
+
+                    this.Comment("Verify current frame when stop at the exception");
+                    threadInspector.AssertStackFrameNames(true, "myException::RaisedUnhandledException.*");
+
+                    this.Comment("Verify the variables after stop at the exception");
+                    Assert.Subset(new HashSet<string>() { "result", "temp", "this", "myvar" }, currentFrame.Variables.ToKeySet());
+                    currentFrame.AssertVariables("result", "10", "temp", "0", "myvar", "200");
+                }
+
+                this.Comment("Stop core dump debugging");
+                runner.DisconnectAndVerify();
+            }
+        }
+
+        #endregion
+    }
+}

--- a/test/CppTests/Tests/DebuggeeHelpers.cs
+++ b/test/CppTests/Tests/DebuggeeHelpers.cs
@@ -1,0 +1,38 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.IO;
+using DebuggerTesting;
+using DebuggerTesting.Compilation;
+using Xunit;
+
+namespace CppTests.Tests
+{
+    internal static class DebuggeeHelper
+    {
+        private static object s_lock = new object();
+
+        public static IDebuggee OpenAndCompile(ILoggingComponent logger, ICompilerSettings settings, int moniker, string name, string outputname, Action<IDebuggee> addSourceFiles)
+        {
+            Assert.NotNull(addSourceFiles);
+            lock (s_lock)
+            {
+                IDebuggee debuggee = Debuggee.Create(logger, settings, name, moniker, outputname);
+                addSourceFiles(debuggee);
+                debuggee.Compile();
+                return debuggee;
+            }
+        }
+
+        public static IDebuggee Open(ILoggingComponent logger, ICompilerSettings settings, int moniker, string name, string outputname)
+        {
+            lock (s_lock)
+            {
+                IDebuggee debuggee = Debuggee.Open(logger, settings, name, moniker, outputname);
+                Assert.True(File.Exists(debuggee.OutputPath), "The debuggee was not compiled. Missing " + debuggee.OutputPath);
+                return debuggee;
+            }
+        }
+    }
+}

--- a/test/CppTests/Tests/DebuggeeMonikers.cs
+++ b/test/CppTests/Tests/DebuggeeMonikers.cs
@@ -1,0 +1,59 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+
+namespace CppTests.Tests
+{
+    /// <summary>
+    /// To make it easier to work with debuggees, each test works with a copy of the original debuggee.
+    /// This allows tests to compile with different options, remove symbols or modify source in ways that
+    /// would effect other tests.
+    /// The debuggee will be copied into a folder appended with the moniker.
+    /// </summary>
+    internal static class DebuggeeMonikers
+    {
+        internal static class HelloWorld
+        {
+            public const int Sample = 1;
+        }
+
+        internal static class KitchenSink
+        {
+            public const int Attach = 1;
+            public const int Threading = 2;
+            public const int Breakpoint = 3;
+            public const int Execution = 4;
+            public const int Expression = 5;
+            public const int Environment = 6;
+        }
+
+        internal static class SharedLib
+        {
+            public const int Default = 1;
+            public const int MismatchedSource = 2;
+        }
+
+        internal static class CoreDump
+        {
+            public const int Default = 1;
+            public const int MismatchedSource = 2;
+            public const int Action = 3;
+        }
+
+        internal static class Exception
+        {
+            public const int Default = 1;
+        }
+
+        internal static class Optimization
+        {
+            public const int OptimizationWithSymbols = 1;
+            public const int OptimizationWithoutSymbols = 2;
+        }
+
+        internal static class SourceMapping
+        {
+            public const int Default = 1;
+        }
+    }
+}

--- a/test/CppTests/Tests/EnvironmentTests.cs
+++ b/test/CppTests/Tests/EnvironmentTests.cs
@@ -1,0 +1,199 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Linq;
+using DebuggerTesting;
+using DebuggerTesting.Compilation;
+using DebuggerTesting.OpenDebug;
+using DebuggerTesting.OpenDebug.Commands;
+using DebuggerTesting.OpenDebug.CrossPlatCpp;
+using DebuggerTesting.OpenDebug.Events;
+using DebuggerTesting.OpenDebug.Extensions;
+using DebuggerTesting.Ordering;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace CppTests.Tests
+{
+    [TestCaseOrderer(DependencyTestOrderer.TypeName, DependencyTestOrderer.AssemblyName)]
+    public class EnvironmentTests : TestBase
+    {
+        #region Constructor
+
+        public EnvironmentTests(ITestOutputHelper outputHelper) : base(outputHelper)
+        {
+        }
+
+        #endregion
+
+        #region Methods
+
+        [Theory]
+        [RequiresTestSettings]
+        public void CompileKitchenSinkForEnvironmentTests(ITestSettings settings)
+        {
+            this.TestPurpose("Compiles the kitchen sink debuggee.");
+            this.WriteSettings(settings);
+
+            IDebuggee debuggee = SinkHelper.OpenAndCompile(this, settings.CompilerSettings, DebuggeeMonikers.KitchenSink.Environment);
+        }
+
+        [Theory]
+        [DependsOnTest(nameof(CompileKitchenSinkForEnvironmentTests))]
+        [RequiresTestSettings]
+        public void EnvironmentVariablesBasic(ITestSettings settings)
+        {
+            this.TestPurpose("Tests basic operation of environment variables");
+            TestEnvironmentVariable(settings, "VAR_NAME_1", "simpleTest", false);
+        }
+
+        [Theory]
+        [DependsOnTest(nameof(CompileKitchenSinkForEnvironmentTests))]
+        [RequiresTestSettings]
+        // Need to support 'runInTerminal' request.
+        [UnsupportedDebugger(SupportedDebugger.VsDbg, SupportedArchitecture.x86 | SupportedArchitecture.x64)]
+        public void EnvironmentVariablesBasicNewTerminal(ITestSettings settings)
+        {
+            this.TestPurpose("Tests basic operation of environment variables using a new terminal window");
+            TestEnvironmentVariable(settings, "VAR_NAME_1", "simpleTest", true);
+        }
+
+        [Theory]
+        [DependsOnTest(nameof(CompileKitchenSinkForEnvironmentTests))]
+        [RequiresTestSettings]
+        public void EnvironmentVariablesUndefined(ITestSettings settings)
+        {
+            this.TestPurpose("Tests environment variables that are undefined");
+            TestEnvironmentVariable(settings, "VAR_NAME_1", null, false);
+        }
+
+
+        [Theory]
+        [DependsOnTest(nameof(CompileKitchenSinkForEnvironmentTests))]
+        [RequiresTestSettings]
+        // Need to support 'runInTerminal' request.
+        [UnsupportedDebugger(SupportedDebugger.VsDbg, SupportedArchitecture.x86 | SupportedArchitecture.x64)]
+        public void EnvironmentVariablesUndefinedNewTerminal(ITestSettings settings)
+        {
+            this.TestPurpose("Tests environment variables that are undefined using a new terminal window");
+            TestEnvironmentVariable(settings, "VAR_NAME_1", null, true);
+        }
+
+        [Theory]
+        [DependsOnTest(nameof(CompileKitchenSinkForEnvironmentTests))]
+        [RequiresTestSettings]
+        public void EnvironmentVariablesSingleQuote(ITestSettings settings)
+        {
+            this.TestPurpose("Tests environment variables that include a single quote");
+            TestEnvironmentVariable(settings, "VAR_NAME_1", "quot'edstring", false);
+        }
+
+        [Theory]
+        [DependsOnTest(nameof(CompileKitchenSinkForEnvironmentTests))]
+        [RequiresTestSettings]
+        // TODO There is a bug in LLDB: when executing the new terminal through the AppleScript,
+        // it doesn't escape quotes and fails
+                // TODO VsDbg: // Need to support 'runInTerminal' request.
+        [UnsupportedDebugger(SupportedDebugger.Lldb | SupportedDebugger.VsDbg, SupportedArchitecture.x86 | SupportedArchitecture.x64)]
+        public void EnvironmentVariablesSingleQuoteNewTerminal(ITestSettings settings)
+        {
+            this.TestPurpose("Tests environment variables that include a single quote in a new terminal window");
+            TestEnvironmentVariable(settings, "VAR_NAME_1", "quot'edstring", true);
+        }
+
+        [Theory]
+        [DependsOnTest(nameof(CompileKitchenSinkForEnvironmentTests))]
+        [RequiresTestSettings]
+        public void EnvironmentVariablesDoubleQuote(ITestSettings settings)
+        {
+            this.TestPurpose("Tests environment variables that include a double quote");
+            TestEnvironmentVariable(settings, "VAR_NAME_1", "quot\"edstring", false);
+        }
+
+        [Theory]
+        [DependsOnTest(nameof(CompileKitchenSinkForEnvironmentTests))]
+        [RequiresTestSettings]
+        // TODO There is a bug in LLDB: when executing the new terminal through the AppleScript,
+        // it doesn't escape quotes and fails
+        // TODO VsDbg: // Need to support 'runInTerminal' request.
+        [UnsupportedDebugger(SupportedDebugger.Lldb | SupportedDebugger.VsDbg, SupportedArchitecture.x86 | SupportedArchitecture.x64)]
+        public void EnvironmentVariablesDoubleQuoteNewTerminal(ITestSettings settings)
+        {
+            this.TestPurpose("Tests environment variables that include a double quote in a new terminal window");
+            TestEnvironmentVariable(settings, "VAR_NAME_1", "quot\"edstring", true);
+        }
+
+        [Theory]
+        [DependsOnTest(nameof(CompileKitchenSinkForEnvironmentTests))]
+        [RequiresTestSettings]
+        public void EnvironmentVariablesSpaces(ITestSettings settings)
+        {
+            this.TestPurpose("Tests environment variables that include a space");
+            TestEnvironmentVariable(settings, "VAR_NAME_1", "string with spaces", false);
+        }
+
+        [Theory]
+        [DependsOnTest(nameof(CompileKitchenSinkForEnvironmentTests))]
+        [RequiresTestSettings]
+        // Need to support 'runInTerminal' request.
+        [UnsupportedDebugger(SupportedDebugger.VsDbg, SupportedArchitecture.x86 | SupportedArchitecture.x64)]
+        public void EnvironmentVariablesSpacesNewTerminal(ITestSettings settings)
+        {
+            this.TestPurpose("Tests environment variables that include a space in a new terminal window");
+            TestEnvironmentVariable(settings, "VAR_NAME_1", "string with spaces", true);
+        }
+
+        [Theory(Skip = "Need to modify the debuggee so that the name of the environment variable is not hardcoded.")]
+        [DependsOnTest(nameof(CompileKitchenSinkForEnvironmentTests))]
+        [RequiresTestSettings]
+        [SupportedDebugger(SupportedDebugger.VsDbg, SupportedArchitecture.x86 | SupportedArchitecture.x64)]
+        public void EnvironmentVariablesSpecialCharactersName(ITestSettings settings)
+        {
+            this.TestPurpose("Tests environment variables that include a space in a new terminal window");
+            TestEnvironmentVariable(settings, "_(){}[]$*+-\\/\"#',;.@!?", "simpleValue", true);
+        }
+
+        private void TestEnvironmentVariable(ITestSettings settings, string variableName, string variableValue, bool newTerminal)
+        {
+            this.WriteSettings(settings);
+
+            IDebuggee debuggee = SinkHelper.Open(this, settings.CompilerSettings, DebuggeeMonikers.KitchenSink.Environment);
+
+            using (IDebuggerRunner runner = CreateDebugAdapterRunner(settings))
+            {
+                this.Comment("Configure launch");
+                LaunchCommand launch = new LaunchCommand(settings.DebuggerSettings, debuggee.OutputPath, false, "-fEnvironment") { StopAtEntry = false };
+                if (variableValue != null)
+                {
+                    launch.Args.environment = new EnvironmentEntry[] {
+                        new EnvironmentEntry { Name = variableName, Value = variableValue }
+                    };
+                }
+
+                launch.Args.externalConsole = newTerminal;
+                runner.RunCommand(launch);
+
+                this.Comment("Set breakpoint");
+                runner.SetBreakpoints(debuggee.Breakpoints(SinkHelper.Environment, 14));
+
+                runner.Expects.StoppedEvent(StoppedReason.Breakpoint).AfterConfigurationDone();
+
+                using (IThreadInspector threadInspector = runner.GetThreadInspector())
+                {
+                    IFrameInspector currentFrame = threadInspector.Stack.First();
+                    this.Comment("Verify locals variables on current frame.");
+                    currentFrame.AssertEvaluateAsString("varValue1", EvaluateContext.Watch, variableValue);
+                }
+
+                this.Comment("Continue until end");
+                runner.Expects.ExitedEvent()
+                              .TerminatedEvent()
+                              .AfterContinue();
+
+                runner.DisconnectAndVerify();
+            }
+        }
+
+        #endregion
+    }
+}

--- a/test/CppTests/Tests/ExceptionTests.cs
+++ b/test/CppTests/Tests/ExceptionTests.cs
@@ -1,0 +1,317 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using DebuggerTesting;
+using DebuggerTesting.Compilation;
+using DebuggerTesting.OpenDebug;
+using DebuggerTesting.OpenDebug.Commands;
+using DebuggerTesting.OpenDebug.CrossPlatCpp;
+using DebuggerTesting.OpenDebug.Events;
+using DebuggerTesting.OpenDebug.Extensions;
+using DebuggerTesting.Ordering;
+using DebuggerTesting.Utilities;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace CppTests.Tests
+{
+    [TestCaseOrderer(DependencyTestOrderer.TypeName, DependencyTestOrderer.AssemblyName)]
+    public class ExceptionTests : TestBase
+    {
+        #region Constructor
+
+        public ExceptionTests(ITestOutputHelper outputHelper) : base(outputHelper)
+        {
+        }
+
+        #endregion
+
+        #region Fields
+
+        private const string srcAppName = "main.cpp";
+        private const string srcClassName = "exception.cpp";
+        private const string outAppName = "myapp";
+        private const string debuggeeName = "exception";
+        private static object syncObject = new object();
+
+        #endregion
+
+        #region Methods
+
+        [Theory]
+        [RequiresTestSettings]
+        public void CompileExceptionDebuggee(ITestSettings settings)
+        {
+            this.TestPurpose("Create and compile the 'exception' debuggee");
+            this.WriteSettings(settings);
+
+            this.Comment("Compile the application");
+            CompileApp(this, settings, DebuggeeMonikers.Exception.Default);
+        }
+
+        [Theory]
+        [DependsOnTest(nameof(CompileExceptionDebuggee))]
+        [RequiresTestSettings]
+        public void RaisedUnhandledException(ITestSettings settings)
+        {
+            this.TestPurpose("This test checks to see if unhandled exception can work during debugging");
+            this.WriteSettings(settings);
+            this.Comment("Set initial debuggee for application");
+            IDebuggee debuggee = OpenDebuggee(this, settings, DebuggeeMonikers.Exception.Default);
+
+            using (IDebuggerRunner runner = CreateDebugAdapterRunner(settings))
+            {
+                this.Comment("Launch the application");
+                runner.Launch(settings.DebuggerSettings, debuggee, "-CallRaisedUnhandledException");
+
+                this.Comment("Start debugging to hit the exception and verify it should stop at correct source file and line");
+                runner.Expects.StoppedEvent(StoppedReason.Exception, srcClassName, 8).AfterConfigurationDone();
+
+                this.Comment("Verify the callstack, variables and evaluation ");
+                using (IThreadInspector threadInspector = runner.GetThreadInspector())
+                {
+                    this.Comment("Get current frame object");
+                    IFrameInspector currentFrame = threadInspector.Stack.First();
+
+                    this.Comment("Verify current frame when stop at the exception");
+                    threadInspector.AssertStackFrameNames(true, "myException::RaisedUnhandledException.*");
+
+                    this.Comment("Verify the variables after stop at the exception");
+                    Assert.Subset(new HashSet<string>() { "result", "temp", "this", "myvar" }, currentFrame.Variables.ToKeySet());
+                    currentFrame.AssertVariables("result", "10", "temp", "0", "myvar", "200");
+
+                    // TODO: LLDB was affected by bug #240441, I wil update this once this bug get fixed
+                    if (settings.DebuggerSettings.DebuggerType != SupportedDebugger.Lldb)
+                    {
+                        this.Comment("Evaluate an expression and verify the results after stop at the exception");
+                        string varEvalResult = currentFrame.Evaluate("result = result + 1");
+                        this.WriteLine("Expected: 11, Actual: {0}", varEvalResult);
+                        Assert.Equal("11", varEvalResult);
+                    }
+
+                    // TODO: Mingw32 was affected by bug #242924, I wil update this once this bug get fixed
+                    if (!(settings.DebuggerSettings.DebuggerType == SupportedDebugger.Gdb_MinGW && settings.DebuggerSettings.DebuggeeArchitecture == SupportedArchitecture.x86))
+                    {
+                        this.Comment("Evaluate a function and verify the the results after stop at exception");
+                        string funEvalResult = currentFrame.Evaluate("EvalFunc(100,100)");
+                        this.WriteLine("Expected: 200, Actual: {0}", funEvalResult);
+                        Assert.Equal("200", funEvalResult);
+                    }
+                }
+
+                this.Comment("Stop debugging");
+                runner.DisconnectAndVerify();
+            }
+        }
+
+        [Theory]
+        [DependsOnTest(nameof(CompileExceptionDebuggee))]
+        [RequiresTestSettings]
+        public void RaisedHandledException(ITestSettings settings)
+        {
+            this.TestPurpose("This test checks to see if user handled exception can work during debugging");
+            this.WriteSettings(settings);
+
+            this.Comment("Set initial debuggee for application");
+            IDebuggee debuggee = OpenDebuggee(this, settings, DebuggeeMonikers.Exception.Default);
+
+            using (IDebuggerRunner runner = CreateDebugAdapterRunner(settings))
+            {
+                this.Comment("Launch the application");
+                runner.Launch(settings.DebuggerSettings, debuggee, "-CallRaisedHandledException");
+
+                this.Comment("Set line breakpoints to the lines with entry of try block and catch block");
+                SourceBreakpoints bps = debuggee.Breakpoints(srcClassName, 20, 33);
+                runner.SetBreakpoints(bps);
+
+                this.Comment("Start debugging and hit the breakpoint in the try block");
+                runner.Expects.HitBreakpointEvent(srcClassName, 20).AfterConfigurationDone();
+
+                this.Comment("Step over in the try block");
+                runner.Expects.HitStepEvent(srcClassName, 21).AfterStepOver();
+
+                this.Comment("Continue to raise the exception and hit the breakpoint set in the catch block");
+                runner.Expects.HitBreakpointEvent(srcClassName, 33).AfterContinue();
+
+                this.Comment("Verify can step over in the catch block");
+                runner.Expects.HitStepEvent(srcClassName, 34).AfterStepOver();
+
+                this.Comment("Verify the callstack, variables and evaluation ");
+                using (IThreadInspector threadInspector = runner.GetThreadInspector())
+                {
+                    this.Comment("Get current frame object");
+                    IFrameInspector currentFrame = threadInspector.Stack.First();
+
+                    this.Comment("Verify current frame when stop at the catch block");
+                    threadInspector.AssertStackFrameNames(true, "myException::RaisedHandledException.*");
+
+                    this.Comment("Verify the variables in the catch block");
+                    Assert.Subset(new HashSet<string>() { "result", "global", "this", "a" ,"errorCode","ex"}, currentFrame.Variables.ToKeySet());
+                    currentFrame.AssertVariables("result", "201", "global", "101", "a", "100");
+
+                    this.Comment("Verify the exception information in the catch block");
+                    IVariableInspector exVar = currentFrame.Variables["ex"];
+                    Assert.Contains("code", exVar.Variables.Keys);
+                    this.WriteLine("Expected: 101, Actual: {0}", exVar.Variables["code"].Value);
+                    Assert.Equal("101", exVar.Variables["code"].Value);
+
+                    // TODO: LLDB was affected by bug #240441, I wil update this once this bug get fixed
+                    if (settings.DebuggerSettings.DebuggerType != SupportedDebugger.Lldb)
+                    {
+                        this.Comment("Evaluate an expression and verify the results");
+                        string varEvalResult = currentFrame.Evaluate("result=result + 1");
+                        this.WriteLine("Expected: 202, Actual: {0}", varEvalResult);
+                        Assert.Equal("202", varEvalResult);
+                    }
+
+                    this.Comment("Evaluate a function and verify the the results");
+                    // TODO: Mingw32 was affected by bug #242924, I wil update this once this bug get fixed
+                    bool evalNotSupportedInCatch =
+                        (settings.DebuggerSettings.DebuggerType == SupportedDebugger.Gdb_MinGW && settings.DebuggerSettings.DebuggeeArchitecture == SupportedArchitecture.x86) ||
+                        (settings.DebuggerSettings.DebuggerType == SupportedDebugger.VsDbg && settings.DebuggerSettings.DebuggeeArchitecture == SupportedArchitecture.x64);
+                    if (!evalNotSupportedInCatch)
+                    {
+                        string funEvalResult = currentFrame.Evaluate("RecursiveFunc(50)");
+                        this.WriteLine("Expected: 1, Actual: {0}", funEvalResult);
+                        Assert.Equal("1", funEvalResult);
+                    }
+                }
+
+                this.Comment("Verify can step over after evaluation in the catch block");
+                runner.Expects.HitStepEvent(srcClassName, 35).AfterStepOver();
+
+                this.Comment("Continue to run at the end of the application");
+                runner.Expects.TerminatedEvent().AfterContinue();
+
+                runner.DisconnectAndVerify();
+            }
+        }
+
+        [Theory]
+        [DependsOnTest(nameof(CompileExceptionDebuggee))]
+        [RequiresTestSettings]
+        public void RaisedReThrowException(ITestSettings settings)
+        {
+            this.TestPurpose("This test checks to see if re-throw exception can work during debugging.");
+            this.WriteSettings(settings);
+
+            this.Comment("Set initial debuggee for application");
+            IDebuggee debuggee = OpenDebuggee(this, settings, DebuggeeMonikers.Exception.Default);
+
+            using (IDebuggerRunner runner = CreateDebugAdapterRunner(settings))
+            {
+                this.Comment("Launch the application");
+                runner.Launch(settings.DebuggerSettings, debuggee, "-CallRaisedReThrowException");
+
+                this.Comment("Set line breakpoints to the lines with entry of try block and catch block");
+                SourceBreakpoints bps = debuggee.Breakpoints(srcClassName, 73, 79, 86);
+                runner.SetBreakpoints(bps);
+
+                this.Comment("Start debugging and hit the breakpoint in the try block");
+                runner.Expects.HitBreakpointEvent(srcClassName, 73).AfterConfigurationDone();
+
+                this.Comment("Continue executing and hit the breakpoint in the frist catch block");
+                runner.Expects.HitBreakpointEvent(srcClassName, 79).AfterContinue();
+
+                using (IThreadInspector threadInspector = runner.GetThreadInspector())
+                {
+                    this.Comment("Get current frame object");
+                    IFrameInspector currentFrame = threadInspector.Stack.First();
+
+                    this.Comment("Verify current frame when stop at the first catch block");
+                    threadInspector.AssertStackFrameNames(true, "myException::RaisedReThrowException.*");
+
+                    this.Comment("Verify the variables of 'errorCode' in the first catch block");
+                    currentFrame.AssertVariables("errorCode", "200");
+
+                    this.Comment("Verify step in can work in the first catch block");
+                    runner.ExpectStepAndStepToTarget(srcClassName, startLine: 41, targetLine: 42).AfterStepIn();
+
+                    this.Comment("Verify current frame after step in another function");
+                    threadInspector.AssertStackFrameNames(true, "myException::EvalFunc.*");
+
+                    this.Comment("Verify step out can work in the first catch block");
+                    runner.Expects.HitStepEvent(srcClassName, 79).AfterStepOut();
+                }
+
+                this.Comment("Continue to hit the re-throw exception in the first catch block");
+                runner.Expects.HitBreakpointEvent(srcClassName, 86).AfterContinue();
+
+                using (IThreadInspector threadInspector = runner.GetThreadInspector())
+                {
+                    this.Comment("Get current frame object");
+                    IFrameInspector currentFrame = threadInspector.Stack.First();
+
+                    this.Comment("Verify current frame when stop at the second catch block");
+                    threadInspector.AssertStackFrameNames(true, "myException::RaisedReThrowException.*");
+
+                    this.Comment("Verify the variables in the second catch block");
+                    Assert.Subset(new HashSet<string>() { "var", "this", "errorCode", "ex2" }, currentFrame.Variables.ToKeySet());
+                    currentFrame.AssertVariables("var", "400", "errorCode", "400");
+
+                    this.Comment("Verify the exception information in the second catch block");
+                    IVariableInspector ex2Var = currentFrame.Variables["ex2"];
+                    Assert.Contains("code", ex2Var.Variables.Keys);
+                    this.WriteLine("Expected: 400, Actual: {0}", ex2Var.Variables["code"].Value);
+                    Assert.Equal("400", ex2Var.Variables["code"].Value);
+
+                    this.Comment("Evaluate a function and verify the the results at the second catch block ");
+                    // TODO: Mingw32 was affected by bug #242924, I wil update this once this bug get fixed
+                    bool evalNotSupportedInCatch =
+                        (settings.DebuggerSettings.DebuggerType == SupportedDebugger.Gdb_MinGW && settings.DebuggerSettings.DebuggeeArchitecture == SupportedArchitecture.x86) ||
+                        (settings.DebuggerSettings.DebuggerType == SupportedDebugger.VsDbg && settings.DebuggerSettings.DebuggeeArchitecture == SupportedArchitecture.x64);
+                    if (!evalNotSupportedInCatch)
+                    {
+                        string funEvalResult = currentFrame.Evaluate("EvalFunc(20,20)");
+                        this.WriteLine("Expected: 40, Actual: {0}", funEvalResult);
+                        Assert.Equal("40", funEvalResult);
+                    }
+                }
+
+                this.Comment("Verify can step out from a catch block");
+                runner.ExpectStopAndStepToTarget(StoppedReason.Step, srcAppName, startLine: 61, targetLine: 64).AfterStepOut();
+
+                this.Comment("Continue to run at the end of the application");
+                runner.Expects.TerminatedEvent().AfterContinue();
+
+                runner.DisconnectAndVerify();
+            }
+        }
+
+        #endregion
+
+        #region Function Helper
+
+        /// <summary>
+        /// Create the debuggee and compile the application
+        /// </summary>
+        private static IDebuggee CompileApp(ILoggingComponent logger, ITestSettings settings, int debuggeeMoniker)
+        {
+            lock (syncObject)
+            {
+                IDebuggee debuggee = Debuggee.Create(logger, settings.CompilerSettings, debuggeeName, debuggeeMoniker, outAppName);
+                debuggee.AddSourceFiles(srcClassName, srcAppName);
+                debuggee.Compile();
+                return debuggee;
+            }
+        }
+
+        /// <summary>
+        /// Open existing debuggee
+        /// </summary>
+        private static IDebuggee OpenDebuggee(ILoggingComponent logger, ITestSettings settings, int debuggeeMoniker)
+        {
+            lock (syncObject)
+            {
+                IDebuggee debuggee = Debuggee.Open(logger, settings.CompilerSettings, debuggeeName, debuggeeMoniker, outAppName);
+                Assert.True(File.Exists(debuggee.OutputPath), "The debuggee was not compiled. Missing " + debuggee.OutputPath);
+                return debuggee;
+            }
+        }
+
+        #endregion
+    }
+}

--- a/test/CppTests/Tests/ExecutionTests.cs
+++ b/test/CppTests/Tests/ExecutionTests.cs
@@ -1,0 +1,224 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Linq;
+using DebuggerTesting;
+using DebuggerTesting.Compilation;
+using DebuggerTesting.OpenDebug;
+using DebuggerTesting.OpenDebug.Commands;
+using DebuggerTesting.OpenDebug.CrossPlatCpp;
+using DebuggerTesting.OpenDebug.Events;
+using DebuggerTesting.OpenDebug.Extensions;
+using DebuggerTesting.Ordering;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace CppTests.Tests
+{
+    [TestCaseOrderer(DependencyTestOrderer.TypeName, DependencyTestOrderer.AssemblyName)]
+    public class ExecutionTests : TestBase
+    {
+        #region Constructor
+
+        public ExecutionTests(ITestOutputHelper outputHelper) : base(outputHelper)
+        {
+        }
+
+        #endregion
+
+        [Theory]
+        [RequiresTestSettings]
+        public void CompileKitchenSinkForExecution(ITestSettings settings)
+        {
+            this.TestPurpose("Compiles the kitchen sink debuggee for execution tests.");
+            this.WriteSettings(settings);
+            IDebuggee debuggee = SinkHelper.OpenAndCompile(this, settings.CompilerSettings, DebuggeeMonikers.KitchenSink.Execution);
+        }
+
+        [Theory]
+        [DependsOnTest(nameof(CompileKitchenSinkForExecution))]
+        [RequiresTestSettings]
+        public void ExecutionStepBasic(ITestSettings settings)
+        {
+            this.TestPurpose("Verify basic step in/over/out should work during debugging");
+            this.WriteSettings(settings);
+
+            this.Comment("Open the kitchen sink debuggee for execution tests.");
+            IDebuggee debuggee = SinkHelper.Open(this, settings.CompilerSettings, DebuggeeMonikers.KitchenSink.Execution);
+
+            using (IDebuggerRunner runner = CreateDebugAdapterRunner(settings))
+            {
+                this.Comment("Configure launch");
+                runner.Launch(settings.DebuggerSettings, debuggee, "-fCalling");
+
+                this.Comment("Set initial source breakpoints");
+                SourceBreakpoints bps = debuggee.Breakpoints(SinkHelper.Main, 21, 33);
+                runner.SetBreakpoints(bps);
+
+                this.Comment("Launch and run until hit the first entry");
+                runner.Expects.HitBreakpointEvent(SinkHelper.Main, 21).AfterConfigurationDone();
+
+                this.Comment("Step over the function");
+                runner.Expects.HitStepEvent(SinkHelper.Main, 23).AfterStepOver();
+
+                this.Comment("Continue to hit the second entry");
+                runner.Expects.HitBreakpointEvent(SinkHelper.Main, 33).AfterContinue();
+
+                this.Comment("Step in the function");
+                runner.ExpectStepAndStepToTarget(SinkHelper.Feature, startLine: 19, targetLine: 20).AfterStepIn();
+
+                this.Comment("Step over the function");
+                runner.Expects.HitStepEvent(SinkHelper.Feature, 21).AfterStepOver();
+                runner.Expects.HitStepEvent(SinkHelper.Feature, 22).AfterStepOver();
+
+                this.Comment("Step in the function");
+                runner.ExpectStepAndStepToTarget(SinkHelper.Calling, startLine: 47, targetLine: 48).AfterStepIn();
+
+                this.Comment("Step out the function");
+                runner.ExpectStepAndStepToTarget(SinkHelper.Feature, startLine: 22, targetLine: 23).AfterStepOut();
+
+                this.Comment("Continue running at the end of application");
+                runner.Expects.ExitedEvent()
+                              .TerminatedEvent()
+                              .AfterContinue();
+
+                this.Comment("Verify debugger and debuggee closed");
+                runner.DisconnectAndVerify();
+            }
+        }
+
+        [Theory]
+        [DependsOnTest(nameof(CompileKitchenSinkForExecution))]
+        [RequiresTestSettings]
+        public void ExecutionStepRecursiveCall(ITestSettings settings)
+        {
+            this.TestPurpose("Verify steps should work when debugging recursive call");
+            this.WriteSettings(settings);
+
+            this.Comment("Open the kitchen sink debuggee for execution tests.");
+            IDebuggee debuggee = SinkHelper.Open(this, settings.CompilerSettings, DebuggeeMonikers.KitchenSink.Execution);
+
+            using (IDebuggerRunner runner = CreateDebugAdapterRunner(settings))
+            {
+                this.Comment("Configure launch");
+                runner.Launch(settings.DebuggerSettings, debuggee, "-fCalling");
+
+                this.Comment("Set initial function breakpoints");
+                FunctionBreakpoints funcBp = new FunctionBreakpoints("Calling::CoreRun()");
+                runner.SetFunctionBreakpoints(funcBp);
+
+                this.Comment("Launch and run until hit function breakpoint in the entry of calling");
+                runner.ExpectBreakpointAndStepToTarget(SinkHelper.Calling, startLine: 47, targetLine: 48).AfterConfigurationDone();
+
+                this.Comment("Step over to go to the entry of recursive call");
+                runner.Expects.HitStepEvent(SinkHelper.Calling, 49).AfterStepOver();
+
+                this.Comment("Step in the recursive call");
+                runner.ExpectStepAndStepToTarget(SinkHelper.Calling, startLine: 25, targetLine: 26).AfterStepIn();
+
+                using (IThreadInspector threadInspector = runner.GetThreadInspector())
+                {
+                    this.Comment("Set count = 2");
+                    IFrameInspector currentFrame = threadInspector.Stack.First();
+                    currentFrame.GetVariable("count").Value = "2";
+
+                    this.Comment("Verify there is only one 'recursiveCall' frames");
+                    threadInspector.AssertStackFrameNames(true, "recursiveCall.*", "Calling::CoreRun.*", "Feature::Run.*", "main.*");
+                }
+
+                this.Comment("Step over and then step in the recursive call once again");
+                runner.Expects.HitStepEvent(SinkHelper.Calling, 29).AfterStepOver();
+                runner.ExpectStepAndStepToTarget(SinkHelper.Calling, startLine: 25, targetLine: 26).AfterStepIn();
+
+                using (IThreadInspector threadInspector = runner.GetThreadInspector())
+                {
+                    this.Comment("Verify there are two 'recursiveCall' frames");
+                    threadInspector.AssertStackFrameNames(true, "recursiveCall.*", "recursiveCall.*", "Calling::CoreRun.*", "Feature::Run.*", "main.*");
+
+                    this.Comment("Set a source breakpoint in recursive call");
+                    SourceBreakpoints srcBp = debuggee.Breakpoints(SinkHelper.Calling, 26);
+                    runner.SetBreakpoints(srcBp);
+                }
+
+                this.Comment("Step over the recursive call and hit the source breakpoint");
+                runner.Expects.HitStepEvent(SinkHelper.Calling, 29).AfterStepOver();
+                runner.Expects.HitBreakpointEvent(SinkHelper.Calling, 26).AfterStepOver();
+
+                using (IThreadInspector threadInspector = runner.GetThreadInspector())
+                {
+                    this.Comment("Verify there are three 'recursiveCall' frames");
+                    threadInspector.AssertStackFrameNames(true, "recursiveCall.*", "recursiveCall.*", "recursiveCall.*", "Calling::CoreRun.*", "Feature::Run.*", "main.*");
+                }
+
+                this.Comment("Try to step out twice from recursive call");
+                runner.ExpectStepAndStepToTarget(SinkHelper.Calling, 29, 30).AfterStepOut();
+                runner.ExpectStepAndStepToTarget(SinkHelper.Calling, 29, 30).AfterStepOut();
+
+                using (IThreadInspector threadInspector = runner.GetThreadInspector())
+                {
+                    this.Comment("Verify 'recursiveCall' return back only one frame");
+                    threadInspector.AssertStackFrameNames(true, "recursiveCall.*", "Calling::CoreRun.*", "Feature::Run.*", "main.*");
+                }
+
+                this.Comment("Step over from recursive call");
+                runner.ExpectStepAndStepToTarget(SinkHelper.Calling, 49, 50).AfterStepOver();
+
+                using (IThreadInspector threadInspector = runner.GetThreadInspector())
+                {
+                    this.Comment("Verify there is not 'recursiveCall' frame");
+                    threadInspector.AssertStackFrameNames(true, "Calling::CoreRun.*", "Feature::Run.*", "main.*");
+                }
+
+                this.Comment("Verify stop debugging");
+                runner.DisconnectAndVerify();
+            }
+        }
+
+        [Theory]
+        [DependsOnTest(nameof(CompileKitchenSinkForExecution))]
+        [RequiresTestSettings]
+        // TODO: Re-enable for VsDbg
+        [UnsupportedDebugger(SupportedDebugger.Gdb_Cygwin | SupportedDebugger.Gdb_MinGW | SupportedDebugger.Lldb | SupportedDebugger.VsDbg, SupportedArchitecture.x86 | SupportedArchitecture.x64)]
+        public void ExecutionAsyncBreak(ITestSettings settings)
+        {
+            this.TestPurpose("Verify break all should work run function");
+            this.WriteSettings(settings);
+
+            this.Comment("Open the kitchen sink debuggee for execution tests.");
+            IDebuggee debuggee = SinkHelper.Open(this, settings.CompilerSettings, DebuggeeMonikers.KitchenSink.Execution);
+
+            using (IDebuggerRunner runner = CreateDebugAdapterRunner(settings))
+            {
+                this.Comment("Configure launch");
+                runner.Launch(settings.DebuggerSettings, debuggee, "-fNonTerminating", "-fCalling");
+
+                this.Comment("Try to break all");
+                StoppedEvent breakAllEvent = new StoppedEvent(StoppedReason.Pause);
+                runner.Expects.Event(breakAllEvent).AfterAsyncBreak();
+
+                this.WriteLine("Break all stopped on:");
+                this.WriteLine(breakAllEvent.ActualEvent.ToString());
+
+                this.Comment("Set a breakpoint while breaking code");
+                runner.SetBreakpoints(debuggee.Breakpoints(SinkHelper.NonTerminating, 28));
+
+                this.Comment("Start running after the async break and then hit the breakpoint");
+                runner.Expects.HitBreakpointEvent(SinkHelper.NonTerminating, 28).AfterContinue();
+
+                this.Comment("Evaluate the shouldExit member to true to stop the infinite loop.");
+                using (IThreadInspector threadInspector = runner.GetThreadInspector())
+                {
+                    IFrameInspector firstFrame = threadInspector.Stack.First();
+                    this.WriteLine(firstFrame.ToString());
+                    firstFrame.GetVariable("shouldExit").Value = "true";
+                }
+
+                this.Comment("Continue running at the end of application");
+                runner.Expects.ExitedEvent().TerminatedEvent().AfterContinue();
+
+                this.Comment("Verify debugger and debuggee closed");
+                runner.DisconnectAndVerify();
+            }
+        }
+    }
+}

--- a/test/CppTests/Tests/ExpressionTests.cs
+++ b/test/CppTests/Tests/ExpressionTests.cs
@@ -1,0 +1,552 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using DebuggerTesting;
+using DebuggerTesting.Compilation;
+using DebuggerTesting.OpenDebug;
+using DebuggerTesting.OpenDebug.Commands;
+using DebuggerTesting.OpenDebug.CrossPlatCpp;
+using DebuggerTesting.OpenDebug.Events;
+using DebuggerTesting.OpenDebug.Extensions;
+using DebuggerTesting.Ordering;
+using DebuggerTesting.Utilities;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace CppTests.Tests
+{
+    [TestCaseOrderer(DependencyTestOrderer.TypeName, DependencyTestOrderer.AssemblyName)]
+    public class ExpressionTests : TestBase
+    {
+        #region Constructor
+
+        public ExpressionTests(ITestOutputHelper outputHelper) : base(outputHelper)
+        {
+        }
+
+        #endregion
+
+        #region Methods
+
+        [Theory]
+        [RequiresTestSettings]
+        public void CompileKitchenSinkForExpressionTests(ITestSettings settings)
+        {
+            this.TestPurpose("Compile kitchen sink debuggee for expression tests.");
+            this.WriteSettings(settings);
+
+            IDebuggee debuggee = SinkHelper.OpenAndCompile(this, settings.CompilerSettings, DebuggeeMonikers.KitchenSink.Expression);
+        }
+
+        [Theory]
+        [DependsOnTest(nameof(CompileKitchenSinkForExpressionTests))]
+        [RequiresTestSettings]
+        public void LocalsBasic(ITestSettings settings)
+        {
+            this.TestPurpose("Check primitives displying in locals.");
+            this.WriteSettings(settings);
+
+            IDebuggee debuggee = SinkHelper.Open(this, settings.CompilerSettings, DebuggeeMonikers.KitchenSink.Expression);
+
+            using (IDebuggerRunner runner = CreateDebugAdapterRunner(settings))
+            {
+                this.Comment("Configure launch.");
+                runner.Launch(settings.DebuggerSettings, debuggee, "-fExpression");
+
+                this.Comment("Set a line breakpoints so that we can stop.");
+                runner.SetBreakpoints(debuggee.Breakpoints(SinkHelper.Expression, 31));
+
+                this.Comment("To start debugging and break");
+                runner.Expects.StoppedEvent(StoppedReason.Breakpoint).AfterConfigurationDone();
+
+                using (IThreadInspector threadInspector = runner.GetThreadInspector())
+                {
+                    IFrameInspector currentFrame = threadInspector.Stack.First();
+
+                    this.Comment("To verify locals variables on current frame.");
+                    Assert.Subset(new HashSet<string>() { "mybool", "mychar", "myint", "mywchar", "myfloat", "mydouble", "this" }, currentFrame.Variables.ToKeySet());
+                    currentFrame.AssertVariables(
+                        "mybool", "true",
+                        "myint", "100");
+
+                    currentFrame.GetVariable("mychar").AssertValueAsChar('A');
+                    currentFrame.GetVariable("mywchar").AssertValueAsWChar('z');
+                    currentFrame.GetVariable("myfloat").AssertValueAsFloat(299);
+                    currentFrame.GetVariable("mydouble").AssertValueAsDouble(321);
+                }
+
+                this.Comment("Run to completion");
+                runner.Expects.TerminatedEvent().AfterContinue();
+
+                runner.DisconnectAndVerify();
+            }
+        }
+
+        [Theory]
+        [DependsOnTest(nameof(CompileKitchenSinkForExpressionTests))]
+        [RequiresTestSettings]
+        public void WatchBasic(ITestSettings settings)
+        {
+            this.TestPurpose("Evaluate some expressions in watch.");
+            this.WriteSettings(settings);
+
+            IDebuggee debuggee = SinkHelper.Open(this, settings.CompilerSettings, DebuggeeMonikers.KitchenSink.Expression);
+
+            using (IDebuggerRunner runner = CreateDebugAdapterRunner(settings))
+            {
+                this.Comment("Configure launch");
+                runner.Launch(settings.DebuggerSettings, debuggee, "-fExpression");
+
+                this.Comment("Set a line breakpoints so that we can stop.");
+                runner.SetBreakpoints(debuggee.Breakpoints(SinkHelper.Expression, 31));
+
+                this.Comment("To start debugging and break");
+                runner.Expects.StoppedEvent(StoppedReason.Breakpoint).AfterConfigurationDone();
+
+                using (IThreadInspector threadInspector = runner.GetThreadInspector())
+                {
+                    IFrameInspector currentFrame = threadInspector.Stack.First();
+
+                    this.Comment("To evaluate variables and functions in watch.");
+                    string evalMyInt = currentFrame.Evaluate("myint-=100", EvaluateContext.Watch);
+                    currentFrame.AssertEvaluateAsChar("mychar", EvaluateContext.Watch, 'A');
+                    string evalMyBool = currentFrame.Evaluate("mybool", EvaluateContext.Watch);
+                    currentFrame.AssertEvaluateAsWChar("mywchar", EvaluateContext.Watch, 'z');
+                    currentFrame.AssertEvaluateAsDouble("mydouble", EvaluateContext.Watch, 321);
+                    currentFrame.AssertEvaluateAsFloat("myfloat", EvaluateContext.Watch, 299);
+                    string evalFuncMaxInt = currentFrame.Evaluate("Test::max(myint,1)", EvaluateContext.Watch);
+                    currentFrame.AssertEvaluateAsDouble("Test::max(mydouble,0.0)-321.0", EvaluateContext.Watch, 0);
+
+                    Assert.Equal("0", evalMyInt);
+                    Assert.Equal("true", evalMyBool);
+                    Assert.Equal("1", evalFuncMaxInt);
+                }
+
+                this.Comment("Run to completion");
+                runner.Expects.TerminatedEvent().AfterContinue();
+
+                runner.DisconnectAndVerify();
+            }
+        }
+
+        [Theory]
+        [DependsOnTest(nameof(CompileKitchenSinkForExpressionTests))]
+        [RequiresTestSettings]
+        public void DataTipBasic(ITestSettings settings)
+        {
+            this.TestPurpose("To test evaluation in datatip.");
+            this.WriteSettings(settings);
+
+            IDebuggee debuggee = SinkHelper.Open(this, settings.CompilerSettings, DebuggeeMonikers.KitchenSink.Expression);
+
+            using (IDebuggerRunner runner = CreateDebugAdapterRunner(settings))
+            {
+                this.Comment("Configure launch.");
+                runner.Launch(settings.DebuggerSettings, debuggee, "-fExpression");
+
+                this.Comment("To set a breakpoint so that we can stop at somewhere for evaluation.");
+                runner.SetBreakpoints(debuggee.Breakpoints(SinkHelper.Expression, 19));
+
+                this.Comment("To start debugging and break");
+                runner.Expects.StoppedEvent(StoppedReason.Breakpoint).AfterConfigurationDone();
+
+                using (IThreadInspector threadInspector = runner.GetThreadInspector())
+                {
+                    IFrameInspector currentFrame;
+
+                    this.Comment("To evaluate in datatip on the first frame.");
+                    currentFrame = threadInspector.Stack.First();
+                    Assert.Equal("true", currentFrame.Evaluate("isCalled", EvaluateContext.DataTip));
+                    currentFrame.AssertEvaluateAsDouble("d", EvaluateContext.DataTip, 10.1);
+
+                    // We only verify the major contents in datatip
+                    Assert.Contains(@"accumulate(int)", currentFrame.Evaluate("accumulate", EvaluateContext.DataTip), StringComparison.Ordinal);
+
+                    this.Comment("To evaluate in datatip on the fourth frame.");
+                    currentFrame = threadInspector.Stack.ElementAt(3);
+                    currentFrame.AssertEvaluateAsDouble("mydouble", EvaluateContext.DataTip, double.PositiveInfinity);
+                    currentFrame.AssertEvaluateAsChar("mynull", EvaluateContext.DataTip, '\0');
+
+                    this.Comment("To evaluate in datatip on the fifth frame.");
+                    currentFrame = threadInspector.Stack.ElementAt(4);
+                    currentFrame.AssertEvaluateAsObject("student", EvaluateContext.DataTip, "name", @"""John""", "age", "10");
+                    Assert.Matches(@"0x[0-9A-Fa-f]+", currentFrame.Evaluate("pStu", EvaluateContext.DataTip));
+
+                    this.Comment("To evaluate in datatip on the sixth frame.");
+                    currentFrame = threadInspector.Stack.ElementAt(5);
+                    currentFrame.AssertEvaluateAsIntArray("arr", EvaluateContext.DataTip, 0, 1, 2, 3, 4);
+                    Assert.Matches(@"0x[0-9A-Fa-f]+", currentFrame.Evaluate("pArr", EvaluateContext.DataTip));
+
+                    this.Comment("To evaluate in datatip on the seventh frame.");
+                    currentFrame = threadInspector.Stack.ElementAt(6);
+                    Assert.Equal("true", currentFrame.Evaluate("mybool", EvaluateContext.DataTip));
+                    Assert.Equal("100", currentFrame.Evaluate("myint", EvaluateContext.DataTip));
+                    currentFrame.AssertEvaluateAsFloat("myfloat", EvaluateContext.DataTip, 299);
+                    currentFrame.AssertEvaluateAsDouble("mydouble", EvaluateContext.DataTip, 321);
+                    currentFrame.AssertEvaluateAsChar("mychar", EvaluateContext.DataTip, 'A');
+                    currentFrame.AssertEvaluateAsWChar("mywchar", EvaluateContext.DataTip, 'z');
+                }
+
+                this.Comment("Continue to run to exist.");
+                runner.Expects.TerminatedEvent().AfterContinue();
+
+                runner.DisconnectAndVerify();
+            }
+        }
+
+        [Theory]
+        [DependsOnTest(nameof(CompileKitchenSinkForExpressionTests))]
+        [RequiresTestSettings]
+        public void CallStackBasic(ITestSettings settings)
+        {
+            this.TestPurpose("To check all frames of callstack on a thead and evaluation on each frame.");
+            this.WriteSettings(settings);
+
+            IDebuggee debuggee = SinkHelper.Open(this, settings.CompilerSettings, DebuggeeMonikers.KitchenSink.Expression);
+
+            this.Comment("Here are stack frames in a list we expect the actual to match with this.");
+            StackFrame[] expectedstackFrames = ExpressionTests.GenerateFramesList(settings.DebuggerSettings);
+
+            using (IDebuggerRunner runner = CreateDebugAdapterRunner(settings))
+            {
+                this.Comment("Configure launch.");
+                runner.Launch(settings.DebuggerSettings, debuggee, "-fExpression");
+
+                this.Comment("Set a breakpoint so that we can stop after starting debugging.");
+                runner.SetBreakpoints(debuggee.Breakpoints(SinkHelper.Expression, 19));
+
+                this.Comment("To start debugging and break");
+                runner.Expects.StoppedEvent(StoppedReason.Breakpoint, SinkHelper.Expression, 19).AfterConfigurationDone();
+
+                this.Comment("To step in several times into the innermost layer of a recursive call.");
+                runner.ExpectStepAndStepToTarget(SinkHelper.Expression, 9, 10).AfterStepIn();
+                runner.Expects.HitStepEvent(SinkHelper.Expression, 12).AfterStepIn();
+                runner.ExpectStepAndStepToTarget(SinkHelper.Expression, 9, 10).AfterStepIn();
+                runner.Expects.HitStepEvent(SinkHelper.Expression, 12).AfterStepIn();
+                runner.ExpectStepAndStepToTarget(SinkHelper.Expression, 9, 10).AfterStepIn();
+
+                using (IThreadInspector threadInspector = runner.GetThreadInspector())
+                {
+                    IEnumerable<IFrameInspector> stackOfCurrentThread = threadInspector.Stack;
+                    this.Comment("To verify the count of stack frames count.");
+                    Assert.True(stackOfCurrentThread.Count() >= 13, "Expected the stack frame count to be at least 13 deep");
+
+                    this.Comment("To verify each frame, include frame name, line number and source name.");
+                    int index = 0;
+                    foreach (IFrameInspector frame in stackOfCurrentThread)
+                    {
+                        if (index >= 13)
+                            break;
+                        StackFrame expectedstackFrame = expectedstackFrames[index];
+                        this.Comment("Comparing Names. Expecected: {0}, Actual: {1}", expectedstackFrame.Name, frame.Name);
+                        Assert.Contains(expectedstackFrame.Name, frame.Name, StringComparison.Ordinal);
+                        this.Comment("Comparing line number. Expecected: {0}, Actual: {1}", expectedstackFrame.Line, frame.Line);
+                        Assert.Equal(expectedstackFrame.Line, frame.Line);
+                        this.Comment("Comparing Source Name. Expecected: {0}, Actual: {1}", expectedstackFrame.SourceName, frame.SourceName);
+                        Assert.Equal(expectedstackFrame.SourceName, frame.SourceName);
+                        index++;
+                    }
+                }
+
+                this.Comment("Continue to run to exist.");
+                runner.Expects.TerminatedEvent().AfterContinue();
+
+                runner.DisconnectAndVerify();
+            }
+        }
+
+        [Theory]
+        [DependsOnTest(nameof(CompileKitchenSinkForExpressionTests))]
+        [RequiresTestSettings]
+        public void EvaluateOnFrames(ITestSettings settings)
+        {
+            this.TestPurpose("To check evalution on different frame with different variable types.");
+            this.WriteSettings(settings);
+
+            this.Comment("Open the debugge with a initialization.");
+            IDebuggee debuggee = SinkHelper.Open(this, settings.CompilerSettings, DebuggeeMonikers.KitchenSink.Expression);
+
+            using (IDebuggerRunner runner = CreateDebugAdapterRunner(settings))
+            {
+                this.Comment("Configure launch.");
+                runner.Launch(settings.DebuggerSettings, debuggee, "-fExpression");
+
+                this.Comment("Set a breakpoint so that we can stop at a line.");
+                runner.SetBreakpoints(debuggee.Breakpoints(SinkHelper.Expression, 19));
+
+                this.Comment("To start debugging and break");
+                runner.Expects.StoppedEvent(StoppedReason.Breakpoint).AfterConfigurationDone();
+
+                using (IThreadInspector threadInspector = runner.GetThreadInspector())
+                {
+                    IFrameInspector currentFrame;
+
+                    this.Comment("To evaluate on the first frame.");
+                    currentFrame = threadInspector.Stack.First();
+                    currentFrame.AssertVariables("isCalled", "true");
+                    Assert.Equal("true", currentFrame.Evaluate("isCalled||false", EvaluateContext.Watch));
+                    currentFrame.AssertEvaluateAsDouble("d", EvaluateContext.Watch, 10.1);
+
+                    this.Comment("Switch to next frame then evaluate on that frame.");
+                    currentFrame = threadInspector.Stack.ElementAt(1);
+                    currentFrame.GetVariable("_f").AssertValueAsFloat(1);
+                    currentFrame.AssertEvaluateAsFloat("_f", EvaluateContext.Watch, 1);
+
+                    this.Comment("To evaluate string and vector type on it, the try to enable pretty printing to evaluate again.");
+                    currentFrame = threadInspector.Stack.ElementAt(2);
+                    currentFrame.GetVariable("vec").AssertValueAsVector(5);
+                    currentFrame.AssertEvaluateAsVector("vec", EvaluateContext.Watch, 5);
+
+                    this.Comment("To evaluate some special values on the fourth frame.");
+                    currentFrame = threadInspector.Stack.ElementAt(3);
+                    currentFrame.AssertEvaluateAsDouble("mydouble=1.0", EvaluateContext.Watch, 1);
+                    currentFrame.GetVariable("mynull").AssertValueAsChar('\0');
+
+                    this.Comment("To evaluate class on stack on the fifth frame.");
+                    currentFrame = threadInspector.Stack.ElementAt(4);
+                    IVariableInspector varInspector;
+                    varInspector = currentFrame.GetVariable("student");
+                    Assert.Equal("10", varInspector.GetVariable("age").Value);
+                    Assert.Equal("19", currentFrame.Evaluate("student.age=19", EvaluateContext.Watch));
+
+                    this.Comment("To evaluate array on the sixth frame.");
+                    currentFrame = threadInspector.Stack.ElementAt(5);
+                    Assert.Equal("10", currentFrame.Evaluate("*(pArr+1)=10", EvaluateContext.Watch));
+                    Assert.Equal("100", currentFrame.Evaluate("arr[0]=100", EvaluateContext.Watch));
+                }
+
+
+                this.Comment("Continue to run to exist.");
+                runner.Expects.TerminatedEvent().AfterContinue();
+
+                runner.DisconnectAndVerify();
+            }
+        }
+
+        [Theory]
+        [DependsOnTest(nameof(CompileKitchenSinkForExpressionTests))]
+        [RequiresTestSettings]
+        public void EvaluateInvalidExpression(ITestSettings settings)
+        {
+            this.TestPurpose("To test invalid expression evaluation return apropriate errors.");
+            this.WriteSettings(settings);
+
+            IDebuggee debuggee = SinkHelper.Open(this, settings.CompilerSettings, DebuggeeMonikers.KitchenSink.Expression);
+
+            using (IDebuggerRunner runner = CreateDebugAdapterRunner(settings))
+            {
+                this.Comment("Configure launch.");
+                runner.Launch(settings.DebuggerSettings, debuggee, "-fExpression");
+
+                this.Comment("Set a breakpoint so that we can stop at a line.");
+                runner.SetBreakpoints(debuggee.Breakpoints(SinkHelper.Expression, 31));
+
+                this.Comment("To start debugging and hit breakpoint.");
+                runner.Expects.HitBreakpointEvent().AfterConfigurationDone();
+
+                using (IThreadInspector threadInspector = runner.GetThreadInspector())
+                {
+                    IFrameInspector currentFrame = threadInspector.Stack.First();
+
+                    this.Comment("To evaluate some invalid expression on curren stack frame.");
+                    currentFrame.AssertEvaluateAsError("notExistVar", EvaluateContext.Watch);
+                }
+
+                this.Comment("Continue to run to exist.");
+                runner.Expects.TerminatedEvent().AfterContinue();
+
+                runner.DisconnectAndVerify();
+            }
+        }
+
+        #region Assign expression
+
+        [Theory]
+        [DependsOnTest(nameof(CompileKitchenSinkForExpressionTests))]
+        [RequiresTestSettings]
+        public void AssignIntExpressionToVariable(ITestSettings settings)
+        {
+            this.TestPurpose("Assign an expression to a variable.");
+            this.WriteSettings(settings);
+
+            IDebuggee debuggee = SinkHelper.Open(this, settings.CompilerSettings, DebuggeeMonikers.KitchenSink.Expression);
+
+            using (IDebuggerRunner runner = CreateDebugAdapterRunner(settings))
+            {
+                this.Comment("Configure launch.");
+                runner.Launch(settings.DebuggerSettings, debuggee, "-fExpression");
+
+                this.Comment("Set a breakpoint so that we can stop at a line.");
+                runner.SetBreakpoints(debuggee.Breakpoints(SinkHelper.Expression, 31));
+
+                this.Comment("Start debugging and hit breakpoint.");
+                runner.Expects.HitBreakpointEvent().AfterConfigurationDone();
+
+                using (IThreadInspector threadInspector = runner.GetThreadInspector())
+                {
+                    IFrameInspector currentFrame = threadInspector.Stack.First();
+
+                    this.Comment("Assign an expression to a variable.");
+                    currentFrame.GetVariable("myint").Value = "39+3";
+                }
+
+                // Start another inspector to refresh values
+                using (IThreadInspector threadInspector = runner.GetThreadInspector())
+                {
+                    IFrameInspector currentFrame = threadInspector.Stack.First();
+
+                    this.Comment("Check the value of the variable has been updated.");
+                    Assert.Equal("42", currentFrame.GetVariable("myint").Value);
+                }
+
+                this.Comment("Continue to run to exist.");
+                runner.Expects.TerminatedEvent().AfterContinue();
+
+                runner.DisconnectAndVerify();
+            }
+        }
+
+        [Theory]
+        [DependsOnTest(nameof(CompileKitchenSinkForExpressionTests))]
+        [RequiresTestSettings]
+        public void AssignInvalidExpressionToVariable(ITestSettings settings)
+        {
+            this.TestPurpose("Assign an invalid expression to a variable.");
+            this.WriteSettings(settings);
+
+            IDebuggee debuggee = SinkHelper.Open(this, settings.CompilerSettings, DebuggeeMonikers.KitchenSink.Expression);
+
+            using (IDebuggerRunner runner = CreateDebugAdapterRunner(settings))
+            {
+                this.Comment("Configure launch.");
+                runner.Launch(settings.DebuggerSettings, debuggee, "-fExpression");
+
+                this.Comment("Set a breakpoint so that we can stop at a line.");
+                runner.SetBreakpoints(debuggee.Breakpoints(SinkHelper.Expression, 31));
+
+                this.Comment("Start debugging and hit breakpoint.");
+                runner.Expects.StoppedEvent(StoppedReason.Breakpoint).AfterConfigurationDone();
+
+                using (IThreadInspector threadInspector = runner.GetThreadInspector())
+                {
+                    IFrameInspector currentFrame = threadInspector.Stack.First();
+
+                    this.Comment("Assign an invalid expression to a variable.");
+                    currentFrame.GetVariable("myint").SetVariableValueExpectFailure("39+nonexistingint");
+                }
+
+                // Start another inspector to refresh values
+                using (IThreadInspector threadInspector = runner.GetThreadInspector())
+                {
+                    IFrameInspector currentFrame = threadInspector.Stack.First();
+
+                    this.Comment("Check the value of the variable hasn't been updated.");
+                    Assert.Equal("100", currentFrame.GetVariable("myint").Value);
+                }
+
+                this.Comment("Continue to run to exist.");
+                runner.Expects.TerminatedEvent().AfterContinue();
+
+                runner.DisconnectAndVerify();
+            }
+        }
+
+        #endregion
+
+        #endregion
+
+        #region Private methods
+
+        private static StackFrame[] GenerateFramesList(IDebuggerSettings debugger)
+        {
+            // VsDbg moves the stack pointer to the return address which is not necessarily the calling address
+            if (debugger.DebuggerType == SupportedDebugger.VsDbg)
+            {
+                // Visual C++ compiler for x64 and x86 generate symbols differently which means that the line numbers will be different.
+                if (debugger.DebuggeeArchitecture == SupportedArchitecture.x64)
+                {
+                    return new[] {
+                        new StackFrame(10, "accumulate(", "expression.cpp", null),
+                        new StackFrame(12, "accumulate(", "expression.cpp", null),
+                        new StackFrame(12, "accumulate(", "expression.cpp", null),
+                        new StackFrame(20, "func(", "expression.cpp", null),
+                        new StackFrame(81, "Expression::checkCallStack(", "expression.cpp", null),
+                        new StackFrame(74, "Expression::checkPrettyPrinting(", "expression.cpp", null),
+                        new StackFrame(63, "Expression::checkSpecialValues(", "expression.cpp", null),
+                        new StackFrame(53, "Expression::checkClassOnStackAndHeap(", "expression.cpp", null),
+                        new StackFrame(40, "Expression::checkArrayAndPointers(", "expression.cpp", null),
+                        new StackFrame(32, "Expression::checkPrimitiveTypes(", "expression.cpp", null),
+                        new StackFrame(86, "Expression::CoreRun(", "expression.cpp", null),
+                        new StackFrame(23, "Feature::Run(", "feature.cpp", null),
+                        new StackFrame(45, "main", "main.cpp", null)
+                    };
+                }
+                else
+                {
+                    return new[] {
+                        new StackFrame(10, "accumulate(", "expression.cpp", null),
+                        new StackFrame(12, "accumulate(", "expression.cpp", null),
+                        new StackFrame(12, "accumulate(", "expression.cpp", null),
+                        new StackFrame(19, "func(", "expression.cpp", null),
+                        new StackFrame(81, "Expression::checkCallStack(", "expression.cpp", null),
+                        new StackFrame(75, "Expression::checkPrettyPrinting(", "expression.cpp", null),
+                        new StackFrame(63, "Expression::checkSpecialValues(", "expression.cpp", null),
+                        new StackFrame(54, "Expression::checkClassOnStackAndHeap(", "expression.cpp", null),
+                        new StackFrame(40, "Expression::checkArrayAndPointers(", "expression.cpp", null),
+                        new StackFrame(32, "Expression::checkPrimitiveTypes(", "expression.cpp", null),
+                        new StackFrame(86, "Expression::CoreRun(", "expression.cpp", null),
+                        new StackFrame(23, "Feature::Run(", "feature.cpp", null),
+                        new StackFrame(46, "main", "main.cpp", null)
+                    };
+                }
+            }
+            else
+            {
+                return new[] {
+                        new StackFrame(10, "accumulate(", "expression.cpp", null),
+                        new StackFrame(12, "accumulate(", "expression.cpp", null),
+                        new StackFrame(12, "accumulate(", "expression.cpp", null),
+                        new StackFrame(19, "func(", "expression.cpp", null),
+                        new StackFrame(80, "Expression::checkCallStack(", "expression.cpp", null),
+                        new StackFrame(74, "Expression::checkPrettyPrinting(", "expression.cpp", null),
+                        new StackFrame(62, "Expression::checkSpecialValues(", "expression.cpp", null),
+                        new StackFrame(53, "Expression::checkClassOnStackAndHeap(", "expression.cpp", null),
+                        new StackFrame(39, "Expression::checkArrayAndPointers(", "expression.cpp", null),
+                        new StackFrame(31, "Expression::checkPrimitiveTypes(", "expression.cpp", null),
+                        new StackFrame(85, "Expression::CoreRun(", "expression.cpp", null),
+                        new StackFrame(22, "Feature::Run(", "feature.cpp", null),
+                        new StackFrame(45, "main", "main.cpp", null)
+                    };
+            }
+        }
+
+        #endregion
+    }
+
+    #region Class of Stack Frame
+
+    /// <summary>
+    /// Represent a stack frame
+    /// </summary>
+    internal class StackFrame
+    {
+        public int Line { get; private set; }
+        public string Name { get; private set; }
+        public string SourceName { get; private set; }
+        public string SourcePath { get; private set; }
+
+        public StackFrame(int line, string name, string sourceName, string sourcePath)
+        {
+            this.Line = line;
+            this.Name = name;
+            this.SourceName = sourceName;
+            this.SourcePath = sourcePath;
+        }
+    }
+
+    #endregion
+
+}

--- a/test/CppTests/Tests/OptimizationTest.cs
+++ b/test/CppTests/Tests/OptimizationTest.cs
@@ -1,0 +1,345 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Linq;
+using DebuggerTesting;
+using DebuggerTesting.Compilation;
+using DebuggerTesting.OpenDebug;
+using DebuggerTesting.OpenDebug.Commands;
+using DebuggerTesting.OpenDebug.CrossPlatCpp;
+using DebuggerTesting.OpenDebug.Extensions;
+using DebuggerTesting.Ordering;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace CppTests.Tests
+{
+    [TestCaseOrderer(DependencyTestOrderer.TypeName, DependencyTestOrderer.AssemblyName)]
+    public class OptimizationTests : TestBase
+    {
+        #region Constructor
+
+        public OptimizationTests(ITestOutputHelper outputHelper) : base(outputHelper)
+        {
+        }
+
+        #endregion
+
+        #region Member Variables
+
+        private const string Name = "optimization";
+        private const string SourceName = "source.cpp";
+        private const string UserDefinedClassName = "foo.cpp";
+        private const string SrcLibName = "mylib.cpp";
+        private const string OutLibName = "mylib";
+
+        #endregion
+
+        #region Methods
+        [Theory]
+        [RequiresTestSettings]
+        public void CompileSharedLibDebuggeeWithoutSymbol(ITestSettings settings)
+        {
+            this.TestPurpose("Create and compile the 'sharedlib' debuggee");
+            this.WriteSettings(settings);
+
+            //Compile the shared library
+            CompileSharedLib(settings, DebuggeeMonikers.Optimization.OptimizationWithoutSymbols, false);
+
+            //Compile the application
+            CompileApp(settings, DebuggeeMonikers.Optimization.OptimizationWithoutSymbols);
+        }
+
+        [Theory]
+        [DependsOnTest(nameof(CompileSharedLibDebuggeeWithoutSymbol))]
+        [UnsupportedDebugger(SupportedDebugger.VsDbg, SupportedArchitecture.x86 | SupportedArchitecture.x64)]
+        [RequiresTestSettings]
+        public void TestSharedLibWithoutSymbol(ITestSettings settings)
+        {
+            this.TestPurpose("Tests basic bps and source information for shared library without symbols");
+            this.WriteSettings(settings);
+
+            IDebuggee debuggee = Debuggee.Open(this, settings.CompilerSettings, Name, DebuggeeMonikers.Optimization.OptimizationWithoutSymbols);
+            using (IDebuggerRunner runner = CreateDebugAdapterRunner(settings))
+            {
+                this.Comment("Configure launch");
+                runner.Launch(settings.DebuggerSettings, debuggee);
+
+                SourceBreakpoints mainBreakpoints = debuggee.Breakpoints(SourceName, 87, 91);
+
+                this.Comment("Set initial breakpoints");
+                runner.SetBreakpoints(mainBreakpoints);
+
+                this.Comment("Launch and run until 1st bp");
+                runner.Expects.HitBreakpointEvent(SourceName, 87)
+                                .AfterConfigurationDone();
+
+                this.Comment("Step into the library source");
+                runner.Expects.HitStepEvent(SourceName, 89)
+                                .AfterStepIn();
+
+                this.Comment("Check the stack for debugging shared library without symbols");
+                using (IThreadInspector inspector = runner.GetThreadInspector())
+                {
+                    IFrameInspector currentFrame = inspector.Stack.First();
+                    inspector.AssertStackFrameNames(true, "main");
+
+                    this.Comment("run to continue to 2nd bp");
+                    runner.Expects.HitBreakpointEvent(SourceName, 91)
+                                  .AfterContinue();
+
+                    this.Comment("Check the stack for debugging shared library without symbols");
+                    currentFrame = inspector.Stack.First();
+                    inspector.AssertStackFrameNames(true, "main");
+                    this.Comment("Check the local variables in main function");
+                    IVariableInspector age = currentFrame.Variables["age"];
+                    Assert.Matches("31", age.Value);
+                }
+
+                runner.DisconnectAndVerify();
+            }
+        }
+
+        [Theory]
+        [RequiresTestSettings]
+        public void CompileSharedLibDebuggeeWithSymbol(ITestSettings settings)
+        {
+            this.TestPurpose("Create and compile the 'sharedlib' debuggee");
+            this.WriteSettings(settings);
+
+            //Compile the shared library
+            CompileSharedLib(settings, DebuggeeMonikers.Optimization.OptimizationWithSymbols,true);
+
+            //Compile the application
+            CompileApp(settings, DebuggeeMonikers.Optimization.OptimizationWithSymbols);
+        }
+
+        [Theory]
+        [DependsOnTest(nameof(CompileSharedLibDebuggeeWithSymbol))]
+        [UnsupportedDebugger(SupportedDebugger.VsDbg, SupportedArchitecture.x86 | SupportedArchitecture.x64)]
+        [RequiresTestSettings]
+        public void TestOptimizedBpsAndSource(ITestSettings settings)
+        {
+            this.TestPurpose("Tests basic operation of bps and source information for optimized app");
+            this.WriteSettings(settings);
+
+            IDebuggee debuggee = Debuggee.Open(this, settings.CompilerSettings, Name, DebuggeeMonikers.Optimization.OptimizationWithSymbols);
+
+            using (IDebuggerRunner runner = CreateDebugAdapterRunner(settings))
+            {
+                this.Comment("Configure launch");
+                runner.Launch(settings.DebuggerSettings, debuggee);
+
+                SourceBreakpoints mainBreakpoints = debuggee.Breakpoints(SourceName, 68);
+                SourceBreakpoints userDefinedClassBreakpoints = debuggee.Breakpoints(UserDefinedClassName, 8,15,54);
+
+                this.Comment("Set initial breakpoints");
+                runner.SetBreakpoints(mainBreakpoints);
+                runner.SetBreakpoints(userDefinedClassBreakpoints);
+
+                this.Comment("Launch and run until 1st bp");
+                runner.Expects.HitBreakpointEvent(UserDefinedClassName, 8)
+                                .AfterConfigurationDone();
+
+                this.Comment("run until 2nd bp");
+                runner.Expects.HitBreakpointEvent(UserDefinedClassName, 54)
+                                .AfterContinue();
+
+                this.Comment("run until 3rd bp");
+                runner.Expects.HitBreakpointEvent(SourceName, 68)
+                                .AfterContinue();
+
+                //Todo: this has different behavior on Mac(:16), Other Platforms(15) I have logged bug#247891 to track
+                this.Comment("run until 4th bp");
+                runner.ExpectBreakpointAndStepToTarget(UserDefinedClassName, 15, 16).AfterContinue();
+
+                this.Comment("continue to next bp");
+                runner.Expects.HitBreakpointEvent(UserDefinedClassName, 54)
+                                .AfterContinue();
+
+                this.Comment("Check the current callstack frame");
+                using (IThreadInspector threadInspector = runner.GetThreadInspector())
+                {
+                    this.Comment("Get current frame object");
+                    IFrameInspector currentFrame = threadInspector.Stack.First();
+
+                    this.Comment("Verify current frame");
+                    threadInspector.AssertStackFrameNames(true, "Foo::Sum");
+                }
+
+                this.Comment("step out to main entry");
+                runner.Expects.HitStepEvent(SourceName, 69)
+                                .AfterStepOut();
+
+                runner.Expects.ExitedEvent(0).TerminatedEvent().AfterContinue();
+                runner.DisconnectAndVerify();
+            }
+        }
+  
+        [Theory]
+        [DependsOnTest(nameof(CompileSharedLibDebuggeeWithSymbol))]
+        [RequiresTestSettings]
+        public void TestOptimizedLocals(ITestSettings settings)
+        {
+            this.TestPurpose("Tests basic local expression which is not been optimized");
+            this.WriteSettings(settings);
+
+            IDebuggee debuggee = Debuggee.Open(this, settings.CompilerSettings, Name, DebuggeeMonikers.Optimization.OptimizationWithSymbols);
+            using (IDebuggerRunner runner = CreateDebugAdapterRunner(settings))
+            {
+                this.Comment("Configure launch");
+                runner.Launch(settings.DebuggerSettings, debuggee);
+
+                SourceBreakpoints userDefinedClassBreakpoints = debuggee.Breakpoints(UserDefinedClassName, 54);
+
+                this.Comment("Set initial breakpoints");
+                runner.SetBreakpoints(userDefinedClassBreakpoints);
+
+                this.Comment("Launch and run until 1st bp");
+                runner.Expects.HitBreakpointEvent(UserDefinedClassName, 54)
+                              .AfterConfigurationDone();
+
+                this.Comment("Check the un-optimized values");
+                using (IThreadInspector inspector = runner.GetThreadInspector())
+                {
+                    IFrameInspector currentFrame = inspector.Stack.First();
+                    IVariableInspector sum = currentFrame.Variables["sum"];
+                    IVariableInspector first = currentFrame.Variables["first"];
+
+                    this.Comment("Check the local variables in sub function");
+                    Assert.Matches("^0",sum.Value);
+                    Assert.Matches("^1",first.Value);
+
+                    this.Comment("Step out");
+                    runner.Expects.HitStepEvent(SourceName, 66)
+                                  .AfterStepOut();
+
+                    this.Comment("Evaluate the expression:");
+                    currentFrame = inspector.Stack.First();
+                    inspector.AssertStackFrameNames(true, "main"); 
+                }
+
+                runner.DisconnectAndVerify();
+            }
+        }
+
+        [Theory]
+        [DependsOnTest(nameof(CompileSharedLibDebuggeeWithSymbol))]
+        [UnsupportedDebugger(SupportedDebugger.VsDbg, SupportedArchitecture.x86 | SupportedArchitecture.x64)]
+        [RequiresTestSettings]
+        public void TestOptimizedSharedLib(ITestSettings settings)
+        {
+            this.TestPurpose("Tests basic bps and source information for shared library");
+            this.WriteSettings(settings);
+
+            IDebuggee debuggee = Debuggee.Open(this, settings.CompilerSettings, Name, DebuggeeMonikers.Optimization.OptimizationWithSymbols);
+            using (IDebuggerRunner runner = CreateDebugAdapterRunner(settings))
+            {
+                this.Comment("Configure launch");
+                runner.Launch(settings.DebuggerSettings, debuggee);
+
+                SourceBreakpoints mainBreakpoints = debuggee.Breakpoints(SourceName, 87, 89);
+                SourceBreakpoints libBreakpoints = debuggee.Breakpoints(SrcLibName, 9, 12);
+
+                this.Comment("Set initial breakpoints");
+                runner.SetBreakpoints(mainBreakpoints);
+                runner.SetBreakpoints(libBreakpoints);
+
+                this.Comment("Launch and run until 1st bp");
+                runner.Expects.HitBreakpointEvent(SourceName, 87)
+                                .AfterConfigurationDone();
+
+                //Todo: this has different behavior on Mac, I have logged bug#247895 to track
+                //Del said that Different compilers generate symbols differently. 
+                //Our tests have to be resilient to this fact. The location of the step is reasonable, 
+                //so this is by design.
+                this.Comment("enter into the library source");
+                runner.ExpectBreakpointAndStepToTarget(SrcLibName, 8, 9).AfterContinue();
+
+                this.Comment("Step over");
+                runner.Expects.HitStepEvent(SrcLibName, 10).AfterStepOver();
+
+                this.Comment("Check the un-optimized values in shared library");
+                using (IThreadInspector inspector = runner.GetThreadInspector())
+                {
+                    IFrameInspector currentFrame = inspector.Stack.First();
+                    IVariableInspector age = currentFrame.Variables["age"];
+
+                    this.Comment("Check the local variable in sub function");
+                    Assert.Matches("31", age.Value);
+
+                    this.Comment("run to continue");
+                    if(settings.DebuggerSettings.DebuggerType == SupportedDebugger.Lldb)
+                    {
+                        runner.Expects.HitBreakpointEvent(SourceName, 89)
+                                  .AfterContinue();
+                        this.Comment("Verify current frame for main func");
+                        inspector.AssertStackFrameNames(true, "main");
+                    }
+                    else
+                    {
+                        runner.Expects.HitBreakpointEvent(SrcLibName, 12)
+                                      .AfterContinue();
+                        this.Comment("Verify current frame for library func");
+                        inspector.AssertStackFrameNames(true, "myClass::DisplayAge");
+
+                        this.Comment("Step out to main entry");
+                        runner.Expects.HitBreakpointEvent(SourceName, 89).AfterContinue();
+
+                        this.Comment("Verify current frame for main entry");
+                        inspector.AssertStackFrameNames(true, "main");
+                    }
+
+                    this.Comment("Evaluate the expression:");
+                    //skip the Mac's verification as bug#247893
+                    currentFrame = inspector.Stack.First();
+                    string strAge = currentFrame.Evaluate("myclass->DisplayAge(30)");
+
+                    if (settings.DebuggerSettings.DebuggerType == SupportedDebugger.Gdb_MinGW || 
+                        settings.DebuggerSettings.DebuggerType == SupportedDebugger.Gdb_Cygwin)
+                    {
+                        Assert.Equal("Cannot evaluate function -- may be inlined", strAge);
+                    }
+                }
+
+                runner.DisconnectAndVerify();
+            }
+        }
+        #endregion
+
+        #region Function Helper
+
+        private void CompileSharedLib(ITestSettings settings, int debuggeeMoniker, bool symbol)
+        {
+            IDebuggee debuggee = Debuggee.Create(this, settings.CompilerSettings, Name, debuggeeMoniker, OutLibName, CompilerOutputType.SharedLibrary);
+            debuggee.AddSourceFiles(SrcLibName);
+            debuggee.CompilerOptions = CompilerOption.OptimizeLevel2;
+            if (symbol)
+            {
+                debuggee.CompilerOptions = CompilerOption.GenerateSymbols;
+            }
+            debuggee.Compile();
+        }
+
+        private void CompileApp(ITestSettings settings, int debuggeeMoniker)
+        {
+            IDebuggee debuggee = Debuggee.Open(this, settings.CompilerSettings, Name, debuggeeMoniker, null, CompilerOutputType.Executable);
+
+            switch (settings.DebuggerSettings.DebuggerType)
+            {
+                case SupportedDebugger.Gdb_Cygwin:
+                case SupportedDebugger.Gdb_Gnu:
+                case SupportedDebugger.Lldb:
+                    debuggee.AddLibraries("dl");
+                    break;
+            }
+
+            debuggee.AddSourceFiles(SourceName,UserDefinedClassName);
+            debuggee.CompilerOptions = CompilerOption.OptimizeLevel2;
+            debuggee.CompilerOptions = CompilerOption.GenerateSymbols;
+            debuggee.Compile();
+        }
+
+        #endregion
+    }
+}

--- a/test/CppTests/Tests/SampleTests.cs
+++ b/test/CppTests/Tests/SampleTests.cs
@@ -1,0 +1,200 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using DebuggerTesting;
+using DebuggerTesting.Compilation;
+using DebuggerTesting.OpenDebug;
+using DebuggerTesting.OpenDebug.CrossPlatCpp;
+using DebuggerTesting.OpenDebug.Events;
+using DebuggerTesting.OpenDebug.Extensions;
+using DebuggerTesting.Ordering;
+using DebuggerTesting.Settings;
+using DebuggerTesting.Utilities;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace CppTests.Tests
+{
+    [TestCaseOrderer(DependencyTestOrderer.TypeName, DependencyTestOrderer.AssemblyName)]
+    public class SampleTests : TestBase
+    {
+        #region Constructor
+
+        public SampleTests(ITestOutputHelper outputHelper) : base(outputHelper)
+        {
+        }
+
+        #endregion
+
+        #region Methods
+
+        [Fact]
+        public void ValidateSettings()
+        {
+            this.WriteLine(PathSettings.GetDebugPathString());
+            AssertDirectoryExists(PathSettings.TempPath);
+            AssertDirectoryExists(PathSettings.DebugAdaptersPath);
+            AssertDirectoryExists(PathSettings.TestsPath);
+            AssertDirectoryExists(PathSettings.DebuggeesPath);
+            AssertFileExists(PathSettings.TestConfigurationFilePath);
+        }
+
+        private static void AssertDirectoryExists(string path)
+        {
+            Assert.True(Directory.Exists(path), "Directory '{0}' does not exist.".FormatInvariantWithArgs(path));
+        }
+
+        private static void AssertFileExists(string path)
+        {
+            Assert.True(File.Exists(path), "File '{0}' does not exist.".FormatInvariantWithArgs(path));
+        }
+
+        [Theory]
+        [RequiresTestSettings]
+        public void LaunchNonExistentDebuggee(ITestSettings settings)
+        {
+            this.TestPurpose("This test checks to see the debugger handles trying to start when there is no debuggee.");
+            this.WriteSettings(settings);
+
+            using (IDebuggerRunner runner = CreateDebugAdapterRunner(settings))
+            {
+                LaunchCommand launch = new LaunchCommand(settings.DebuggerSettings, "foofoo");
+                launch.ExpectsSuccess = false;
+                runner.RunCommand(launch);
+
+                Assert.Matches(".*does not exist.*", launch.Message);
+
+                runner.DisconnectAndVerify();
+            }
+        }
+
+        private const string HelloName = "hello";
+        private const string HelloSourceName = "hello.cpp";
+        private const string HexNumberPattern = @"0x[0-9A-Fa-f]+";
+
+        [Theory]
+        [RequiresTestSettings]
+        public void CompileHelloDebuggee(ITestSettings settings)
+        {
+            this.TestPurpose("Create and compile the 'hello' debuggee");
+            this.WriteSettings(settings);
+
+            IDebuggee debuggee = Debuggee.Create(this, settings.CompilerSettings, HelloName, DebuggeeMonikers.HelloWorld.Sample);
+            debuggee.AddSourceFiles(HelloSourceName);
+            debuggee.Compile();
+        }
+
+        [Theory]
+        [DependsOnTest(nameof(CompileHelloDebuggee))]
+        [RequiresTestSettings]
+        [UnsupportedDebugger(SupportedDebugger.Lldb, SupportedArchitecture.x64 | SupportedArchitecture.x86)]
+        public void TestArguments(ITestSettings settings)
+        {
+            this.TestPurpose("This test checks to see if arguments are passed to the debugee.");
+            this.WriteSettings(settings);
+
+            IDebuggee debuggee = Debuggee.Open(this, settings.CompilerSettings, HelloName, DebuggeeMonikers.HelloWorld.Sample);
+
+            this.Comment("Run the debuggee, check argument count");
+            using (IDebuggerRunner runner = CreateDebugAdapterRunner(settings))
+            {
+                runner.Launch(settings.DebuggerSettings, debuggee, "Param 1", "Param 2");
+                int args = 2;
+                runner.Expects.ExitedEvent(exitCode: args).TerminatedEvent().AfterConfigurationDone();
+                runner.DisconnectAndVerify();
+            }
+        }
+
+        [Theory]
+        [DependsOnTest(nameof(CompileHelloDebuggee))]
+        [RequiresTestSettings]
+        public void TestFolderol(ITestSettings settings)
+        {
+            this.TestPurpose("This test checks a bunch of commands and events.");
+            this.WriteSettings(settings);
+
+            IDebuggee debuggee = Debuggee.Open(this, settings.CompilerSettings, HelloName, DebuggeeMonikers.HelloWorld.Sample);
+
+            using (IDebuggerRunner runner = CreateDebugAdapterRunner(settings))
+            {
+                this.Comment("Launch the debuggee");
+                runner.Launch(settings.DebuggerSettings, debuggee);
+
+                StoppedEvent stopAtBreak = new StoppedEvent(StoppedReason.Breakpoint);
+
+                // VsDbg does not fire Breakpoint Change events when breakpoints are set.
+                // Instead it sends a new breakpoint event when it is bound (after configuration done).
+                bool bindsLate = (settings.DebuggerSettings.DebuggerType == SupportedDebugger.VsDbg);
+
+                this.Comment("Set a breakpoint on line 8, but expect it to resolve to line 9.");
+                runner.Expects.ConditionalEvent(!bindsLate, x => x.BreakpointChangedEvent(BreakpointReason.Changed, 9))
+                              .AfterSetBreakpoints(debuggee.Breakpoints(HelloSourceName, 8));
+
+                this.Comment("Start debuggging until breakpoint is hit.");
+                runner.Expects.ConditionalEvent(bindsLate, x => x.BreakpointChangedEvent(BreakpointReason.Changed, 9))
+                              .Event(stopAtBreak)
+                              .AfterConfigurationDone();
+
+                Assert.Equal(HelloSourceName, stopAtBreak.ActualEventInfo.Filename);
+                Assert.Equal(9, stopAtBreak.ActualEventInfo.Line);
+                Assert.Equal(StoppedReason.Breakpoint, stopAtBreak.ActualEventInfo.Reason);
+
+                this.Comment("Step forward twice until we have initialized variables");
+                runner.Expects.StoppedEvent(StoppedReason.Step, HelloSourceName, 10)
+                              .AfterStepOver();
+                runner.Expects.StoppedEvent(StoppedReason.Step, HelloSourceName, 11)
+                              .AfterStepIn();
+
+                this.Comment("Inspect the stack and try evaluation.");
+                using (IThreadInspector inspector = runner.GetThreadInspector())
+                {
+                    this.Comment("Get the stack trace");
+                    IFrameInspector mainFrame = inspector.Stack.First();
+                    inspector.AssertStackFrameNames(true, "main.*");
+
+                    this.WriteLine("Main frame: {0}", mainFrame);
+
+                    this.Comment("Get variables");
+                    Assert.Subset(new HashSet<string>() { "x", "y", "argc", "argv" }, mainFrame.Variables.ToKeySet());
+                    mainFrame.AssertVariables(
+                        "x", "6",
+                        "argc", "1");
+
+                    IVariableInspector argv = mainFrame.Variables["argv"];
+                    Assert.Matches(HexNumberPattern, argv.Value);
+
+                    this.Comment("Expand a variable (argv has *argv under it)");
+                    string variableName = "*argv";
+                    if (settings.DebuggerSettings.DebuggerType == SupportedDebugger.VsDbg)
+                    {
+                        variableName = String.Empty;
+                    }
+                    Assert.Contains(variableName, argv.Variables.Keys);
+                    Assert.Matches(HexNumberPattern, argv.Variables[variableName].Value);
+
+                    this.Comment("Evaluate with side effect");
+                    string result = mainFrame.Evaluate("x = x + 1");
+                    Assert.Equal("7", result);
+                }
+
+                this.Comment("Step to force stack info to refresh");
+                runner.Expects.StoppedEvent(StoppedReason.Step).AfterStepOver();
+
+                using (IThreadInspector inspector = runner.GetThreadInspector())
+                {
+                    this.Comment("Evaluation has side effect, make sure it propagates");
+                    Assert.Equal("7", inspector.Stack.First().Variables["x"].Value);
+                }
+
+                runner.Expects.ExitedEvent(0).TerminatedEvent().AfterContinue();
+                runner.DisconnectAndVerify();
+            }
+        }
+
+        #endregion
+    }
+}

--- a/test/CppTests/Tests/SharedLibTests.cs
+++ b/test/CppTests/Tests/SharedLibTests.cs
@@ -1,0 +1,221 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Globalization;
+using System.IO;
+using DebuggerTesting;
+using DebuggerTesting.Compilation;
+using DebuggerTesting.OpenDebug;
+using DebuggerTesting.OpenDebug.Commands;
+using DebuggerTesting.OpenDebug.CrossPlatCpp;
+using DebuggerTesting.OpenDebug.Extensions;
+using DebuggerTesting.Ordering;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace CppTests.Tests
+{
+    [TestCaseOrderer(DependencyTestOrderer.TypeName, DependencyTestOrderer.AssemblyName)]
+    public class SharedLibTests : TestBase
+    {
+        #region Constructor
+
+        public SharedLibTests(ITestOutputHelper outputHelper) : base(outputHelper)
+        {
+        }
+
+        #endregion
+
+        #region Fields
+
+        private const string srcLibName = "mylib.cpp";
+        private const string srcAppName = "myapp.cpp";
+        private const string outAppName = "myapp";
+        private const string outLibName = "mylib";
+        private const string debuggeeName = "sharedlib";
+
+        #endregion
+
+        #region Methods
+
+        [Theory]
+        [RequiresTestSettings]
+        public void CompileSharedLibDebuggee(ITestSettings settings)
+        {
+            this.TestPurpose("Create and compile the 'sharedlib' debuggee");
+            this.WriteSettings(settings);
+
+            //Compile the shared library
+            CompileSharedLib(settings, DebuggeeMonikers.SharedLib.Default);
+
+            //Compile the application
+            CompileApp(settings, DebuggeeMonikers.SharedLib.Default);
+        }
+
+        [Theory]
+        [DependsOnTest(nameof(CompileSharedLibDebuggee))]
+        [UnsupportedDebugger(SupportedDebugger.VsDbg, SupportedArchitecture.x86 | SupportedArchitecture.x64)]
+        [RequiresTestSettings]
+        public void SharedLibBasic(ITestSettings settings)
+        {
+            this.TestPurpose("This test checks to see if basic debugging scenarios work for application invoked shared library.");
+            this.WriteSettings(settings);
+
+            this.Comment("Start running targeted scenarios");
+            RunTargetedScenarios(settings, outAppName, DebuggeeMonikers.SharedLib.Default);
+        }
+
+        [Theory]
+        [UnsupportedDebugger(SupportedDebugger.VsDbg, SupportedArchitecture.x86 | SupportedArchitecture.x64)]
+        [RequiresTestSettings]
+        public void SharedLibMismatchSourceAndSymbols(ITestSettings settings)
+        {
+            this.TestPurpose("This test checks to see if it crashs when debugging the mismatch source and symbols of shared library.");
+            this.WriteSettings(settings);
+
+            //Compile the shared library
+            CompileSharedLib(settings, DebuggeeMonikers.SharedLib.MismatchedSource);
+
+            //Compile the application
+            CompileApp(settings, DebuggeeMonikers.SharedLib.MismatchedSource);
+
+            this.Comment("Apply changes in the source of shared library after build");
+            ApplyChangesInSharedLib(settings, DebuggeeMonikers.SharedLib.MismatchedSource);
+
+            this.Comment("Start running targeted scenarios");
+            RunTargetedScenarios(settings, outAppName, DebuggeeMonikers.SharedLib.MismatchedSource);
+        }
+
+        #endregion
+
+        #region Function Helper
+
+        /// <summary>
+        /// Compile the shared library
+        /// </summary>
+        private void CompileSharedLib(ITestSettings settings, int debuggeeMoniker)
+        {
+            IDebuggee debuggee = Debuggee.Create(this, settings.CompilerSettings, debuggeeName, debuggeeMoniker, outLibName, CompilerOutputType.SharedLibrary);
+            debuggee.AddSourceFiles(srcLibName);
+            debuggee.Compile();
+        }
+
+        /// <summary>
+        /// Compile the application
+        /// </summary>
+        private void CompileApp(ITestSettings settings, int debuggeeMoniker)
+        {
+            IDebuggee debuggee = Debuggee.Open(this, settings.CompilerSettings, debuggeeName, debuggeeMoniker, outAppName);
+
+            switch (settings.DebuggerSettings.DebuggerType)
+            {
+                case SupportedDebugger.Gdb_Cygwin:
+                case SupportedDebugger.Gdb_Gnu:
+                case SupportedDebugger.Lldb:
+                    debuggee.AddLibraries("dl");
+                    break;
+                case SupportedDebugger.Gdb_MinGW:
+                    // The sharedlib debuggee contains both POSIX and Windows support on loading dynamic library, we use "_MinGW" to identify the relevant testing code
+                    debuggee.AddDefineConstant("_MINGW");
+                    break;
+            }
+
+            debuggee.AddSourceFiles(srcAppName);
+
+            debuggee.Compile();
+        }
+
+        /// <summary>
+        /// Apply changes in shared library so that the source and symbols is not matached anymore
+        /// </summary>
+        private void ApplyChangesInSharedLib(ITestSettings settings, int debuggeeMoniker)
+        {
+            IDebuggee debuggee = Debuggee.Open(this, settings.CompilerSettings, debuggeeName, debuggeeMoniker, outLibName);
+            string libPath = string.Format(CultureInfo.InvariantCulture, Path.Combine(debuggee.SourceRoot, srcLibName));
+            Assert.True(File.Exists(libPath), string.Format(CultureInfo.InvariantCulture, "ERROR: Didn't find the source file:{0} under {1}", libPath, debuggee.SourceRoot));
+            try
+            {
+                using (StreamWriter writer = File.AppendText(libPath))
+                {
+                    //TODO: I just simply added a new line to make the symbols mismatch after compile the library, we can add some real code changes here if need it.
+                    writer.WriteLine(System.Environment.NewLine);
+                }
+            }
+            catch
+            {
+                this.Comment("ERROR: Didn't apply the changes in shared library successfully.");
+                throw;
+            }
+        }
+
+        /// <summary>
+        /// Testing the common targeted scenarios
+        /// </summary>
+        private void RunTargetedScenarios(ITestSettings settings, string outputName, int debuggeeMoniker)
+        {
+            this.Comment("Set initial debuggee");
+            IDebuggee debuggee = Debuggee.Open(this, settings.CompilerSettings, debuggeeName, debuggeeMoniker, outAppName);
+
+            using (IDebuggerRunner runner = CreateDebugAdapterRunner(settings))
+            {
+                this.Comment("Configure launch");
+                runner.Launch(settings.DebuggerSettings, debuggee);
+
+                this.Comment("Set initial function breakpoints");
+                FunctionBreakpoints functionBreakpoints = new FunctionBreakpoints("main", "myClass::DisplayName", "myClass::DisplayAge");
+                runner.SetFunctionBreakpoints(functionBreakpoints);
+
+                this.Comment("Set line breakpoints to the lines with entry of shared library");
+                SourceBreakpoints bps = debuggee.Breakpoints(srcAppName, 71, 77);
+                runner.SetBreakpoints(bps);
+
+                this.Comment("Launch and run until first breakpoint in the entry of main");
+                runner.ExpectBreakpointAndStepToTarget(srcAppName, startLine: 62, targetLine: 63)
+                              .AfterConfigurationDone();
+
+                this.Comment("Continue to go to the line which is the first entry of shared library");
+                runner.Expects.HitBreakpointEvent(srcAppName, 71)
+                       .AfterContinue();
+
+                this.Comment("Step into the function in shared library");
+                runner.Expects.HitStepEvent(srcLibName, 23)
+                       .AfterStepIn();
+
+                this.Comment("Step out to go back to the entry in main function");
+                runner.Expects.HitStepEvent(srcAppName, 71)
+                       .AfterStepOut();
+
+                this.Comment("Step over to go to the line which is the second entry of shared library");
+                runner.Expects.HitStepEvent(srcAppName, 73).AfterStepOver();
+
+                this.Comment("Step over a function which have a breakpoint set in shared library");
+                runner.ExpectBreakpointAndStepToTarget(srcLibName, startLine: 8, targetLine: 9).AfterStepOver();
+
+                this.Comment("Step over a line in function which is inside shared library");
+                runner.Expects.HitStepEvent(srcLibName, 10).AfterStepOver();
+
+                this.Comment("Step out to go back to the entry in main function");
+                runner.ExpectStepAndStepToTarget(srcAppName, startLine: 73, targetLine: 75).AfterStepOut();
+
+                this.Comment("Continue to hit breakpoint in function which is inside shared library");
+                runner.ExpectBreakpointAndStepToTarget(srcLibName, startLine: 15, targetLine: 16)
+                       .AfterContinue();
+
+                this.Comment("Continue to hit breakpoint which set in the last entry of shared library");
+                runner.Expects.HitBreakpointEvent(srcAppName, 77).AfterContinue();
+
+                this.Comment("Step over a function which don't have breakpoint set in shared library");
+
+                runner.Expects.HitStepEvent(srcAppName, 79)
+                       .AfterStepOver();
+
+                this.Comment("Continue to run till at the end of the application");
+                runner.Expects.TerminatedEvent().AfterContinue();
+
+                runner.DisconnectAndVerify();
+            }
+        }
+
+        #endregion
+    }
+}

--- a/test/CppTests/Tests/SinkHelper.cs
+++ b/test/CppTests/Tests/SinkHelper.cs
@@ -1,0 +1,54 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.IO;
+using DebuggerTesting;
+using DebuggerTesting.Compilation;
+using Xunit;
+
+namespace CppTests.Tests
+{
+    /// <summary>
+    /// Helpers to use the kitchen sink debuggee
+    /// </summary>
+    internal static class SinkHelper
+    {
+        public const string Main = "main.cpp";
+        public const string Arguments = "arguments.cpp";
+        public const string Calling = "calling.cpp";
+        public const string Feature = "feature.cpp";
+        public const string Threading = "threading.cpp";
+        public const string NonTerminating = "nonterminating.cpp";
+        public const string Expression = "expression.cpp";
+        public const string Environment = "environment.cpp";
+
+        private const string Name = "kitchensink";
+        private const string OutputName = "sink";
+
+        public static IDebuggee Open(ILoggingComponent logger, ICompilerSettings settings, int moniker)
+        {
+            return DebuggeeHelper.Open(logger, settings, moniker, SinkHelper.Name, SinkHelper.OutputName);
+        }
+
+        public static IDebuggee OpenAndCompile(ILoggingComponent logger, ICompilerSettings settings, int moniker)
+        {
+            return DebuggeeHelper.OpenAndCompile(logger, settings, moniker, SinkHelper.Name, SinkHelper.OutputName, SinkHelper.AddSourceFiles);
+        }
+
+        private static void AddSourceFiles(IDebuggee debuggee)
+        {
+            // Add a source files, specify type, compile
+            debuggee.AddSourceFiles(
+                SinkHelper.Main,
+                SinkHelper.Arguments,
+                SinkHelper.Calling,
+                SinkHelper.Environment,
+                SinkHelper.Feature,
+                SinkHelper.Threading,
+                SinkHelper.NonTerminating,
+                SinkHelper.Expression);
+            debuggee.CompilerOptions |= CompilerOption.SupportThreading;
+        }
+    }
+}

--- a/test/CppTests/Tests/SourceMappingTests.cs
+++ b/test/CppTests/Tests/SourceMappingTests.cs
@@ -1,0 +1,302 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.IO;
+using DebuggerTesting;
+using DebuggerTesting.Compilation;
+using DebuggerTesting.OpenDebug;
+using DebuggerTesting.OpenDebug.Commands;
+using DebuggerTesting.OpenDebug.CrossPlatCpp;
+using DebuggerTesting.OpenDebug.Events;
+using DebuggerTesting.OpenDebug.Extensions;
+using DebuggerTesting.Ordering;
+using DebuggerTesting.Utilities;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace CppTests.Tests
+{
+    [TestCaseOrderer(DependencyTestOrderer.TypeName, DependencyTestOrderer.AssemblyName)]
+    public class SourceMappingTests : TestBase
+    {
+        #region Constructor
+
+        public SourceMappingTests(ITestOutputHelper outputHelper) : base(outputHelper)
+        {
+        }
+
+        #endregion
+
+        #region SourceMappingHelper
+
+        private static class SourceMappingHelper
+        {
+            public const string Main = "main.cpp";
+
+            public const string Writer = "writer.cpp";
+            public const string WriterFolder = "writer";
+
+            public const string Manager = "manager.cpp";
+            public const string ManagerFolder = "manager";
+
+            private const string Name = "sourcemap";
+            private const string OutputName = "mapping";
+
+            public static IDebuggee OpenAndCompile(ILoggingComponent logger, ICompilerSettings settings, int moniker)
+            {
+                return DebuggeeHelper.OpenAndCompile(logger, settings, moniker, SourceMappingHelper.Name, SourceMappingHelper.OutputName, SourceMappingHelper.AddSourceFiles);
+            }
+
+            public static IDebuggee Open(ILoggingComponent logger, ICompilerSettings settings, int moniker)
+            {
+                return DebuggeeHelper.Open(logger, settings, moniker, SourceMappingHelper.Name, SourceMappingHelper.OutputName);
+            }
+
+            private static void AddSourceFiles(IDebuggee debuggee)
+            {
+                debuggee.AddSourceFiles(
+                    SourceMappingHelper.Main,
+                    Path.Combine(SourceMappingHelper.WriterFolder, SourceMappingHelper.Writer),
+                    Path.Combine(SourceMappingHelper.ManagerFolder, SourceMappingHelper.Manager));
+            }
+        }
+
+        #endregion
+
+        private static void ValidateMappingToFrame(string expectedFileName, string expectedFilePath, IFrameInspector frame, StringComparison comparison)
+        {
+            Assert.True(frame.SourceName.Equals(expectedFileName, comparison), string.Format(CultureInfo.InvariantCulture, "Frame File name. Expected: {0} Actual: {1}", expectedFileName, frame.SourceName));
+            Assert.True(frame.SourcePath.Equals(expectedFilePath, comparison), string.Format(CultureInfo.InvariantCulture, "Frame full path. Expected: {0} Actual: {1}", expectedFilePath, frame.SourcePath));
+        }
+
+        private string EnsureDriveLetterLowercase(string path)
+        {
+            if (path.Length > 2 && path[1] == ':')
+            {
+                path = String.Format(CultureInfo.CurrentUICulture, "{0}{1}", Char.ToLowerInvariant(path[0]), path.Substring(1));
+            }
+
+            return path;
+        }
+
+        [Theory]
+        [RequiresTestSettings]
+        public void CompileSourceMapForSourceMapping(ITestSettings settings)
+        {
+            this.TestPurpose("Compiles source map debuggee for source mapping.");
+            this.WriteSettings(settings);
+
+            IDebuggee debuggee = SourceMappingHelper.OpenAndCompile(this, settings.CompilerSettings, DebuggeeMonikers.SourceMapping.Default);
+        }
+
+        [Theory]
+        [DependsOnTest(nameof(CompileSourceMapForSourceMapping))]
+        [RequiresTestSettings]
+        public void MapSpecificFile(ITestSettings settings)
+        {
+            this.TestPurpose("Validate Specific File Mapping.");
+
+            this.WriteSettings(settings);
+
+            IDebuggee debuggee = SourceMappingHelper.Open(this, settings.CompilerSettings, DebuggeeMonikers.SourceMapping.Default);
+
+            // VsDbg is case insensitive on Windows so sometimes stackframe file names might all be lowercase
+            StringComparison comparison = settings.DebuggerSettings.DebuggerType == SupportedDebugger.VsDbg ? StringComparison.OrdinalIgnoreCase : StringComparison.Ordinal;
+
+            using (IDebuggerRunner runner = CreateDebugAdapterRunner(settings))
+            {
+                this.Comment("Configure");
+                LaunchCommand launch = new LaunchCommand(settings.DebuggerSettings, debuggee.OutputPath, false);
+
+                launch.Args.externalConsole = false;
+
+                this.Comment("Setting up Source File Mappings");
+
+                Dictionary<string, string> sourceMappings = new Dictionary<string, string>();
+                string pathRoot = Path.GetPathRoot(debuggee.SourceRoot);
+
+                string sourceFileMapping = Path.Combine(pathRoot, Path.GetRandomFileName(), SourceMappingHelper.Writer);
+                string compileFileMapping = Path.Combine(debuggee.SourceRoot, SourceMappingHelper.WriterFolder, SourceMappingHelper.Writer);
+
+                if (PlatformUtilities.IsWindows)
+                {
+                    // Move file to the location
+                    Directory.CreateDirectory(Path.GetDirectoryName(sourceFileMapping));
+                    File.Copy(compileFileMapping, sourceFileMapping, true);
+                }
+
+                // Drive letter should be lowercase
+                sourceMappings.Add(compileFileMapping, sourceFileMapping);
+
+                launch.Args.sourceFileMap = sourceMappings;
+                try
+                {
+                    runner.RunCommand(launch);
+
+                    this.Comment("Set Breakpoint");
+
+                    SourceBreakpoints writerBreakpoints = debuggee.Breakpoints(SourceMappingHelper.Writer, 9);
+                    runner.SetBreakpoints(writerBreakpoints);
+                    runner.Expects.StoppedEvent(StoppedReason.Breakpoint).AfterConfigurationDone();
+
+                    using (IThreadInspector threadInspector = runner.GetThreadInspector())
+                    {
+                        IEnumerator<IFrameInspector> frameEnumerator = threadInspector.Stack.GetEnumerator();
+
+                        // Move to first stack item
+                        Assert.True(frameEnumerator.MoveNext());
+                        this.Comment("Verify path is changed for writer.cpp frame");
+                        ValidateMappingToFrame(SourceMappingHelper.Writer, EnsureDriveLetterLowercase(sourceFileMapping), frameEnumerator.Current, comparison);
+
+                        // Move to second stack item
+                        Assert.True(frameEnumerator.MoveNext());
+                        this.Comment("Verify path is not changed for main.cpp frame.");
+                        ValidateMappingToFrame(SourceMappingHelper.Main, EnsureDriveLetterLowercase(Path.Combine(debuggee.SourceRoot, SourceMappingHelper.Main)), frameEnumerator.Current, comparison);
+
+                        writerBreakpoints.Remove(9);
+                        runner.SetBreakpoints(writerBreakpoints);
+                        this.Comment("Continue to end");
+
+                        runner.Expects.TerminatedEvent().AfterContinue();
+                        runner.DisconnectAndVerify();
+                    }
+                }
+                finally
+                {
+                    if (PlatformUtilities.IsWindows)
+                    {
+                        // Cleanup the directory
+                        if (Directory.Exists(Path.GetDirectoryName(sourceFileMapping)))
+                        {
+                            Directory.Delete(Path.GetDirectoryName(sourceFileMapping), true);
+                        }
+                    }
+                }
+            }
+        }
+
+        [Theory]
+        [DependsOnTest(nameof(CompileSourceMapForSourceMapping))]
+        [RequiresTestSettings]
+        public void MapDirectory(ITestSettings settings)
+        {
+            this.TestPurpose("Validate Source Mapping.");
+
+            this.WriteSettings(settings);
+
+            IDebuggee debuggee = SourceMappingHelper.Open(this, settings.CompilerSettings, DebuggeeMonikers.SourceMapping.Default);
+
+            // VsDbg is case insensitive on Windows so sometimes stackframe file names might all be lowercase
+            StringComparison comparison = settings.DebuggerSettings.DebuggerType == SupportedDebugger.VsDbg ? StringComparison.OrdinalIgnoreCase : StringComparison.Ordinal;
+
+            using (IDebuggerRunner runner = CreateDebugAdapterRunner(settings))
+            {
+                this.Comment("Configure");
+                LaunchCommand launch = new LaunchCommand(settings.DebuggerSettings, debuggee.OutputPath, false, "-fCalling");
+
+                launch.Args.externalConsole = false;
+
+                this.Comment("Setting up Source File Mappings");
+
+                Dictionary<string, string> sourceMappings = new Dictionary<string, string>();
+                string pathRoot = Path.GetPathRoot(debuggee.SourceRoot);
+
+                string mgrDirectoryMapping = Path.Combine(debuggee.SourceRoot, SourceMappingHelper.Manager, Path.GetRandomFileName());
+                string writerDirectoryMapping = Path.Combine(pathRoot, Path.GetRandomFileName(), Path.GetRandomFileName());
+                string rootDirectoryMapping = Path.Combine(pathRoot, Path.GetRandomFileName());
+                sourceMappings.Add(Path.Combine(debuggee.SourceRoot, SourceMappingHelper.WriterFolder), writerDirectoryMapping);
+                sourceMappings.Add(Path.Combine(debuggee.SourceRoot, SourceMappingHelper.ManagerFolder), mgrDirectoryMapping);
+                sourceMappings.Add(debuggee.SourceRoot, rootDirectoryMapping);
+
+                launch.Args.sourceFileMap = sourceMappings;
+
+                try
+                {
+                    if (PlatformUtilities.IsWindows)
+                    {
+                        // Create all the directories but only some of the files will exist on disk.
+                        foreach (var dir in sourceMappings.Values)
+                        {
+                            Directory.CreateDirectory(dir);
+                        }
+                        File.Copy(Path.Combine(debuggee.SourceRoot, SourceMappingHelper.WriterFolder, SourceMappingHelper.Writer), Path.Combine(writerDirectoryMapping, SourceMappingHelper.Writer), true);
+                        File.Copy(Path.Combine(debuggee.SourceRoot, SourceMappingHelper.Main), Path.Combine(rootDirectoryMapping, SourceMappingHelper.Main), true);
+                    }
+
+                    runner.RunCommand(launch);
+
+                    this.Comment("Set Breakpoint");
+
+                    SourceBreakpoints writerBreakpoints = debuggee.Breakpoints(SourceMappingHelper.Writer, 9);
+                    SourceBreakpoints managerBreakpoints = debuggee.Breakpoints(SourceMappingHelper.Manager, 8);
+                    runner.SetBreakpoints(writerBreakpoints);
+                    runner.SetBreakpoints(managerBreakpoints);
+                    runner.Expects.StoppedEvent(StoppedReason.Breakpoint).AfterConfigurationDone();
+
+                    using (IThreadInspector threadInspector = runner.GetThreadInspector())
+                    {
+                        IEnumerator<IFrameInspector> frameEnumerator = threadInspector.Stack.GetEnumerator();
+
+                        // Move to first stack item
+                        Assert.True(frameEnumerator.MoveNext());
+                        this.Comment(string.Format(CultureInfo.InvariantCulture, "Verify source path for {0}.", SourceMappingHelper.Writer));
+                        // Since file is there, lowercase the drive letter
+                        ValidateMappingToFrame(SourceMappingHelper.Writer, EnsureDriveLetterLowercase(Path.Combine(writerDirectoryMapping, SourceMappingHelper.Writer)), frameEnumerator.Current, comparison);
+
+
+                        // Move to second stack item
+                        Assert.True(frameEnumerator.MoveNext());
+                        this.Comment(string.Format(CultureInfo.InvariantCulture, "Verify source path for {0}.", SourceMappingHelper.Main));
+                        // Since file is there, lowercase the drive letter
+                        ValidateMappingToFrame(SourceMappingHelper.Main, EnsureDriveLetterLowercase(Path.Combine(rootDirectoryMapping, SourceMappingHelper.Main)), frameEnumerator.Current, comparison);
+
+                    }
+                    runner.Expects.StoppedEvent(StoppedReason.Breakpoint).AfterContinue();
+
+                    using (IThreadInspector threadInspector = runner.GetThreadInspector())
+                    {
+                        IEnumerator<IFrameInspector> frameEnumerator = threadInspector.Stack.GetEnumerator();
+
+                        // Move to first stack item
+                        Assert.True(frameEnumerator.MoveNext());
+                        this.Comment(string.Format(CultureInfo.InvariantCulture, "Verify source path for {0}.", SourceMappingHelper.Manager));
+                        // Since file is not there, keep what was passed in
+                        ValidateMappingToFrame(SourceMappingHelper.Manager, EnsureDriveLetterLowercase(Path.Combine(mgrDirectoryMapping, SourceMappingHelper.Manager)), frameEnumerator.Current, comparison);
+
+                        // Move to second stack item
+                        Assert.True(frameEnumerator.MoveNext());
+                        this.Comment(string.Format(CultureInfo.InvariantCulture, "Verify source path for {0}.", SourceMappingHelper.Main));
+                        // Since file is there, lowercase the drive letter
+                        ValidateMappingToFrame(SourceMappingHelper.Main, EnsureDriveLetterLowercase(Path.Combine(rootDirectoryMapping, SourceMappingHelper.Main)), frameEnumerator.Current, comparison);
+                    }
+
+                    writerBreakpoints.Remove(9);
+                    managerBreakpoints.Remove(8);
+                    runner.SetBreakpoints(writerBreakpoints);
+                    runner.SetBreakpoints(managerBreakpoints);
+
+                    this.Comment("Continue to end");
+
+                    runner.Expects.TerminatedEvent().AfterContinue();
+                    runner.DisconnectAndVerify();
+                }
+                finally
+                {
+                    if (PlatformUtilities.IsWindows)
+                    {
+                        foreach (var dir in sourceMappings.Values)
+                        {
+                            if (Directory.Exists(dir))
+                            {
+                                Directory.Delete(dir, recursive: true);
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/test/CppTests/Tests/ThreadingTests.cs
+++ b/test/CppTests/Tests/ThreadingTests.cs
@@ -1,0 +1,163 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+using DebuggerTesting;
+using DebuggerTesting.Compilation;
+using DebuggerTesting.OpenDebug;
+using DebuggerTesting.OpenDebug.CrossPlatCpp;
+using DebuggerTesting.OpenDebug.Events;
+using DebuggerTesting.OpenDebug.Extensions;
+using DebuggerTesting.Ordering;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace CppTests.Tests
+{
+
+    [TestCaseOrderer(DependencyTestOrderer.TypeName, DependencyTestOrderer.AssemblyName)]
+    public class ThreadingTests : TestBase
+    {
+        #region Constructor
+
+        public ThreadingTests(ITestOutputHelper outputHelper) : base(outputHelper)
+        {
+        }
+
+        #endregion
+
+        [Theory]
+        [RequiresTestSettings]
+        public void CompileKitchenSinkForThreading(ITestSettings settings)
+        {
+            this.TestPurpose("Compiles the kitchen sink debuggee for threading.");
+            this.WriteSettings(settings);
+
+            IDebuggee debuggee = SinkHelper.OpenAndCompile(this, settings.CompilerSettings, DebuggeeMonikers.KitchenSink.Threading);
+        }
+
+        [Theory]
+        [DependsOnTest(nameof(CompileKitchenSinkForThreading))]
+        [RequiresTestSettings]
+        [UnsupportedDebugger(SupportedDebugger.Gdb_MinGW | SupportedDebugger.Gdb_Gnu, SupportedArchitecture.x86)]
+        // TODO: Re-enable for vsdbg
+        [UnsupportedDebugger(SupportedDebugger.VsDbg, SupportedArchitecture.x64)]
+        public void ThreadingBasic(ITestSettings settings)
+        {
+            this.TestPurpose("Test basic multithreading scenario.");
+            this.WriteSettings(settings);
+
+            IDebuggee debuggee = SinkHelper.Open(this, settings.CompilerSettings, DebuggeeMonikers.KitchenSink.Threading);
+
+            using (IDebuggerRunner runner = CreateDebugAdapterRunner(settings))
+            {
+                this.Comment("Launching debuggee. Run until multiple threads are running.");
+                runner.Launch(settings.DebuggerSettings, debuggee, "-fThreading");
+                runner.SetBreakpoints(debuggee.Breakpoints(SinkHelper.Threading, 37));
+
+                runner.Expects.HitBreakpointEvent()
+                              .AfterConfigurationDone();
+
+                IEnumerable<IThreadInfo> threads = runner.GetThreads();
+                List<string> loopCounts = new List<string>();
+
+                this.Comment("Inspect threads and find 'loopCount' variable on each worker thread.");
+                this.WriteLine("Threads:");
+                foreach (var threadInfo in threads)
+                {
+                    IThreadInspector threadInspector = threadInfo.GetThreadInspector();
+
+                    // Don't look at main thread, just workers
+                    if (threadInspector.ThreadId == runner.StoppedThreadId)
+                        continue;
+
+                    this.Comment("Thread '{0}', Id: {1}".FormatInvariantWithArgs(threadInfo.Name, threadInspector.ThreadId));
+                    IFrameInspector threadLoopFrame = threadInspector.Stack.FirstOrDefault(s => s.Name.Contains("ThreadLoop"));
+
+                    // Fail the test if the ThreadLoop frame could not be found
+                    if (threadLoopFrame == null)
+                    {
+                        this.WriteLine("This thread's stack did not contain a frame with 'ThreadLoop'");
+                        this.WriteLine("Stack Trace:");
+                        foreach (var frame in threadInspector.Stack)
+                        {
+                            this.WriteLine(frame.Name);
+                        }
+                        continue;
+                    }
+
+                    string variables = threadLoopFrame.Variables.ToReadableString();
+                    this.WriteLine("Variables in 'ThreadLoop' frame:");
+                    this.WriteLine(variables);
+
+                    // Put the different loopCounts in a list, so they can be verified order agnostic
+                    string loopCountValue = threadLoopFrame.GetVariable("loopCount").Value;
+                    this.WriteLine("loopCount = {0}", loopCountValue);
+                    loopCounts.Add(loopCountValue);
+                }
+
+                //Verify all the worker threads were observed
+                Assert.True(loopCounts.Contains("0"), "Could not find thread with loop count 0");
+                Assert.True(loopCounts.Contains("1"), "Could not find thread with loop count 1");
+                Assert.True(loopCounts.Contains("2"), "Could not find thread with loop count 2");
+                Assert.True(loopCounts.Contains("3"), "Could not find thread with loop count 3");
+                Assert.True(4 == loopCounts.Count, "Expected to find 4 threads, but found " + loopCounts.Count.ToString(CultureInfo.InvariantCulture));
+
+                this.Comment("Run to end.");
+                runner.Expects.TerminatedEvent().AfterContinue();
+
+                runner.DisconnectAndVerify();
+            }
+        }
+
+        [Theory]
+        [DependsOnTest(nameof(CompileKitchenSinkForThreading))]
+        [RequiresTestSettings]
+        public void ThreadingBreakpoint(ITestSettings settings)
+        {
+            this.TestPurpose("Test breakpoint on multiple threads.");
+            this.WriteSettings(settings);
+
+            IDebuggee debuggee = SinkHelper.Open(this, settings.CompilerSettings, DebuggeeMonikers.KitchenSink.Threading);
+
+            using (IDebuggerRunner runner = CreateDebugAdapterRunner(settings))
+            {
+                this.Comment("Launching debuggee. Set breakpoint in worker thread code.");
+                runner.Launch(settings.DebuggerSettings, true, debuggee, "-fThreading");
+                runner.SetBreakpoints(debuggee.Breakpoints(SinkHelper.Threading, 16));
+
+                // Turned on stop at entry, so should stop before anything is executed.
+                // On Concord, this is a reason of "entry" versus "step" when it is hit.
+                if (settings.DebuggerSettings.DebuggerType == SupportedDebugger.VsDbg)
+                {
+                    runner.Expects.HitEntryEvent().AfterConfigurationDone();
+                }
+                else
+                {
+                    runner.Expects.HitStepEvent()
+                                  .AfterConfigurationDone();
+                }
+                // Since there are 4 worker threads, expect to hit the
+                // breakpoint 4 times, once on each thread.
+                for (int i = 1; i <= 4; i++)
+                {
+                    StoppedEvent breakpointEvent = new StoppedEvent(StoppedReason.Breakpoint, SinkHelper.Threading, 16);
+                    this.Comment("Run until breakpoint #{0}.", i);
+                    runner.Expects.Event(breakpointEvent).AfterContinue();
+                    this.WriteLine("Stopped on thread: {0}", breakpointEvent.ThreadId);
+
+                    this.WriteLine("Ensure stopped thread exists in ThreadList");
+                    IEnumerable<IThreadInfo> threadInfo = runner.GetThreads();
+                    Assert.True(threadInfo.Any(thread => thread.Id == breakpointEvent.ThreadId), string.Format(CultureInfo.CurrentCulture, "ThreadId {0} should exist in ThreadList", breakpointEvent.ThreadId));
+                }
+                
+                this.Comment("Run to end.");
+                runner.Expects.TerminatedEvent().AfterContinue();
+
+                runner.DisconnectAndVerify();
+            }
+        }
+    }
+}

--- a/test/CppTests/debuggees/exception/src/exception.cpp
+++ b/test/CppTests/debuggees/exception/src/exception.cpp
@@ -1,0 +1,98 @@
+#include "exception.h"
+
+int myException::RaisedUnhandledException(int myvar)
+{
+	int result = 10;
+	int temp = -1;
+	temp++;
+	myvar = result / temp;
+	result = EvalFunc(myvar, myvar);
+	result++;
+	return result;
+}
+
+int myException::RaisedHandledException(int a)
+{
+	int global = 100;
+	int result = 0;
+	try
+	{
+		global++;
+		RecursiveFunc(global);
+		if (result == 0)
+		{
+			throw newException(global);
+		}
+		else
+		{
+			result = global / result;
+		}
+	}
+	catch (newException ex)
+	{
+		result = a + global;
+		int errorCode = ex.code;
+		global++;
+	}
+	return result;
+}
+
+int myException::EvalFunc(int var1, int var2)
+{
+	int result = var1 + var2;
+	return result;
+}
+
+int myException::RecursiveFunc(int a)
+{
+	if (a == 0)
+	{
+		return 1;
+	}
+	else
+	{
+		return RecursiveFunc(a - 1);
+	}
+}
+
+void myException::RaisedThrowNewException()
+{
+	throw newException(200);
+}
+
+void myException::RaisedReThrowException()
+{
+	int var = 100;
+	try
+	{
+		try
+		{
+			var = var - 100;
+			if (var == 0)
+			{
+				RaisedThrowNewException();
+			}
+		}
+		catch (newException ex1)
+		{
+			int errorCode = ex1.code;
+			var = EvalFunc(errorCode, errorCode);
+			throw newException(var);
+		}
+	}
+	catch (newException ex2)
+	{
+		int errorCode = ex2.code;
+		var = 0;
+	}
+}
+
+newException::newException(int c)
+{
+	code = c;
+}
+
+newException::~newException()
+{
+	code = 0;
+}

--- a/test/CppTests/debuggees/exception/src/exception.h
+++ b/test/CppTests/debuggees/exception/src/exception.h
@@ -1,0 +1,20 @@
+class myException
+{
+public:
+
+	int RaisedUnhandledException(int a);
+	int RaisedHandledException(int b);
+	int EvalFunc(int a, int b);
+	int RecursiveFunc(int a);
+	void RaisedThrowNewException();
+	void RaisedReThrowException();
+};
+
+class newException
+{
+public:
+	int code;
+	newException(int c);
+
+	~newException();
+};

--- a/test/CppTests/debuggees/exception/src/main.cpp
+++ b/test/CppTests/debuggees/exception/src/main.cpp
@@ -1,0 +1,72 @@
+#include "exception.h"
+#include <iostream>
+#include <string>
+
+using namespace std;
+
+int main(int argc, char* argv[])
+{
+	cout << "Start testing" << endl;
+
+	bool isUnhandledException = false;
+
+	bool isHandledException = false;
+
+	bool isReThrowException = false;
+
+	if (argc > 1)
+	{
+		for (int i = 1; i < argc; i++)
+		{
+			string input = argv[i];
+			if (input.compare("-CallRaisedUnhandledException") == 0)
+			{
+				isUnhandledException = true;
+			}
+			else if (input.compare("-CallRaisedHandledException") == 0)
+			{
+				isHandledException = true;
+			}
+			else if (input.compare("-CallRaisedReThrowException") == 0)
+			{
+				isReThrowException = true;
+			}
+		}
+	}
+
+	int myVar1 = 100;
+
+	int myVar2 = 200;
+
+	int mySum = myVar1 + myVar2;
+
+	myException *pInstance = new myException();
+
+	int result = pInstance->RecursiveFunc(mySum);
+
+	if (isHandledException)
+	{
+		pInstance->RaisedHandledException(myVar1);
+	}
+
+	if (isUnhandledException)
+	{
+		pInstance->RaisedUnhandledException(myVar2);
+	}
+
+	pInstance->EvalFunc(myVar1, myVar2);
+
+	if (isReThrowException)
+	{
+		pInstance->RaisedReThrowException();
+	}
+
+	if (pInstance != NULL)
+	{
+		delete pInstance;
+	}
+
+	cout << "Finish testing" << endl;
+
+	return 0;
+}

--- a/test/CppTests/debuggees/hello/src/hello.cpp
+++ b/test/CppTests/debuggees/hello/src/hello.cpp
@@ -1,0 +1,13 @@
+#include <iostream>
+
+
+using namespace std;
+
+int main(int argc, char *argv[])
+{
+    int x,y;
+    cout << "Hello, World!" << endl;
+    x = 6;
+    y = 7;
+    return argc - 1;
+}

--- a/test/CppTests/debuggees/kitchensink/src/arguments.cpp
+++ b/test/CppTests/debuggees/kitchensink/src/arguments.cpp
@@ -1,0 +1,47 @@
+#include "arguments.h"
+
+Arguments::Arguments()
+    : Feature("Arguments")
+{
+}
+
+void Arguments::CoreRun()
+{
+    this->Log("Parsing Arguments.");
+
+    if (this->argc > 1)
+    {
+        this->Log("Count: ", this->argc - 1);
+        for (int i = 0; i < this->argc - 1; i++)
+        {
+            char* arg = this->argv[i + 1];
+            std::string argStr(arg);
+            this->Log("Arg ", i + 1, ": ", argStr);
+
+            if (argStr.compare("-fCalling") == 0)
+            {
+                this->runCalling = true;
+            }
+
+            if (argStr.compare("-fThreading") == 0)
+            {
+                this->runThreading = true;
+            }
+
+            if (argStr.compare("-fNonTerminating") == 0)
+            {
+                this->runNonTerminating = true;
+            }
+
+            if (argStr.compare("-fExpression") == 0)
+            {
+                this->runExpression = true;
+            }
+
+            if (argStr.compare("-fEnvironment") == 0)
+            {
+                this->runEnvironment = true;
+            }
+        }
+    }
+}

--- a/test/CppTests/debuggees/kitchensink/src/arguments.h
+++ b/test/CppTests/debuggees/kitchensink/src/arguments.h
@@ -1,0 +1,26 @@
+#pragma once
+#include "global.h"
+#include <iostream>
+#include <vector>
+#include <string>
+#include <stdarg.h>
+
+#include "feature.h"
+
+using namespace std;
+
+class Arguments : public Feature
+{
+public:
+    Arguments();
+    virtual void CoreRun();
+
+    int argc = 0;
+    char ** argv = NULL;
+
+    bool runNonTerminating = false;
+    bool runCalling = false;
+    bool runThreading = false;
+    bool runExpression = false;
+    bool runEnvironment = false;
+};

--- a/test/CppTests/debuggees/kitchensink/src/calling.cpp
+++ b/test/CppTests/debuggees/kitchensink/src/calling.cpp
@@ -1,0 +1,55 @@
+#include "calling.h"
+
+Calling::Calling()
+    : Feature("Calling")
+{
+}
+
+// Averages a variable number of doubles. Pass the count into argCount
+double average(int argCount, ...)
+{
+    va_list args;
+    va_start(args, argCount);
+
+    double total = 0;
+    for (int i = 0; i < argCount; i++)
+    {
+        total += va_arg(args, double);
+    }
+
+    va_end(args);
+    return total / argCount;
+}
+
+void recursiveCall(int count)
+{
+    if (count <= 0)
+        return;
+
+    recursiveCall(count - 1);
+}
+
+void c()
+{
+}
+
+void b()
+{
+    c();
+}
+
+void a()
+{
+    b();
+}
+
+void Calling::CoreRun()
+{
+    this->Log("Calling recursive function.");
+    recursiveCall(30);
+    a();
+
+    this->Log("Calling variable arg function.");
+    double ave = average(10, 1.0, 3.0, 4.5, 11.0, -30.0, 17.4, 2.1, -4.0, 0.0, 12.1);
+    this->Log("Average ", ave);
+}

--- a/test/CppTests/debuggees/kitchensink/src/calling.h
+++ b/test/CppTests/debuggees/kitchensink/src/calling.h
@@ -1,0 +1,17 @@
+#pragma once
+#include "global.h"
+#include <iostream>
+#include <vector>
+#include <string>
+#include <stdarg.h>
+
+#include "feature.h"
+
+using namespace std;
+
+class Calling : public Feature
+{
+public:
+    Calling();
+    virtual void CoreRun();
+};

--- a/test/CppTests/debuggees/kitchensink/src/environment.cpp
+++ b/test/CppTests/debuggees/kitchensink/src/environment.cpp
@@ -1,0 +1,15 @@
+#include "environment.h"
+#include <cstdlib>
+
+Environment::Environment()
+    : Feature("Environment")
+{
+}
+
+void Environment::CoreRun()
+{
+    const char* varName1 = "VAR_NAME_1";
+    this->Log("Getting environment variable: ", varName1);
+    const char* varValue1 = std::getenv(varName1);
+    this->Log("Obtained variable");
+}

--- a/test/CppTests/debuggees/kitchensink/src/environment.h
+++ b/test/CppTests/debuggees/kitchensink/src/environment.h
@@ -1,0 +1,17 @@
+#pragma once
+#include "global.h"
+#include <iostream>
+#include <vector>
+#include <string>
+#include <stdarg.h>
+
+#include "feature.h"
+
+using namespace std;
+
+class Environment : public Feature
+{
+public:
+    Environment();
+    virtual void CoreRun();
+};

--- a/test/CppTests/debuggees/kitchensink/src/expression.cpp
+++ b/test/CppTests/debuggees/kitchensink/src/expression.cpp
@@ -1,0 +1,107 @@
+#include <string>
+#include <vector>
+#include "expression.h"
+
+using namespace std;
+
+
+int accumulate(int x)
+{
+    if (x <= 1)
+        return 1;
+    return x + accumulate(x - 1);
+}
+
+extern "C" void func()
+{
+    bool isCalled = true;
+    double d = 10.10;
+    accumulate(3);
+}
+
+void Expression::checkPrimitiveTypes()
+{
+    bool mybool = true;
+    char mychar = 'A';
+    int myint = 100;
+    float myfloat = 299.0f;
+    double mydouble = 321.00;
+    wchar_t mywchar = 'z';
+
+    this->checkArrayAndPointers();
+}
+
+void Expression::checkArrayAndPointers()
+{
+    int arr[] = { 0,1,2,3,4 };
+    int *pArr = arr;
+
+    this->checkClassOnStackAndHeap();
+}
+
+void Expression::checkClassOnStackAndHeap()
+{
+    Test::Student student;
+    student.name = "John";
+    student.age = 10;
+
+    Test::Student* pStu = new Test::Student();
+    pStu->name = "Bob";
+    pStu->age = 9;
+    delete pStu;
+    pStu = nullptr;
+    this->checkSpecialValues();
+}
+
+void Expression::checkSpecialValues()
+{
+    char mynull = '\0';
+    double mydouble = 1.0, zero = 0.0;
+    mydouble /= zero;
+
+    this->checkPrettyPrinting();
+}
+
+void Expression::checkPrettyPrinting()
+{
+    string str = "hello, world";
+
+    vector<int> vec;
+    for (int i = 0; i < 5; i++) {
+        vec.push_back(i);
+    }
+
+    this->checkCallStack(&func);
+}
+
+void Expression::checkCallStack(void(*callback)())
+{
+    float _f = 1.0f;
+    callback();
+}
+
+void Expression::CoreRun()
+{
+    this->checkPrimitiveTypes();
+}
+
+Expression::Expression() : Feature("Expression")
+{
+
+}
+
+int Test::max(int x, int y)
+{
+    if ((x - y) >= 0)
+        return x;
+    else
+        return y;
+}
+
+double Test::max(double x, double y)
+{
+    if ((x - y) >= 0)
+        return x;
+    else
+        return y;
+}

--- a/test/CppTests/debuggees/kitchensink/src/expression.h
+++ b/test/CppTests/debuggees/kitchensink/src/expression.h
@@ -1,0 +1,37 @@
+#include <string>
+#include "feature.h"
+
+using namespace std;
+
+extern "C" void func();
+int accumulate(int x);
+extern void (*callback)();
+
+class Expression: public Feature
+{
+public:
+	Expression();
+	virtual void CoreRun();
+private:
+	void checkCallStack(void(*callback)());
+	void checkPrettyPrinting();
+	void checkPrimitiveTypes();
+	void checkArrayAndPointers();
+	void checkClassOnStackAndHeap();
+	void checkSpecialValues();
+	void checkTreeOfValue();
+};
+
+namespace Test
+{
+	class Student
+	{
+	public:
+		string name;
+		int age;
+		Student(){}
+	};
+
+	int max(int x, int y);
+	double max(double, double y);
+}

--- a/test/CppTests/debuggees/kitchensink/src/feature.cpp
+++ b/test/CppTests/debuggees/kitchensink/src/feature.cpp
@@ -1,0 +1,24 @@
+#include "feature.h"
+
+Feature::Feature(string name)
+{
+    this->_name = name;
+}
+
+string Feature::GetName()
+{
+    return this->_name;
+}
+
+void Feature::Log()
+{
+    cout << endl;
+}
+
+void Feature::Run()
+{
+    this->Log();
+    this->Log("##### Feature '", this->GetName(), "' #####");
+    this->CoreRun();
+    this->Log("----- Feature '", this->GetName(), "' -----");
+}

--- a/test/CppTests/debuggees/kitchensink/src/feature.h
+++ b/test/CppTests/debuggees/kitchensink/src/feature.h
@@ -1,0 +1,36 @@
+#pragma once
+#include "global.h"
+#include <iostream>
+#include <vector>
+#include <string>
+
+using namespace std;
+
+class Feature
+{
+public:
+    Feature(string name);
+    virtual ~Feature() {}
+
+    string GetName();
+    void Run();
+    void Log();
+
+    // These logging function seem to need to be inline, I'm guessing it is
+    // because the signatures are created on demand.
+    template <typename T> void Log(const T& t)
+    {
+        cout << t << endl;
+    }
+
+    template <typename First, typename... Rest> void Log(const First& first, const Rest&... rest)
+    {
+        // Logs the first item, then recurse
+        cout << first;
+        this->Log(rest...);
+    }
+
+    virtual void CoreRun() = 0;
+private:
+    string _name;
+};

--- a/test/CppTests/debuggees/kitchensink/src/global.h
+++ b/test/CppTests/debuggees/kitchensink/src/global.h
@@ -1,0 +1,14 @@
+#pragma once
+
+#define STRINGIFY2( x) #x
+#define STRINGIFY(x) STRINGIFY2(x)
+
+#if DEBUGGEE_ARCH==32
+    #define ARCH "x86"
+#elif DEBUGGEE_ARCH==64
+    #define ARCH "x64"
+#elif DEBUGGEE_ARCH==arm
+    #define ARCH "arm"
+#else
+    #define ARCH "Unknown"
+#endif

--- a/test/CppTests/debuggees/kitchensink/src/main.cpp
+++ b/test/CppTests/debuggees/kitchensink/src/main.cpp
@@ -1,0 +1,56 @@
+// NOTE THAT CHANGING THE LINE NUMBERS FOR EXISTING SOURCE CODE WILL REQUIRE CHANGING OTHER TESTS
+// SEE https://devdiv.visualstudio.com/DevDiv/_git/OpenDebugAD7/pullrequest/37021 for an example
+
+#include "main.h"
+#include "arguments.h"
+#include "nonterminating.h"
+#include "calling.h"
+#include "threading.h"
+#include "expression.h"
+#include "environment.h"
+
+using namespace std;
+
+int main(int argc, char *argv[])
+{
+    cout << "KitchenSink for Business! (" << STRINGIFY(DEBUGGEE_COMPILER) << "/" << ARCH << " Edition)" << endl;
+
+    Arguments argumentsFeature;
+    argumentsFeature.argc = argc;
+    argumentsFeature.argv = argv;
+    argumentsFeature.Run();
+
+    if (argumentsFeature.runNonTerminating == true)
+    {
+        // This feature just runs in an infinite loop.
+        NonTerminating nonTerminatingFeature;
+        nonTerminatingFeature.Run();
+    }
+
+    if (argumentsFeature.runCalling == true)
+    {
+        Calling callingFeature;
+        callingFeature.Run();
+    }
+
+    if (argumentsFeature.runThreading == true)
+    {
+        Threading threadingFeature;
+        threadingFeature.Run();
+    }
+
+    if (argumentsFeature.runExpression == true)
+    {
+        Expression expressionFeature;
+        expressionFeature.Run();
+    }
+
+    if (argumentsFeature.runEnvironment == true)
+    {
+        Environment environmentFeature;;
+        environmentFeature.Run();
+    }
+
+    cout << "Goodbye.\n";
+    return 0;
+}

--- a/test/CppTests/debuggees/kitchensink/src/main.h
+++ b/test/CppTests/debuggees/kitchensink/src/main.h
@@ -1,0 +1,4 @@
+#pragma once
+#include "global.h"
+#include <iostream>
+#include <vector>

--- a/test/CppTests/debuggees/kitchensink/src/nonterminating.cpp
+++ b/test/CppTests/debuggees/kitchensink/src/nonterminating.cpp
@@ -1,0 +1,39 @@
+#include "nonterminating.h"
+
+NonTerminating::NonTerminating()
+    : Feature("NonTerminating")
+{
+}
+
+void ThreadLoop(NonTerminating* t)
+{
+    t->Log("Starting thread in NonTerminating");
+    while (!t->shouldExit)
+    {
+        this_thread::sleep_for(chrono::milliseconds(10));
+    }
+    t->Log("Ending NonTerminating thread");
+}
+
+void NonTerminating::CoreRun()
+{
+    // Threading introduces timining differences when debugging.
+    // Add background thread for common attach scenarios.
+    thread backgroundThread(ThreadLoop, this);
+
+    this->Log("Starting infinite loop.");
+    bool shouldExitLocal = false;
+    while (!(this->shouldExit || shouldExitLocal))
+    {
+        this->DoSleep();
+    }
+    this->shouldExit = true;
+    this->Log("Exited infinite loop.");
+
+    backgroundThread.join();
+}
+
+void NonTerminating::DoSleep()
+{
+    this_thread::sleep_for(chrono::milliseconds(30));
+}

--- a/test/CppTests/debuggees/kitchensink/src/nonterminating.h
+++ b/test/CppTests/debuggees/kitchensink/src/nonterminating.h
@@ -1,0 +1,25 @@
+#pragma once
+#include "global.h"
+#include <iostream>
+#include <vector>
+#include <string>
+#include <thread>
+#include <stdarg.h>
+#include <condition_variable>
+#include <chrono>
+
+#include "feature.h"
+
+using namespace std;
+
+class NonTerminating : public Feature
+{
+public:
+    NonTerminating();
+    virtual void CoreRun();
+
+    bool shouldExit = false;
+
+private:
+    void DoSleep();
+};

--- a/test/CppTests/debuggees/kitchensink/src/threading.cpp
+++ b/test/CppTests/debuggees/kitchensink/src/threading.cpp
@@ -1,0 +1,51 @@
+#include "threading.h"
+
+Threading::Threading()
+    : Feature("Threading"), runningWorkingThreadCount(0)
+{
+}
+
+// Body of "worker" threads. Loop for loopCount seconds
+void WorkerThreadLoop(Threading* t, int loopCount, string threadName)
+{
+    t->Log("Starting thread ", threadName, ". LoopCount: ", loopCount);
+    t->runningWorkingThreadCount++;
+
+    // Wait until main is ready before closing thread
+    unique_lock<mutex> lk(t->mainClosingMutex);
+    t->mainClosing.wait(lk);
+
+    t->Log("Ending thread ", threadName, ". LoopCount: ", loopCount);
+    t->runningWorkingThreadCount--;
+}
+
+void Threading::CoreRun()
+{
+    this->Log("Creating a few threads.");
+
+    thread A(WorkerThreadLoop, this, 3, "A-Blue");
+    thread B(WorkerThreadLoop, this, 2, "B-Green");
+    thread C(WorkerThreadLoop, this, 0, "C-Orange");
+    thread D(WorkerThreadLoop, this, 1, "D-Red");
+
+    this->Log("Wait for threads to start...");
+    while (this->runningWorkingThreadCount < 4)
+    {
+        this_thread::sleep_for(chrono::milliseconds(100));
+    }
+
+    this->Log("All threads running!");
+
+    this->Log("Notify threads to close...");
+
+    while (this->runningWorkingThreadCount > 0)
+    {
+        this->mainClosing.notify_all();
+        this_thread::sleep_for(chrono::milliseconds(100));
+    }
+
+    A.join();
+    B.join();
+    C.join();
+    D.join();
+}

--- a/test/CppTests/debuggees/kitchensink/src/threading.h
+++ b/test/CppTests/debuggees/kitchensink/src/threading.h
@@ -1,0 +1,22 @@
+#pragma once
+#include <atomic>
+#include "global.h"
+#include <string>
+#include <thread>
+#include <condition_variable>
+#include <chrono>
+
+#include "feature.h"
+
+using namespace std;
+
+class Threading : public Feature
+{
+public:
+    Threading();
+    virtual void CoreRun();
+
+    condition_variable mainClosing;
+    std::atomic_int runningWorkingThreadCount;
+    std::mutex mainClosingMutex;
+};

--- a/test/CppTests/debuggees/optimization/src/foo.cpp
+++ b/test/CppTests/debuggees/optimization/src/foo.cpp
@@ -1,0 +1,63 @@
+#include "foo.h"
+#include <iostream>
+#include <string>
+using namespace std;
+
+Foo::Foo()
+{
+	cout << "default constructor called" << endl;
+	this->number = 10;
+	FillContainer();
+}
+
+Foo::Foo(int number)
+{
+	cout << "one-argument constructor called" << endl;
+	if (Validate(number))
+	{
+		this->number = number;
+		FillContainer();
+	}
+	else
+	{
+		this->number = 10;
+		FillContainer();
+	}
+}
+
+bool Foo::Validate(int number)
+{
+	if (number <= 0 || number>100)
+	{
+		return false;
+	}
+	else
+	{
+		return true;
+	}
+}
+
+void Foo::FillContainer()
+{
+	for (int i = 1; i <= this->number; ++i)
+	{
+		m_collection.push_back(i);
+	}
+}
+
+int Foo::Sum()
+{
+	vector<int>::const_iterator iterBegin = m_collection.begin();
+	vector<int>::const_iterator iterEnd = m_collection.end();
+	int sum = 0;
+	int first = m_collection[0];
+	cout << first << endl;
+
+	while (iterBegin != iterEnd)
+	{
+		sum += *iterBegin;
+		++iterBegin;
+	}
+
+	return sum;
+}

--- a/test/CppTests/debuggees/optimization/src/foo.h
+++ b/test/CppTests/debuggees/optimization/src/foo.h
@@ -1,0 +1,23 @@
+#pragma once
+#include <vector>
+using std::vector;
+
+/*
+Author : Williams Ma
+Date   : 2016-7-24
+Desc   : Encapsuate a class for suming of collection 
+*/
+
+class Foo
+{
+public:
+	Foo();
+	Foo(int num);
+	int Sum();
+
+private:
+	bool Validate(int number);
+	void FillContainer();
+	int number;
+	vector<int> m_collection;
+};

--- a/test/CppTests/debuggees/optimization/src/mylib.cpp
+++ b/test/CppTests/debuggees/optimization/src/mylib.cpp
@@ -1,0 +1,29 @@
+#include "mylib.h"
+#include <iostream>
+#include <string>
+
+using namespace std;
+
+int myClass::DisplayAge(int age)
+{
+    age++;
+    cout << "my age: " << age << endl;
+    return age;
+}
+
+string myClass::DisplayName(string firstName, string lastName)
+{
+	string name = firstName + lastName;
+	cout << "my name: " << name << endl;
+    return name; 
+}
+
+extern "C" myClass* Create()
+{
+     return new myClass;
+}
+
+extern "C" void Destroy(myClass *myclass)
+{
+     delete myclass;
+}

--- a/test/CppTests/debuggees/optimization/src/mylib.h
+++ b/test/CppTests/debuggees/optimization/src/mylib.h
@@ -1,0 +1,13 @@
+#include <string>
+#include "mylib_base.h"
+
+using namespace std;
+
+class myClass:public myBase
+{
+    public:
+    int DisplayAge(int age);
+    string DisplayName(string firstName, string lastName);
+};
+
+

--- a/test/CppTests/debuggees/optimization/src/mylib_base.h
+++ b/test/CppTests/debuggees/optimization/src/mylib_base.h
@@ -1,0 +1,12 @@
+#include <string>
+
+using namespace std;
+
+class myBase
+{
+    public:
+    virtual int DisplayAge(int age)=0;
+    virtual string DisplayName(string firstName, string lastName)=0;
+};
+
+

--- a/test/CppTests/debuggees/optimization/src/source.cpp
+++ b/test/CppTests/debuggees/optimization/src/source.cpp
@@ -1,0 +1,98 @@
+#include <iostream>
+#include <string>
+#include "mylib_base.h"
+#include "foo.h"
+#include "..//..//..//sharedlib//src//global.h"
+#include "..//..//..//sharedlib//src//sharedlib.h"
+
+using namespace std;
+
+typedef myBase* p_create();
+typedef void p_destroy(myBase*);
+
+p_create* create;
+p_destroy* destroy;
+
+LIBRARY_HANDLE pHandle;
+
+void OpenMyLibrary()
+{
+	string platform = STRINGIFY(DEBUGGEE_PLATFORM);
+	create = NULL;
+	destroy = NULL;
+
+	string dllName = "mylib.dll";
+	string soName = "./mylib.so";
+	string libraryName = (platform.compare("WINDOWS") == 0) ? dllName : soName;
+	pHandle = OpenLibrary(libraryName);
+	if (!pHandle)
+	{
+		LogLibraryError("OpenLibrary");
+		return;
+	}
+
+	create = (p_create*)GetLibraryFunction(pHandle, "Create");
+	if (!create)
+	{
+		LogLibraryError("Get Create");
+	}
+
+	destroy = (p_destroy*)GetLibraryFunction(pHandle, "Destroy");
+	if (!destroy)
+	{
+		LogLibraryError("Get Destroy");
+	}
+}
+
+void CloseMyLibrary()
+{
+	create = NULL;
+	destroy = NULL;
+
+	if (pHandle != NULL)
+	{
+		bool closed = CloseLibrary(pHandle);
+		if (!closed)
+		{
+			LogLibraryError("CloseLibarary");
+		}
+	}
+}
+
+int main()
+{
+	Foo * pFoo = new Foo();
+	
+	cout << "default sum: " << pFoo->Sum() << endl;
+
+	pFoo = new Foo(10);
+	cout << " new sum:" << pFoo->Sum() << endl;
+
+	if (pFoo)
+	{
+		delete pFoo;
+		pFoo = NULL;
+	}
+
+	cout << "Start testing" << endl;
+
+	string firstName = "Richard";
+
+	string lastName = "Zeng";
+
+	OpenMyLibrary();
+
+	myBase* myclass = create();
+
+	int age = myclass->DisplayAge(30);
+
+	myclass->DisplayName(firstName, lastName);
+
+	destroy(myclass);
+
+	CloseMyLibrary();
+
+	cout << "Finish testing" << endl;
+
+	return 0;
+}

--- a/test/CppTests/debuggees/sharedlib/src/global.h
+++ b/test/CppTests/debuggees/sharedlib/src/global.h
@@ -1,0 +1,12 @@
+#pragma once
+
+#define STRINGIFY2( x) #x
+#define STRINGIFY(x) STRINGIFY2(x)
+
+#ifdef _MINGW
+    #define WIN32_SHARED_LIBRARY
+#endif
+
+#ifdef _WIN32
+    #define WIN32_SHARED_LIBRARY
+#endif

--- a/test/CppTests/debuggees/sharedlib/src/myapp.cpp
+++ b/test/CppTests/debuggees/sharedlib/src/myapp.cpp
@@ -1,0 +1,84 @@
+#include "global.h"
+#include "sharedlib.h"
+#include "mylib_base.h"
+#include <iostream>
+#include <string>
+
+using namespace std;
+
+typedef myBase* p_create();
+typedef void p_destroy(myBase*);
+
+p_create* create;
+p_destroy* destroy;
+
+LIBRARY_HANDLE pHandle;
+
+void OpenMyLibrary()
+{
+    string platform = STRINGIFY(DEBUGGEE_PLATFORM);
+    create = NULL;
+    destroy = NULL;
+
+    string dllName = "mylib.dll";
+    string soName = "./mylib.so";
+    string libraryName = (platform.compare("WINDOWS") == 0) ? dllName : soName;
+    pHandle = OpenLibrary(libraryName);
+    if (!pHandle)
+    {
+        LogLibraryError("OpenLibrary");
+        return;
+    }
+
+    create = (p_create*)GetLibraryFunction(pHandle, "Create");
+    if (!create)
+    {
+        LogLibraryError("Get Create");
+    }
+
+    destroy = (p_destroy*)GetLibraryFunction(pHandle, "Destroy");
+    if (!destroy)
+    {
+        LogLibraryError("Get Destroy");
+    }
+}
+
+void CloseMyLibrary()
+{
+    create = NULL;
+    destroy = NULL;
+
+    if (pHandle != NULL)
+    {
+        bool closed = CloseLibrary(pHandle);
+        if (!closed)
+        {
+            LogLibraryError("CloseLibarary");
+        }
+    }
+}
+
+int main(int argc, char* argv[])
+{
+    cout << "Start testing" << endl;
+
+    string firstName = "Richard";
+
+    string lastName = "Zeng";
+
+    OpenMyLibrary();
+
+    myBase* myclass = create();
+
+    myclass->DisplayAge(30);
+
+    myclass->DisplayName(firstName, lastName);
+
+    destroy(myclass);
+
+    CloseMyLibrary();
+
+    cout << "Finish testing" << endl;
+
+    return 0;
+}

--- a/test/CppTests/debuggees/sharedlib/src/mylib.cpp
+++ b/test/CppTests/debuggees/sharedlib/src/mylib.cpp
@@ -1,0 +1,29 @@
+#include "mylib.h"
+#include <iostream>
+#include <string>
+
+using namespace std;
+
+int myClass::DisplayAge(int age)
+{
+    age++;
+    cout << "my age: " << age << endl;
+    return age;
+}
+
+string myClass::DisplayName(string firstName, string lastName)
+{
+    string name = firstName + lastName;
+    cout << "my name: " << name << endl;
+    return name;
+}
+
+extern "C" myClass* Create()
+{
+    return new myClass;
+}
+
+extern "C" void Destroy(myClass *myclass)
+{
+    delete myclass;
+}

--- a/test/CppTests/debuggees/sharedlib/src/mylib.h
+++ b/test/CppTests/debuggees/sharedlib/src/mylib.h
@@ -1,0 +1,13 @@
+#pragma once
+
+#include <string>
+#include "mylib_base.h"
+
+using namespace std;
+
+class myClass :public myBase
+{
+public:
+    int DisplayAge(int age);
+    string DisplayName(string firstName, string lastName);
+};

--- a/test/CppTests/debuggees/sharedlib/src/mylib_base.h
+++ b/test/CppTests/debuggees/sharedlib/src/mylib_base.h
@@ -1,0 +1,10 @@
+#include <string>
+
+using namespace std;
+
+class myBase
+{
+public:
+    virtual int DisplayAge(int age) = 0;
+    virtual string DisplayName(string firstName, string lastName) = 0;
+};

--- a/test/CppTests/debuggees/sharedlib/src/sharedlib.h
+++ b/test/CppTests/debuggees/sharedlib/src/sharedlib.h
@@ -1,0 +1,62 @@
+#pragma once
+
+#include <iostream>
+#include <string>
+
+using namespace std;
+
+#ifdef WIN32_SHARED_LIBRARY
+// *********** Win32 Shared Library Implementation *************
+
+#include <windows.h>
+
+typedef HINSTANCE LIBRARY_HANDLE;
+
+LIBRARY_HANDLE OpenLibrary(string libraryName)
+{
+    return LoadLibraryA(libraryName.c_str());
+}
+
+bool CloseLibrary(LIBRARY_HANDLE library)
+{
+    return FreeLibrary(library) == TRUE;
+}
+
+void* GetLibraryFunction(LIBRARY_HANDLE library, string functionName)
+{
+    return (void*)GetProcAddress(library, functionName.c_str());
+}
+
+void LogLibraryError(string location)
+{
+    cout << "Error in " << location << ": " << GetLastError() << endl;
+}
+
+#else
+// *********** POSIX Shared Library Implementation *************
+
+#include <dlfcn.h>
+typedef void* LIBRARY_HANDLE;
+
+LIBRARY_HANDLE OpenLibrary(string libraryName)
+{
+    return dlopen(libraryName.c_str(), RTLD_LAZY);
+}
+
+bool CloseLibrary(LIBRARY_HANDLE library)
+{
+    return dlclose(library) == 0;
+}
+
+void* GetLibraryFunction(LIBRARY_HANDLE library, string functionName)
+{
+    return dlsym(library, functionName.c_str());
+}
+
+void LogLibraryError(string location)
+{
+    cout << "Error in " << location << ": " << dlerror() << endl;
+}
+
+
+#endif

--- a/test/CppTests/debuggees/sourcemap/src/main.cpp
+++ b/test/CppTests/debuggees/sourcemap/src/main.cpp
@@ -1,0 +1,33 @@
+﻿#ifdef _WIN32
+#include "writer\writer.h"
+#include "manager\manager.h"
+#else
+#include "writer/writer.h"
+#include "manager/manager.h"
+#endif
+
+int main(int argv, char** argc)
+{
+    Writer writer;
+
+    writer.Write("Hello World");
+    Manager mgr;
+
+    for (int i = 90; i > 0; i -= 10)
+    {
+        mgr.AddInt(i);
+    }
+
+    writer.Write("Mgr has ");
+    writer.Write(mgr.Size());
+    writer.WriteLine(" items.");
+
+    writer.Write("The sum of Mgr is: ");
+    writer.WriteLine(mgr.Sum());
+    
+    writer.Write("Removing ");
+    writer.Write(mgr.RemoveInt());
+    writer.Write(". The sum is now: ");
+    writer.Write(mgr.Sum());
+    return 0;
+}

--- a/test/CppTests/debuggees/sourcemap/src/manager/manager.cpp
+++ b/test/CppTests/debuggees/sourcemap/src/manager/manager.cpp
@@ -1,0 +1,31 @@
+﻿#include "manager.h"
+
+Manager::Manager() 
+{ }
+
+void Manager::AddInt(int number)
+{
+    this->items.push_back(number);
+}
+
+int Manager::RemoveInt()
+{
+    int val = this->items.back();
+    this->items.pop_back();
+    return val;
+}
+
+int Manager::Size()
+{
+    return (int)this->items.size();
+}
+
+int Manager::Sum()
+{
+    int sum = 0;
+    for (auto & it : items)
+    {
+        sum += it;
+    }
+    return sum;
+}

--- a/test/CppTests/debuggees/sourcemap/src/manager/manager.h
+++ b/test/CppTests/debuggees/sourcemap/src/manager/manager.h
@@ -1,0 +1,12 @@
+﻿#include <vector>
+class Manager
+{
+public:
+    Manager();
+    void AddInt(int value);
+    int RemoveInt();
+    int Size();
+    int Sum();
+private: 
+    std::vector<int> items;
+};

--- a/test/CppTests/debuggees/sourcemap/src/writer/writer.cpp
+++ b/test/CppTests/debuggees/sourcemap/src/writer/writer.cpp
@@ -1,0 +1,26 @@
+﻿#include <iostream>
+#include "writer.h"
+
+Writer::Writer()
+{ }
+
+void Writer::Write(const std::string msg)
+{
+    std::cout << msg << std::endl;
+}
+
+void Writer::WriteLine(const std::string msg)
+{
+    this->Write(msg);
+    std::cout << std::endl;
+}
+
+void Writer::Write(const int number)
+{
+    std::cout << number;
+}
+
+void Writer::WriteLine(const int number)
+{
+    std::cout << "Writing number: " << number << std::endl;
+}

--- a/test/CppTests/debuggees/sourcemap/src/writer/writer.h
+++ b/test/CppTests/debuggees/sourcemap/src/writer/writer.h
@@ -1,0 +1,14 @@
+﻿#pragma once
+#include <stdio.h>
+#include <string>
+
+class Writer
+{
+public:
+    Writer();
+    void Write(const std::string msg);
+    void Write(const int number);
+
+    void WriteLine(const std::string msg);
+    void WriteLine(const int number);
+};

--- a/test/DebugAdapterRunner/Command.cs
+++ b/test/DebugAdapterRunner/Command.cs
@@ -1,0 +1,21 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Collections.Generic;
+
+namespace DebugAdapterRunner
+{
+    /// <summary>Base test script command</summary>
+    /// <remarks>Commands that are sent to the debug adapters can use DebugAdapterCommand.
+    /// Custom commands can be derived from this base class</remarks>
+    public class Command
+    {
+        public string Name;
+
+        public List<DebugAdapterResponse> ExpectedResponses = new List<DebugAdapterResponse>();
+
+        public virtual void Run(DebugAdapterRunner runner)
+        {
+        }
+    }
+}

--- a/test/DebugAdapterRunner/DARException.cs
+++ b/test/DebugAdapterRunner/DARException.cs
@@ -1,0 +1,14 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+
+namespace DebugAdapterRunner
+{
+    public class DARException : Exception
+    {
+        public DARException(string message) : base(message)
+        {
+        }
+    }
+}

--- a/test/DebugAdapterRunner/DebugAdapterResponse.cs
+++ b/test/DebugAdapterRunner/DebugAdapterResponse.cs
@@ -1,0 +1,26 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace DebugAdapterRunner
+{
+    /// <summary>Represents a response expected from a <see cref="DebugAdapterCommand"/></summary>
+    public class DebugAdapterResponse
+    {
+        public object Response { get; private set; }
+        public dynamic Match { get; internal set; }
+        public bool IgnoreOrder { get; private set; }
+
+        public DebugAdapterResponse(object response, bool ignoreOrder = false)
+        {
+            Response = response;
+            Match = null;
+            IgnoreOrder = ignoreOrder;
+        }
+    }
+}

--- a/test/DebugAdapterRunner/DebugAdapterRunner.cs
+++ b/test/DebugAdapterRunner/DebugAdapterRunner.cs
@@ -1,0 +1,306 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Newtonsoft.Json;
+using OpenDebug;
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Globalization;
+using System.IO;
+using System.Text;
+using System.Threading;
+
+namespace DebugAdapterRunner
+{
+    /// <summary>
+    /// Delegate for a callback request handler. For example, handler for `runInTerminal`
+    /// </summary>
+    /// <param name="runner">The runner instance</param>
+    /// <param name="dispatcherRequest">The dispatcher request</param>
+    public delegate void CallbackRequestHandler(DebugAdapterRunner runner, DispatcherRequest dispatcherRequest);
+
+    public enum TraceDebugAdapterMode
+    {
+        None = 0,
+        Console = 1,
+        Memory = 2,
+    }
+
+    public class DebugAdapterRunner
+    {
+        // Whether the tool will dump requests and responses between the debug adapter and itself
+        private TraceDebugAdapterMode _traceDebugAdapterOutput = TraceDebugAdapterMode.None;
+
+        private volatile int _seq;
+
+        private bool _hasAsserted;
+
+        private string _assertionFileName;
+
+        private readonly Action<string> _errorLogger;
+
+        // The timeout for getting a response from the debug adapter
+        public int ResponseTimeout;
+
+        // Reference to debug adapter process
+        public Process DebugAdapter;
+
+        // The current thread id which is automatically updated when the tool receives a stopped event
+        public int CurrentThreadId;
+
+        // Keep a trace of the debug adapter output if requested
+        private StringBuilder _debugAdapterOutput = new StringBuilder();
+
+        private IDictionary<string, CallbackRequestHandler> _callbackHandlers = new Dictionary<string, CallbackRequestHandler>();
+
+        // Current list of responses received from the debug adapter
+        public List<string> Responses { get; private set; }
+
+        public string DebugAdapterOutput
+        {
+            get { return _debugAdapterOutput.ToString(); }
+        }
+
+        public void AppendLineToDebugAdapterOutput(string line)
+        {
+            if (_traceDebugAdapterOutput == TraceDebugAdapterMode.Memory)
+            {
+                _debugAdapterOutput.AppendLine(line);
+            }
+        }
+
+
+        public DebugAdapterRunner(
+            string adapterPath,
+            TraceDebugAdapterMode traceDebugAdapterOutput = TraceDebugAdapterMode.None,
+            bool engineLogging = false,
+            string engineLogPath = null,
+            bool pauseForDebugger = false,
+            bool isVsDbg = false,
+            bool isNative = true,
+            int responseTimeout = 5000,
+            Action<string> errorLogger = null,
+            bool redirectVSAssert = false,
+            IEnumerable<KeyValuePair<string, string>> additionalEnvironmentVariables = null)
+        {
+            this._errorLogger = errorLogger;
+
+            List<string> adapterArgs = new List<string>();
+            if (isVsDbg)
+            {
+                adapterArgs.Add("--interpreter=vscode");
+            }
+            else
+            {
+                if (traceDebugAdapterOutput != TraceDebugAdapterMode.None)
+                {
+                    adapterArgs.Add("--trace=response");
+                }
+            }
+
+            if (pauseForDebugger)
+            {
+                adapterArgs.Add("--pauseForDebugger");
+            }
+
+            if (!string.IsNullOrEmpty(engineLogPath))
+            {
+                adapterArgs.Add("--engineLogging=" + engineLogPath);
+            }
+            else if (engineLogging)
+            {
+                adapterArgs.Add("--engineLogging");
+            }
+
+            StartDebugAdapter(adapterPath, string.Join(" ", adapterArgs), traceDebugAdapterOutput, pauseForDebugger, redirectVSAssert, responseTimeout, additionalEnvironmentVariables);
+        }
+
+        public DebugAdapterRunner(
+            string adapterPath,
+            string adapterArgs,
+            TraceDebugAdapterMode traceDebugAdapterOutput,
+            bool pauseForDebugger,
+            bool redirectVSAssert,
+            int responseTimeout,
+            Action<string> errorLogger,
+            IEnumerable<KeyValuePair<string, string>> additionalEnvironmentVariables)
+        {
+            _errorLogger = errorLogger;
+
+            StartDebugAdapter(adapterPath, adapterArgs, traceDebugAdapterOutput, pauseForDebugger, redirectVSAssert, responseTimeout, additionalEnvironmentVariables);
+        }
+
+        private void StartDebugAdapter(
+            string adapterPath,
+            string adapterArgs,
+            TraceDebugAdapterMode traceDebugAdapterOutput,
+            bool pauseForDebugger,
+            bool redirectVSAssert,
+            int responseTimeout,
+            IEnumerable<KeyValuePair<string, string>> additionalEnvironmentVariables)
+        {
+            // If pauseForDebugger is enabled, we might be debugging the adapter for a while.
+            ResponseTimeout = pauseForDebugger ? 1000 * 60 * 60 * 24 : responseTimeout;
+
+            _traceDebugAdapterOutput = traceDebugAdapterOutput;
+
+            EventWaitHandle debugAdapterStarted = new EventWaitHandle(false, EventResetMode.AutoReset);
+            Responses = new List<string>();
+
+            ProcessStartInfo startInfo = new ProcessStartInfo(adapterPath, adapterArgs);
+            startInfo.UseShellExecute = false;
+            startInfo.CreateNoWindow = true;
+            startInfo.RedirectStandardInput = true;
+            startInfo.RedirectStandardOutput = true;
+            startInfo.RedirectStandardError = true;                
+
+            if (redirectVSAssert)
+            {
+                _assertionFileName = Path.Combine(Path.GetTempPath(), string.Format(CultureInfo.InvariantCulture, "vsassert.{0}.txt", Guid.NewGuid()));
+                startInfo.Environment["VSASSERT"] = _assertionFileName;
+            }
+
+            if (additionalEnvironmentVariables != null)
+            {
+                foreach (KeyValuePair<string, string> pair in additionalEnvironmentVariables)
+                {
+                    startInfo.Environment[pair.Key] = pair.Value;
+                }
+            }
+
+            DebugAdapter = Process.Start(startInfo);
+
+            DebugAdapter.ErrorDataReceived += (o, a) =>
+            {
+                if (pauseForDebugger)
+                {
+                    debugAdapterStarted.Set();
+                }
+
+                string message = a.Data ?? string.Empty;
+                if (message.StartsWith("ASSERT FAILED", StringComparison.Ordinal))
+                {
+                    _hasAsserted = true;
+                }
+
+                LogErrorLine(message);
+            };
+            DebugAdapter.BeginErrorReadLine();
+
+            if (pauseForDebugger)
+            {
+                Console.WriteLine(string.Format(CultureInfo.InvariantCulture, "Attach a debugger to PID {0}", DebugAdapter.Id));
+                debugAdapterStarted.WaitOne();
+            }
+        }
+
+        private void LogErrorLine(string message)
+        {
+            try
+            {
+                if (Debugger.IsAttached)
+                {
+                    Debug.WriteLine(message);
+                }
+
+                if (_errorLogger != null)
+                {
+                    _errorLogger(message);
+                }
+                else if (_traceDebugAdapterOutput == TraceDebugAdapterMode.Console)
+                {
+                    Console.WriteLine(message);
+                }
+
+                if (_traceDebugAdapterOutput != TraceDebugAdapterMode.None)
+                {
+                    AppendLineToDebugAdapterOutput(message);
+                }
+            }
+            catch
+            {
+            }
+        }
+
+        /// <summary>
+        /// Returns the sequence number for the next message
+        /// </summary>
+        /// <returns>Sequence number</returns>
+        public int GetNextSequenceNumber()
+        {
+            return Interlocked.Increment(ref _seq);
+        }
+
+        public string SerializeMessage(DispatcherMessage message)
+        {
+            string serialized = JsonConvert.SerializeObject(message);
+            byte[] bytes = Encoding.UTF8.GetBytes(serialized);
+            return string.Format(CultureInfo.InvariantCulture, "{0}{1}{2}{3}", DAPConstants.ContentLength, bytes.Length, DAPConstants.TwoCrLf, serialized);
+        }
+
+        public void Run(Command command)
+        {
+            try
+            {
+                command.Run(this);
+            }
+            catch (DARException darException)
+            {
+                throw new DARException(string.Format(CultureInfo.InvariantCulture, "Test command execution failed...\nFailure = {0}\n\nCommand = {1}\n\nFull output = {2}",
+                    darException.Message, JsonConvert.SerializeObject(command), DebugAdapterOutput));
+            }
+
+            if (this.HasAsserted())
+            {
+                throw new DARException(string.Format(CultureInfo.InvariantCulture, "Debug adapter has asserted wher running command. See test log for details. Command: {0}", JsonConvert.SerializeObject(command)));
+            }
+        }
+
+        public bool HasAsserted()
+        {
+            if (_hasAsserted)
+                return true;
+
+            if (_assertionFileName != null && File.Exists(_assertionFileName))
+            {
+                _hasAsserted = true;
+
+                try
+                {
+                    foreach (var line in File.ReadAllLines(_assertionFileName))
+                    {
+                        LogErrorLine(line);
+                    }
+                }
+                catch
+                {
+                }
+
+                return true;
+            }
+
+            return false;
+        }
+
+        public void AddCallbackRequestHandler(string commandName, CallbackRequestHandler handler)
+        {
+            this._callbackHandlers.Add(commandName, handler);
+        }
+
+        internal void HandleCallbackRequest(string receivedMessage)
+        {
+            DispatcherRequest dispatcherRequest = JsonConvert.DeserializeObject<DispatcherRequest>(receivedMessage);
+
+            if (_callbackHandlers.TryGetValue(dispatcherRequest.command, out CallbackRequestHandler handler))
+            {
+                handler(this, dispatcherRequest);
+            }
+            else
+            {
+                string errorMessage = String.Format(CultureInfo.CurrentCulture, "Received unhandled callback command '{0}'", dispatcherRequest.command);
+                throw new DARException(errorMessage);
+            }
+        }
+    }
+}

--- a/test/DebugAdapterRunner/DebugAdapterRunner.csproj
+++ b/test/DebugAdapterRunner/DebugAdapterRunner.csproj
@@ -1,0 +1,25 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+  <Import Project="..\..\build\debuggertesting.settings.targets" />
+
+  <PropertyGroup>
+    <AssemblyName>dar</AssemblyName>
+    <RootNamespace>DebugAdapterRunner</RootNamespace>
+    <TargetFramework>netcoreapp5.0</TargetFramework>
+  </PropertyGroup>
+
+  <ItemGroup Label="Package References">
+    <PackageReference Include="Microsoft.VisualStudioEng.MicroBuild.Core" Version="$(Microsoft_VisualStudioEng_MicroBuild_Core_Version)">
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+
+    <PackageReference Include="Newtonsoft.Json" Version="$(Newtonsoft_Json_VSCode_Version)" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <DropSignedFile Include="$(OutputPath)dar.dll" />
+    <DropUnsignedFile Include="$(OutputPath)dar.pdb" />
+  </ItemGroup>
+
+  <Import Project="..\..\build\DropFiles.targets" />
+
+</Project>

--- a/test/DebugAdapterRunner/DebugAdapterRunner.nuspec
+++ b/test/DebugAdapterRunner/DebugAdapterRunner.nuspec
@@ -1,0 +1,24 @@
+<?xml version="1.0"?>
+<package xmlns="http://schemas.microsoft.com/packaging/2011/08/nuspec.xsd">
+  <metadata>
+    <id>Microsoft.VisualStudio.DebugAdapterRunner</id>
+    <version>$version$</version>
+    <title>Microsoft.VisualStudio.DebugAdapterRunner</title>
+    <authors>Microsoft</authors>
+    <owners>Microsoft</owners>
+    <licenseUrl>https://aka.ms/pexunj</licenseUrl>
+    <projectUrl>https://aka.ms/vsextensibility</projectUrl>
+    <iconUrl>https://aka.ms/vsextensibilityicon</iconUrl>
+    <requireLicenseAcceptance>true</requireLicenseAcceptance>
+    <description>Contains helper for testing Debug Adapters. This package should only be used for testing Debug Adapters owned by the Microsoft Visual Studio Diagnostics team and isn't supported for other purposes.</description>
+    <releaseNotes>https://go.microsoft.com/fwlink/?LinkID=746387</releaseNotes>
+    <copyright>© Microsoft Corporation. All rights reserved.</copyright>
+    <dependencies>
+      <dependency id="Newtonsoft.Json" version="9.0.1" />
+    </dependencies>
+  </metadata>
+  <files>
+    <file src="$binRoot$dar.dll" target="lib\net5.0" />
+    <file src="$binRoot$dar.pdb" target="lib\net5.0" />
+  </files>
+</package>

--- a/test/DebugAdapterRunner/OpenDebug/DAPConstants.cs
+++ b/test/DebugAdapterRunner/OpenDebug/DAPConstants.cs
@@ -1,0 +1,17 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace OpenDebug
+{
+    internal static class DAPConstants
+    {
+        public const string TwoCrLf = "\r\n\r\n";
+        public const string ContentLength = "Content-Length: ";
+    }
+}

--- a/test/DebugAdapterRunner/OpenDebug/Messages.cs
+++ b/test/DebugAdapterRunner/OpenDebug/Messages.cs
@@ -1,0 +1,104 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Newtonsoft.Json;
+
+namespace OpenDebug
+{
+    public class DispatcherMessage
+    {
+        public int seq;
+        public string type;
+
+        public DispatcherMessage(string typ)
+        {
+            type = typ;
+        }
+    }
+
+    public class DispatcherRequest : DispatcherMessage
+    {
+        public string command;
+        public dynamic arguments;
+
+        public DispatcherRequest() : base("request")
+        {
+        }
+
+        public DispatcherRequest(int id, string cmd, dynamic arg) : base("request")
+        {
+            seq = id;
+            command = cmd;
+            arguments = arg;
+        }
+    }
+
+    public class DispatcherResponse : DispatcherMessage
+    {
+        public bool success;
+        public string message;
+        public int request_seq;
+        public string command;
+        public dynamic body;
+        public bool running;
+        public dynamic refs;
+
+        public DispatcherResponse() : base("response")
+        {
+        }
+
+        public DispatcherResponse(string msg) : base("response")
+        {
+            success = false;
+            message = msg;
+        }
+
+        public DispatcherResponse(bool succ, string msg) : base("response")
+        {
+            success = succ;
+            message = msg;
+        }
+
+        public DispatcherResponse(dynamic m) : base("response")
+        {
+            seq = m.seq;
+            success = m.success;
+            message = m.message;
+            request_seq = m.request_seq;
+            command = m.command;
+            body = m.body;
+            running = m.running;
+            refs = m.refs;
+        }
+
+        public DispatcherResponse(int rseq, string cmd) : base("response")
+        {
+            request_seq = rseq;
+            command = cmd;
+        }
+    }
+
+    public class DispatcherEvent : DispatcherMessage
+    {
+        [JsonProperty(PropertyName = "event")]
+        public string eventType;
+        public dynamic body;
+
+        public DispatcherEvent() : base("event")
+        {
+        }
+
+        public DispatcherEvent(dynamic m) : base("event")
+        {
+            seq = m.seq;
+            eventType = m["event"];
+            body = m.body;
+        }
+
+        public DispatcherEvent(string type, dynamic bdy = null) : base("event")
+        {
+            eventType = type;
+            body = bdy;
+        }
+    }
+}

--- a/test/DebugAdapterRunner/Utils.cs
+++ b/test/DebugAdapterRunner/Utils.cs
@@ -1,0 +1,161 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Newtonsoft.Json.Linq;
+using System.Linq;
+using System.Text.RegularExpressions;
+
+namespace DebugAdapterRunner
+{
+    internal class Utils
+    {
+        /// <summary>Returns whether the given array matches the pattern specified in the 'expected' array</summary>
+        /// <returns>True if matching, false otherwise</returns>
+        /// <remarks>The 'expected' array contains a list of elements that are searched in the actual array
+        /// The actual array can have more elements. Whether the order of elements matters is up to
+        /// the 'ignoreOrder' flag</remarks>
+        private static bool CompareArrays(JArray expected, JArray actual, bool ignoreOrder)
+        {
+            return ignoreOrder ? CompareArraysUnordered(expected, actual) : CompareArraysInOrder(expected, actual);
+        }
+
+        /// <summary>Returns whether the given array contains each of the patterns specified in the 'expected' array in order.</summary>
+        /// <returns>True if matching, false otherwise</returns>
+        /// <remarks>The 'expected' array contains a list of elements that are searched in the actual array
+        /// The actual array can have more elements. The order of elements in the 'actual' array must
+        /// match the order found in the expected array</remarks>
+        private static bool CompareArraysInOrder(JArray expected, JArray actual)
+        {
+            int currentExpectedIndex = 0;
+            int currentActualIndex = 0;
+
+            JToken[] expectedChildren = expected.Children().ToArray();
+            JToken[] actualChildren = actual.Children().ToArray();
+
+            while (currentExpectedIndex < expectedChildren.Length)
+            {
+                JToken expectedMember = expectedChildren[currentExpectedIndex];
+                bool foundMatching = false;
+
+                while (currentActualIndex < actualChildren.Length)
+                {
+                    JToken actualMember = actualChildren[currentActualIndex];
+
+                    if (!CompareObjects(expectedMember.Value<object>(), actualMember.Value<object>(), ignoreOrder: false))
+                    {
+                        currentActualIndex++;
+                    }
+                    else
+                    {
+                        foundMatching = true;
+                        break;
+                    }
+                }
+
+                if (!foundMatching)
+                {
+                    return false;
+                }
+
+                currentActualIndex++;
+                currentExpectedIndex++;
+            }
+
+            return true;
+        }
+
+        /// <summary>Returns whether the given array contains each of the patterns specified in the 'expected' array.</summary>
+        /// <returns>True if matching, false otherwise</returns>
+        /// <remarks>The 'expected' array contains a list of elements that are searched in the actual array.
+        /// The actual array can have more elements, and the order of elements in the 'actual' array does not
+        /// need to match the order found in the expected array. If there are multiple identical expected responses,
+        /// there must be at least that many identical actual responses.</remarks>
+        private static bool CompareArraysUnordered(JArray expected, JArray actual)
+        {
+            JArray actualCopy = new JArray(actual);
+            foreach (JToken expectedMember in expected)
+            {
+                JToken foundMember = null;
+
+                foreach (JToken actualMember in actualCopy)
+                {
+                    if (CompareObjects(expectedMember.Value<object>(), actualMember.Value<object>(), ignoreOrder: true))
+                    {
+                        foundMember = actualMember;
+                        break;
+                    }
+                }
+
+                if (foundMember != null)
+                {
+                    // Don't compare against this item again.
+                    actualCopy.Remove(foundMember);
+                }
+                else
+                {
+                    return false;
+                }
+            }
+
+            return true;
+        }
+
+        private static bool CompareSimpleValues(object expected, object actual)
+        {
+            return Regex.IsMatch(actual.ToString(), expected.ToString(), RegexOptions.IgnoreCase);
+        }
+
+        /// <summary>Returns whether a given object matches the pattern specified by a given 'expected' object</summary>
+        /// <returns>True, if matching, false otherwise</returns>
+        /// <remarks>
+        ///  - 'expected' object fields should specify a regex pattern to be matched in the target object
+        ///  - Only the fields specified in the 'expected' object are matched (i.e. the target object can have more fields)
+        ///  - Fields that are arrays are matched by searching the target array for the elements specified in the array field of the 'expected' object
+        ///  - Arrays are searched in order by default. To ignore the order, specify 'ignoreOrder = true'
+        /// </remarks>
+        public static bool CompareObjects(object expected, object actual, bool ignoreOrder = false)
+        {
+            JObject expectedObject = JObject.FromObject(expected);
+            JObject actualObject = JObject.FromObject(actual);
+
+            foreach (JToken expectedToken in expectedObject.Children())
+            {
+                JProperty property = expectedToken as JProperty;
+                JToken actualToken = actualObject.Property(property.Name);
+
+                if (actualToken == null || !(actualToken is JProperty)) // Property not found
+                    return false;
+
+                JProperty actualProperty = actualToken as JProperty;
+
+                if (property.Value is JArray)
+                {
+                    if (!(actualProperty.Value is JArray))
+                        return false;
+
+                    if (!CompareArrays(property.Value as JArray, actualProperty.Value as JArray, ignoreOrder))
+                        return false;
+                }
+                else if (property.Value.HasValues)
+                {
+                    if (!actualProperty.Value.HasValues)
+                        return false;
+
+                    if (!CompareObjects(property.Value.Value<object>(), actualProperty.Value.Value<object>(), ignoreOrder))
+                        return false;
+                }
+                else if (!property.Value.HasValues && property.Value is JObject && actualProperty.Value is JObject)
+                {
+                    // If property.Value is an empty object, we want to ignore actualProperty.Value's values as long as they are both JObject
+                }
+                else
+                {
+                    if (!CompareSimpleValues(property.Value.Value<object>(), actualProperty.Value.Value<object>()))
+                        return false;
+                }
+            }
+
+            return true;
+        }
+    }
+}

--- a/test/DebuggerTesting/Attribution/CompilerSettings.cs
+++ b/test/DebuggerTesting/Attribution/CompilerSettings.cs
@@ -1,0 +1,111 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using DebuggerTesting.Utilities;
+
+namespace DebuggerTesting
+{
+    internal sealed class CompilerSettings :
+        ICompilerSettings
+    {
+        #region Constructor
+
+        public CompilerSettings(
+            string compilerName, 
+            SupportedCompiler compilerType, 
+            string compilerPath, 
+            SupportedArchitecture debuggeeArchitecture,
+            IDictionary<string, string> compilerProperties)
+        {
+            this.CompilerName = compilerName;
+            this.CompilerType = compilerType;
+            this.CompilerPath = compilerPath;
+            this.DebuggeeArchitecture = debuggeeArchitecture;
+            this.Properties = compilerProperties ?? new Dictionary<string, string>(StringComparer.Ordinal);
+        }
+
+        #endregion
+
+        #region Methods
+
+        public static bool operator ==(CompilerSettings left, CompilerSettings right)
+        {
+            if (Object.ReferenceEquals(left, null))
+                return Object.ReferenceEquals(right, null);
+
+            return left.Equals(right);
+        }
+
+        public static bool operator !=(CompilerSettings left, CompilerSettings right)
+        {
+            if (Object.ReferenceEquals(left, null))
+                return !Object.ReferenceEquals(right, null);
+
+            return !left.Equals(right);
+        }
+
+        public override bool Equals(object obj)
+        {
+            return this.Equals(obj as CompilerSettings);
+        }
+
+        public bool Equals(CompilerSettings obj)
+        {
+            if (Object.ReferenceEquals(obj, null))
+                return false;
+
+            if (!String.Equals(this.CompilerName, obj.CompilerName, StringComparison.Ordinal))
+                return false;
+
+            if (this.CompilerType != obj.CompilerType)
+                return false;
+
+            if (!String.Equals(this.CompilerPath, obj.CompilerPath, StringComparison.Ordinal))
+                return false;
+
+            if (this.DebuggeeArchitecture != obj.DebuggeeArchitecture)
+                return false;
+
+            if (!Enumerable.SequenceEqual(this.Properties.Keys, obj.Properties.Keys, StringComparer.Ordinal))
+                return false;
+
+            if (!Enumerable.SequenceEqual(this.Properties.Values, obj.Properties.Values, StringComparer.Ordinal))
+                return false;
+
+            return true;
+        }
+
+        public override int GetHashCode()
+        {
+            return HashUtilities.CombineHashCodes(
+                this.CompilerName?.GetHashCode() ?? 0,
+                this.CompilerType.GetHashCode(),
+                this.CompilerPath?.GetHashCode() ?? 0,
+                this.DebuggeeArchitecture.GetHashCode());
+        }
+
+        public override string ToString()
+        {
+            return "Compiler - Name: {0} Type: {1} ({2}) Path: {3}".FormatInvariantWithArgs(this.CompilerName, this.CompilerType, this.DebuggeeArchitecture, this.CompilerPath);
+        }
+
+        #endregion
+
+        #region Properties
+
+        public string CompilerName { get; private set; }
+
+        public SupportedCompiler CompilerType { get; private set; }
+
+        public string CompilerPath { get; private set; }
+
+        public SupportedArchitecture DebuggeeArchitecture { get; private set; }
+
+        public IDictionary<string,string> Properties { get; private set; }
+
+        #endregion
+    }
+}

--- a/test/DebuggerTesting/Attribution/DebuggerAttribute.cs
+++ b/test/DebuggerTesting/Attribution/DebuggerAttribute.cs
@@ -1,0 +1,29 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+
+namespace DebuggerTesting
+{
+    public abstract class DebuggerAttribute :
+        Attribute
+    {
+        #region Constructor
+
+        public DebuggerAttribute(SupportedDebugger debugger, SupportedArchitecture architecture)
+        {
+            this.Debugger = debugger;
+            this.Architecture = architecture;
+        }
+
+        #endregion
+
+        #region Properties
+
+        public SupportedDebugger Debugger { get; private set; }
+
+        public SupportedArchitecture Architecture { get; private set; }
+
+        #endregion
+    }
+}

--- a/test/DebuggerTesting/Attribution/DebuggerSettings.cs
+++ b/test/DebuggerTesting/Attribution/DebuggerSettings.cs
@@ -1,0 +1,124 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using DebuggerTesting.Utilities;
+
+namespace DebuggerTesting
+{
+    internal sealed class DebuggerSettings :
+        IDebuggerSettings
+    {
+        #region Constructor
+
+        public DebuggerSettings(
+            string debuggerName,
+            SupportedDebugger debuggerType,
+            string debuggerPath,
+            string debuggerAdapterPath,
+            string miMode,
+            SupportedArchitecture debuggeeArchitecture,
+            IDictionary<string, string> debuggerProperties)
+        {
+            this.DebuggeeArchitecture = debuggeeArchitecture;
+            this.DebuggerName = debuggerName;
+            this.DebuggerType = debuggerType;
+            this.DebuggerPath = debuggerPath;
+            this.DebuggerAdapterPath = debuggerAdapterPath;
+            if (!string.IsNullOrWhiteSpace(miMode))
+                this.MIMode = miMode;
+            this.Properties = debuggerProperties ?? new Dictionary<string, string>(StringComparer.Ordinal);
+        }
+
+        #endregion
+
+        #region Methods
+
+        public static bool operator ==(DebuggerSettings left, DebuggerSettings right)
+        {
+            if (Object.ReferenceEquals(left, null))
+                return Object.ReferenceEquals(right, null);
+
+            return left.Equals(right);
+        }
+
+        public static bool operator !=(DebuggerSettings left, DebuggerSettings right)
+        {
+            if (Object.ReferenceEquals(left, null))
+                return !Object.ReferenceEquals(right, null);
+
+            return !left.Equals(right);
+        }
+
+        public override bool Equals(object obj)
+        {
+            return this.Equals(obj as DebuggerSettings);
+        }
+
+        public bool Equals(DebuggerSettings obj)
+        {
+            if (Object.ReferenceEquals(obj, null))
+                return false;
+
+            if (this.DebuggeeArchitecture != obj.DebuggeeArchitecture)
+                return false;
+
+            if (!String.Equals(this.DebuggerName, obj.DebuggerName, StringComparison.Ordinal))
+                return false;
+
+            if (this.DebuggerType != obj.DebuggerType)
+                return false;
+
+            if (!String.Equals(this.DebuggerPath, obj.DebuggerPath, StringComparison.Ordinal))
+                return false;
+
+            if (!String.Equals(this.MIMode, obj.MIMode, StringComparison.Ordinal))
+                return false;
+
+            if (!Enumerable.SequenceEqual(this.Properties.Keys, obj.Properties.Keys, StringComparer.Ordinal))
+                return false;
+
+            if (!Enumerable.SequenceEqual(this.Properties.Values, obj.Properties.Values, StringComparer.Ordinal))
+                return false;
+
+            return true;
+        }
+
+        public override int GetHashCode()
+        {
+            return HashUtilities.CombineHashCodes(
+                this.DebuggeeArchitecture.GetHashCode(),
+                this.DebuggerName?.GetHashCode() ?? 0,
+                this.DebuggerType.GetHashCode(),
+                this.DebuggerPath?.GetHashCode() ?? 0,
+                this.MIMode?.GetHashCode() ?? 0);
+        }
+
+        public override string ToString()
+        {
+            return "Debugger - Name: {0} Type: {1} ({2}) Path: {3} MIMode: {4}".FormatInvariantWithArgs(this.DebuggerName, this.DebuggerType, this.DebuggeeArchitecture, this.DebuggerPath, this.MIMode);
+        }
+
+        #endregion
+
+        #region Properties
+
+        public SupportedArchitecture DebuggeeArchitecture { get; private set; }
+
+        public string DebuggerName { get; private set; }
+
+        public SupportedDebugger DebuggerType { get; private set; }
+
+        public string DebuggerPath { get; private set; }
+
+        public string DebuggerAdapterPath { get; private set; }
+
+        public string MIMode { get; private set; }
+
+        public IDictionary<string, string> Properties { get; private set; }
+
+        #endregion
+    }
+}

--- a/test/DebuggerTesting/Attribution/RequiresTestSettingsAttribute.cs
+++ b/test/DebuggerTesting/Attribution/RequiresTestSettingsAttribute.cs
@@ -1,0 +1,61 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using DebuggerTesting.Settings;
+using DebuggerTesting.Utilities;
+using Xunit.Sdk;
+
+namespace DebuggerTesting
+{
+    /// <summary>
+    /// Attribute used for providing an xUnit theory test with test setting data.
+    /// </summary>
+    [AttributeUsage(AttributeTargets.Method, AllowMultiple = false, Inherited = false)]
+    [DataDiscoverer("DebuggerTesting.TestFramework.TestSettingsDataDiscoverer", "DebuggerTesting")]
+    public class RequiresTestSettingsAttribute :
+        DataAttribute
+    {
+        #region Constructor
+
+        static RequiresTestSettingsAttribute()
+        {
+            if (PlatformUtilities.IsLinux)
+                s_platform = SupportedPlatform.Linux;
+            else if (PlatformUtilities.IsOSX)
+                s_platform = SupportedPlatform.MacOS;
+            else if (PlatformUtilities.IsWindows)
+                s_platform = SupportedPlatform.Windows;
+            else
+                throw new PlatformNotSupportedException();
+
+            s_platformArchitecture = PlatformUtilities.Is64Bit ? SupportedArchitecture.x64 : SupportedArchitecture.x86;
+        }
+
+        #endregion
+
+        #region Methods
+
+        /// <summary>
+        /// Retrieves the parameters that will be passed into the test method.
+        /// </summary>
+        /// <param name="testMethod">The method information of the test method.</param>
+        public override IEnumerable<object[]> GetData(MethodInfo testMethod)
+        {
+            return TestSettingsHelper.GetSettings(testMethod, s_platform, s_platformArchitecture)
+                .Select(settings => new object[] { settings });
+        }
+
+        #endregion
+
+        #region Fields
+
+        private static SupportedPlatform s_platform;
+        private static SupportedArchitecture s_platformArchitecture;
+
+        #endregion
+    }
+}

--- a/test/DebuggerTesting/Attribution/SupportedCompilerAttribute.cs
+++ b/test/DebuggerTesting/Attribution/SupportedCompilerAttribute.cs
@@ -1,0 +1,34 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+
+namespace DebuggerTesting
+{
+    /// <summary>
+    /// Attribute used by xUnit theory test for specifying which compilers and debuggee architectures
+    /// are required by the test.
+    /// </summary>
+    [AttributeUsage(AttributeTargets.Method, AllowMultiple = true, Inherited = false)]
+    public class SupportedCompilerAttribute :
+        Attribute
+    {
+        #region Constructor
+
+        public SupportedCompilerAttribute(SupportedCompiler compiler, SupportedArchitecture debuggeeArchitecture)
+        {
+            this.Compiler = compiler;
+            this.Architecture = debuggeeArchitecture;
+        }
+
+        #endregion
+
+        #region Properties
+
+        public SupportedCompiler Compiler { get; private set; }
+
+        public SupportedArchitecture Architecture { get; private set; }
+
+        #endregion
+    }
+}

--- a/test/DebuggerTesting/Attribution/SupportedDebuggerAttribute.cs
+++ b/test/DebuggerTesting/Attribution/SupportedDebuggerAttribute.cs
@@ -1,0 +1,24 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+
+namespace DebuggerTesting
+{
+    /// <summary>
+    /// Attribute used by xUnit theory test for specifying which debuggers are required by the test.
+    /// </summary>
+    [AttributeUsage(AttributeTargets.Method, AllowMultiple = true, Inherited = false)]
+    public class SupportedDebuggerAttribute :
+        DebuggerAttribute
+    {
+        #region Constructor
+
+        public SupportedDebuggerAttribute(SupportedDebugger debugger, SupportedArchitecture architecture)
+            : base(debugger, architecture)
+        {
+        }
+
+        #endregion
+    }
+}

--- a/test/DebuggerTesting/Attribution/SupportedPlatformAttribute.cs
+++ b/test/DebuggerTesting/Attribution/SupportedPlatformAttribute.cs
@@ -1,0 +1,34 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+
+namespace DebuggerTesting
+{
+    /// <summary>
+    /// Attribute used by xUnit theory test for specifying which platforms and platform architectures
+    /// are required by the test.
+    /// </summary>
+    [AttributeUsage(AttributeTargets.Method, AllowMultiple = false, Inherited = false)]
+    public class SupportedPlatformAttribute :
+        Attribute
+    {
+        #region Constructor
+
+        public SupportedPlatformAttribute(SupportedPlatform platform, SupportedArchitecture architecture)
+        {
+            this.Architecture = architecture;
+            this.Platform = platform;
+        }
+
+        #endregion
+
+        #region Properties
+
+        public SupportedArchitecture Architecture { get; private set; }
+
+        public SupportedPlatform Platform { get; private set; }
+
+        #endregion
+    }
+}

--- a/test/DebuggerTesting/Attribution/TestSettings.cs
+++ b/test/DebuggerTesting/Attribution/TestSettings.cs
@@ -1,0 +1,118 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Collections.Generic;
+using System.Text;
+using DebuggerTesting.Utilities;
+
+namespace DebuggerTesting
+{
+    internal sealed class TestSettings :
+        ITestSettings
+    {
+        #region Constructor
+
+        internal TestSettings(
+            SupportedArchitecture debuggeeArchitecture,
+            string compilerName,
+            SupportedCompiler compilerType,
+            string compilerPath,
+            IDictionary<string, string> compilerProperties,
+            string debuggerName,
+            SupportedDebugger debuggerType,
+            string debuggerPath,
+            string debuggerAdapterPath,
+            string miMode,
+            IDictionary<string, string> debuggerProperties)
+        {
+            this.CompilerSettings = new CompilerSettings(compilerName, compilerType, compilerPath, debuggeeArchitecture, compilerProperties);
+            this.DebuggerSettings = new DebuggerSettings(debuggerName, debuggerType, debuggerPath, debuggerAdapterPath, miMode, debuggeeArchitecture, debuggerProperties);
+        }
+
+        private TestSettings(ITestSettings original, string name)
+        {
+            this.Name = name;
+            this.CompilerSettings = original.CompilerSettings;
+            this.DebuggerSettings = original.DebuggerSettings;
+        }
+
+        #endregion
+
+        #region Methods
+
+        public static bool operator ==(TestSettings left, TestSettings right)
+        {
+            if (Object.ReferenceEquals(left, null))
+                return Object.ReferenceEquals(right, null);
+
+            return left.Equals(right);
+        }
+
+        public static bool operator !=(TestSettings left, TestSettings right)
+        {
+            if (Object.ReferenceEquals(left, null))
+                return !Object.ReferenceEquals(right, null);
+
+            return !left.Equals(right);
+        }
+
+        internal static ITestSettings CloneWithName(ITestSettings original, string name)
+        {
+            return new TestSettings(original, name);
+        }
+
+        public override bool Equals(object obj)
+        {
+            return this.Equals(obj as TestSettings);
+        }
+
+        public bool Equals(TestSettings obj)
+        {
+            if (Object.ReferenceEquals(obj, null))
+                return false;
+
+            if (!String.Equals(this.Name, obj.Name, StringComparison.Ordinal))
+                return false;
+
+            if (this.CompilerSettings != obj.CompilerSettings)
+                return false;
+
+            if (this.DebuggerSettings != obj.DebuggerSettings)
+                return false;
+
+            return true;
+        }
+
+        public override int GetHashCode()
+        {
+            return HashUtilities.CombineHashCodes(
+                this.Name?.GetHashCode() ?? 0,
+                this.CompilerSettings?.GetHashCode() ?? 0,
+                this.DebuggerSettings?.GetHashCode() ?? 0);
+        }
+
+        public override string ToString()
+        {
+            StringBuilder builder = new StringBuilder();
+            builder.Append(this.CompilerSettings.CompilerName);
+            builder.Append("/");
+            builder.Append(this.CompilerSettings.DebuggeeArchitecture);
+            builder.Append("/");
+            builder.Append(this.DebuggerSettings.DebuggerName);
+            return builder.ToString();
+        }
+
+        #endregion
+
+        #region Properties
+
+        public string Name { get; private set; }
+
+        public ICompilerSettings CompilerSettings { get; private set; }
+
+        public IDebuggerSettings DebuggerSettings { get; private set; }
+
+        #endregion
+    }
+}

--- a/test/DebuggerTesting/Attribution/TestSettingsHelper.cs
+++ b/test/DebuggerTesting/Attribution/TestSettingsHelper.cs
@@ -1,0 +1,232 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using System.Xml;
+using System.Xml.Linq;
+using DebuggerTesting.Attribution;
+using DebuggerTesting.TestFramework;
+using DebuggerTesting.Utilities;
+using Xunit;
+
+namespace DebuggerTesting
+{
+    public static class TestSettingsHelper
+    {
+        #region Methods
+
+        internal static IEnumerable<ITestSettings> FilterSettings(this IEnumerable<ITestSettings> settings, MethodInfo methodInfo, SupportedPlatform platform, SupportedArchitecture platformArchitecture)
+        {
+            // Makre sure that the test runs for the platform and platform architecture
+            SupportedPlatformAttribute platformAttribute = methodInfo.GetCustomAttribute<SupportedPlatformAttribute>();
+            // If platform attribute is not specified, implicitly assume that all platforms are supported
+            if (null != platformAttribute)
+            {
+                if (!platformAttribute.Platform.HasFlag(platform))
+                    return Enumerable.Empty<ITestSettings>();
+                if (!platformAttribute.Architecture.HasFlag(platformArchitecture))
+                    return Enumerable.Empty<ITestSettings>();
+            }
+
+            IReadOnlyCollection<SupportedCompilerAttribute> supportedCompilers = methodInfo.GetCustomAttributes<SupportedCompilerAttribute>().ToArray();
+            IReadOnlyCollection<SupportedDebuggerAttribute> supportedDebuggers = methodInfo.GetCustomAttributes<SupportedDebuggerAttribute>().ToArray();
+            IReadOnlyCollection<UnsupportedDebuggerAttribute> unsupportedDebuggers = methodInfo.GetCustomAttributes<UnsupportedDebuggerAttribute>().ToArray();
+
+            // Get the subset of test settings that match the requirements of the test.
+            // The test will be run for each test setting in the set. If an empty set is returned,
+            // the test is not run.
+            return settings.Where(s =>
+                (supportedCompilers.Count == 0 || supportedCompilers.Matches(s.CompilerSettings)) &&
+                (supportedDebuggers.Count == 0 || supportedDebuggers.Matches(s.DebuggerSettings)) &&
+                !unsupportedDebuggers.Matches(s.DebuggerSettings))
+                .Select(x => TestSettings.CloneWithName(x, methodInfo.Name))
+                .ToArray();
+        }
+
+        private static SupportedArchitecture GetArchitecture(this XElement element, string attributeName)
+        {
+            return element.GetAttributeEnum<SupportedArchitecture>(attributeName);
+        }
+
+        private static SupportedCompiler GetCompiler(this XElement element, string attributeName)
+        {
+            return element.GetAttributeEnum<SupportedCompiler>(attributeName);
+        }
+
+        private static SupportedDebugger GetDebugger(this XElement element, string attributeName)
+        {
+            return element.GetAttributeEnum<SupportedDebugger>(attributeName);
+        }
+
+        internal static IEnumerable<ITestSettings> GetSettings(MethodInfo testMethod, SupportedPlatform platform, SupportedArchitecture platformArchitecture)
+        {
+            Parameter.AssertIfNull(testMethod, nameof(testMethod));
+
+            // Find the attribute in the context of the test method.
+            // Currently, only look at the assembly of the test method.
+            TestSettingsProviderAttribute providerAttribute = testMethod.DeclaringType?.GetTypeInfo().Assembly?.GetCustomAttribute<TestSettingsProviderAttribute>();
+            UDebug.AssertNotNull(providerAttribute, "Unable to locate TestSettingsProviderAttribute.");
+            if (null == providerAttribute)
+                return Enumerable.Empty<ITestSettings>();
+
+            UDebug.AssertNotNull(providerAttribute.ProviderType, "TestSettingsProviderAttribute.ProviderType is null");
+            if (null == providerAttribute.ProviderType)
+                return Enumerable.Empty<ITestSettings>();
+
+            ITestSettingsProvider provider = null;
+            lock (s_providerMapping)
+            {
+                // Get the provider from the attribute if the provider was not already created
+                if (!s_providerMapping.TryGetValue(providerAttribute.ProviderType, out provider))
+                {
+                    // If not cached, create the provide from the attribute and cache it
+                    provider = (ITestSettingsProvider)Activator.CreateInstance(providerAttribute.ProviderType);
+                    s_providerMapping.Add(providerAttribute.ProviderType, provider);
+                }
+            }
+
+            // Get the list of settings from the provider
+            IEnumerable<ITestSettings> settings = provider.GetSettings(testMethod);
+            UDebug.AssertNotNull(settings, "Settings were not provided by the test settings provider.");
+            if (null == settings)
+                return Enumerable.Empty<ITestSettings>();
+
+            // Filter the settings according to the attribution on the test method
+            return settings.FilterSettings(testMethod, platform, platformArchitecture);
+        }
+
+        public static IEnumerable<ITestSettings> LoadSettingsFromConfig(string configPath)
+        {
+            Assert.True(File.Exists(configPath), "Test configuration should exist at '{0}'".FormatInvariantWithArgs(configPath));
+
+            using (XmlReader machineReader = XmlHelper.CreateXmlReader(configPath))
+            {
+                XDocument machineConfigDoc = null;
+                try
+                {
+                    machineConfigDoc = XDocument.Load(machineReader);
+                }
+                catch (XmlException) { }
+                Assert.True(null != machineConfigDoc, "Object loaded from '{0}' is not a TestMachineConfiguration. Invalid Xml.".FormatInvariantWithArgs(configPath));
+
+                XElement machineConfig = machineConfigDoc.Element("TestMachineConfiguration");
+                Assert.True(null != machineConfig, "Object loaded from '{0}' is not a TestMachineConfiguration. Missing TestMachineConfiguration.".FormatInvariantWithArgs(configPath));
+
+                // Get the list of compilers
+                var compilers = machineConfig
+                    .Element("Compilers")
+                    .Elements("Compiler")
+                    .ToDictionary(
+                        x => x.GetAttributeValue("Name"),
+                        x => new
+                        {
+                            Name = x.GetAttributeValue("Name"),
+                            Type = x.GetCompiler("Type"),
+                            Path = x.GetAttributeValue("Path"),
+                            Properties = x.GetPropertiesDictionary()
+                        });
+                Assert.True(null != compilers && compilers.Count != 0, "Object loaded from '{0}' is not a TestMachineConfiguration. Missing Compilers.".FormatInvariantWithArgs(configPath));
+
+                // Get the list of debuggers
+                var debuggers = machineConfig
+                    .Element("Debuggers")
+                    .Elements("Debugger")
+                    .ToDictionary(
+                        x => x.GetAttributeValue("Name"),
+                        x => new
+                        {
+                            Name = x.GetAttributeValue("Name"),
+                            Type = x.GetDebugger("Type"),
+                            Path = x.GetAttributeValue("Path"),
+                            AdapterPath = x.GetAttributeValue("AdapterPath"),
+                            MIMode = x.GetAttributeValue("MIMode"),
+                            Properties = x.GetPropertiesDictionary()
+                        });
+                Assert.True(null != debuggers && debuggers.Count != 0, "Object loaded from '{0}' is not a TestMachineConfiguration. Missing Debuggers.".FormatInvariantWithArgs(configPath));
+
+                // Get the list of test configurations
+                var testConfigurations = machineConfig
+                    .Element("TestConfigurations")
+                    .Elements("TestConfiguration")
+                    .Select(x => new
+                    {
+                        DebuggeeArchitecture = x.GetArchitecture("DebuggeeArchitecture"),
+                        CompilerName = x.GetAttributeValue("Compiler"),
+                        DebuggerName = x.GetAttributeValue("Debugger")
+                    });
+                Assert.True(null != testConfigurations && testConfigurations.Count() != 0, "Object loaded from '{0}' is not a TestMachineConfiguration. Missing TestConfigurations.".FormatInvariantWithArgs(configPath));
+
+                // Create a TestSettings for each combination of architectures, compilers, and debuggers
+                var testSettings =
+                    from testConfiguration in testConfigurations
+                    where compilers.ContainsKey(testConfiguration.CompilerName)
+                    where debuggers.ContainsKey(testConfiguration.DebuggerName)
+                    select new
+                    {
+                        DebuggeeArchitecture = testConfiguration.DebuggeeArchitecture,
+                        Compiler = compilers[testConfiguration.CompilerName],
+                        Debugger = debuggers[testConfiguration.DebuggerName]
+                    }
+                    into config
+                    select new TestSettings(
+                        config.DebuggeeArchitecture,
+                        config.Compiler.Name,
+                        config.Compiler.Type,
+                        SafeExpandEnvironmentVariables(config.Compiler.Path),
+                        config.Compiler.Properties,
+                        config.Debugger.Name,
+                        config.Debugger.Type,
+                        SafeExpandEnvironmentVariables(config.Debugger.Path),
+                        SafeExpandEnvironmentVariables(config.Debugger.AdapterPath),
+                        config.Debugger.MIMode,
+                        config.Debugger.Properties);
+
+                // Force evaluation
+                return testSettings.ToArray();
+            }
+        }
+
+        /// <summary>
+        /// Reads a property bag in the XML and turns it to a dictionary.
+        /// </summary>
+        private static IDictionary<string, string> GetPropertiesDictionary(this XElement element)
+        {
+            return element
+                .Element("Properties")
+                ?.Elements("Property")
+                ?.ToDictionary(p => p.GetAttributeValue("Name"), p => SafeExpandEnvironmentVariables(p.Value), StringComparer.Ordinal);
+        }
+
+        private static bool Matches(this IEnumerable<SupportedCompilerAttribute> compilers, ICompilerSettings settings)
+        {
+            return compilers.Any(ca => ca.Compiler.HasFlag(settings.CompilerType) && ca.Architecture.HasFlag(settings.DebuggeeArchitecture));
+        }
+
+        private static bool Matches(this IEnumerable<DebuggerAttribute> debuggers, IDebuggerSettings settings)
+        {
+            return debuggers.Any(da => da.Debugger.HasFlag(settings.DebuggerType) && da.Architecture.HasFlag(settings.DebuggeeArchitecture));
+        }
+
+        private static string SafeExpandEnvironmentVariables(string value)
+        {
+            if (!String.IsNullOrEmpty(value))
+            {
+                value = Environment.ExpandEnvironmentVariables(value);
+            }
+            return value;
+        }
+
+        #endregion
+
+        #region Fields
+
+        private static IDictionary<Type, ITestSettingsProvider> s_providerMapping =
+            new Dictionary<Type, ITestSettingsProvider>();
+
+        #endregion
+    }
+}

--- a/test/DebuggerTesting/Attribution/TestSettingsProviderAttribute.cs
+++ b/test/DebuggerTesting/Attribution/TestSettingsProviderAttribute.cs
@@ -1,0 +1,33 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using DebuggerTesting.TestFramework;
+
+namespace DebuggerTesting.Attribution
+{
+    /// <summary>
+    /// Attribute used to specify which class is used from providing test settings.
+    /// </summary>
+    [AttributeUsage(AttributeTargets.Assembly, AllowMultiple = false, Inherited = false)]
+    public sealed class TestSettingsProviderAttribute :
+        Attribute
+    {
+        #region Constructor
+
+        public TestSettingsProviderAttribute(Type providerType)
+        {
+            Parameter.AssertIfNotOfType<ITestSettingsProvider>(providerType, nameof(providerType));
+
+            this.ProviderType = providerType;
+        }
+
+        #endregion
+
+        #region Properties
+
+        public Type ProviderType { get; private set; }
+
+        #endregion
+    }
+}

--- a/test/DebuggerTesting/Attribution/UnsupportedDebuggerAttribute.cs
+++ b/test/DebuggerTesting/Attribution/UnsupportedDebuggerAttribute.cs
@@ -1,0 +1,24 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+
+namespace DebuggerTesting
+{
+    /// <summary>
+    /// Attribute used by xUnit theory test for specifying which debuggers will not be used by the test.
+    /// </summary>
+    [AttributeUsage(AttributeTargets.Method, AllowMultiple = true, Inherited = false)]
+    public class UnsupportedDebuggerAttribute :
+        DebuggerAttribute
+    {
+        #region Constructor
+
+        public UnsupportedDebuggerAttribute(SupportedDebugger debugger, SupportedArchitecture architecture)
+            : base(debugger, architecture)
+        {
+        }
+
+        #endregion
+    }
+}

--- a/test/DebuggerTesting/Compilation/ClangCompiler.cs
+++ b/test/DebuggerTesting/Compilation/ClangCompiler.cs
@@ -1,0 +1,22 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using DebuggerTesting.Utilities;
+
+namespace DebuggerTesting.Compilation
+{
+    internal sealed class ClangCompiler :
+        GppStyleCompiler
+    {
+        public ClangCompiler(ILoggingComponent logger, ICompilerSettings settings)
+            : base(logger, settings)
+        {
+        }
+
+        protected override void SetAdditionalArguments(ArgumentBuilder builder)
+        {
+            base.SetAdditionalArguments(builder);
+            DefineConstant(builder, "DEBUGGEE_COMPILER", "Clang");
+        }
+    }
+}

--- a/test/DebuggerTesting/Compilation/CompilerBase.cs
+++ b/test/DebuggerTesting/Compilation/CompilerBase.cs
@@ -1,0 +1,143 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Collections.Generic;
+using System.Collections.Specialized;
+using System.Diagnostics;
+using System.IO;
+using DebuggerTesting.Utilities;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace DebuggerTesting.Compilation
+{
+    internal abstract class CompilerBase : ICompiler, ILoggingComponent
+    {
+        #region Constructor
+
+        public CompilerBase(ILoggingComponent logger, ICompilerSettings settings, bool addDebuggerDirToPath)
+        {
+            Parameter.ThrowIfNull(logger, nameof(logger));
+            Parameter.ThrowIfNull(settings, nameof(settings));
+
+            this.addDebuggerDirToPath = addDebuggerDirToPath;
+            this.OutputHelper = logger.OutputHelper;
+            this.Settings = settings;
+        }
+
+        #endregion
+
+        #region ICompiler Members
+
+        public void Compile(
+            CompilerOutputType outputType,
+            IEnumerable<string> libraries,
+            IEnumerable<string> sourceFilePaths,
+            string targetFilePath,
+            CompilerOption options,
+            IDictionary<string, string> defineConstants)
+        {
+            Parameter.ThrowIfNull(libraries, nameof(libraries));
+            Parameter.ThrowIfNull(sourceFilePaths, nameof(sourceFilePaths));
+            Parameter.ThrowIfNullOrWhiteSpace(targetFilePath, nameof(targetFilePath));
+            Parameter.ThrowIfNull(defineConstants, nameof(defineConstants));
+
+            bool result = this.CompileCore(outputType,
+                this.Settings.DebuggeeArchitecture,
+                libraries,
+                sourceFilePaths,
+                targetFilePath,
+                options,
+                defineConstants);
+
+            Assert.True(result, "The compilation failed.");
+
+            // If the output file was not created, then error
+            Assert.True(File.Exists(targetFilePath), "The compiler did not create the expected output. " + targetFilePath);
+        }
+
+        #endregion
+
+        #region ILoggingComponent Members
+
+        public ITestOutputHelper OutputHelper { get; private set; }
+
+        #endregion
+
+        #region Methods
+
+        protected abstract bool CompileCore(
+            CompilerOutputType outputType,
+            SupportedArchitecture architecture,
+            IEnumerable<string> libraries,
+            IEnumerable<string> sourceFilePaths,
+            string targetFilePath,
+            CompilerOption options,
+            IDictionary<string, string> defineConstants);
+
+        protected int RunCompiler(string compilerArguments, string targetFilePath)
+        {
+            this.WriteLine("Compiling target \"{0}\"", targetFilePath);
+            this.WriteLine("Calling compiler \"{0}\" with arguments \"{1}\"", this.Settings.CompilerPath, compilerArguments);
+
+            string targetDir = Path.GetDirectoryName(targetFilePath);
+            if (!Directory.Exists(targetDir))
+            {
+                this.WriteLine("Creating \"{0}\" because it does not exist.", targetDir);
+                Directory.CreateDirectory(targetDir);
+            }
+
+            using (Process process = ProcessHelper.CreateProcess(this.Settings.CompilerPath, compilerArguments))
+            {
+                if (this.addDebuggerDirToPath)
+                {
+                    process.AddToPath(Path.GetDirectoryName(this.Settings.CompilerPath));
+                }
+
+                process.Start();
+                process.WaitForExit(60 * 1000);
+
+                if (!process.StandardOutput.EndOfStream)
+                {
+                    this.WriteLine("Compiler standard output:");
+                    this.WriteLines(process.StandardOutput);
+                }
+                if (!process.StandardError.EndOfStream)
+                {
+                    this.WriteLine("Compiler standard error:");
+                    this.WriteLines(process.StandardError);
+                }
+                this.WriteLine("Compiler exited with code {0}", process.ExitCode);
+
+                return process.ExitCode;
+            }
+        }
+
+        protected static string GetPlatformName()
+        {
+            if (PlatformUtilities.IsWindows)
+                return "WINDOWS";
+            else if (PlatformUtilities.IsLinux)
+                return "LINUX";
+            else if (PlatformUtilities.IsOSX)
+                return "OSX";
+            else
+                return "UNKNOWN";
+        }
+
+
+        #endregion
+
+        #region Properties
+
+        protected ICompilerSettings Settings { get; private set; }
+
+        #endregion
+
+        #region Fields
+
+        private bool addDebuggerDirToPath;
+
+        #endregion
+    }
+}

--- a/test/DebuggerTesting/Compilation/CompilerOption.cs
+++ b/test/DebuggerTesting/Compilation/CompilerOption.cs
@@ -1,0 +1,18 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+
+namespace DebuggerTesting.Compilation
+{
+    [Flags]
+    public enum CompilerOption
+    {
+        None = 0x0,
+        GenerateSymbols = 0x1,
+        SupportThreading = 0x2,
+        OptimizeLevel1 = 0x4,  
+        OptimizeLevel2 = 0x8,
+        OptimizeLevel3 = 0x10
+    }
+}

--- a/test/DebuggerTesting/Compilation/CompilerOutputType.cs
+++ b/test/DebuggerTesting/Compilation/CompilerOutputType.cs
@@ -1,0 +1,13 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace DebuggerTesting.Compilation
+{
+    public enum CompilerOutputType
+    {
+        Unspecified = 0,
+        ObjectFile,
+        SharedLibrary,
+        Executable
+    }
+}

--- a/test/DebuggerTesting/Compilation/Debuggee.cs
+++ b/test/DebuggerTesting/Compilation/Debuggee.cs
@@ -1,0 +1,252 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.Linq;
+using DebuggerTesting.Settings;
+using DebuggerTesting.Utilities;
+using Xunit.Abstractions;
+
+namespace DebuggerTesting.Compilation
+{
+    public class Debuggee :
+        IDebuggee, ILoggingComponent
+    {
+        #region Constructor
+
+        private Debuggee(ILoggingComponent logger, ICompilerSettings settings, string debuggeeName, int debuggeeMoniker, string outputName, CompilerOutputType outputType)
+        {
+            Parameter.ThrowIfNull(logger, nameof(logger));
+            Parameter.ThrowIfNullOrWhiteSpace(debuggeeName, nameof(debuggeeName));
+            Parameter.ThrowIfNegativeOrZero(debuggeeMoniker, nameof(debuggeeMoniker));
+            Parameter.ThrowIfNull(settings, nameof(settings));
+
+            this.OutputHelper = logger.OutputHelper;
+            this.compilerDefineConstants = new Dictionary<string, string>();
+            this.debuggeeName = debuggeeName;
+            this.debuggeeMoniker = debuggeeMoniker;
+            this.CompilerOptions = CompilerOption.GenerateSymbols;
+            this.libraries = new List<string>();
+            this.outputType = outputType;
+            this.settings = settings;
+            this.sourceFilePaths = new List<string>();
+
+            if (String.IsNullOrEmpty(outputName))
+            {
+                // If the outputName was not provided, assume it is called "a.out" and update the extension
+                outputName = Debuggee.UpdateOutputName("a.out", outputType);
+            }
+            else if (String.IsNullOrEmpty(Path.GetExtension(outputName)))
+            {
+                // If the outputName has no extension, add the appropriate extension
+                outputName = Debuggee.UpdateOutputName(outputName, outputType);
+            }
+
+            this.outputName = outputName;
+        }
+
+        private Debuggee(Debuggee debuggee)
+        {
+            Parameter.ThrowIfNull(debuggee, nameof(debuggee));
+
+            this.OutputHelper = debuggee.OutputHelper;
+            this.compilerDefineConstants = new Dictionary<string, string>(debuggee.compilerDefineConstants);
+            this.debuggeeName = debuggee.debuggeeName;
+            this.debuggeeMoniker = debuggee.debuggeeMoniker;
+            this.CompilerOptions = debuggee.CompilerOptions;
+            this.libraries = debuggee.libraries.ToList();
+            this.outputName = debuggee.outputName;
+            this.outputType = debuggee.outputType;
+            this.settings = debuggee.settings;
+            this.sourceFilePaths = debuggee.sourceFilePaths.ToList();
+        }
+
+        #endregion
+
+        #region IDebuggee Members
+
+        public void AddDefineConstant(string name, string value = null)
+        {
+            this.compilerDefineConstants.Add(name, value);
+        }
+
+        void IDebuggee.AddLibraries(params string[] libraries)
+        {
+            this.libraries.AddRange(libraries);
+        }
+
+        void IDebuggee.AddSourceFiles(params string[] fileNames)
+        {
+            this.sourceFilePaths.AddRange(fileNames.Select(n => Path.Combine(this.SourceRoot, n)));
+        }
+
+        IDebuggee IDebuggee.Clone()
+        {
+            return new Debuggee(this);
+        }
+
+        void IDebuggee.Compile()
+        {
+            ICompiler compiler = Debuggee.CreateCompiler(this, this.settings);
+            compiler.Compile(
+                this.outputType,
+                this.libraries,
+                this.sourceFilePaths,
+                this.OutputPath,
+                this.CompilerOptions,
+                this.compilerDefineConstants);
+        }
+
+        Process IDebuggee.Launch(params string[] arguments)
+        {
+            string allArguments = string.Join(" ", arguments);
+            this.WriteLine("Launching debuggee {0} {1}", this.OutputPath, allArguments);
+            Process p = ProcessHelper.CreateProcess(this.OutputPath, allArguments);
+            if (PlatformUtilities.IsWindows)
+            {
+                p.AddToPath(Path.GetDirectoryName(this.settings.CompilerPath));
+            }
+            p.Start();
+            return p;
+        }
+
+        public CompilerOption CompilerOptions { get; set; }
+
+        public string OutputPath
+        {
+            get { return Path.Combine(this.GetOutputRoot(this.settings), this.outputName); }
+        }
+
+        public CompilerOutputType OutputType
+        {
+            get { return this.outputType; }
+        }
+
+        public string SourceRoot
+        {
+            get { return Path.Combine(this.DebuggeeInstance, "src"); }
+        }
+
+        #endregion
+
+        #region ILoggingComponent Members
+
+        public ITestOutputHelper OutputHelper { get; private set; }
+
+        #endregion
+
+        #region Methods
+
+        /// <summary>
+        /// Creates a new debuggee instance. This will copy the debuggee into a new folder based on the debuggeeMoniker.
+        /// This should only be called once per debuggee.
+        /// </summary>
+        public static IDebuggee Create(ILoggingComponent logger, ICompilerSettings settings, string debuggeeName, int debuggeeMoniker, string outputName = null, CompilerOutputType outputType = CompilerOutputType.Executable)
+        {
+            Debuggee newDebuggee = new Debuggee(logger, settings, debuggeeName, debuggeeMoniker, outputName, outputType);
+            newDebuggee.CopySource();
+            return newDebuggee;
+        }
+
+        /// <summary>
+        /// Opens an existing debuggee instance.
+        /// </summary>
+        public static IDebuggee Open(ILoggingComponent logger, ICompilerSettings settings, string debuggeeName, int debuggeeMoniker, string outputName = null, CompilerOutputType outputType = CompilerOutputType.Executable)
+        {
+            return new Debuggee(logger, settings, debuggeeName, debuggeeMoniker, outputName, outputType);
+        }
+
+
+        private static CompilerBase CreateCompiler(ILoggingComponent logger, ICompilerSettings settings)
+        {
+            switch (settings.CompilerType)
+            {
+                case SupportedCompiler.GPlusPlus:
+                    return new GppCompiler(logger, settings);
+                case SupportedCompiler.ClangPlusPlus:
+                    return new ClangCompiler(logger, settings);
+                case SupportedCompiler.VisualCPlusPlus:
+                    return new VisualCPlusPlusCompiler(logger, settings);
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(settings.CompilerType), "Unhandled compiler toolset: " + settings.CompilerType);
+            }
+        }
+
+        private string GetOutputRoot(ICompilerSettings settings)
+        {
+            return Path.Combine(this.DebuggeeInstance, "out", settings.CompilerName, settings.DebuggeeArchitecture.ToArchitectureString());
+        }
+
+        private void CopySource()
+        {
+            try
+            {
+                this.WriteLine("Creating instance of debuggee by copying source.");
+                FileUtilities.DirectoryCopy(this.DebuggeeRoot, this.DebuggeeInstance, true);
+            }
+            catch (IOException ex)
+            {
+                this.WriteLine("Error copying debuggee folder. Copying from '{0}' to '{1}'.", this.DebuggeeRoot, this.DebuggeeInstance);
+                this.WriteLine(UDebug.ExceptionToString(ex));
+                throw;
+            }
+        }
+
+        private static string UpdateOutputName(string outputName, CompilerOutputType outputType)
+        {
+            switch (outputType)
+            {
+                case CompilerOutputType.Executable:
+                    if (PlatformUtilities.IsWindows)
+                        return Path.ChangeExtension(outputName, "exe");
+                    else
+                        return outputName;
+                case CompilerOutputType.SharedLibrary:
+                    if (PlatformUtilities.IsWindows)
+                        return Path.ChangeExtension(outputName, "dll");
+                    else
+                        return Path.ChangeExtension(outputName, "so");
+                default:
+                    throw new NotSupportedException("Support for output type '{0}' has not been implemented.".FormatInvariantWithArgs(outputType));
+            }
+        }
+
+        #endregion
+
+        #region Properties
+
+        // The folder that contains the original source of the debuggee
+        private string DebuggeeRoot
+        {
+            get { return Path.Combine(PathSettings.DebuggeesPath, this.debuggeeName); }
+        }
+
+        // The folder that contains the specific instance of the debuggee (suffixed by the debuggee moniker)
+        private string DebuggeeInstance
+        {
+            get
+            {
+                string debuggeeInstanceName = "{0}-{1}".FormatInvariantWithArgs(this.debuggeeName, this.debuggeeMoniker);
+                return Path.Combine(PathSettings.DebuggeesPath, "instance", debuggeeInstanceName);
+            }
+        }
+
+        #endregion
+
+        #region Fields
+
+        private Dictionary<string, string> compilerDefineConstants;
+        private string debuggeeName;
+        private int debuggeeMoniker;
+        private List<string> libraries;
+        private string outputName;
+        private CompilerOutputType outputType;
+        private ICompilerSettings settings;
+        private List<string> sourceFilePaths;
+
+        #endregion
+    }
+}

--- a/test/DebuggerTesting/Compilation/GppCompiler.cs
+++ b/test/DebuggerTesting/Compilation/GppCompiler.cs
@@ -1,0 +1,22 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using DebuggerTesting.Utilities;
+
+namespace DebuggerTesting.Compilation
+{
+    internal sealed class GppCompiler :
+        GppStyleCompiler
+    {
+        public GppCompiler(ILoggingComponent logger, ICompilerSettings settings)
+            : base(logger, settings)
+        {
+        }
+
+        protected override void SetAdditionalArguments(ArgumentBuilder builder)
+        {
+            base.SetAdditionalArguments(builder);
+            DefineConstant(builder, "DEBUGGEE_COMPILER", "G++");
+        }
+    }
+}

--- a/test/DebuggerTesting/Compilation/GppStyleCompiler.cs
+++ b/test/DebuggerTesting/Compilation/GppStyleCompiler.cs
@@ -1,0 +1,144 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Collections.Generic;
+using DebuggerTesting.Utilities;
+
+namespace DebuggerTesting.Compilation
+{
+    internal abstract class GppStyleCompiler :
+        CompilerBase
+    {
+        #region Constructor
+
+        public GppStyleCompiler(ILoggingComponent logger, ICompilerSettings settings)
+            : base(logger, settings, PlatformUtilities.IsWindows)
+        {
+        }
+
+        #endregion
+
+        #region Methods
+
+        protected override bool CompileCore(
+            CompilerOutputType outputType,
+            SupportedArchitecture architecture,
+            IEnumerable<string> libraries,
+            IEnumerable<string> sourceFilePaths,
+            string targetFilePath,
+            CompilerOption options,
+            IDictionary<string, string> defineConstants)
+        {
+            ArgumentBuilder builder = new ArgumentBuilder("-", String.Empty);
+            if (options.HasFlag(CompilerOption.GenerateSymbols))
+            {
+                builder.AppendNamedArgument("g", null);
+            }
+
+            if (options.HasFlag(CompilerOption.OptimizeLevel1))
+            {
+                builder.AppendNamedArgument("O1", null);
+            }
+            else if (options.HasFlag(CompilerOption.OptimizeLevel2))
+            {
+                builder.AppendNamedArgument("O2", null);
+            }
+            else if (options.HasFlag(CompilerOption.OptimizeLevel3))
+            {
+                builder.AppendNamedArgument("O3", null);
+            }
+            else
+            {
+                builder.AppendNamedArgument("O0", null);
+            }
+
+            // Enable pthreads
+            if (options.HasFlag(CompilerOption.SupportThreading))
+            {
+                builder.AppendNamedArgument("pthread", null);
+            }
+
+            // Just use C++ 11
+            builder.AppendNamedArgument("std", "c++11", "=");
+
+            switch (outputType)
+            {
+                case CompilerOutputType.SharedLibrary:
+                    builder.AppendNamedArgument("shared", null);
+                    builder.AppendNamedArgument("fpic", null);
+                    break;
+                case CompilerOutputType.ObjectFile:
+                    builder.AppendNamedArgument("c", null);
+                    builder.AppendNamedArgument("fpic", null);
+                    break;
+                case CompilerOutputType.Unspecified:
+                // Treat Unspecified as Executable, since executable is the default
+                case CompilerOutputType.Executable:
+                    // Compiling an executable does not have a command line option, it's the default
+                    break;
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(outputType), "Unhandled output type: " + outputType);
+            }
+
+            switch (architecture)
+            {
+                case SupportedArchitecture.x64:
+                    builder.AppendNamedArgument("m", "64");
+                    DefineConstant(builder, "DEBUGGEE_ARCH", "64");
+                    break;
+                case SupportedArchitecture.x86:
+                    builder.AppendNamedArgument("m", "32");
+                    DefineConstant(builder, "DEBUGGEE_ARCH", "32");
+                    break;
+                case SupportedArchitecture.arm:
+                    builder.AppendNamedArgument("m", "arm");
+                    DefineConstant(builder, "DEBUGGEE_ARCH", "ARM");
+                    break;
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(architecture), "Unhandled target architecture: " + architecture);
+            }
+
+            // Define a constant for the platform name.
+            DefineConstant(builder, "DEBUGGEE_PLATFORM", GetPlatformName());
+
+            this.SetAdditionalArguments(builder);
+
+            builder.AppendNamedArgument("o", targetFilePath);
+
+            foreach (string sourceFilePath in sourceFilePaths)
+            {
+                builder.AppendArgument(sourceFilePath);
+            }
+
+            foreach (string library in libraries)
+            {
+                builder.AppendNamedArgument("l", library);
+            }
+
+            foreach (var defineConstant in defineConstants)
+            {
+                DefineConstant(builder, defineConstant.Key, defineConstant.Value);
+            }
+
+            return 0 == this.RunCompiler(builder.ToString(), targetFilePath);
+        }
+
+        protected static void DefineConstant(ArgumentBuilder builder, string name, string value = null)
+        {
+            string constant = name;
+            if (value != null)
+                constant += "=" + ArgumentBuilder.MakeQuotedIfRequired(value);
+            builder.AppendNamedArgument("D", constant);
+        }
+
+        /// <summary>
+        /// Add any compiler specific aguments to the command line
+        /// </summary>
+        protected virtual void SetAdditionalArguments(ArgumentBuilder builder)
+        {
+        }
+
+        #endregion
+    }
+}

--- a/test/DebuggerTesting/Compilation/ICompiler.cs
+++ b/test/DebuggerTesting/Compilation/ICompiler.cs
@@ -1,0 +1,22 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Collections.Generic;
+
+namespace DebuggerTesting.Compilation
+{
+    internal interface ICompiler
+    {
+        #region Methods
+
+        void Compile(
+            CompilerOutputType outputType,
+            IEnumerable<string> libraries,
+            IEnumerable<string> sourceFilePaths,
+            string targetFilePath,
+            CompilerOption options,
+            IDictionary<string, string> defineConstants);
+
+        #endregion
+    }
+}

--- a/test/DebuggerTesting/Compilation/IDebuggee.cs
+++ b/test/DebuggerTesting/Compilation/IDebuggee.cs
@@ -1,0 +1,39 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Diagnostics;
+
+namespace DebuggerTesting.Compilation
+{
+    public interface IDebuggee
+    {
+        #region Methods
+
+        void AddDefineConstant(string name, string value = null);
+
+        void AddLibraries(params string[] libraries);
+
+        void AddSourceFiles(params string[] fileNames);
+
+        IDebuggee Clone();
+
+        void Compile();
+
+        Process Launch(params string[] arguments);
+
+        #endregion
+
+        #region Properties
+
+        CompilerOption CompilerOptions { get; set; }
+
+        string OutputPath { get; }
+
+        CompilerOutputType OutputType { get; }
+
+        string SourceRoot { get; }
+
+        #endregion
+    }
+}

--- a/test/DebuggerTesting/Compilation/VisualCPlusPlusCompiler.cs
+++ b/test/DebuggerTesting/Compilation/VisualCPlusPlusCompiler.cs
@@ -1,0 +1,189 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using DebuggerTesting.Utilities;
+
+namespace DebuggerTesting.Compilation
+{
+    internal class VisualCPlusPlusCompiler : CompilerBase
+    {
+        public VisualCPlusPlusCompiler(ILoggingComponent logger, ICompilerSettings settings)
+            : base(logger, settings, addDebuggerDirToPath: false)
+        {
+        }
+
+        protected override bool CompileCore(
+            CompilerOutputType outputType,
+            SupportedArchitecture architecture,
+            IEnumerable<string> libraries,
+            IEnumerable<string> sourceFilePaths,
+            string targetFilePath,
+            CompilerOption options,
+            IDictionary<string, string> defineConstants)
+        {
+            ArgumentBuilder clBuilder = new ArgumentBuilder("/", ":");
+            ArgumentBuilder linkBuilder = new ArgumentBuilder("/", ":");
+
+            foreach (var defineConstant in defineConstants)
+            {
+                DefineConstant(clBuilder, defineConstant.Key, defineConstant.Value);
+            }
+            DefineConstant(clBuilder, "_WIN32");
+
+            // Suppresses error C4996 for 'getenv' (in debuggees/kitchensink/src/environment.cpp)
+            DefineConstant(clBuilder, "_CRT_SECURE_NO_WARNINGS");
+
+            if (options.HasFlag(CompilerOption.GenerateSymbols))
+            {
+                clBuilder.AppendNamedArgument("ZI", null);
+                clBuilder.AppendNamedArgument("Debug", null);
+            }
+
+            if (!options.HasFlag(CompilerOption.OptimizeLevel1) &&
+                !options.HasFlag(CompilerOption.OptimizeLevel2) &&
+                !options.HasFlag(CompilerOption.OptimizeLevel3))
+            {
+                // Disable optimization
+                clBuilder.AppendNamedArgument("Od", null);
+            }
+
+            // Add options that are set by default in VS
+            AddDefaultOptions(clBuilder);
+            
+            if (this.Settings.Properties != null)
+            {
+                // Get the include folders from the compiler properties
+                string rawIncludes;
+                if(!this.Settings.Properties.TryGetValue("Include", out rawIncludes))
+                {
+                    rawIncludes = String.Empty;
+                }
+
+                IEnumerable<string> includes = rawIncludes.Split(new[] { ';' }, StringSplitOptions.RemoveEmptyEntries).Select(x => x.Trim());
+                foreach (string include in includes)
+                {
+                    clBuilder.AppendNamedArgumentQuoted("I", include, string.Empty);
+                }
+
+                // Get the lib folders from the compiler properties
+                string rawLibs;
+                if (!this.Settings.Properties.TryGetValue("Lib", out rawLibs))
+                {
+                    rawLibs = String.Empty;
+                }
+
+                IEnumerable<string> libs = rawLibs.Split(new[] { ';' }, StringSplitOptions.RemoveEmptyEntries).Select(x => x.Trim());
+                foreach (string lib in libs)
+                {
+                    linkBuilder.AppendNamedArgumentQuoted("LIBPATH", lib);
+                }
+            }
+
+            switch (outputType)
+            {
+                case CompilerOutputType.SharedLibrary:
+                    // Create.DLL
+                    clBuilder.AppendNamedArgument("LD", null);
+                    clBuilder.AppendNamedArgument("Fo", Path.GetDirectoryName(targetFilePath) + Path.DirectorySeparatorChar);
+                    clBuilder.AppendNamedArgument("Fe", targetFilePath);
+                    break;
+                case CompilerOutputType.ObjectFile:
+                    // Name obj
+                    clBuilder.AppendNamedArgument("Fo", targetFilePath);
+                    break;
+                case CompilerOutputType.Unspecified:
+                // Treat Unspecified as Executable, since executable is the default
+                case CompilerOutputType.Executable:
+                    // Compiling an executable does not have a command line option, it's the default
+                    // Name exe
+                    clBuilder.AppendNamedArgument("Fo", Path.GetDirectoryName(targetFilePath) + Path.DirectorySeparatorChar);
+                    clBuilder.AppendNamedArgument("Fe", targetFilePath);
+                    break;
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(outputType), "Unhandled output type: " + outputType);
+            }
+
+            // Specify the PDB name
+            clBuilder.AppendNamedArgument("Fd", Path.ChangeExtension(targetFilePath, "pdb"));
+
+            // Define a constant for the platform name.
+            DefineConstant(clBuilder, "DEBUGGEE_PLATFORM", GetPlatformName());
+            DefineConstant(clBuilder, "DEBUGGEE_COMPILER", "Visual C++");
+
+            foreach (string sourceFilePath in sourceFilePaths)
+            {
+                clBuilder.AppendArgument(sourceFilePath);
+            }
+
+            foreach (string library in libraries)
+            {
+                clBuilder.AppendArgument(library);
+            }
+
+            switch (architecture)
+            {
+                case SupportedArchitecture.x64:
+                    DefineConstant(clBuilder, "DEBUGGEE_ARCH", "64");
+                    linkBuilder.AppendNamedArgument("MACHINE", "X64");
+                    break;
+                case SupportedArchitecture.x86:
+                    DefineConstant(clBuilder, "DEBUGGEE_ARCH", "32");
+                    linkBuilder.AppendNamedArgument("MACHINE", "X86");
+                    break;
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(architecture), "Unhandled target architecture: " + architecture);
+            }
+
+            // Pass the linker arguments (Note, the link parameter doesn't use the ":" suffix)
+            clBuilder.AppendNamedArgument("link", linkBuilder.ToString(), overrideSuffix: " ");
+
+            return 0 == this.RunCompiler(clBuilder.ToString(), targetFilePath);
+        }
+
+        protected static void DefineConstant(ArgumentBuilder clBuilder, string name, string value = null)
+        {
+            string constant = name;
+            if (value != null)
+                constant += "=" + ArgumentBuilder.MakeQuotedIfRequired(value);
+            clBuilder.AppendNamedArgument("D", constant, overrideSuffix: string.Empty);
+        }
+
+        private static void AddDefaultOptions(ArgumentBuilder clBuilder)
+        {
+            // Make wchar_t a native type
+            clBuilder.AppendNamedArgument("Zc", "wchar_t");
+
+            // Remove unreferenced function or data
+            clBuilder.AppendNamedArgument("Zc", "inline");
+
+            // Use standard C++ scope rules
+            clBuilder.AppendNamedArgument("Zc", "forScope");
+
+            // Minimal rebuild
+            clBuilder.AppendNamedArgument("Gm", null);
+
+            // Enable C++ exceptions
+            clBuilder.AppendNamedArgument("EHsc", null);
+
+            // Multi-threaded debug dll
+            clBuilder.AppendNamedArgument("MDd", null);
+
+            // Floating point mode
+            clBuilder.AppendNamedArgument("fp", "precise");
+
+            // Turn on warnings and treat as errors
+            clBuilder.AppendNamedArgument("W3", null);
+            clBuilder.AppendNamedArgument("WX", null);
+
+            // Turn on sdl warnings
+            clBuilder.AppendNamedArgument("sdl", null);
+
+            // __cdecl calling convention
+            clBuilder.AppendNamedArgument("Gd", null);
+        }
+    }
+}

--- a/test/DebuggerTesting/DebuggerTesting.csproj
+++ b/test/DebuggerTesting/DebuggerTesting.csproj
@@ -1,0 +1,28 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+  <Import Project="..\..\build\debuggertesting.settings.targets" />
+
+  <PropertyGroup>
+    <TargetFramework>net5.0</TargetFramework>
+
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup Label="Package References">
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="$(Microsoft_NET_Test_Sdk_Version)" />
+    <PackageReference Include="xunit" Version="$(xunit_Version)" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="$(xunit_runner_visualstudio_Version)">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+  </ItemGroup>
+
+  <ItemGroup Label="Project References">
+    <ProjectReference Include="..\DebugAdapterRunner\DebugAdapterRunner.csproj" />
+  </ItemGroup>
+
+  <ItemGroup Label="Files to Drop">
+    <DropUnsignedFile Include="$(OutputPath)DebuggerTesting.dll" />
+    <DropUnsignedFile Include="$(OutputPath)DebuggerTesting.pdb" />
+  </ItemGroup>
+
+</Project>

--- a/test/DebuggerTesting/ICompilerSettings.cs
+++ b/test/DebuggerTesting/ICompilerSettings.cs
@@ -1,0 +1,27 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Collections.Generic;
+
+namespace DebuggerTesting
+{
+    /// <summary>
+    /// Interface describing the settings used to compile a debuggee.
+    /// </summary>
+    public interface ICompilerSettings
+    {
+        #region Properties
+
+        string CompilerName { get; }
+
+        SupportedCompiler CompilerType { get; }
+
+        string CompilerPath { get; }
+
+        SupportedArchitecture DebuggeeArchitecture { get; }
+
+        IDictionary<string, string> Properties { get; }
+
+        #endregion
+    }
+}

--- a/test/DebuggerTesting/IDebuggerSettings.cs
+++ b/test/DebuggerTesting/IDebuggerSettings.cs
@@ -1,0 +1,31 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Collections.Generic;
+
+namespace DebuggerTesting
+{
+    /// <summary>
+    /// Interface describing the settings used to debug a debuggee.
+    /// </summary>
+    public interface IDebuggerSettings
+    {
+        #region Properties
+
+        SupportedArchitecture DebuggeeArchitecture { get; }
+
+        string DebuggerName { get; }
+
+        SupportedDebugger DebuggerType { get; }
+
+        string DebuggerPath { get; }
+
+        string DebuggerAdapterPath { get; }
+
+        string MIMode { get; }
+
+        IDictionary<string, string> Properties { get; }
+
+        #endregion
+    }
+}

--- a/test/DebuggerTesting/ILoggingComponent.cs
+++ b/test/DebuggerTesting/ILoggingComponent.cs
@@ -1,0 +1,87 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.IO;
+using Xunit.Abstractions;
+
+namespace DebuggerTesting
+{
+    /// <summary>
+    /// A component that can log to the test output.
+    /// </summary>
+    public interface ILoggingComponent
+    {
+        ITestOutputHelper OutputHelper { get; }
+    }
+
+    /// <summary>
+    /// Provide some extensions to a test logging component.
+    /// </summary>
+    public static class LoggingTestExtensions
+    {
+        public static void WriteLine(this ILoggingComponent component, string message = "", params object[] args)
+        {
+            // Invalid XML characters cause xUnit not to write the whole results file
+            // For now we only handle null characters since that's what's causing issues and
+            // this is just a temporary workaround.
+            // See https://github.com/xunit/xunit/issues/876#issuecomment-253337669
+            if (!string.IsNullOrEmpty(message))
+            {
+                message = message.Replace("\0", "<null>");
+            }
+
+            if (args.Length > 0)
+                component?.OutputHelper?.WriteLine(message, args);
+            else
+                component?.OutputHelper?.WriteLine(message);
+        }
+
+        public static void WriteLines(this ILoggingComponent component, StreamReader reader)
+        {
+            Parameter.ThrowIfNull(reader, nameof(reader));
+
+            string line = null;
+            while (null != (line = reader.ReadLine()))
+            {
+                component.WriteLine(line);
+            }
+        }
+
+        /// <summary>
+        /// Log a message with details on the tests current settings
+        /// </summary>
+        public static void WriteSettings(this ILoggingComponent component, ITestSettings testSettings)
+        {
+            component.WriteLine("Test: {0}", testSettings.Name);
+            component.WriteLine(testSettings.CompilerSettings.ToString());
+            component.WriteLine(testSettings.DebuggerSettings.ToString());
+        }
+
+        /// <summary>
+        /// Log a message commenting on what the test is currently trying to accomplish.
+        /// </summary>
+        public static void Comment(this ILoggingComponent component, string message, params object[] args)
+        {
+            component.WriteLine();
+            component.WriteLine("# " + message + GetTimestamp(), args);
+        }
+
+        /// <summary>
+        /// Log a message commenting on what the overall purpose of the test
+        /// </summary>
+        public static void TestPurpose(this ILoggingComponent component, string message)
+        {
+            string timestamp = GetTimestamp();
+            string commentLine = new string('#', message.Length + timestamp.Length + 4);
+            component.WriteLine(commentLine);
+            component.WriteLine("# {0}{1} #", message , timestamp);
+            component.WriteLine(commentLine);
+        }
+
+        private static string GetTimestamp()
+        {
+            return " ({0:HH:mm:ss.fff})".FormatInvariantWithArgs(DateTime.Now);
+        }
+    }
+}

--- a/test/DebuggerTesting/ITestSettings.cs
+++ b/test/DebuggerTesting/ITestSettings.cs
@@ -1,0 +1,21 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace DebuggerTesting
+{
+    /// <summary>
+    /// Interface describing the settings that are passed into a theory test.
+    /// </summary>
+    public interface ITestSettings
+    {
+        #region Properties
+
+        string Name { get; }
+
+        ICompilerSettings CompilerSettings { get; }
+
+        IDebuggerSettings DebuggerSettings { get; }
+
+        #endregion
+    }
+}

--- a/test/DebuggerTesting/OpenDebug/Commands/AsyncBreakCommand.cs
+++ b/test/DebuggerTesting/OpenDebug/Commands/AsyncBreakCommand.cs
@@ -1,0 +1,17 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace DebuggerTesting.OpenDebug.Commands
+{
+    /// <summary>
+    /// Causes the debugger to break into code
+    /// </summary>
+    public class AsyncBreakCommand : Command<ThreadCommandArgs>
+    {
+        public AsyncBreakCommand()
+            : base("pause")
+        {
+            this.Args.threadId = 0;
+        }
+    }
+}

--- a/test/DebuggerTesting/OpenDebug/Commands/AttachCommand.cs
+++ b/test/DebuggerTesting/OpenDebug/Commands/AttachCommand.cs
@@ -1,0 +1,14 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace DebuggerTesting.OpenDebug.Commands
+{
+    public abstract class AttachCommand<T> : Command<T>
+        where T : LaunchCommandArgs, new()
+    {
+        public AttachCommand() 
+            : base("attach")
+        {
+        }
+    }
+}

--- a/test/DebuggerTesting/OpenDebug/Commands/Command.cs
+++ b/test/DebuggerTesting/OpenDebug/Commands/Command.cs
@@ -1,0 +1,265 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Collections.Generic;
+using DebugAdapterRunner;
+using DebuggerTesting.OpenDebug.Commands.Responses;
+using Newtonsoft.Json;
+using DarCommand = DebugAdapterRunner.Command;
+using DarRunner = DebugAdapterRunner.DebugAdapterRunner;
+
+namespace DebuggerTesting.OpenDebug.Commands
+{
+    /// <summary>
+    /// Base class for all Debug Adapter commands. Commands are issued and expect a response.
+    /// </summary>
+    /// <typeparam name="T">The class containing arguments to the command</typeparam>
+    public abstract class Command<T> : DarCommand, ICommand
+        where T : new()
+    {
+        public Command(string name)
+        {
+            Parameter.ThrowIfNull(name, nameof(name));
+            base.Name = name;
+            this.Name = name;
+            this.Args = new T();
+            this.SetExpectedResponse(success: true);
+            this.Timeout = TimeSpan.Zero;
+        }
+
+        /// <summary>
+        /// Call to set the expected success response of the command
+        /// </summary>
+        private void SetExpectedResponse(bool success)
+        {
+            this.ExpectedResponse = new CommandResponse(this.Name, success);
+        }
+
+        #region ICommand
+
+        public new string Name { get; private set; }
+
+        object ICommand.DynamicArgs { get { return Args; } }
+
+        IResponse ICommand.ExpectedResponse { get { return this.ExpectedResponse; } }
+
+        public virtual void ProcessActualResponse(IActualResponse response)
+        {
+            Parameter.ThrowIfNull(response, nameof(response));
+            CommandResponseValue commandResponse = response.Convert<CommandResponseValue>();
+            Parameter.ThrowIfNull(commandResponse, nameof(commandResponse));
+            this.Success = commandResponse.success;
+            this.Message = commandResponse.message;
+        }
+
+        #endregion
+
+        /// <summary>
+        /// Arguments to the command.
+        /// </summary>
+        public T Args { get; protected set; }
+
+        #region Response Handling
+
+        protected IResponse ExpectedResponse { get; set; }
+
+        public bool ExpectsSuccess
+        {
+            get
+            {
+                throw new NotImplementedException();
+            }
+            set
+            {
+                this.SetExpectedResponse(success: value);
+            }
+        }
+
+        public bool Success { get; private set; }
+
+        public string Message { get; private set; }
+
+        #endregion
+
+        public TimeSpan Timeout { get; set; }
+
+        #region Running
+
+        public override void Run(DarRunner darRunner)
+        {
+            this.Run(darRunner, null);
+        }
+
+        public void Run(IDebuggerRunner runner, params IEvent[] expectedEvents)
+        {
+            Parameter.ThrowIfNull(runner, nameof(runner));
+
+            if (runner.ErrorEncountered)
+            {
+                runner.WriteLine("Previous error. Skipping command '{0}'.", this.Name);
+                return;
+            }
+
+            try
+            {
+                this.Run(runner.DarRunner, runner, expectedEvents);
+            }
+            catch (Exception)
+            {
+                runner.ErrorEncountered = true;
+                  throw;
+            }
+        }
+
+        /// <summary>
+        /// Runs a command against the debugger.
+        /// </summary>
+        /// <param name="command">The command to run.</param>
+        /// <param name="expectedEvents">[OPTIONAL] If the command causes an event to occur, pass the expected event(s)</param>
+        private void Run(DarRunner darRunner, ILoggingComponent log, params IEvent[] expectedEvents)
+        {
+            Parameter.ThrowIfNull(darRunner, nameof(darRunner));
+
+            log?.WriteLine("Running command {0}", this.ToString());
+            log?.WriteLine("Command '{0}' expecting response: {1}", this.Name, this.ExpectedResponse.ToString());
+
+            DebugAdapterResponse darCommandResponse = GetDarResponse(this.ExpectedResponse);
+            DebugAdapterCommand darCommand = new DebugAdapterCommand(
+                this.Name,
+                this.Args,
+                new[] { darCommandResponse });
+            List<Tuple<DebugAdapterResponse, IEvent>> darEventMap = new List<Tuple<DebugAdapterResponse, IEvent>>(expectedEvents.Length);
+
+            // Add additional expected events to match if requested
+            if (expectedEvents != null && expectedEvents.Length > 0)
+            {
+                if (expectedEvents.Length > 1)
+                    log?.WriteLine("Command '{0}' expecting {1} events:", this.Name, expectedEvents.Length);
+
+                foreach (var expectedEvent in expectedEvents)
+                {
+                    DebugAdapterResponse darEventResponse = GetDarResponse(expectedEvent);
+                    darCommand.ExpectedResponses.Add(darEventResponse);
+                    darEventMap.Add(Tuple.Create(darEventResponse, expectedEvent));
+
+                    // Debug info for expected response
+                    string eventMessage = expectedEvents.Length > 1 ? "  - {1}" : "Command '{0}' expecting event: {1}";
+                    log?.WriteLine(eventMessage, this.Name, expectedEvent.ToString());
+                }
+            }
+
+            // Allow the command to override the timeout
+            int overrideTimeout = Convert.ToInt32(this.Timeout.TotalMilliseconds);
+            int savedTimeout = darRunner.ResponseTimeout;
+
+            try
+            {
+                if (overrideTimeout > 0)
+                {
+                    darRunner.ResponseTimeout = overrideTimeout;
+                    log?.WriteLine("Command '{0}' timeout set to {1:n0} seconds.", this.Name, this.Timeout.TotalSeconds);
+                }
+
+                darCommand.Run(darRunner);
+
+                // Allow the command to retrieve properties from the actual matched response.
+                string responseJson = JsonConvert.SerializeObject(darCommandResponse.Match);
+                if (!string.IsNullOrWhiteSpace(responseJson))
+                {
+                    this.ProcessActualResponse(new ActualResponse(responseJson));
+                }
+
+                // Allow the events to retrieve properties from the actual event.
+                foreach (var darEvent in darEventMap)
+                {
+                    string eventJson = JsonConvert.SerializeObject(darEvent.Item1.Match);
+                    darEvent.Item2.ProcessActualResponse(new ActualResponse(eventJson));
+                }
+            }
+            catch (Exception ex)
+            {
+                // Add information to the log when the exception occurs
+                log?.WriteLine("ERROR: Running command '{0}'. Exception thrown.", this.Name);
+                log?.WriteLine(UDebug.ExceptionToString(ex));
+
+                // The DARException is not serializable, create a new exception
+                if (ex is DARException)
+                    throw new RunnerException(ex.Message);
+                else
+                    throw;
+            }
+            finally
+            {
+                if (overrideTimeout > 0)
+                    darRunner.ResponseTimeout = savedTimeout;
+            }
+        }
+
+        // Create a DAR Response from an expected response
+        private static DebugAdapterResponse GetDarResponse(IResponse response)
+        {
+            return new DebugAdapterResponse(response.DynamicResponse, response.IgnoreOrder);
+        }
+
+        #region ActualResponse
+
+        /// <summary>
+        /// Provides a way to get the command to interperet the actual result
+        /// that comes back from the Debug Adapter.
+        /// </summary>
+        private class ActualResponse : IActualResponse
+        {
+            private string responseJson;
+
+            public ActualResponse(string responseJson)
+            {
+                this.responseJson = responseJson;
+            }
+
+            public R Convert<R>()
+            {
+                try
+                {
+                    return JsonConvert.DeserializeObject<R>(responseJson);
+                }
+                catch (JsonReaderException ex)
+                {
+                    throw new FormatException("Malformed JSON: " + responseJson, ex);
+                }
+            }
+        }
+
+        #endregion
+
+        #endregion
+
+        public override string ToString()
+        {
+            return this.Name;
+        }
+    }
+
+    public abstract class CommandWithResponse<T, R> : Command<T>, ICommandWithResponse<R>
+        where T : new()
+        where R : new()
+    {
+        public CommandWithResponse(string name) : base(name)
+        {
+        }
+
+        public R ActualResponse { get; protected set; }
+
+        public override void ProcessActualResponse(IActualResponse response)
+        {
+            base.ProcessActualResponse(response);
+            this.ActualResponse = response.Convert<R>();
+        }
+
+        public new R Run(IDebuggerRunner runner, params IEvent[] expectedEvents)
+        {
+            base.Run(runner, expectedEvents);
+            return this.ActualResponse;
+        }
+    }
+}

--- a/test/DebuggerTesting/OpenDebug/Commands/ConfigurationDoneCommand.cs
+++ b/test/DebuggerTesting/OpenDebug/Commands/ConfigurationDoneCommand.cs
@@ -1,0 +1,19 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+
+namespace DebuggerTesting.OpenDebug.Commands
+{
+    /// <summary>
+    /// Command used to start the debuggee after initial breakpoint and configuration
+    /// commands have been issued.
+    /// </summary>
+    public class ConfigurationDoneCommand : Command<object>
+    {
+        public ConfigurationDoneCommand() : base("configurationDone")
+        {
+            this.Timeout = TimeSpan.FromSeconds(10);
+        }
+    }
+}

--- a/test/DebuggerTesting/OpenDebug/Commands/DisconnectCommand.cs
+++ b/test/DebuggerTesting/OpenDebug/Commands/DisconnectCommand.cs
@@ -1,0 +1,30 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace DebuggerTesting.OpenDebug.Commands
+{
+    #region DisconnectCommandArgs
+
+    public sealed class DisconnectCommandArgs : JsonValue
+    {
+        public sealed class ExtensionHostData
+        {
+            public bool restart;
+        }
+
+        public ExtensionHostData extensionHostData = new ExtensionHostData();
+    }
+
+    #endregion
+
+    /// <summary>
+    /// Disconnects the debugger.
+    /// </summary>
+    public class DisconnectCommand : Command<DisconnectCommandArgs>
+    {
+        public DisconnectCommand() : base("disconnect")
+        {
+            this.Args.extensionHostData.restart = false;
+        }
+    }
+}

--- a/test/DebuggerTesting/OpenDebug/Commands/EvaluateCommand.cs
+++ b/test/DebuggerTesting/OpenDebug/Commands/EvaluateCommand.cs
@@ -1,0 +1,75 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using DebuggerTesting.OpenDebug.Commands.Responses;
+using Newtonsoft.Json;
+
+namespace DebuggerTesting.OpenDebug.Commands
+{
+    public enum EvaluateContext
+    {
+        Unset = 0,
+        None,
+        DataTip,
+        Watch,
+    }
+
+    #region EvaluateCommandArgs
+
+    public sealed class EvaluateCommandArgs : JsonValue
+    {
+        public string expression;
+
+        [JsonProperty(DefaultValueHandling = DefaultValueHandling.Ignore)]
+        public int? frameId;
+
+        [JsonProperty(DefaultValueHandling = DefaultValueHandling.Ignore)]
+        public string context;
+    }
+
+    #endregion
+
+    /// <summary>
+    /// Evaluates an expression
+    /// </summary>
+    public class EvaluateCommand : CommandWithResponse<EvaluateCommandArgs, EvaluateResponseValue>
+    {
+        public EvaluateCommand(string expression, int frameId, EvaluateContext context = EvaluateContext.None)
+            : base("evaluate")
+        {
+            Parameter.ThrowIfIsInvalid(context, EvaluateContext.Unset, nameof(context));
+            this.Args.expression = expression;
+            this.Args.frameId = frameId;
+            this.Args.context = ContextToName(context);
+        }
+
+        private static string ContextToName(EvaluateContext context)
+        {
+            switch (context)
+            {
+                case EvaluateContext.None:
+                    return null;
+                case EvaluateContext.DataTip:
+                    return "hover";
+                case EvaluateContext.Watch:
+                    return "watch";
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(context));
+            }
+        }
+
+        public string ActualResult { get; private set; }
+
+        public override void ProcessActualResponse(IActualResponse response)
+        {
+            base.ProcessActualResponse(response);
+            this.ActualResult = this.ActualResponse?.body?.result;
+        }
+
+        public override string ToString()
+        {
+            return "{0} ({1})".FormatInvariantWithArgs(base.ToString(), this.Args.expression);
+        }
+    }
+}

--- a/test/DebuggerTesting/OpenDebug/Commands/InitializeCommand.cs
+++ b/test/DebuggerTesting/OpenDebug/Commands/InitializeCommand.cs
@@ -1,0 +1,63 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+using DebuggerTesting.OpenDebug.Commands.Responses;
+using Newtonsoft.Json;
+
+namespace DebuggerTesting.OpenDebug.Commands
+{
+    #region InitializeCommandArgs
+
+    public sealed class InitializeCommandArgs : JsonValue
+    {
+        public string adapterID;
+        public bool linesStartAt1;
+        public bool columnsStartAt1;
+        public string pathFormat;
+    }
+
+    #endregion
+
+    public sealed class InitializeResponseValue : CommandResponseValue
+    {
+        public sealed class Body
+        {
+            [JsonProperty(DefaultValueHandling = DefaultValueHandling.Ignore)]
+            public bool? supportsConfigurationDoneRequest;
+
+            [JsonProperty(DefaultValueHandling = DefaultValueHandling.Ignore)]
+            public bool? supportsFunctionBreakpoints;
+
+            [JsonProperty(DefaultValueHandling = DefaultValueHandling.Ignore)]
+            public bool? supportsConditionalBreakpoints;
+
+            [JsonProperty(DefaultValueHandling = DefaultValueHandling.Ignore)]
+            public bool? supportsEvaluateForHovers;
+
+            [JsonProperty(DefaultValueHandling = DefaultValueHandling.Ignore)]
+            public bool? supportsSetVariable;
+        }
+
+        public Body body = new Body();
+    }
+
+    internal class InitializeResponse : CommandResponse<InitializeResponseValue>
+    {
+        public InitializeResponse(string commandName)
+            : base(commandName)
+        { }
+    }
+
+    /// <summary>
+    /// Required initialization information passed to the debugger.
+    /// </summary>
+    public class InitializeCommand : CommandWithResponse<InitializeCommandArgs, InitializeResponseValue>
+    {
+        public InitializeCommand(string adapterId) : base("initialize")
+        {
+            this.Args.adapterID = adapterId;
+            this.Args.linesStartAt1 = true;
+            this.Args.columnsStartAt1 = true;
+            this.Args.pathFormat = "path";
+        }
+    }
+}

--- a/test/DebuggerTesting/OpenDebug/Commands/LaunchCommand.cs
+++ b/test/DebuggerTesting/OpenDebug/Commands/LaunchCommand.cs
@@ -1,0 +1,57 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Collections.Generic;
+using Newtonsoft.Json;
+
+namespace DebuggerTesting.OpenDebug.Commands
+{
+    public abstract class LaunchCommandArgs : JsonValue
+    {
+        public string name;
+        public string type;
+        public string request;
+        public string program;
+        public string[] args;
+        public bool stopAtEntry;
+        public string cwd;
+        public EnvironmentEntry[] environment;
+        public bool noDebug;
+        public IDictionary<string, string> sourceFileMap;
+    }
+
+    public abstract class LaunchCommand<T> : Command<T>
+        where T : LaunchCommandArgs, new()
+    {
+        public LaunchCommand() : base("launch")
+        {
+        }
+
+        public bool StopAtEntry
+        {
+            get { return this.Args.stopAtEntry; }
+            set { this.Args.stopAtEntry = value; }
+        }
+
+        public EnvironmentEntry[] Environment
+        {
+            get { return this.Args.environment; }
+            set { this.Args.environment = value; }
+        }
+
+        public IDictionary<string, string> SourceFileMap
+        {
+            get { return this.Args.sourceFileMap; }
+            set { this.Args.sourceFileMap = value; }
+        }
+    }
+
+    public class EnvironmentEntry : JsonValue
+    {
+        [JsonProperty(PropertyName = "name")]
+        public string Name { get; set; }
+
+        [JsonProperty(PropertyName = "value")]
+        public string Value { get; set; }
+    }
+}

--- a/test/DebuggerTesting/OpenDebug/Commands/Responses/CommandResponse.cs
+++ b/test/DebuggerTesting/OpenDebug/Commands/Responses/CommandResponse.cs
@@ -1,0 +1,59 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Newtonsoft.Json;
+
+namespace DebuggerTesting.OpenDebug.Commands.Responses
+{
+    public class CommandResponseValue : JsonValue
+    {
+        public bool success;
+        public string command;
+
+        [JsonProperty(DefaultValueHandling = DefaultValueHandling.Ignore)]
+        public string message;
+
+        [JsonProperty(DefaultValueHandling = DefaultValueHandling.Ignore)]
+        public int? request_seq;
+
+        [JsonProperty(DefaultValueHandling = DefaultValueHandling.Ignore)]
+        public int? seq;
+    }
+
+    public abstract class CommandResponse<T> : Response<T>
+        where T : CommandResponseValue, new()
+    {
+        public CommandResponse(string commandName, bool success = true)
+        {
+            this.ExpectedResponse.command = commandName;
+            this.ExpectedResponse.success = success;
+            this.ExpectedResponse.message = null;
+        }
+
+        public CommandResponse(string commandName, string message)
+        {
+            this.ExpectedResponse.command = commandName;
+            this.ExpectedResponse.success = false;
+            this.ExpectedResponse.message = message;
+        }
+
+        public override string ToString()
+        {
+            if (this.ExpectedResponse.message != null)
+                return "{0} (Fail '{1}')".FormatInvariantWithArgs(base.ToString(), this.ExpectedResponse.message);
+            else
+                return "{0} ({1})".FormatInvariantWithArgs(base.ToString(), this.ExpectedResponse.success ? "Success" : "Fail");
+        }
+    }
+
+    /// <summary>
+    /// The most common command response, returns the command name and a bool with success result.
+    /// </summary>
+    public sealed class CommandResponse : CommandResponse<CommandResponseValue>
+    {
+        public CommandResponse(string commandName, bool success)
+            : base(commandName, success)
+        {
+        }
+    }
+}

--- a/test/DebuggerTesting/OpenDebug/Commands/Responses/EvaluateResponseValue.cs
+++ b/test/DebuggerTesting/OpenDebug/Commands/Responses/EvaluateResponseValue.cs
@@ -1,0 +1,18 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Newtonsoft.Json;
+
+namespace DebuggerTesting.OpenDebug.Commands.Responses
+{
+    public sealed class EvaluateResponseValue : CommandResponseValue
+    {
+        public sealed class Body
+        {
+            [JsonProperty(DefaultValueHandling = DefaultValueHandling.Ignore)]
+            public string result;
+        }
+
+        public Body body = new Body();
+    }
+}

--- a/test/DebuggerTesting/OpenDebug/Commands/Responses/ScopesResponseValue.cs
+++ b/test/DebuggerTesting/OpenDebug/Commands/Responses/ScopesResponseValue.cs
@@ -1,0 +1,46 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Newtonsoft.Json;
+
+namespace DebuggerTesting.OpenDebug.Commands.Responses
+{
+    #region ScopesResponseValue
+
+    public sealed class ScopesResponseValue : CommandResponseValue
+    {
+        public sealed class Body
+        {
+            public sealed class Scope
+            {
+                public Scope(string name, bool expensive)
+                {
+                    this.name = name;
+                    this.expensive = expensive;
+                }
+                public bool expensive;
+                public string name;
+
+                [JsonProperty(DefaultValueHandling = DefaultValueHandling.Ignore)]
+                public int? variablesReference;
+            }
+
+            public Scope[] scopes;
+        }
+
+        public Body body = new Body();
+    }
+
+    #endregion
+
+    internal class ScopesResponse : CommandResponse<ScopesResponseValue>
+    {
+        public ScopesResponse(string commandName)
+            : base(commandName)
+        {
+            this.ExpectedResponse.body.scopes = new ScopesResponseValue.Body.Scope[] {
+                new ScopesResponseValue.Body.Scope("Locals", false)
+            };
+        }
+    }
+}

--- a/test/DebuggerTesting/OpenDebug/Commands/Responses/SetBreakpointsResponseValue.cs
+++ b/test/DebuggerTesting/OpenDebug/Commands/Responses/SetBreakpointsResponseValue.cs
@@ -1,0 +1,21 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace DebuggerTesting.OpenDebug.Commands.Responses
+{
+    public sealed class SetBreakpointsResponseValue : CommandResponseValue
+    {
+        public sealed class Body
+        {
+            public sealed class Breakpoint
+            {
+                public int? id;
+                public bool? verified;
+                public int? line;
+                public string message;
+            }
+            public Breakpoint[] breakpoints;
+        }
+        public Body body = new Body();
+    }
+}

--- a/test/DebuggerTesting/OpenDebug/Commands/Responses/SetVariableResponse.cs
+++ b/test/DebuggerTesting/OpenDebug/Commands/Responses/SetVariableResponse.cs
@@ -1,0 +1,18 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Newtonsoft.Json;
+
+namespace DebuggerTesting.OpenDebug.Commands.Responses
+{
+    public sealed class SetVariableResponseValue : CommandResponseValue
+    {
+        public sealed class Body
+        {
+            [JsonProperty(DefaultValueHandling = DefaultValueHandling.Ignore)]
+            public string value;
+        }
+
+        public Body body = new Body();
+    }
+}

--- a/test/DebuggerTesting/OpenDebug/Commands/Responses/Source.cs
+++ b/test/DebuggerTesting/OpenDebug/Commands/Responses/Source.cs
@@ -1,0 +1,22 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Newtonsoft.Json;
+
+namespace DebuggerTesting.OpenDebug.Commands.Responses
+{
+    /// <summary>
+    /// This data is used in multiple command args and responses
+    /// </summary>
+    public sealed class Source
+    {
+        [JsonProperty(DefaultValueHandling = DefaultValueHandling.Ignore)]
+        public string name;
+
+        [JsonProperty(DefaultValueHandling = DefaultValueHandling.Ignore)]
+        public string path;
+
+        [JsonProperty(DefaultValueHandling = DefaultValueHandling.Ignore)]
+        public int? sourceReference;
+    }
+}

--- a/test/DebuggerTesting/OpenDebug/Commands/Responses/SourceResponseValue.cs
+++ b/test/DebuggerTesting/OpenDebug/Commands/Responses/SourceResponseValue.cs
@@ -1,0 +1,18 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Newtonsoft.Json;
+
+namespace DebuggerTesting.OpenDebug.Commands.Responses
+{
+    public sealed class SourceResponseValue : CommandResponseValue
+    {
+        public sealed class Body
+        {
+            [JsonProperty(DefaultValueHandling = DefaultValueHandling.Ignore)]
+            public string content;
+        }
+
+        public Body body = new Body();
+    }
+}

--- a/test/DebuggerTesting/OpenDebug/Commands/Responses/StackTraceResponseValue.cs
+++ b/test/DebuggerTesting/OpenDebug/Commands/Responses/StackTraceResponseValue.cs
@@ -1,0 +1,33 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Newtonsoft.Json;
+
+namespace DebuggerTesting.OpenDebug.Commands.Responses
+{
+    public sealed class StackTraceResponseValue : CommandResponseValue
+    {
+        public sealed class Body
+        {
+            public sealed class StackFrame
+            {
+                public string name;
+
+                [JsonProperty(DefaultValueHandling = DefaultValueHandling.Ignore)]
+                public int? id;
+
+                [JsonProperty(DefaultValueHandling = DefaultValueHandling.Ignore)]
+                public int? line;
+
+                [JsonProperty(DefaultValueHandling = DefaultValueHandling.Ignore)]
+                public int? column;
+
+                [JsonProperty(DefaultValueHandling = DefaultValueHandling.Ignore)]
+                public Source source;
+            }
+            public StackFrame[] stackFrames;
+        }
+
+        public Body body = new Body();
+    }
+}

--- a/test/DebuggerTesting/OpenDebug/Commands/Responses/ThreadsResponseValue.cs
+++ b/test/DebuggerTesting/OpenDebug/Commands/Responses/ThreadsResponseValue.cs
@@ -1,0 +1,26 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Newtonsoft.Json;
+
+namespace DebuggerTesting.OpenDebug.Commands.Responses
+{
+    public sealed class ThreadsResponseValue : CommandResponseValue
+    {
+        public sealed class Body
+        {
+            public sealed class Thread
+            {
+                [JsonProperty(DefaultValueHandling = DefaultValueHandling.Ignore)]
+                public int? id;
+
+                [JsonProperty(DefaultValueHandling = DefaultValueHandling.Ignore)]
+                public string name;
+            }
+
+            public Thread[] threads;
+        }
+
+        public Body body = new Body();
+    }
+}

--- a/test/DebuggerTesting/OpenDebug/Commands/Responses/VariablesResponseValue.cs
+++ b/test/DebuggerTesting/OpenDebug/Commands/Responses/VariablesResponseValue.cs
@@ -1,0 +1,29 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Newtonsoft.Json;
+
+namespace DebuggerTesting.OpenDebug.Commands.Responses
+{
+    public sealed class VariablesResponseValue : CommandResponseValue
+    {
+        public sealed class Body
+        {
+            public sealed class Variable
+            {
+                [JsonProperty(DefaultValueHandling=DefaultValueHandling.Ignore)]
+                public string name;
+
+                [JsonProperty(DefaultValueHandling = DefaultValueHandling.Ignore)]
+                public string value;
+
+                [JsonProperty(DefaultValueHandling = DefaultValueHandling.Ignore)]
+                public int? variablesReference;
+            }
+
+            public Variable[] variables;
+        }
+
+        public Body body = new Body();
+    }
+}

--- a/test/DebuggerTesting/OpenDebug/Commands/ScopesCommand.cs
+++ b/test/DebuggerTesting/OpenDebug/Commands/ScopesCommand.cs
@@ -1,0 +1,29 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using DebuggerTesting.OpenDebug.Commands.Responses;
+
+namespace DebuggerTesting.OpenDebug.Commands
+{
+    public sealed class ScopesArgs : JsonValue
+    {
+        public int frameId;
+    }
+
+    public class ScopesCommand : CommandWithResponse<ScopesArgs, ScopesResponseValue>
+    {
+        public ScopesCommand(int frameId) : base("scopes")
+        {
+            this.Args.frameId = frameId;
+            this.ExpectedResponse = new ScopesResponse(this.Name);
+        }
+
+        public int VariablesReference { get; private set; }
+
+        public override void ProcessActualResponse(IActualResponse response)
+        {
+            base.ProcessActualResponse(response);
+            this.VariablesReference = this.ActualResponse?.body?.scopes?[0]?.variablesReference ?? -1;
+        }
+    }
+}

--- a/test/DebuggerTesting/OpenDebug/Commands/SetBreakpointsCommand.cs
+++ b/test/DebuggerTesting/OpenDebug/Commands/SetBreakpointsCommand.cs
@@ -1,0 +1,130 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using DebuggerTesting.Compilation;
+using DebuggerTesting.OpenDebug.Commands.Responses;
+using Newtonsoft.Json;
+
+namespace DebuggerTesting.OpenDebug.Commands
+{
+
+    #region SetBreakpointsCommandArgs
+
+    public sealed class SetBreakpointsCommandArgs : JsonValue
+    {
+        public sealed class SourceBreakpoint
+        {
+            public SourceBreakpoint(int line, int? column, string condition)
+            {
+                this.line = line;
+                this.condition = condition;
+            }
+
+            public int line;
+
+            [JsonProperty(DefaultValueHandling = DefaultValueHandling.Ignore)]
+            public int? column;
+
+            [JsonProperty(DefaultValueHandling = DefaultValueHandling.Ignore)]
+            public string condition;
+        }
+
+        public Source source = new Source();
+        public int[] lines;
+        public SourceBreakpoint[] breakpoints;
+    }
+
+    #endregion
+
+    #region SourceBreakpoints
+
+    /// <summary>
+    /// Contains information on all the breakpoints for a source file
+    /// </summary>
+    public sealed class SourceBreakpoints
+    {
+        #region Constructor/Create
+
+        public SourceBreakpoints(IDebuggee debuggee, string relativePath)
+            : this(debuggee?.SourceRoot, relativePath)
+        {
+        }
+
+        public SourceBreakpoints(string sourceRoot, string relativePath)
+        {
+            Parameter.ThrowIfNull(sourceRoot, nameof(sourceRoot));
+            Parameter.ThrowIfNull(relativePath, nameof(relativePath));
+            this.Breakpoints = new Dictionary<int, string>();
+            this.RelativePath = relativePath;
+            this.FullPath = Path.Combine(sourceRoot, relativePath);
+        }
+
+        #endregion
+
+        #region Add/Remove
+
+        public SourceBreakpoints Add(int lineNumber, string condition = null)
+        {
+            if (this.Breakpoints.ContainsKey(lineNumber))
+                throw new RunnerException("Breakpoint line {0} already added to file {1}.", lineNumber, this.RelativePath);
+            this.Breakpoints.Add(lineNumber, condition);
+            return this;
+        }
+
+        public SourceBreakpoints Remove(int lineNumber)
+        {
+            if (!this.Breakpoints.ContainsKey(lineNumber))
+                throw new RunnerException("Breakpoint line {0} does not exist in file {1}.", lineNumber, this.RelativePath);
+            this.Breakpoints.Remove(lineNumber);
+            return this;
+        }
+
+        #endregion
+
+        #region Source File Info
+
+        public string FullPath { get; private set; }
+
+        public string RelativePath { get; private set; }
+
+        #endregion
+
+        /// <summary>
+        /// Keep the breakpoint info in a dictionary indexed by line number.
+        /// Store the condition as the value.
+        /// </summary>
+        public IDictionary<int, string> Breakpoints { get; private set; }
+    }
+
+    #endregion
+
+    public class SetBreakpointsCommand : CommandWithResponse<SetBreakpointsCommandArgs, SetBreakpointsResponseValue>
+    {
+        public SetBreakpointsCommand() : base("setBreakpoints")
+        {
+        }
+
+        public SetBreakpointsCommand(SourceBreakpoints sourceBreakpoints) :
+            this()
+        {
+            this.Args.source.path = sourceBreakpoints.FullPath;
+            IDictionary<int, string> breakpoints = sourceBreakpoints.Breakpoints;
+            this.Args.breakpoints = breakpoints.Select(x =>
+                    new SetBreakpointsCommandArgs.SourceBreakpoint(x.Key, null, x.Value)
+                ).ToArray();
+            this.Args.lines = this.Args.breakpoints.Select(x => x.line).ToArray();
+        }
+
+        public override string ToString()
+        {
+            return "{0} ({1}:{2})".FormatInvariantWithArgs(base.ToString(), this.Args.source.path,
+                this.Args.lines.Count() == 0 ?
+                    "(none)" :
+                    "[{0}]".FormatInvariantWithArgs(String.Join(", ", this.Args.lines)));
+        }
+    }
+}

--- a/test/DebuggerTesting/OpenDebug/Commands/SetExceptionBreakpointsCommand.cs
+++ b/test/DebuggerTesting/OpenDebug/Commands/SetExceptionBreakpointsCommand.cs
@@ -1,0 +1,22 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace DebuggerTesting.OpenDebug.Commands
+{
+    public sealed class SetExceptionBreakpointsCommandArgs : JsonValue
+    {
+        public string[] filters;
+    }
+
+    public class SetExceptionBreakpointsCommand : Command<SetExceptionBreakpointsCommandArgs>
+    {
+        public const string FilterUserUnhandler = "user-unhandled";
+        public const string FilterAll = "all";
+
+        public SetExceptionBreakpointsCommand(params string[] filters)
+           : base("setExceptionBreakpoints")
+        {
+            this.Args.filters = (filters.Length > 0) ? filters : new string[] { FilterUserUnhandler };
+        }
+    }
+}

--- a/test/DebuggerTesting/OpenDebug/Commands/SetFunctionBreakpointsCommand.cs
+++ b/test/DebuggerTesting/OpenDebug/Commands/SetFunctionBreakpointsCommand.cs
@@ -1,0 +1,92 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using DebuggerTesting.OpenDebug.Commands.Responses;
+using Newtonsoft.Json;
+
+namespace DebuggerTesting.OpenDebug.Commands
+{
+    #region SetBreakpointsCommandArgs
+
+    public sealed class SetFunctionBreakpointsCommandArgs : JsonValue
+    {
+        public sealed class FunctionBreakpoint
+        {
+            public FunctionBreakpoint(string name, string condition = null)
+            {
+                this.name = name;
+                this.condition = condition;
+            }
+
+            public string name;
+
+            [JsonProperty(DefaultValueHandling = DefaultValueHandling.Ignore)]
+            public string condition;
+        }
+
+        public FunctionBreakpoint[] breakpoints;
+    }
+
+    #endregion
+
+    #region FunctionBreakpoints
+
+    public sealed class FunctionBreakpoints
+    {
+        private List<SetFunctionBreakpointsCommandArgs.FunctionBreakpoint> breakpoints;
+
+        public FunctionBreakpoints()
+        {
+            this.breakpoints = new List<SetFunctionBreakpointsCommandArgs.FunctionBreakpoint>();
+        }
+
+        public FunctionBreakpoints(params string[] functions)
+            : this()
+        {
+            foreach (string function in functions)
+            {
+                this.Add(function);
+            }
+        }
+
+        public FunctionBreakpoints Add(string function, string condition = null)
+        {
+            this.breakpoints.Add(new SetFunctionBreakpointsCommandArgs.FunctionBreakpoint(function, condition));
+            return this;
+        }
+
+        public FunctionBreakpoints Remove(string function)
+        {
+            this.breakpoints.RemoveAll(bp => String.Equals(bp.name, function, StringComparison.Ordinal));
+            return this;
+        }
+
+        internal IList<SetFunctionBreakpointsCommandArgs.FunctionBreakpoint> Breakpoints
+        {
+            get { return this.breakpoints; }
+        }
+    }
+
+    #endregion
+
+    public class SetFunctionBreakpointsCommand : CommandWithResponse<SetFunctionBreakpointsCommandArgs, SetBreakpointsResponseValue>
+    {
+        public SetFunctionBreakpointsCommand() : base("setFunctionBreakpoints")
+        {
+        }
+
+        public SetFunctionBreakpointsCommand(FunctionBreakpoints breakpoints) :
+            this()
+        {
+            this.Args.breakpoints = breakpoints.Breakpoints.ToArray();
+        }
+
+        public override string ToString()
+        {
+            return "{0} ({1})".FormatInvariantWithArgs(base.ToString(), String.Join(", ", this.Args.breakpoints.Select(bp => bp.name)));
+        }
+    }
+}

--- a/test/DebuggerTesting/OpenDebug/Commands/SetVariableCommand.cs
+++ b/test/DebuggerTesting/OpenDebug/Commands/SetVariableCommand.cs
@@ -1,0 +1,31 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using DebuggerTesting.OpenDebug.Commands.Responses;
+
+namespace DebuggerTesting.OpenDebug.Commands
+{
+    public sealed class SetVariableCommandArgs
+    {
+        public string name;
+        public string value;
+        public int variablesReference;
+    }
+
+    public class SetVariableCommand : CommandWithResponse<SetVariableCommandArgs, SetVariableResponseValue>
+    {
+        public SetVariableCommand(int variablesReference, string name, string value) : base("setVariable")
+        {
+            Parameter.ThrowIfNullOrWhiteSpace(name, nameof(name));
+            Parameter.ThrowIfNullOrWhiteSpace(value, nameof(value));
+            this.Args.variablesReference = variablesReference;
+            this.Args.name = name;
+            this.Args.value = value;
+        }
+
+        public override string ToString()
+        {
+            return "{0} ({1}={2})".FormatInvariantWithArgs(base.ToString(), this.Args.name, this.Args.value);
+        }
+    }
+}

--- a/test/DebuggerTesting/OpenDebug/Commands/SourceCommand.cs
+++ b/test/DebuggerTesting/OpenDebug/Commands/SourceCommand.cs
@@ -1,0 +1,20 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using DebuggerTesting.OpenDebug.Commands.Responses;
+
+namespace DebuggerTesting.OpenDebug.Commands
+{
+    public sealed class SourceCommandArgs : JsonValue
+    {
+        public int sourceReference;
+    }
+
+    public class SourceCommand : CommandWithResponse<SourceCommandArgs, SourceResponseValue>
+    {
+        public SourceCommand(int sourceReference) : base("source")
+        {
+            this.Args.sourceReference = sourceReference;
+        }
+    }
+}

--- a/test/DebuggerTesting/OpenDebug/Commands/StackTraceCommand.cs
+++ b/test/DebuggerTesting/OpenDebug/Commands/StackTraceCommand.cs
@@ -1,0 +1,27 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using DebuggerTesting.OpenDebug.Commands.Responses;
+using Newtonsoft.Json;
+
+namespace DebuggerTesting.OpenDebug.Commands
+{
+    public sealed class StackTraceArgs : ThreadCommandArgs
+    {
+        public int levels;
+
+        [JsonProperty(DefaultValueHandling = DefaultValueHandling.Ignore)]
+        public int? startFrame;
+    }
+
+    public class StackTraceCommand : CommandWithResponse<StackTraceArgs, StackTraceResponseValue>
+    {
+        public StackTraceCommand(int threadId, int? startFrame = null)
+            : base("stackTrace")
+        {
+            this.Args.threadId = threadId;
+            this.Args.levels = 20;
+            this.Args.startFrame = startFrame;
+        }
+    }
+}

--- a/test/DebuggerTesting/OpenDebug/Commands/StepCommands.cs
+++ b/test/DebuggerTesting/OpenDebug/Commands/StepCommands.cs
@@ -1,0 +1,52 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+
+namespace DebuggerTesting.OpenDebug.Commands
+{
+    public class ThreadCommandArgs : JsonValue
+    {
+        public int threadId;
+    }
+
+    public class ContinueCommand : Command<ThreadCommandArgs>
+    {
+        public ContinueCommand(int threadId)
+            : base("continue")
+        {
+            this.Args.threadId = threadId;
+            this.Timeout = TimeSpan.FromSeconds(10);
+        }
+    }
+
+    public class StepInCommand : Command<ThreadCommandArgs>
+    {
+        public StepInCommand(int threadId)
+            : base("stepIn")
+        {
+            this.Args.threadId = threadId;
+            this.Timeout = TimeSpan.FromSeconds(10);
+        }
+    }
+
+    public class StepOutCommand : Command<ThreadCommandArgs>
+    {
+        public StepOutCommand(int threadId)
+            : base("stepOut")
+        {
+            this.Args.threadId = threadId;
+            this.Timeout = TimeSpan.FromSeconds(10);
+        }
+    }
+
+    public class StepOverCommand : Command<ThreadCommandArgs>
+    {
+        public StepOverCommand(int threadId)
+            : base("next")
+        {
+            this.Args.threadId = threadId;
+            this.Timeout = TimeSpan.FromSeconds(10);
+        }
+    }
+}

--- a/test/DebuggerTesting/OpenDebug/Commands/ThreadsCommand.cs
+++ b/test/DebuggerTesting/OpenDebug/Commands/ThreadsCommand.cs
@@ -1,0 +1,14 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using DebuggerTesting.OpenDebug.Commands.Responses;
+
+namespace DebuggerTesting.OpenDebug.Commands
+{
+    public class ThreadsCommand : CommandWithResponse<object, ThreadsResponseValue>
+    {
+        public ThreadsCommand() : base("threads")
+        {
+        }
+    }
+}

--- a/test/DebuggerTesting/OpenDebug/Commands/VariablesCommand.cs
+++ b/test/DebuggerTesting/OpenDebug/Commands/VariablesCommand.cs
@@ -1,0 +1,21 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using DebuggerTesting.OpenDebug.Commands.Responses;
+
+namespace DebuggerTesting.OpenDebug.Commands
+{
+    public sealed class VariablesCommandArgs : JsonValue
+    {
+        public int variablesReference;
+    }
+
+    public class VariablesCommand : CommandWithResponse<VariablesCommandArgs, VariablesResponseValue>
+    {
+        public VariablesCommand(int variablesRefernce)
+            : base("variables")
+        {
+            this.Args.variablesReference = variablesRefernce;
+        }
+    }
+}

--- a/test/DebuggerTesting/OpenDebug/Events/BreakpointEvent.cs
+++ b/test/DebuggerTesting/OpenDebug/Events/BreakpointEvent.cs
@@ -1,0 +1,113 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Globalization;
+using Newtonsoft.Json;
+
+namespace DebuggerTesting.OpenDebug.Events
+{
+    public enum BreakpointReason
+    {
+        Unset = 0,
+        Changed,
+        New,
+    }
+
+    #region BreakpointEventValue
+
+    public sealed class BreakpointEventValue : EventValue
+    {
+        public sealed class Body
+        {
+            public sealed class Breakpoint
+            {
+                [JsonProperty(DefaultValueHandling = DefaultValueHandling.Ignore)]
+                public int? id;
+
+                [JsonProperty(DefaultValueHandling = DefaultValueHandling.Ignore)]
+                public bool? verified;
+
+                [JsonProperty(DefaultValueHandling = DefaultValueHandling.Ignore)]
+                public string message;
+
+                [JsonProperty(DefaultValueHandling = DefaultValueHandling.Ignore)]
+                public int? line;
+
+                [JsonProperty(DefaultValueHandling = DefaultValueHandling.Ignore)]
+                public int? column;
+            }
+
+            [JsonProperty(DefaultValueHandling = DefaultValueHandling.Ignore)]
+            public string reason;
+
+            [JsonProperty(DefaultValueHandling = DefaultValueHandling.Ignore)]
+            public Breakpoint breakpoint;
+        }
+
+        public Body body = new Body();
+    }
+
+    #endregion
+
+    /// <summary>
+    /// Event that fires when a breakpoint has been modified
+    /// </summary>
+    public class BreakpointEvent : Event<BreakpointEventValue>
+    {
+        private bool verifyLineRange;
+        private int startLine;
+        private int endLine;
+
+        public BreakpointEvent(BreakpointReason reason, int? line)
+            : base("breakpoint")
+        {
+            this.ExpectedResponse.body.reason = GetReason(reason);
+
+            if (line != null)
+            {
+                this.ExpectedResponse.body.breakpoint = new BreakpointEventValue.Body.Breakpoint();
+                this.ExpectedResponse.body.breakpoint.line = line;
+            }
+        }
+
+        /// <summary>
+        /// Create an expected breakpoint event that works over a range of lines
+        /// </summary>
+        public BreakpointEvent(BreakpointReason reason, int startLine, int endLine)
+            : this(reason, line: null)
+        {
+            Parameter.ThrowIfNegativeOrZero(startLine, nameof(startLine));
+            Parameter.ThrowIfNegativeOrZero(startLine, nameof(endLine));
+
+            this.startLine = startLine;
+            this.endLine = endLine;
+            this.verifyLineRange = true;
+        }
+
+        private static string GetReason(BreakpointReason reason)
+        {
+            Parameter.ThrowIfIsInvalid(reason, BreakpointReason.Unset, nameof(reason));
+            return reason.ToString().ToLowerInvariant();
+        }
+
+        public override void ProcessActualResponse(IActualResponse response)
+        {
+            base.ProcessActualResponse(response);
+
+            if (this.verifyLineRange)
+                StoppedEvent.VerifyLineRange(this?.ActualEvent?.body?.breakpoint?.line, this.startLine, this.endLine);
+        }
+
+        private string GetExpectedLine()
+        {
+            if (this.verifyLineRange)
+                return "{0}-{1}".FormatInvariantWithArgs(this.startLine, this.endLine);
+            return (this.ExpectedResponse.body.breakpoint?.line ?? 0).ToString(CultureInfo.InvariantCulture);
+        }
+
+        public override string ToString()
+        {
+            return "{0} ({1}, line {2})".FormatInvariantWithArgs(base.ToString(), this.ExpectedResponse.body.reason, this.GetExpectedLine());
+        }
+    }
+}

--- a/test/DebuggerTesting/OpenDebug/Events/ConsoleEvent.cs
+++ b/test/DebuggerTesting/OpenDebug/Events/ConsoleEvent.cs
@@ -1,0 +1,34 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Newtonsoft.Json;
+
+namespace DebuggerTesting.OpenDebug.Events
+{
+
+    #region ConsoleEventValue
+
+    public sealed class ConsoleEventValue : EventValue
+    {
+        public sealed class Body
+        {
+            [JsonProperty(DefaultValueHandling = DefaultValueHandling.Ignore)]
+            public string output;
+
+            public string category;
+        }
+
+        public Body body = new Body();
+    }
+
+    #endregion
+
+    public class ConsoleEvent : Event<ConsoleEventValue>
+    {
+        public ConsoleEvent(string text) : base("console")
+        {
+            this.ExpectedResponse.body.category = "console";
+            this.ExpectedResponse.body.output = text;
+        }
+    }
+}

--- a/test/DebuggerTesting/OpenDebug/Events/Event.cs
+++ b/test/DebuggerTesting/OpenDebug/Events/Event.cs
@@ -1,0 +1,37 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace DebuggerTesting.OpenDebug.Events
+{
+    public abstract class EventValue : JsonValue
+    {
+        public string @event;
+    }
+
+    public abstract class Event<T> : Response<T>, IEvent
+        where T : EventValue, new()
+    {
+        public Event(string eventName)
+        {
+            Parameter.ThrowIfNull(eventName, nameof(eventName));
+            this.ExpectedResponse.@event = eventName;
+        }
+
+        public string Name
+        {
+            get { return this.ExpectedResponse.@event; }
+        }
+
+        public virtual void ProcessActualResponse(IActualResponse response)
+        {
+            this.ActualEvent = response.Convert<T>();
+        }
+
+        public T ActualEvent { get; protected set; }
+
+        public override string ToString()
+        {
+            return this.Name;
+        }
+    }
+}

--- a/test/DebuggerTesting/OpenDebug/Events/ExitedEvent.cs
+++ b/test/DebuggerTesting/OpenDebug/Events/ExitedEvent.cs
@@ -1,0 +1,47 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Newtonsoft.Json;
+
+namespace DebuggerTesting.OpenDebug.Events
+{
+    #region ExitedEventValue
+
+    public sealed class ExitedEventValue : EventValue
+    {
+        public sealed class Body
+        {
+            [JsonProperty(DefaultValueHandling = DefaultValueHandling.Ignore)]
+            public int? exitCode;
+        }
+
+        public Body body = new Body();
+    }
+
+    #endregion
+
+    /// <summary>
+    /// Event that fires when the process exits
+    /// </summary>
+    public class ExitedEvent : Event<ExitedEventValue>
+    {
+        public ExitedEvent(int? exitCode = null)
+            : base("exited")
+        {
+            this.ExpectedResponse.body.exitCode = exitCode;
+        }
+
+        public int ActualExitCode { get; private set; }
+
+        public override void ProcessActualResponse(IActualResponse response)
+        {
+            base.ProcessActualResponse(response);
+            this.ActualExitCode = this.ActualEvent?.body?.exitCode ?? -1;
+        }
+
+        public override string ToString()
+        {
+            return "{0} ({1})".FormatInvariantWithArgs(base.ToString(), this.ExpectedResponse.body.exitCode);
+        }
+    }
+}

--- a/test/DebuggerTesting/OpenDebug/Events/StoppedEvent.cs
+++ b/test/DebuggerTesting/OpenDebug/Events/StoppedEvent.cs
@@ -1,0 +1,199 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Globalization;
+using DebuggerTesting.OpenDebug.Commands.Responses;
+using Newtonsoft.Json;
+using Xunit;
+
+namespace DebuggerTesting.OpenDebug.Events
+{
+    public enum StoppedReason
+    {
+        Unknown = 0,
+        Step,
+        Breakpoint,
+        Pause,
+        Exception,
+        Entry
+    }
+
+    #region StoppedEventValue
+
+    public sealed class StoppedEventValue : EventValue
+    {
+        public sealed class Body
+        {
+            [JsonProperty(DefaultValueHandling = DefaultValueHandling.Ignore)]
+            public string reason;
+
+            [JsonProperty(DefaultValueHandling = DefaultValueHandling.Ignore)]
+            public Source source;
+
+            [JsonProperty(DefaultValueHandling = DefaultValueHandling.Ignore)]
+            public int? line;
+
+            [JsonProperty(DefaultValueHandling = DefaultValueHandling.Ignore)]
+            public string text;
+
+            [JsonProperty(DefaultValueHandling = DefaultValueHandling.Ignore)]
+            public int? threadId;
+        }
+
+        public Body body = new Body();
+    }
+
+    #endregion
+
+    public interface IStoppedInfo
+    {
+        StoppedReason Reason { get; }
+        string Filename { get; }
+        int? Line { get; }
+        string Text { get; }
+        int? ThreadId { get; }
+    }
+
+    /// <summary>
+    /// Event that fires when entering break mode
+    /// </summary>
+    public class StoppedEvent : Event<StoppedEventValue>
+    {
+        private bool verifyLineRange;
+        private int startLine;
+        private int endLine;
+
+        public StoppedEvent(StoppedReason? reason = null, string fileName = null, int? lineNumber = null, string text = null)
+            : base("stopped")
+        {
+            this.ExpectedResponse.body.reason = FromReason(reason);
+            if (fileName != null)
+            {
+                this.ExpectedResponse.body.source = new Source();
+                this.ExpectedResponse.body.source.name = fileName;
+            }
+            this.ExpectedResponse.body.line = lineNumber;
+            this.ExpectedResponse.body.text = text;
+            this.verifyLineRange = false;
+        }
+
+        /// <summary>
+        /// Create an expected stopped event that works over a range of lines
+        /// </summary>
+        public StoppedEvent(StoppedReason? reason, string fileName, int startLine, int endLine)
+            : base("stopped")
+        {
+            Parameter.ThrowIfNegativeOrZero(startLine, nameof(startLine));
+            Parameter.ThrowIfNegativeOrZero(startLine, nameof(endLine));
+
+            this.ExpectedResponse.body.reason = FromReason(reason);
+            if (fileName != null)
+            {
+                this.ExpectedResponse.body.source = new Source();
+                this.ExpectedResponse.body.source.name = fileName;
+            }
+
+            this.startLine = startLine;
+            this.endLine = endLine;
+            this.verifyLineRange = true;
+        }
+
+
+        private static string FromReason(StoppedReason? reason)
+        {
+            if (reason == null)
+                return null;
+
+            Parameter.ThrowIfIsInvalid(reason.Value, StoppedReason.Unknown, nameof(reason));
+            return Enum.GetName(typeof(StoppedReason), reason.Value).ToLowerInvariant();
+        }
+
+        private static StoppedReason? ToReason(string value)
+        {
+            StoppedReason reason;
+            if (Enum.TryParse(value, true, out reason))
+                return reason;
+            return null;
+        }
+
+        /// <summary>
+        /// The actual information from the event
+        /// </summary>
+        public IStoppedInfo ActualEventInfo { get; private set; }
+
+        public int ThreadId
+        {
+            get { return this.ActualEventInfo.ThreadId ?? -1; }
+        }
+
+        public override void ProcessActualResponse(IActualResponse response)
+        {
+            base.ProcessActualResponse(response);
+            this.ActualEventInfo = new StoppedInfo(this.ActualEvent);
+
+            if (this.verifyLineRange)
+                VerifyLineRange(this.ActualEventInfo.Line, this.startLine, this.endLine);
+        }
+
+        /// <summary>
+        /// Validates that the line number was withing an expected range.
+        /// This may occur on debuggers that change behavior between different versions or on different platforms.
+        /// </summary>
+        /// <param name="actualLine">The line number that was encountered.</param>
+        /// <param name="expectedStartLine">The first valid line number that could be encountered.</param>
+        /// <param name="expectedLineRange">The range of valid line numbers.</param>
+        internal static void VerifyLineRange(int? actualLine, int expectedStartLine, int expectedEndLine)
+        {
+            // If verifying over line range check result and error now
+            if (actualLine == null || actualLine < expectedStartLine || actualLine > expectedEndLine)
+            {
+                string message = "Expected a line within {0}-{1} but actual line was {2}.".FormatInvariantWithArgs(expectedStartLine, expectedEndLine, actualLine);
+                Assert.True(false, message);
+            }
+        }
+
+        private string GetExpectedLine()
+        {
+            if (this.verifyLineRange)
+                return "{0}-{1}".FormatInvariantWithArgs(this.startLine, this.endLine);
+            return (this.ExpectedResponse.body.line ?? 0).ToString(CultureInfo.InvariantCulture);
+        }
+
+        public override string ToString()
+        {
+            string source = null;
+            if (this.ExpectedResponse.body.source != null)
+            {
+                source = " ({0}:{1})".FormatInvariantWithArgs(this.ExpectedResponse.body.source.name, this.GetExpectedLine());
+            }
+            return "{0} ({1}){2}".FormatInvariantWithArgs(base.ToString(), this.ExpectedResponse.body.reason, source);
+        }
+
+        #region StoppedInfo
+
+        private class StoppedInfo : IStoppedInfo
+        {
+            public StoppedInfo(StoppedEventValue value)
+            {
+                this.Reason = ToReason(value?.body?.reason) ?? StoppedReason.Unknown;
+                this.Filename = value?.body?.source?.name;
+                this.Line = value?.body?.line;
+                this.Text = value?.body?.text;
+                this.ThreadId = value?.body?.threadId;
+            }
+
+            public string Filename { get; private set; }
+
+            public int? Line { get; private set; }
+
+            public StoppedReason Reason { get; private set; }
+
+            public string Text { get; private set; }
+
+            public int? ThreadId { get; private set; }
+        }
+
+        #endregion
+    }
+}

--- a/test/DebuggerTesting/OpenDebug/Events/TerminatedEvent.cs
+++ b/test/DebuggerTesting/OpenDebug/Events/TerminatedEvent.cs
@@ -1,0 +1,17 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace DebuggerTesting.OpenDebug.Events
+{
+    public sealed class TerminatedEventValue : EventValue
+    {
+    }
+
+    public class TerminatedEvent : Event<TerminatedEventValue>
+    {
+        public TerminatedEvent()
+            : base("terminated")
+        {
+        }
+    }
+}

--- a/test/DebuggerTesting/OpenDebug/Extensions/DebuggeeExtensions.cs
+++ b/test/DebuggerTesting/OpenDebug/Extensions/DebuggeeExtensions.cs
@@ -1,0 +1,23 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using DebuggerTesting.Compilation;
+using DebuggerTesting.OpenDebug.Commands;
+
+namespace DebuggerTesting.OpenDebug.Extensions
+{
+    public static class DebuggeeExtensions
+    {
+        /// <summary>
+        /// Creates a SourceBreakpoints object that can be used to keep
+        /// track of all the breakpoints in a file.
+        /// </summary>
+        public static SourceBreakpoints Breakpoints(this IDebuggee debuggee, string sourceRelativePath, params int[] lineNumbers)
+        {
+            SourceBreakpoints breakpoints = new SourceBreakpoints(debuggee, sourceRelativePath);
+            foreach (int lineNumber in lineNumbers)
+                breakpoints.Add(lineNumber);
+            return breakpoints;
+        }
+    }
+}

--- a/test/DebuggerTesting/OpenDebug/Extensions/DebuggerRunnerExtensions.cs
+++ b/test/DebuggerTesting/OpenDebug/Extensions/DebuggerRunnerExtensions.cs
@@ -1,0 +1,210 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using DebuggerTesting.OpenDebug.Commands;
+using DebuggerTesting.OpenDebug.Commands.Responses;
+using DebuggerTesting.OpenDebug.Events;
+using Xunit;
+
+namespace DebuggerTesting.OpenDebug.Extensions
+{
+    public interface IThreadInfo
+    {
+        int Id { get; }
+        string Name { get; }
+        IThreadInspector GetThreadInspector();
+    }
+
+    public static class DebuggerRunnerExtensions
+    {
+        /// <summary>
+        /// Provides an abstraction over the commands that
+        /// retrieve debugger information on inspecting debuggee
+        /// data when the debugger is in a break state.
+        /// </summary>
+        public static IThreadInspector GetThreadInspector(this IDebuggerRunner runner, int? threadId = null)
+        {
+            return new ThreadInspector(runner, threadId);
+        }
+
+        /// <summary>
+        /// Verifies the names of the frames in the stack
+        /// </summary>
+        /// <param name="threadInspector">The thread to verify</param>
+        /// <param name="useRegEx">Set to true if the frame names are regular expressions, otherwise expects exact match.</param>
+        /// <param name="frameNames">The list of the frame names to verify.</param>
+        public static void AssertStackFrameNames(this IThreadInspector threadInspector, bool useRegEx, params string[] frameNames)
+        {
+            Parameter.ThrowIfOutOfRange(frameNames.Length, 1, int.MaxValue, nameof(frameNames));
+
+            int frameCount = 0;
+            foreach (IFrameInspector frameInspector in threadInspector.Stack)
+            {
+                AssertFrameName(frameInspector, useRegEx, frameNames[frameCount]);
+
+                frameCount++;
+                if (frameCount >= frameNames.Length)
+                    break;
+            }
+        }
+
+        private static void AssertFrameName(this IFrameInspector frameInspector, bool useRegEx, string frameName)
+        {
+            if (useRegEx)
+                Assert.Matches(frameName, frameInspector.Name);
+            else
+                Assert.Equal(frameName, frameInspector.Name);
+        }
+
+        /// <summary>
+        /// Verify the child variables match the expected names and values.
+        /// </summary>
+        /// <param name="variableExpander">The parent to the variables</param>
+        /// <param name="variables">An alternating list of variable name and variabl value.</param>
+        public static void AssertVariables(this IVariableExpander variableExpander, params string[] variables)
+        {
+            if (variables.Length % 2 != 0)
+            {
+                throw new ArgumentException("Missing a property!");
+            }
+
+            for (int i = 0; i < variables.Length; i += 2)
+            {
+                string name = variables[i];
+                string value = variables[i + 1];
+                Assert.True(variableExpander.Variables.ContainsKey(name), "Expected variable name '{0}'.".FormatInvariantWithArgs(name));
+                Assert.True(string.Equals(variableExpander.Variables[name].Value, value, StringComparison.Ordinal),
+                            "Expected variable value '{0}' for '{1}'.  Actual value is '{2}'.".FormatInvariantWithArgs(value, name, variableExpander.Variables[name].Value));
+            }
+        }
+
+        /// <summary>
+        /// Get's a variable, but fails with more detailed message if it doesn't exist. Can be called with child variable names
+        /// to follow variable expansion tree.
+        /// </summary>
+        public static IVariableInspector GetVariable(this IVariableExpander variableExpander, params string[] names)
+        {
+            Parameter.ThrowIfIsInvalid(names.Length, 0, nameof(names));
+
+            IVariableInspector variableInspector = null;
+            foreach (var name in names)
+            {
+                variableInspector = GetVariablePart(variableExpander, name);
+                variableExpander = variableInspector;
+            }
+            return variableInspector;
+        }
+
+        private static IVariableInspector GetVariablePart(IVariableExpander variableExpander, string name)
+        {
+            IVariableInspector inspector;
+            if (variableExpander.Variables.TryGetValue(name, out inspector))
+                return inspector;
+
+            string existingVariables = variableExpander.Variables.ToReadableString();
+            throw new KeyNotFoundException("Variable " + name + " not found. Existing variables: " + existingVariables);
+        }
+
+        public static IEnumerable<IThreadInfo> GetThreads(this IDebuggerRunner runner)
+        {
+            ThreadsResponseValue threads = runner.RunCommand(new ThreadsCommand());
+            return threads?.body?.threads?.Select(t => new ThreadInfo(runner, t.name, t.id ?? -1));
+        }
+
+        #region ThreadInfo
+
+        internal class ThreadInfo : IThreadInfo
+        {
+            #region Constructor
+
+            public ThreadInfo(IDebuggerRunner runner, string name, int id)
+            {
+                this.Runner = runner;
+                this.Name = name;
+                this.Id = id;
+            }
+
+            #endregion
+
+            private IDebuggerRunner Runner { get; set; }
+            public string Name { get; private set; }
+            public int Id { get; private set; }
+
+            public IThreadInspector GetThreadInspector()
+            {
+                return new ThreadInspector(this.Runner, this.Id);
+            }
+        }
+
+        #endregion
+
+        public static void RunCommandExpectFailure(this IDebuggerRunner runner, ICommand command)
+        {
+            command.ExpectsSuccess = false;
+            runner.RunCommand(command);
+        }
+
+        public static SetBreakpointsResponseValue SetBreakpoints(this IDebuggerRunner runner, SourceBreakpoints sourceBreakpoints)
+        {
+            return runner.RunCommand(new SetBreakpointsCommand(sourceBreakpoints));
+        }
+
+        public static void SetExceptionBreakpoints(this IDebuggerRunner runner, params string[] filters)
+        {
+                runner.RunCommand(new SetExceptionBreakpointsCommand(filters));
+        }
+
+        public static SetBreakpointsResponseValue SetFunctionBreakpoints(this IDebuggerRunner runner, FunctionBreakpoints breakpoints)
+        {
+            return runner.RunCommand(new SetFunctionBreakpointsCommand(breakpoints));
+        }
+
+        public static void Continue(this IDebuggerRunner runner)
+        {
+            runner.RunCommand(new ContinueCommand(runner.StoppedThreadId));
+        }
+
+        public static void ConfigurationDone(this IDebuggerRunner runner)
+        {
+            runner.RunCommand(new ConfigurationDoneCommand());
+        }
+
+        /// <summary>
+        /// Adds an expected stop event within a range of line numbers. If the stop does not occur on <paramref name="targetLine"/>, then perform a step over
+        /// and verify that the debuggee breaks at the <paramref name="targetLine"/>.
+        /// </summary>
+        /// <param name="startLine">The first line number onto which it is acceptable that the stop occurs.</param>
+        /// <param name="targetLine">The line number which is the desired stopping line.</param>
+        public static IRunBuilder ExpectStopAndStepToTarget(this IDebuggerRunner runner, StoppedReason reason, string fileName, int startLine, int targetLine)
+        {
+            return runner.Expects.HitStopEventWithinRange(reason, fileName, startLine, targetLine, (e) =>
+            {
+                if (e.ActualEvent.body.line != targetLine)
+                {
+                    runner.Expects.HitStepEvent(fileName, targetLine).AfterStepOver();
+                }
+            });
+        }
+
+        /// <summary>
+        /// Adds an expected step event within a range of line numbers. If the step does not occur on <paramref name="targetLine"/>, then perform a step over
+        /// and verify that the debuggee breaks at the <paramref name="targetLine"/>.
+        /// </summary>
+        public static IRunBuilder ExpectStepAndStepToTarget(this IDebuggerRunner runner, string fileName, int startLine, int targetLine)
+        {
+            return runner.ExpectStopAndStepToTarget(StoppedReason.Step, fileName, startLine, targetLine);
+        }
+
+        /// <summary>
+        /// Adds an expected breakpoint event within a range of line numbers. If the breakpoint does not occur on <paramref name="targetLine"/>, then perform a step over
+        /// and verify that the debuggee breaks at the <paramref name="targetLine"/>.
+        /// </summary>
+        public static IRunBuilder ExpectBreakpointAndStepToTarget(this IDebuggerRunner runner, string fileName, int startLine, int targetLine)
+        {
+            return runner.ExpectStopAndStepToTarget(StoppedReason.Breakpoint, fileName, startLine, targetLine);
+        }
+    }
+}

--- a/test/DebuggerTesting/OpenDebug/Extensions/FrameInspector.cs
+++ b/test/DebuggerTesting/OpenDebug/Extensions/FrameInspector.cs
@@ -1,0 +1,190 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Collections.Generic;
+using System.Text;
+using DebuggerTesting.OpenDebug.Commands;
+using DebuggerTesting.OpenDebug.Commands.Responses;
+using DebuggerTesting.Utilities;
+
+namespace DebuggerTesting.OpenDebug.Extensions
+{
+    internal class FrameInspector : DisposableObject, IFrameInspector
+    {
+        private int? variablesReference;
+        private Dictionary<string, IVariableInspector> variables;
+        private string name;
+        private int id;
+        private string sourceName;
+        private string sourcePath;
+        private int? line;
+        private int? column;
+        private int? sourceReference;
+
+        #region Constructor/Dispose
+
+        public FrameInspector(IDebuggerRunner runner, string name, int id, string sourceName, string sourcePath, int? sourceReference, int? line, int? column)
+        {
+            Parameter.ThrowIfNull(runner, nameof(runner));
+            this.DebuggerRunner = runner;
+            this.name = name;
+            this.id = id;
+            this.sourceName = sourceName;
+            this.sourcePath = sourcePath;
+            this.sourceReference = sourceReference;
+            this.line = line;
+            this.column = column;
+        }
+
+        protected override void Dispose(bool isDisposing)
+        {
+            if (isDisposing)
+            {
+                DisposableHelper.SafeDisposeAll(this.variables?.Values);
+                this.variables = null;
+                this.DebuggerRunner = null;
+            }
+            base.Dispose(IsDisposed);
+        }
+
+        #endregion
+
+        #region Frame Info
+
+        public IDebuggerRunner DebuggerRunner { get; private set; }
+
+        public string Name
+        {
+            get
+            {
+                this.VerifyNotDisposed();
+                return this.name;
+            }
+        }
+
+        public int Id
+        {
+            get
+            {
+                this.VerifyNotDisposed();
+                return this.id;
+            }
+        }
+
+        public string SourceName
+        {
+            get
+            {
+                this.VerifyNotDisposed();
+                return this.sourceName;
+            }
+        }
+
+        public string SourcePath
+        {
+            get
+            {
+                this.VerifyNotDisposed();
+                return this.sourcePath;
+            }
+        }
+
+        public int? SourceReference
+        {
+            get
+            {
+                this.VerifyNotDisposed();
+                return this.sourceReference;
+            }
+        }
+
+        public int? Line
+        {
+            get
+            {
+                this.VerifyNotDisposed();
+                return this.line;
+            }
+        }
+
+        public int? Column
+        {
+            get
+            {
+                this.VerifyNotDisposed();
+                return this.column;
+            }
+        }
+
+        #endregion
+
+        /// <summary>
+        /// Gets the local variables on this frame.
+        /// </summary>
+        public IDictionary<string, IVariableInspector> Variables
+        {
+            get
+            {
+                this.VerifyNotDisposed();
+                if (this.variables == null)
+                {
+                    // Ensure the scope has been created
+                    if (this.variablesReference == null)
+                    {
+                        ScopesCommand scopesCommand = new ScopesCommand(this.Id);
+                        this.DebuggerRunner.RunCommand(scopesCommand);
+                        this.variablesReference = scopesCommand.VariablesReference;
+                    }
+
+                    if (this.variablesReference == null || this.variablesReference == 0)
+                        return null;
+
+                    // Get the variables
+                    this.variables = VariableInspector.GetChildVariables(this.DebuggerRunner, this.variablesReference.Value);
+                }
+                return this.variables;
+            }
+        }
+
+        /// <summary>
+        /// Evaluates an expression on this frame.
+        /// WARNING: if an expression has side effects, you will need to Refresh the IInspector and
+        /// get the stack information to get up to date info.
+        /// </summary>
+        public string Evaluate(string expression, EvaluateContext context = EvaluateContext.None)
+        {
+            this.VerifyNotDisposed();
+            EvaluateResponseValue response = this.DebuggerRunner.RunCommand(new EvaluateCommand(expression, this.Id, context));
+            return response.body.result;
+        }
+
+        public string GetSourceContent()
+        {
+            this.VerifyNotDisposed();
+            if (this.sourceReference == null)
+                return null;
+            return this.DebuggerRunner.RunCommand(new SourceCommand(this.sourceReference.Value))?.body?.content;
+        }
+
+        public override string ToString()
+        {
+            StringBuilder sb = new StringBuilder(this.Name);
+            sb.Append(" (");
+            sb.Append(this.Id);
+            sb.Append(")");
+            if (this.SourceName != null)
+            {
+                sb.Append(" [");
+                sb.Append(this.SourceName);
+                if (this.Line != null)
+                {
+                    sb.Append(":");
+                    sb.Append(this.Line.Value);
+                }
+                sb.Append("]");
+            }
+            return sb.ToString();
+        }
+
+    }
+}

--- a/test/DebuggerTesting/OpenDebug/Extensions/IInspectors.cs
+++ b/test/DebuggerTesting/OpenDebug/Extensions/IInspectors.cs
@@ -1,0 +1,95 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Collections.Generic;
+using DebuggerTesting.OpenDebug.Commands;
+
+namespace DebuggerTesting.OpenDebug.Extensions
+{
+    public interface IInspector
+    {
+        IDebuggerRunner DebuggerRunner { get; }
+    }
+
+    /// <summary>
+    /// Provides an abstraction over the commands that
+    /// retrieve debugger information on inspecting debuggee
+    /// data when the debugger is in a break state.
+    /// </summary>
+    public interface IThreadInspector : IInspector, IDisposable
+    {
+        IEnumerable<IFrameInspector> Stack { get; }
+
+        int ThreadId { get; }
+
+        void Refresh();
+    }
+
+    public interface IVariableExpander
+    {
+        /// <summary>
+        /// Gets the variables and their values on this frame
+        /// </summary>
+        IDictionary<string, IVariableInspector> Variables { get; }
+    }
+
+    /// <summary>
+    /// Provides an abstraction over the commands that
+    /// retrieve debugger information on a frame and
+    /// variables in the frame's scope.
+    /// </summary>
+    public interface IFrameInspector : IVariableExpander, IInspector
+    {
+        /// <summary>
+        /// The name of the frame. i.e. main(int argc, char ** argv)
+        /// </summary>
+        string Name { get; }
+
+        /// <summary>
+        /// The OpenDebug id for the frame. Usually aroung 1000
+        /// </summary>
+        int Id { get; }
+
+        /// <summary>
+        /// The source code file name
+        /// </summary>
+        string SourceName { get; }
+
+        /// <summary>
+        /// The full path to the source code file name
+        /// </summary>
+        string SourcePath { get; }
+
+        /// <summary>
+        /// The reference used to get more info on the source
+        /// </summary>
+        int? SourceReference { get; }
+
+        int? Line { get; }
+        int? Column { get; }
+
+        /// <summary>
+        /// Evaluates an expression on this frame
+        /// </summary>
+        string Evaluate(string expression, EvaluateContext context = EvaluateContext.None);
+
+        /// <summary>
+        /// Gets the source associated with this frame
+        /// </summary>
+        string GetSourceContent();
+    }
+
+    /// <summary>
+    /// Provides an abstraction over the commands that
+    /// retrieve debugger information on a variable and
+    /// can expand on child variable info.
+    /// </summary>
+    public interface IVariableInspector : IVariableExpander, IInspector
+    {
+        string Name { get; }
+        string Value { get; set; }
+        int? VariablesReference { get; }
+        void SetVariableValueExpectFailure(string expression);
+    }
+}

--- a/test/DebuggerTesting/OpenDebug/Extensions/ThreadInspector.cs
+++ b/test/DebuggerTesting/OpenDebug/Extensions/ThreadInspector.cs
@@ -1,0 +1,83 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Collections.Generic;
+using DebuggerTesting.OpenDebug.Commands;
+using DebuggerTesting.OpenDebug.Commands.Responses;
+using DebuggerTesting.Utilities;
+
+namespace DebuggerTesting.OpenDebug.Extensions
+{
+    internal class ThreadInspector : DisposableObject, IThreadInspector
+    {
+        private int threadId;
+        private IList<FrameInspector> frameInspectors = new List<FrameInspector>(20);
+
+        #region Constructor/Dispose
+
+        public ThreadInspector(IDebuggerRunner runner, int? threadId = null)
+        {
+            Parameter.ThrowIfNull(runner, nameof(runner));
+            this.DebuggerRunner = runner;
+            this.threadId = threadId ?? runner.StoppedThreadId;
+        }
+
+        protected override void Dispose(bool isDisposing)
+        {
+            if (isDisposing)
+            {
+                this.Refresh();
+                this.DebuggerRunner = null;
+            }
+            base.Dispose(isDisposing);
+        }
+
+        #endregion
+
+        public IDebuggerRunner DebuggerRunner { get; private set; }
+
+        public int ThreadId
+        {
+            get { return this.threadId; }
+        }
+
+        public IEnumerable<IFrameInspector> Stack
+        {
+            get
+            {
+                this.VerifyNotDisposed();
+                int startFrame = 0;
+
+                while (true)
+                {
+                    StackTraceCommand stackTraceCommand = new StackTraceCommand(this.threadId, startFrame);
+                    StackTraceResponseValue response = this.DebuggerRunner.RunCommand(stackTraceCommand);
+                    if (response?.body?.stackFrames == null || response.body.stackFrames.Length <= 0)
+                        yield break;
+
+                    startFrame += response.body.stackFrames.Length;
+                    foreach (var stackFrame in response.body.stackFrames)
+                    {
+                        string name = stackFrame.name;
+                        int id = stackFrame.id ?? -1;
+                        string sourceName = stackFrame.source?.name;
+                        string sourcePath = stackFrame.source?.path;
+                        int? sourceReference = stackFrame.source?.sourceReference;
+                        int? line = stackFrame.line;
+                        int? column = stackFrame.column;
+
+                        FrameInspector frame = new FrameInspector(this.DebuggerRunner, name, id, sourceName, sourcePath, sourceReference, line, column);
+                        this.frameInspectors.Add(frame);
+                        yield return frame;
+                    }
+                }
+            }
+        }
+
+        public void Refresh()
+        {
+            this.frameInspectors.SafeDisposeAll();
+            this.frameInspectors.Clear();
+        }
+    }
+}

--- a/test/DebuggerTesting/OpenDebug/Extensions/VariableInspector.cs
+++ b/test/DebuggerTesting/OpenDebug/Extensions/VariableInspector.cs
@@ -1,0 +1,123 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Collections.Generic;
+using System.Linq;
+using DebuggerTesting.OpenDebug.Commands;
+using DebuggerTesting.OpenDebug.Commands.Responses;
+using DebuggerTesting.Utilities;
+
+namespace DebuggerTesting.OpenDebug.Extensions
+{
+    /// <summary>
+    /// Returns info on a variable, and allows expanded evaluation of variable info.
+    /// </summary>
+    internal class VariableInspector : DisposableObject, IVariableInspector
+    {
+        private Dictionary<string, IVariableInspector> variables;
+        private string name;
+        private string value;
+        private int parentVariablesReference;
+        private int? variablesReference;
+
+        #region Constructor/Create/Dispose
+
+        public VariableInspector(IDebuggerRunner runner, int parentVariablesReference, string name, string value, int? variablesReference)
+        {
+            Parameter.ThrowIfNull(runner, nameof(runner));
+            this.DebuggerRunner = runner;
+            this.parentVariablesReference = parentVariablesReference;
+            this.name = name;
+            this.value = value;
+            this.variablesReference = variablesReference;
+        }
+
+        protected override void Dispose(bool isDisposing)
+        {
+            if (isDisposing)
+            {
+                DisposableHelper.SafeDisposeAll(this.variables?.Values);
+                this.variables = null;
+                this.DebuggerRunner = null;
+            }
+            base.Dispose(isDisposing);
+        }
+
+        #endregion
+
+        public IDebuggerRunner DebuggerRunner { get; private set; }
+
+        #region Variable Info
+
+        public string Name
+        {
+            get
+            {
+                this.VerifyNotDisposed();
+                return this.name;
+            }
+        }
+
+        public string Value
+        {
+            get
+            {
+                this.VerifyNotDisposed();
+                return this.value;
+            }
+            set
+            {
+                this.VerifyNotDisposed();
+                this.DebuggerRunner.RunCommand(this.GetSetVariableCommand(value));
+            }
+        }
+
+        public int? VariablesReference
+        {
+            get
+            {
+                this.VerifyNotDisposed();
+                return this.variablesReference;
+            }
+        }
+
+        #endregion
+
+        public void SetVariableValueExpectFailure(string expression)
+        {
+            this.DebuggerRunner.RunCommandExpectFailure(this.GetSetVariableCommand(expression));
+        }
+
+        public IDictionary<string, IVariableInspector> Variables
+        {
+            get
+            {
+                this.VerifyNotDisposed();
+                if (this.VariablesReference == null || this.VariablesReference == 0)
+                    return null;
+
+                if (this.variables == null)
+                {
+                    this.variables = GetChildVariables(this.DebuggerRunner, this.VariablesReference.Value);
+                }
+                return this.variables;
+            }
+        }
+
+        internal static Dictionary<string, IVariableInspector> GetChildVariables(IDebuggerRunner runner, int variablesReference)
+        {
+            VariablesResponseValue variablesResponse = runner.RunCommand(new VariablesCommand(variablesReference));
+            return variablesResponse.body.variables.ToDictionary<VariablesResponseValue.Body.Variable, string, IVariableInspector>(v => v.name, v => new VariableInspector(runner, variablesReference, v.name, v.value, v.variablesReference));
+        }
+
+        private ICommandWithResponse<SetVariableResponseValue> GetSetVariableCommand(string expression)
+        {
+            return new SetVariableCommand(this.parentVariablesReference, this.name, expression);
+        }
+
+        public override string ToString()
+        {
+            return "{0}={1}".FormatInvariantWithArgs(this.Name, this.Value);
+        }
+    }
+}

--- a/test/DebuggerTesting/OpenDebug/ICommand.cs
+++ b/test/DebuggerTesting/OpenDebug/ICommand.cs
@@ -1,0 +1,64 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+
+namespace DebuggerTesting.OpenDebug
+{
+    /// <summary>
+    /// Represents a Debug Adapter command.
+    /// </summary>
+    public interface ICommand
+    {
+        string Name { get; }
+
+        /// <summary>
+        /// The object that gets converted to JSON to represent the commands args.
+        /// </summary>
+        object DynamicArgs { get; }
+
+        /// <summary>
+        /// Represents the expected response from the command.
+        /// If the actual response does not match this value, the command will throw.
+        /// </summary>
+        IResponse ExpectedResponse { get; }
+
+        /// <summary>
+        /// Sets the expectation of the commands success value
+        /// </summary>
+        bool ExpectsSuccess { get; set; }
+
+        /// <summary>
+        /// After the command is run if the command response matches ExpectedResponse,
+        /// this method is called with the actual match.
+        /// This can be used to read data from the response.
+        /// </summary>
+        void ProcessActualResponse(IActualResponse response);
+
+        /// <summary>
+        /// Set this to override the default timeout for the duration of this command.
+        /// </summary>
+        TimeSpan Timeout { get; set; }
+
+        void Run(IDebuggerRunner runner, params IEvent[] expectedEvents);
+    }
+
+    /// <summary>
+    /// Applies to a Debug Adapter command that can return results. 
+    /// </summary>
+    public interface ICommandWithResponse<T> : ICommand
+    {
+        T ActualResponse { get; }
+
+        new T Run(IDebuggerRunner runner, params IEvent[] expectedEvents);
+    }
+
+    /// <summary>
+    /// Provides a way to get the command to interperet the actual result
+    /// that comes back from the Debug Adapter.
+    /// </summary>
+    public interface IActualResponse
+    {
+        R Convert<R>();
+    }
+}

--- a/test/DebuggerTesting/OpenDebug/IDebuggerRunner.cs
+++ b/test/DebuggerTesting/OpenDebug/IDebuggerRunner.cs
@@ -1,0 +1,63 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using DebuggerTesting.OpenDebug.Commands;
+using DarRunner = DebugAdapterRunner.DebugAdapterRunner;
+
+namespace DebuggerTesting.OpenDebug
+{
+    /// <summary>
+    /// A wrapper around the DAR debugger adapter runner. 
+    /// The abstracts parameters that need to be passed to the DAR runner.
+    /// It also has logic to check for leaked processes and files.
+    /// </summary>
+    public interface IDebuggerRunner : ILoggingComponent, IDisposable
+    {
+        /// <summary>
+        /// The debug adapter runner this wraps.
+        /// </summary>
+        DarRunner DarRunner { get; }
+
+        /// <summary>
+        /// If an error is encountered running a previous command, this gets set to true
+        /// and subsequent commands are not issued.
+        /// </summary>
+        bool ErrorEncountered { get; set; }
+
+        /// <summary>
+        /// When a break event occurs this reports the thread id of the current thread.
+        /// </summary>
+        int StoppedThreadId { get; }
+
+        /// <summary>
+        /// Runs a debug adapter command.
+        /// </summary>
+        /// <param name="command">The command to run</param>
+        /// <param name="expectedEvents">[OPTIONAL] If the command expects to raise events, provide the list of events to look for.</param>
+        void RunCommand(ICommand command, params IEvent[] expectedEvents);
+
+        R RunCommand<R>(ICommandWithResponse<R> command, params IEvent[] expectedEvents);
+
+        /// <summary>
+        /// Provides a builder for describing expected events and command.
+        /// First provides events in the order they are expected, then finish
+        /// with the command to be run.
+        /// </summary>
+        IRunBuilder Expects { get; }
+
+        /// <summary>
+        /// Performs a disconnct command and verifies that child processes are closed.
+        /// If they are not, this fails the test.
+        /// If you just call Dispose, the processes are closed, but the test does not fail.
+        /// </summary>
+        void DisconnectAndVerify();
+
+        InitializeResponseValue InitializeResponse { get; }
+
+        /// <summary>
+        /// Gets the settings for the debugger
+        /// </summary>
+        IDebuggerSettings DebuggerSettings { get;  }
+    }
+}

--- a/test/DebuggerTesting/OpenDebug/IEvent.cs
+++ b/test/DebuggerTesting/OpenDebug/IEvent.cs
@@ -1,0 +1,17 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace DebuggerTesting.OpenDebug
+{
+    public interface IEvent : IResponse
+    {
+        string Name { get; }
+
+        /// <summary>
+        /// Called after an event is hit if the event response matches.
+        /// This method is called with the actual match.
+        /// This can be used to read data from the event.
+        /// </summary>
+        void ProcessActualResponse(IActualResponse response);
+    }
+}

--- a/test/DebuggerTesting/OpenDebug/IResponse.cs
+++ b/test/DebuggerTesting/OpenDebug/IResponse.cs
@@ -1,0 +1,21 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace DebuggerTesting.OpenDebug
+{
+    /// <summary>
+    /// Represents a Debug Adapter responses
+    /// </summary>
+    public interface IResponse
+    {
+        /// <summary>
+        /// The object that gets converted to JSON to represent a debug adapter response
+        /// </summary>
+        object DynamicResponse { get; }
+
+        /// <summary>
+        /// Set to true if the order of the items in the response is not important (like variable lists)
+        /// </summary>
+        bool IgnoreOrder { get; }
+    }
+}

--- a/test/DebuggerTesting/OpenDebug/Response.cs
+++ b/test/DebuggerTesting/OpenDebug/Response.cs
@@ -1,0 +1,43 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Newtonsoft.Json;
+
+namespace DebuggerTesting.OpenDebug
+{
+    /// <summary>
+    /// Provides a convenience base class for classes
+    /// that will be serialized to JSON.
+    /// </summary>
+    public class JsonValue
+    {
+        public override string ToString()
+        {
+            return JsonConvert.SerializeObject(this);
+        }
+    }
+
+    public abstract class Response<T> : IResponse
+        where T : new()
+    {
+        public Response()
+        {
+            this.ExpectedResponse = new T();
+        }
+
+        #region IResponse
+
+        object IResponse.DynamicResponse { get { return ExpectedResponse; } }
+
+        public bool IgnoreOrder { get; protected set; }
+
+        #endregion
+
+        public T ExpectedResponse { get; protected set; }
+
+        public override string ToString()
+        {
+            return this.GetType().Name;
+        }
+    }
+}

--- a/test/DebuggerTesting/OpenDebug/RunBuilder.cs
+++ b/test/DebuggerTesting/OpenDebug/RunBuilder.cs
@@ -1,0 +1,219 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Collections.Generic;
+using DebuggerTesting.OpenDebug.Commands;
+using DebuggerTesting.OpenDebug.Events;
+
+namespace DebuggerTesting.OpenDebug
+{
+    /// <summary>
+    /// A builder for running a command with a set of expected events
+    /// </summary>
+    public interface IRunBuilder
+    {
+        IRunBuilder Event<T>(T expectedEvent, Action<T> postSatisfyAction = null) where T : IEvent;
+
+        void AfterCommand(ICommand command);
+
+        /// <summary>
+        /// Specify the amount of time to wait for the command and all the events
+        /// </summary>
+        IRunBuilder WithTimeout(TimeSpan timeout);
+    }
+
+    /// <summary>
+    /// Extension methods for specific events and commands
+    /// </summary>
+    public static class RunBuilderExtensions
+    {
+        /// <summary>
+        /// Check for event only if the condition is true
+        /// </summary>
+        public static IRunBuilder ConditionalEvent(this IRunBuilder runBuilder, bool condition, Func<IRunBuilder, IRunBuilder> thenEvent)
+        {
+            return (condition) ?
+                thenEvent(runBuilder) :
+                runBuilder;
+        }
+
+        #region Specific Events
+
+        public static IRunBuilder StoppedEvent(this IRunBuilder runBuilder, StoppedReason reason, string fileName = null, int? lineNumber = null, string text = null)
+        {
+            return runBuilder.Event(new StoppedEvent(reason, fileName, lineNumber, text));
+        }
+
+        public static IRunBuilder HitBreakpointEvent(this IRunBuilder runBuilder, string fileName = null, int? lineNumber = null, string text = null)
+        {
+            return runBuilder.StoppedEvent(StoppedReason.Breakpoint, fileName, lineNumber, text);
+        }
+
+        public static IRunBuilder HitStepEvent(this IRunBuilder runBuilder, string fileName = null, int? lineNumber = null, string text = null)
+        {
+            return runBuilder.StoppedEvent(StoppedReason.Step, fileName, lineNumber, text);
+        }
+
+        public static IRunBuilder HitEntryEvent(this IRunBuilder runBuilder, string fileName = null, int? lineNumber = null, string text = null)
+        {
+            return runBuilder.StoppedEvent(StoppedReason.Entry, fileName, lineNumber, text);
+        }
+
+        public static IRunBuilder HitStopEventWithinRange(this IRunBuilder runBuilder, StoppedReason reason, string fileName, int startLine, int endLine, Action<StoppedEvent> postSatisfyAction = null)
+        {
+            return runBuilder.Event(new StoppedEvent(reason, fileName, startLine, endLine), postSatisfyAction);
+        }
+
+        public static IRunBuilder ExitedEvent(this IRunBuilder runBuilder, int? exitCode = null)
+        {
+            return runBuilder.Event(new ExitedEvent(exitCode));
+        }
+
+        public static IRunBuilder TerminatedEvent(this IRunBuilder runBuilder)
+        {
+            return runBuilder.Event(new TerminatedEvent());
+        }
+
+        public static IRunBuilder BreakpointChangedEvent(this IRunBuilder runBuilder, BreakpointReason reason, int line)
+        {
+            return runBuilder.Event(new BreakpointEvent(reason, line));
+        }
+
+        /// <summary>
+        /// Function breakpoints may resolve to different lines depending on the compiler/debugger combination.
+        /// Sometimes they resolve to the curly brace line. Other times on the first line of code.
+        /// </summary>
+        public static IRunBuilder FunctionBreakpointChangedEvent(this IRunBuilder runBuilder, BreakpointReason reason, int startLine, int endLine)
+        {
+            return runBuilder.Event(new BreakpointEvent(reason, startLine, endLine));
+        }
+
+        public static IRunBuilder ConsoleEvent(this IRunBuilder runBuilder, string text)
+        {
+            return runBuilder.Event(new ConsoleEvent(text));
+        }
+
+        #endregion
+
+        #region Specific Commands
+
+        private static int GetStoppedThreadId(IRunBuilder runBuilder)
+        {
+            return ((RunBuilder)runBuilder).Runner.StoppedThreadId;
+        }
+
+        public static void AfterContinue(this IRunBuilder runBuilder)
+        {
+            runBuilder.AfterCommand(new ContinueCommand(GetStoppedThreadId(runBuilder)));
+        }
+
+        public static void AfterStepIn(this IRunBuilder runBuilder)
+        {
+            runBuilder.AfterCommand(new StepInCommand(GetStoppedThreadId(runBuilder)));
+        }
+
+        public static void AfterStepOver(this IRunBuilder runBuilder)
+        {
+            runBuilder.AfterCommand(new StepOverCommand(GetStoppedThreadId(runBuilder)));
+        }
+
+        public static void AfterStepOut(this IRunBuilder runBuilder)
+        {
+            runBuilder.AfterCommand(new StepOutCommand(GetStoppedThreadId(runBuilder)));
+        }
+
+        public static void AfterConfigurationDone(this IRunBuilder runBuilder)
+        {
+            runBuilder.AfterCommand(new ConfigurationDoneCommand());
+        }
+
+        public static void AfterAsyncBreak(this IRunBuilder runBuilder)
+        {
+            runBuilder.AfterCommand(new AsyncBreakCommand());
+        }
+
+        public static void AfterSetBreakpoints(this IRunBuilder runBuilder, SourceBreakpoints sourceBreakpoints)
+        {
+            runBuilder.AfterCommand(new SetBreakpointsCommand(sourceBreakpoints));
+        }
+
+        public static void AfterSetFunctionBreakpoints(this IRunBuilder runBuilder, FunctionBreakpoints functionBreakpoints)
+        {
+            runBuilder.AfterCommand(new SetFunctionBreakpointsCommand(functionBreakpoints));
+        }
+
+        #endregion
+    }
+
+    #region RunBuilder
+
+    public class RunBuilder : DisposableObject, IRunBuilder
+    {
+        private List<IEvent> expectedEvents;
+        private Stack<Action> postSatisfyActions;
+        private TimeSpan? timeout;
+
+        #region Constructor/Dispose
+
+        public RunBuilder(IDebuggerRunner runner)
+        {
+            this.Runner = runner;
+            this.expectedEvents = new List<IEvent>(1);
+            this.postSatisfyActions = new Stack<Action>();
+        }
+
+        protected override void Dispose(bool isDisposing)
+        {
+            // If the composed statement doesn't have a command at the end,
+            // it will not run. So throw an exception if this is detected.
+            if (!isDisposing && !this.IsDisposed)
+            {
+                throw new RunnerException("RunBuilder requires a call to AfterCommand to execute.");
+            }
+            base.Dispose(isDisposing);
+        }
+
+        #endregion
+
+        public IDebuggerRunner Runner { get; private set; }
+
+        public IRunBuilder Event<T>(T expectedEvent, Action<T> postSatisfyAction) where T : IEvent
+        {
+            this.VerifyNotDisposed();
+            this.expectedEvents.Add(expectedEvent);
+            if (null != postSatisfyAction)
+            {
+                this.postSatisfyActions.Push(() => postSatisfyAction(expectedEvent));
+            }
+            return this;
+        }
+
+        public IRunBuilder WithTimeout(TimeSpan timeout)
+        {
+            this.timeout = timeout;
+            return this;
+        }
+
+        public void AfterCommand(ICommand command)
+        {
+            this.VerifyNotDisposed();
+            try
+            {
+                if (this.timeout != null)
+                    command.Timeout = this.timeout.Value;
+                this.Runner.RunCommand(command, this.expectedEvents.ToArray());
+                // At this point, the command has been executed and the expected events have been satisfied.
+                // Run the actions that should occur after the events have been satisfied.
+                while (this.postSatisfyActions.Count > 0)
+                    this.postSatisfyActions.Pop().Invoke();
+            }
+            finally
+            {
+                this.Dispose();
+            }
+        }
+    }
+
+    #endregion
+}

--- a/test/DebuggerTesting/OpenDebug/RunnerException.cs
+++ b/test/DebuggerTesting/OpenDebug/RunnerException.cs
@@ -1,0 +1,42 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Globalization;
+using System.Runtime.Serialization;
+
+namespace DebuggerTesting.OpenDebug
+{
+    /// <summary>
+    /// Provides a serializable exception for errors that occur when running
+    /// the debug adapter runner.
+    /// </summary>
+
+#if !CORECLR
+    [Serializable]
+#endif
+    public class RunnerException : Exception
+    {
+        // Required for serialization
+        public RunnerException() { }
+
+        // Required for serialization
+        public RunnerException(string message)
+            : base(message) { }
+
+        public RunnerException(string messageFormat, params object[] messageArgs)
+            : base(string.Format(CultureInfo.CurrentCulture, messageFormat, messageArgs)) { }
+
+        public RunnerException(string message, Exception innerException)
+            : base(message, innerException) { }
+
+        public RunnerException(Exception innerException, string messageFormat, params object[] messageArgs)
+            : base(string.Format(CultureInfo.CurrentCulture, messageFormat, messageArgs), innerException) { }
+
+#if !CORECLR
+        // Required for serialization
+        protected RunnerException(SerializationInfo info, StreamingContext context)
+            : base(info, context) { }
+#endif
+    }
+}

--- a/test/DebuggerTesting/Ordering/DependencyOrderer.cs
+++ b/test/DebuggerTesting/Ordering/DependencyOrderer.cs
@@ -1,0 +1,106 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Collections;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
+
+namespace DebuggerTesting.Ordering
+{
+    /// <summary>
+    /// Base class that provides generic way to order items that declare their
+    /// dependency. This removes items that can't fullfil their dependencies as
+    /// well as items with circular dependencies.
+    /// </summary>
+    public abstract class DependencyOrderer<T, TKey>
+    {
+        protected IEnumerable<T> OrderBasedOnDependencies(IEnumerable<T> itemsEnumerable)
+        {
+            List<T> items = new List<T>(itemsEnumerable);
+
+            // Keep track of times we are stuck in a loop
+            int stallCount = 0;
+
+            int i = 0;
+            while (i < items.Count)
+            {
+                T currentItem = items[i];
+                IEnumerable<int> dependencyIndexes = GetDependencyIndexes(items, currentItem);
+                if (dependencyIndexes == null)
+                    continue;
+
+                if (dependencyIndexes.Any(x => x < 0))
+                {
+                    // Remove item if dependency cannot be resolved in this set of items
+                    Debug.WriteLine("ERROR: Cannot find dependency for '{0}'.".FormatWithArgs(GetItemName(currentItem)));
+
+                    // Remove the item and start over
+                    items.RemoveAt(i);
+                    stallCount = 0;
+                    i = 0;
+                    continue;
+                }
+
+                // Move the current test after any required dependencies.
+                // Verify we aren't stuck in an infinite loop
+                int lastDependencyIndex = dependencyIndexes.Any() ? dependencyIndexes.Max() : -1;
+                if (lastDependencyIndex > i)
+                {
+                    MoveAfter(items, i, lastDependencyIndex);
+                    stallCount++;
+                    if (stallCount > (items.Count - i))
+                    {
+                        Debug.WriteLine("ERROR: Circular test dependency found.");
+                        // Based on the stall count, the items at the end of the list
+                        // have a circular reference. Remove them all.
+                        items.RemoveRange(i, items.Count - i);
+                        break;
+                    }
+                }
+                else
+                {
+                    stallCount = 0;
+                    i++;
+                }
+            }
+
+            return items;
+        }
+
+        private static void MoveAfter(IList list, int itemIndex, int afterIndex)
+        {
+            while (itemIndex < afterIndex)
+            {
+                SwapItems(list, itemIndex, itemIndex + 1);
+                itemIndex += 1;
+            }
+        }
+
+        private static void SwapItems(IList list, int indexA, int indexB)
+        {
+            object item = list[indexA];
+            list[indexA] = list[indexB];
+            list[indexB] = item;
+        }
+
+        #region Dependency Helpers
+
+        private IEnumerable<int> GetDependencyIndexes(IList<T> items, T currentItem)
+        {
+            IEnumerable<TKey> dependencies = GetDependencies(currentItem);
+            return dependencies?.Select(x => GetIndexOfDependency(items, x));
+        }
+
+        protected abstract IEnumerable<TKey> GetDependencies(T currentItem);
+
+        protected abstract int GetIndexOfDependency(IList<T> items, TKey dependency);
+
+        protected virtual string GetItemName(T item)
+        {
+            return item.ToString();
+        }
+
+        #endregion
+    }
+}

--- a/test/DebuggerTesting/Ordering/DependencyTestOrderer.cs
+++ b/test/DebuggerTesting/Ordering/DependencyTestOrderer.cs
@@ -1,0 +1,53 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Xunit.Abstractions;
+using Xunit.Sdk;
+
+namespace DebuggerTesting.Ordering
+{
+    public class DependencyTestOrderer : DependencyOrderer<ITestCase, string>, ITestCaseOrderer
+    {
+        // These are used in attributes, so they must be constant.
+        public const string TypeName = nameof(DebuggerTesting) + "." + nameof(Ordering) + "." + nameof(DependencyTestOrderer);
+        public const string AssemblyName = nameof(DebuggerTesting);
+
+        public IEnumerable<TTestCase> OrderTestCases<TTestCase>(IEnumerable<TTestCase> testCases)
+            where TTestCase : ITestCase
+        {
+            return OrderBasedOnDependencies(testCases.Cast<ITestCase>()).Cast<TTestCase>();
+        }
+
+        #region Dependency Helpers
+
+        protected override int GetIndexOfDependency(IList<ITestCase> tests, string testName)
+        {
+            for (int i = tests.Count - 1; i >= 0; i--)
+            {
+                string currentTestName = tests[i].TestMethod.Method.Name;
+                if (string.Equals(currentTestName, testName, StringComparison.Ordinal))
+                    return i;
+            }
+            return -1;
+        }
+
+        protected override IEnumerable<string> GetDependencies(ITestCase testCase)
+        {
+            IMethodInfo testMethodInfo = testCase.TestMethod.Method;
+            if (testMethodInfo == null)
+                return null;
+            IEnumerable<IAttributeInfo> attributes = testMethodInfo.GetCustomAttributes(typeof(DependsOnTestAttribute));
+            return attributes.Select(x => x.GetConstructorArguments().OfType<string>().First());
+        }
+
+        #endregion
+
+        protected override string GetItemName(ITestCase item)
+        {
+            return item.DisplayName;
+        }
+    }
+}

--- a/test/DebuggerTesting/Ordering/DependsOnTestAttribute.cs
+++ b/test/DebuggerTesting/Ordering/DependsOnTestAttribute.cs
@@ -1,0 +1,19 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+
+namespace DebuggerTesting.Ordering
+{
+    [AttributeUsage(AttributeTargets.Method, AllowMultiple = true)]
+    public class DependsOnTestAttribute : Attribute
+    {
+        public DependsOnTestAttribute(string testName)
+        {
+            Parameter.ThrowIfNull(testName, nameof(testName));
+            this.TestName = testName;
+        }
+
+        public string TestName { get; set; }
+    }
+}

--- a/test/DebuggerTesting/Properties/AssemblyInfo.cs
+++ b/test/DebuggerTesting/Properties/AssemblyInfo.cs
@@ -1,0 +1,10 @@
+﻿using System.Reflection;
+using System.Runtime.InteropServices;
+
+// Setting ComVisible to false makes the types in this assembly not visible 
+// to COM components.  If you need to access a type in this assembly from 
+// COM, set the ComVisible attribute to true on that type.
+[assembly: ComVisible(false)]
+
+// The following GUID is for the ID of the typelib if this project is exposed to COM
+[assembly: Guid("e9e28bb1-83b9-4d58-98b1-2cd0981e20ec")]

--- a/test/DebuggerTesting/Settings/DiagnosticsSettings.cs
+++ b/test/DebuggerTesting/Settings/DiagnosticsSettings.cs
@@ -1,0 +1,50 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+
+namespace DebuggerTesting.Settings
+{
+    public static class DiagnosticsSettings
+    {
+        private static bool? logMIEngine;
+
+        /// <summary>
+        /// Set to true to log mi engine output
+        /// </summary>
+        public static bool LogMIEngine
+        {
+            get
+            {
+                // Allow setting to be overridden for dev environments
+                if (DiagnosticsSettings.logMIEngine == null)
+                    DiagnosticsSettings.logMIEngine = Environment.GetEnvironmentVariable("TEST_LOGMIENGINE").ToBool();
+
+                if (DiagnosticsSettings.logMIEngine == null)
+                    DiagnosticsSettings.logMIEngine = true;
+
+                return logMIEngine.Value;
+            }
+        }
+
+        private static bool? logDebugAdapter;
+
+        /// <summary>
+        /// Set to true to log debug adapter output
+        /// </summary>
+        public static bool LogDebugAdapter
+        {
+            get
+            {
+                // Allow setting to be overridden for dev environments
+                if (DiagnosticsSettings.logDebugAdapter == null)
+                    DiagnosticsSettings.logDebugAdapter = Environment.GetEnvironmentVariable("TEST_LOGDEBUGADAPTER").ToBool();
+
+                if (DiagnosticsSettings.logDebugAdapter == null)
+                    DiagnosticsSettings.logDebugAdapter = true;
+
+                return DiagnosticsSettings.logDebugAdapter.Value;
+            }
+        }
+    }
+}

--- a/test/DebuggerTesting/Settings/PathSettings.cs
+++ b/test/DebuggerTesting/Settings/PathSettings.cs
@@ -1,0 +1,142 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.IO;
+using System.Reflection;
+using System.Text;
+using DebuggerTesting.Utilities;
+
+namespace DebuggerTesting.Settings
+{
+    public static class PathSettings
+    {
+        private static string tempPath;
+        public static string TempPath
+        {
+            get
+            {
+                if (PathSettings.tempPath == null)
+                {
+                    PathSettings.tempPath = Path.GetTempPath();
+                }
+                return PathSettings.tempPath;
+            }
+        }
+
+        private static string rootPath;
+        private static string RootPath
+        {
+            get
+            {
+                if (PathSettings.rootPath == null)
+                {
+                    // Allow root path to be overridden for dev environments
+                    PathSettings.rootPath = Environment.GetEnvironmentVariable("TEST_ROOT");
+#if !CORECLR
+                    if (String.IsNullOrEmpty(PathSettings.rootPath))
+                    {
+                        // If not overridden, the root path is one level up from the path containing the test binaries
+                        string thisAssemblyFolder = Path.GetDirectoryName(Assembly.GetExecutingAssembly().GetPath());
+                        PathSettings.rootPath = Path.GetDirectoryName(thisAssemblyFolder);
+                    }
+#endif
+                }
+                return PathSettings.rootPath;
+            }
+        }
+
+        private static string testsPath;
+        public static string TestsPath
+        {
+            get
+            {
+                if (PathSettings.testsPath == null)
+                {
+                    PathSettings.testsPath = Path.Combine(PathSettings.RootPath, "tests");
+
+#if !CORECLR
+                    // If the normal debuggees path doesn't exist, try an alternative one.
+                    // This may occur if running the test from VS.
+                    if (!Directory.Exists(PathSettings.testsPath))
+                    {
+                        string thisAssemblyFolder = Path.GetDirectoryName(Assembly.GetExecutingAssembly().GetPath());
+                        if (Directory.Exists(thisAssemblyFolder))
+                        {
+                            PathSettings.testsPath = thisAssemblyFolder;
+                        }
+                    }
+#endif
+                }
+                return PathSettings.testsPath;
+            }
+        }
+
+        private static string debuggeesPath;
+        public static string DebuggeesPath
+        {
+            get
+            {
+                if (PathSettings.debuggeesPath == null)
+                {
+                    PathSettings.debuggeesPath = Path.Combine(PathSettings.TestsPath, "debuggees");
+                }
+                return PathSettings.debuggeesPath;
+            }
+        }
+
+        private static string debugAdaptersPath;
+        public static string DebugAdaptersPath
+        {
+            get
+            {
+                if (PathSettings.debugAdaptersPath == null)
+                {
+                    PathSettings.debugAdaptersPath = Path.Combine(PathSettings.RootPath, "extension", "debugAdapters");
+                }
+                return PathSettings.debugAdaptersPath;
+            }
+        }
+
+        private static string testConfigurationFilePath;
+        public static string TestConfigurationFilePath
+        {
+            get
+            {
+                if (PathSettings.testConfigurationFilePath == null)
+                {
+                    PathSettings.testConfigurationFilePath = Path.Combine(PathSettings.TestsPath, "config.xml");
+
+                    // If the normal config file path doesn't exist, try an alternative one.
+                    // This may occur if running the test from VS.
+                    if (!File.Exists(PathSettings.testConfigurationFilePath))
+                    {
+                        string alternatePath = Path.Combine(PathSettings.RootPath, "config.xml");
+                        if (File.Exists(alternatePath))
+                        {
+                            PathSettings.testConfigurationFilePath = alternatePath;
+                        }
+                    }
+
+                }
+                return PathSettings.testConfigurationFilePath;
+            }
+        }
+
+        public static string GetDebugPathString()
+        {
+            StringBuilder sb = new StringBuilder();
+            sb.Append("Temp      =");
+            sb.AppendLine(PathSettings.TempPath);
+            sb.Append("Adapters  =");
+            sb.AppendLine(PathSettings.DebugAdaptersPath);
+            sb.Append("Tests     =");
+            sb.AppendLine(PathSettings.TestsPath);
+            sb.Append("Debuggees =");
+            sb.AppendLine(PathSettings.DebuggeesPath);
+            sb.Append("Config    =");
+            sb.AppendLine(PathSettings.TestConfigurationFilePath);
+            return sb.ToString();
+        }
+    }
+}

--- a/test/DebuggerTesting/SupportedArchitecture.cs
+++ b/test/DebuggerTesting/SupportedArchitecture.cs
@@ -1,0 +1,15 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+
+namespace DebuggerTesting
+{
+    [Flags]
+    public enum SupportedArchitecture
+    {
+        x86 = 0x1,
+        x64 = 0x2,
+        arm = 0x4
+    }
+}

--- a/test/DebuggerTesting/SupportedCompiler.cs
+++ b/test/DebuggerTesting/SupportedCompiler.cs
@@ -1,0 +1,15 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+
+namespace DebuggerTesting
+{
+    [Flags]
+    public enum SupportedCompiler
+    {
+        ClangPlusPlus = 0x1,
+        GPlusPlus = 0x2,
+        VisualCPlusPlus = 0x4,
+    }
+}

--- a/test/DebuggerTesting/SupportedDebugger.cs
+++ b/test/DebuggerTesting/SupportedDebugger.cs
@@ -1,0 +1,17 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+
+namespace DebuggerTesting
+{
+    [Flags]
+    public enum SupportedDebugger
+    {
+        Gdb_Gnu = 0x1,
+        Gdb_Cygwin = 0x2,
+        Gdb_MinGW = 0x4,
+        Lldb = 0x8,
+        VsDbg = 0x10,
+    }
+}

--- a/test/DebuggerTesting/SupportedPlatform.cs
+++ b/test/DebuggerTesting/SupportedPlatform.cs
@@ -1,0 +1,15 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+
+namespace DebuggerTesting
+{
+    [Flags]
+    public enum SupportedPlatform
+    {
+        Linux = 0x1,
+        MacOS = 0x2,
+        Windows = 0x4
+    }
+}

--- a/test/DebuggerTesting/TestFramework/ITestSettingsProvider.cs
+++ b/test/DebuggerTesting/TestFramework/ITestSettingsProvider.cs
@@ -1,0 +1,23 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Collections.Generic;
+using System.Reflection;
+
+namespace DebuggerTesting.TestFramework
+{
+    /// <summary>
+    /// Interface use for providing test settings based on reflection of a test method.
+    /// </summary>
+    public interface ITestSettingsProvider
+    {
+        #region Methods
+
+        /// <summary>
+        /// Gets the test settings associated with the test method.
+        /// </summary>
+        IEnumerable<ITestSettings> GetSettings(MethodInfo testMethod);
+
+        #endregion
+    }
+}

--- a/test/DebuggerTesting/TestFramework/TestSettingsDataDiscoverer.cs
+++ b/test/DebuggerTesting/TestFramework/TestSettingsDataDiscoverer.cs
@@ -1,0 +1,28 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Xunit.Abstractions;
+using Xunit.Sdk;
+
+namespace DebuggerTesting.TestFramework
+{
+    /// <summary>
+    /// Custom data discovered for xUnit theory tests that overrides the default behavior of data discovery.
+    /// </summary>
+    public class TestSettingsDataDiscoverer :
+        DataDiscoverer
+    {
+        #region Methods
+
+        public override bool SupportsDiscoveryEnumeration(IAttributeInfo dataAttribute, IMethodInfo testMethod)
+        {
+            // Return false to force xUnit to enumerate the test data during the execution phase of the test
+            // rather than during the discovery phase. This is required because test data that is enuemrated
+            // during the discovery phase must be serializable, but xUnit cannot serialize arbitrary complex
+            // objects such as the ITestSettings implementation.
+            return false;
+        }
+
+        #endregion
+    }
+}

--- a/test/DebuggerTesting/Tests/AttributionTests.cs
+++ b/test/DebuggerTesting/Tests/AttributionTests.cs
@@ -1,0 +1,451 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace DebuggerTesting.Tests
+{
+    public sealed class AttributionTests :
+        ILoggingComponent
+    {
+        #region Constructor
+
+        public AttributionTests(ITestOutputHelper outputHelper)
+        {
+            this.OutputHelper = outputHelper;
+        }
+
+        #endregion
+
+        #region ILoggingComponent Members
+
+        public ITestOutputHelper OutputHelper { get; private set; }
+
+        #endregion
+
+        #region Methods
+
+        #region Test Methods
+
+        [Fact]
+        public void TestPlatformWithoutAttribute()
+        {
+            this.TestPurpose("Check that tests without SupportedPlatformAttribute will run with all test settings.");
+            IEnumerable<ITestSettings> actual = AttributionTests.FilterSettings(
+                nameof(AttributionTests.MockTest_PlatformNeutral),
+                SupportedPlatform.Windows,
+                SupportedArchitecture.x64);
+            IEnumerable<ITestSettings> expected = AttributionTests.ChangeName(
+                AttributionTests.AllSettings,
+                nameof(AttributionTests.MockTest_PlatformNeutral));
+            Assert.Equal(expected, actual);
+
+            actual = AttributionTests.FilterSettings(
+                nameof(AttributionTests.MockTest_PlatformNeutral),
+                SupportedPlatform.Windows,
+                SupportedArchitecture.x86);
+            Assert.Equal(expected, actual);
+
+            actual = AttributionTests.FilterSettings(
+                nameof(AttributionTests.MockTest_PlatformNeutral),
+                SupportedPlatform.Linux,
+                SupportedArchitecture.x64);
+            Assert.Equal(expected, actual);
+
+            actual = AttributionTests.FilterSettings(
+                nameof(AttributionTests.MockTest_PlatformNeutral),
+                SupportedPlatform.Linux,
+                SupportedArchitecture.x86);
+            Assert.Equal(expected, actual);
+
+            actual = AttributionTests.FilterSettings(
+                nameof(AttributionTests.MockTest_PlatformNeutral),
+                SupportedPlatform.MacOS,
+                SupportedArchitecture.x64);
+            Assert.Equal(expected, actual);
+
+            actual = AttributionTests.FilterSettings(
+                nameof(AttributionTests.MockTest_PlatformNeutral),
+                SupportedPlatform.MacOS,
+                SupportedArchitecture.x86);
+            Assert.Equal(expected, actual);
+        }
+
+        [Fact]
+        public void TestPlatformIsSame()
+        {
+            this.TestPurpose("Check that tests with SupportedPlatformAttribute will run on the specified platform.");
+            IEnumerable<ITestSettings> actual = AttributionTests.FilterSettings(
+                nameof(AttributionTests.MockTest_PlatformWindows),
+                SupportedPlatform.Windows,
+                SupportedArchitecture.x64);
+            IEnumerable<ITestSettings> expected = AttributionTests.ChangeName(
+                AttributionTests.AllSettings,
+                nameof(AttributionTests.MockTest_PlatformWindows));
+            Assert.Equal(expected, actual);
+        }
+
+        [Fact]
+        public void TestPlatformIsSameArchitectureIsSame()
+        {
+            this.TestPurpose("Check that tests with SupportedPlatformAttribute will run on the specified platform and architecture.");
+            IEnumerable<ITestSettings> actual = AttributionTests.FilterSettings(
+                nameof(AttributionTests.MockTest_PlatformMac64),
+                SupportedPlatform.MacOS,
+                SupportedArchitecture.x64);
+            IEnumerable<ITestSettings> expected = AttributionTests.ChangeName(
+                AttributionTests.AllSettings,
+                nameof(AttributionTests.MockTest_PlatformMac64));
+            Assert.Equal(expected, actual);
+        }
+
+        [Fact]
+        public void TestPlatformIsSameArchitectureIsDifferent()
+        {
+            this.TestPurpose("Check that tests with SupportedPlatformAttribute will not run on the specified platform and different architecture.");
+            IEnumerable<ITestSettings> actual = AttributionTests.FilterSettings(
+                nameof(AttributionTests.MockTest_PlatformLinux86),
+                SupportedPlatform.Linux,
+                SupportedArchitecture.x64);
+            IEnumerable<ITestSettings> expected = Enumerable.Empty<ITestSettings>();
+            Assert.Equal(expected, actual);
+        }
+
+        [Fact]
+        public void TestPlatformIsDifferent()
+        {
+            this.TestPurpose("Check that tests with SupportedPlatformAttribute will not run on a different platform.");
+            IEnumerable<ITestSettings> actual = AttributionTests.FilterSettings(
+                nameof(AttributionTests.MockTest_PlatformWindows),
+                SupportedPlatform.Linux,
+                SupportedArchitecture.x86);
+            IEnumerable<ITestSettings> expected = Enumerable.Empty<ITestSettings>();
+            Assert.Equal(expected, actual);
+
+            actual = AttributionTests.FilterSettings(
+                nameof(AttributionTests.MockTest_PlatformWindows),
+                SupportedPlatform.MacOS,
+                SupportedArchitecture.x86);
+            Assert.Equal(expected, actual);
+        }
+
+        [Fact]
+        public void TestDebuggerSupported()
+        {
+            this.TestPurpose("Check that tests with a single SupportedDebuggerAttribute will only run with the specified debugger.");
+
+            IEnumerable<ITestSettings> actual = AttributionTests.FilterSettings(
+                nameof(AttributionTests.MockTest_DebuggerGdbSupported),
+                SupportedPlatform.Windows,
+                SupportedArchitecture.x64);
+            IEnumerable<ITestSettings> expected = AttributionTests.ChangeName(
+                new ITestSettings[]
+                {
+                    AttributionTests.Settings_GppGdbX64,
+                    AttributionTests.Settings_GppGdbX86
+                },
+                nameof(AttributionTests.MockTest_DebuggerGdbSupported));
+            Assert.Equal(expected, actual);
+        }
+
+        [Fact]
+        public void TestDebuggerMultipleSupported()
+        {
+            this.TestPurpose("Check that tests with several SupportedDebuggerAttribute will only run with the specified debuggers.");
+
+            IEnumerable<ITestSettings> actual = AttributionTests.FilterSettings(
+                nameof(AttributionTests.MockTest_DebuggerGdbLldbSupported),
+                SupportedPlatform.Windows,
+                SupportedArchitecture.x64);
+            IEnumerable<ITestSettings> expected = AttributionTests.ChangeName(
+                new ITestSettings[]
+                {
+                    AttributionTests.Settings_GppGdbX64,
+                    AttributionTests.Settings_GppGdbX86,
+                    AttributionTests.Settings_ClangLldbX64
+                },
+                nameof(AttributionTests.MockTest_DebuggerGdbLldbSupported));
+            Assert.Equal(expected, actual);
+        }
+
+        [Fact]
+        public void TestDebuggerUnmatched()
+        {
+            this.TestPurpose("Check that tests that do not match the settings will not run.");
+
+            IEnumerable<ITestSettings> settings = new ITestSettings[]
+            {
+                AttributionTests.Settings_ClangLldbX64,
+                AttributionTests.Settings_ClangLldbX86
+            };
+            IEnumerable<ITestSettings> actual = settings.FilterSettings(
+                AttributionTests.GetTestMethodInfo(nameof(AttributionTests.MockTest_DebuggerGdbSupported)),
+                SupportedPlatform.Windows,
+                SupportedArchitecture.x64);
+            IEnumerable<ITestSettings> expected = Enumerable.Empty<ITestSettings>();
+            Assert.Equal(expected, actual);
+        }
+
+        [Fact]
+        public void TestDebuggerUnsupported()
+        {
+            this.TestPurpose("Check that tests with a single UnsupportedDebuggerAttribute will not run for the specified debugger.");
+
+            IEnumerable<ITestSettings> actual = AttributionTests.FilterSettings(
+                nameof(AttributionTests.MockTest_DebuggerLldbUnsupported),
+                SupportedPlatform.Windows,
+                SupportedArchitecture.x64);
+            IEnumerable<ITestSettings> expected = AttributionTests.ChangeName(
+                new ITestSettings[]
+                {
+                    AttributionTests.Settings_GppGdbX64,
+                    AttributionTests.Settings_GppGdbX86,
+                    AttributionTests.Settings_CygwinGppGdbX64,
+                    AttributionTests.Settings_CygwinGppGdbX86,
+                    AttributionTests.Settings_MingwGppGdbX64,
+                    AttributionTests.Settings_MingwGppGdbX86
+                },
+                nameof(AttributionTests.MockTest_DebuggerLldbUnsupported));
+            Assert.Equal(expected, actual);
+        }
+
+        [Fact]
+        public void TestDebuggerMultipleUnsupported()
+        {
+            this.TestPurpose("Check that tests with multiple UnsupportedDebuggerAttribute will not run for the specified debuggers.");
+
+            IEnumerable<ITestSettings> actual = AttributionTests.FilterSettings(
+                nameof(AttributionTests.MockTest_DebuggerGdbLldbUnsupported),
+                SupportedPlatform.Windows,
+                SupportedArchitecture.x64);
+            IEnumerable<ITestSettings> expected = AttributionTests.ChangeName(
+                new ITestSettings[]
+                {
+                    AttributionTests.Settings_GppGdbX64,
+                    AttributionTests.Settings_CygwinGppGdbX64,
+                    AttributionTests.Settings_CygwinGppGdbX86,
+                    AttributionTests.Settings_MingwGppGdbX86,
+                },
+                nameof(AttributionTests.MockTest_DebuggerGdbLldbUnsupported));
+            Assert.Equal(expected, actual);
+        }
+
+        [Fact]
+        public void TestDebuggerSupportedUnsupportedIsSame()
+        {
+            this.TestPurpose("Check that tests that specify the same debugger as supported and unsupported will not run with that debugger.");
+
+            IEnumerable<ITestSettings> actual = AttributionTests.FilterSettings(
+                nameof(AttributionTests.MockTest_DebuggerGdbSupportedUnsupported),
+                SupportedPlatform.Windows,
+                SupportedArchitecture.x64);
+            IEnumerable<ITestSettings> expected = Enumerable.Empty<ITestSettings>();
+            Assert.Equal(expected, actual);
+        }
+
+        [Fact]
+        public void TestCompilerSupported()
+        {
+            this.TestPurpose("Check that tests with a single SupportedCompilerAttribute will only run with the specified compiler.");
+
+            IEnumerable<ITestSettings> actual = AttributionTests.FilterSettings(
+                nameof(AttributionTests.MockTest_CompilerGPlusPlus86Supported),
+                SupportedPlatform.Windows,
+                SupportedArchitecture.x64);
+            IEnumerable<ITestSettings> expected = AttributionTests.ChangeName(
+                new ITestSettings[]
+                {
+                    AttributionTests.Settings_GppGdbX86,
+                    AttributionTests.Settings_CygwinGppGdbX86,
+                    AttributionTests.Settings_MingwGppGdbX86
+                },
+                nameof(AttributionTests.MockTest_CompilerGPlusPlus86Supported));
+            Assert.Equal(expected, actual);
+        }
+
+        [Fact]
+        public void TestCompilerMultipleSupported()
+        {
+            this.TestPurpose("Check that tests with several SupportedCompilerAttribute will only run with the specified compilers.");
+
+            IEnumerable<ITestSettings> actual = AttributionTests.FilterSettings(
+                nameof(AttributionTests.MockTest_CompilerGPlusPlus86ClangPlusPlus64Supported),
+                SupportedPlatform.Windows,
+                SupportedArchitecture.x64);
+            IEnumerable<ITestSettings> expected = AttributionTests.ChangeName(
+                new ITestSettings[]
+                {
+                    AttributionTests.Settings_GppGdbX64,
+                    AttributionTests.Settings_CygwinGppGdbX64,
+                    AttributionTests.Settings_MingwGppGdbX64,
+                    AttributionTests.Settings_ClangLldbX86
+                },
+                nameof(AttributionTests.MockTest_CompilerGPlusPlus86ClangPlusPlus64Supported));
+            Assert.Equal(expected, actual);
+        }
+
+        #endregion
+
+        #region Mock Tests
+
+#pragma warning disable xUnit1013
+
+        public void MockTest_PlatformNeutral(ITestSettings settings)
+        {
+        }
+
+        [SupportedPlatform(SupportedPlatform.Windows, SupportedArchitecture.x64 | SupportedArchitecture.x86)]
+        public void MockTest_PlatformWindows(ITestSettings settings)
+        {
+        }
+
+        [SupportedPlatform(SupportedPlatform.MacOS, SupportedArchitecture.x64)]
+        public void MockTest_PlatformMac64(ITestSettings settings)
+        {
+        }
+
+        [SupportedPlatform(SupportedPlatform.Linux, SupportedArchitecture.x86)]
+        public void MockTest_PlatformLinux86(ITestSettings settings)
+        {
+        }
+
+        [SupportedDebugger(SupportedDebugger.Gdb_Gnu, SupportedArchitecture.x64 | SupportedArchitecture.x86)]
+        public void MockTest_DebuggerGdbSupported(ITestSettings settings)
+        {
+        }
+
+        [SupportedDebugger(SupportedDebugger.Gdb_Gnu, SupportedArchitecture.x64 | SupportedArchitecture.x86)]
+        [SupportedDebugger(SupportedDebugger.Lldb, SupportedArchitecture.x64)]
+        public void MockTest_DebuggerGdbLldbSupported(ITestSettings settings)
+        {
+        }
+
+        [UnsupportedDebugger(SupportedDebugger.Lldb, SupportedArchitecture.x64 | SupportedArchitecture.x86)]
+        public void MockTest_DebuggerLldbUnsupported(ITestSettings settings)
+        {
+        }
+
+        [UnsupportedDebugger(SupportedDebugger.Gdb_Gnu, SupportedArchitecture.x86)]
+        [UnsupportedDebugger(SupportedDebugger.Lldb, SupportedArchitecture.x64 | SupportedArchitecture.x86)]
+        [UnsupportedDebugger(SupportedDebugger.Gdb_MinGW, SupportedArchitecture.x64)]
+        public void MockTest_DebuggerGdbLldbUnsupported(ITestSettings settings)
+        {
+        }
+
+        [SupportedDebugger(SupportedDebugger.Gdb_Gnu, SupportedArchitecture.x64 | SupportedArchitecture.x86)]
+        [UnsupportedDebugger(SupportedDebugger.Gdb_Gnu, SupportedArchitecture.x64 | SupportedArchitecture.x86)]
+        public void MockTest_DebuggerGdbSupportedUnsupported(ITestSettings settings)
+        {
+        }
+
+        [SupportedCompiler(SupportedCompiler.GPlusPlus, SupportedArchitecture.x86)]
+        public void MockTest_CompilerGPlusPlus86Supported(ITestSettings settings)
+        {
+        }
+
+        [SupportedCompiler(SupportedCompiler.GPlusPlus, SupportedArchitecture.x64)]
+        [SupportedCompiler(SupportedCompiler.ClangPlusPlus, SupportedArchitecture.x86)]
+        public void MockTest_CompilerGPlusPlus86ClangPlusPlus64Supported(ITestSettings settings)
+        {
+        }
+
+#pragma warning restore xUnit1013
+
+        #endregion
+
+        #region Helpers
+
+        private static IEnumerable<ITestSettings> ChangeName(IEnumerable<ITestSettings> settings, string name)
+        {
+            return settings.Select(s => TestSettings.CloneWithName(s, name)).ToArray();
+        }
+
+        private static TestSettings CreateClangLldbSettings(SupportedArchitecture debuggeeArchitecture, string compilerName, string debuggerName)
+        {
+            return new TestSettings(debuggeeArchitecture, compilerName, SupportedCompiler.ClangPlusPlus, "clang++", null, debuggerName, SupportedDebugger.Lldb, "lldb-mi", null, "lldb", null);
+        }
+
+        private static TestSettings CreateGppGdbSettings(SupportedArchitecture debuggeeArchitecture, string compilerName, string debuggerName, SupportedDebugger debuggerType)
+        {
+            return new TestSettings(debuggeeArchitecture, compilerName, SupportedCompiler.GPlusPlus, "g++", null, debuggerName, debuggerType, "gdb", null, null, null);
+        }
+
+        private static IEnumerable<ITestSettings> FilterSettings(string methodName, SupportedPlatform platform, SupportedArchitecture platformArchitecture)
+        {
+            MethodInfo methodInfo = AttributionTests.GetTestMethodInfo(methodName);
+            return AttributionTests.AllSettings.FilterSettings(methodInfo, platform, platformArchitecture);
+        }
+
+        private static MethodInfo GetTestMethodInfo(string methodName)
+        {
+            MethodInfo testMethod = typeof(AttributionTests).GetTypeInfo().GetDeclaredMethod(methodName);
+            Assert.NotNull(testMethod);
+            return testMethod;
+        }
+
+        #endregion
+
+        #endregion
+
+        #region Properties
+
+        private static IEnumerable<ITestSettings> AllSettings
+        {
+            get
+            {
+                if (null == AttributionTests.s_settings)
+                {
+                    lock (AttributionTests.s_syncObject)
+                    {
+                        if (null == AttributionTests.s_settings)
+                        {
+                            IList<ITestSettings> settings = new List<ITestSettings>();
+
+                            settings.Add(AttributionTests.Settings_GppGdbX64);
+                            settings.Add(AttributionTests.Settings_GppGdbX86);
+                            settings.Add(AttributionTests.Settings_CygwinGppGdbX64);
+                            settings.Add(AttributionTests.Settings_CygwinGppGdbX86);
+                            settings.Add(AttributionTests.Settings_MingwGppGdbX64);
+                            settings.Add(AttributionTests.Settings_MingwGppGdbX86);
+                            settings.Add(AttributionTests.Settings_ClangLldbX64);
+                            settings.Add(AttributionTests.Settings_ClangLldbX86);
+
+                            AttributionTests.s_settings = settings;
+                        }
+                    }
+                }
+                return AttributionTests.s_settings;
+            }
+        }
+
+        #endregion
+
+        #region Fields
+
+        private static IEnumerable<ITestSettings> s_settings;
+        private static object s_syncObject = new object();
+
+        private static readonly ITestSettings Settings_GppGdbX64 =
+            AttributionTests.CreateGppGdbSettings(SupportedArchitecture.x64, "Gpp", "Gdb", SupportedDebugger.Gdb_Gnu);
+        private static readonly ITestSettings Settings_GppGdbX86 =
+            AttributionTests.CreateGppGdbSettings(SupportedArchitecture.x86, "Gpp", "Gdb", SupportedDebugger.Gdb_Gnu);
+        private static readonly ITestSettings Settings_CygwinGppGdbX64 =
+            AttributionTests.CreateGppGdbSettings(SupportedArchitecture.x64, "GppCygwin64", "GdbCygwin64", SupportedDebugger.Gdb_Cygwin);
+        private static readonly ITestSettings Settings_CygwinGppGdbX86 =
+            AttributionTests.CreateGppGdbSettings(SupportedArchitecture.x86, "GppCygwin86", "GdbCygwin86", SupportedDebugger.Gdb_Cygwin);
+        private static readonly ITestSettings Settings_MingwGppGdbX64 =
+            AttributionTests.CreateGppGdbSettings(SupportedArchitecture.x64, "GppMingw64", "GdbMingw64", SupportedDebugger.Gdb_MinGW);
+        private static readonly ITestSettings Settings_MingwGppGdbX86 =
+            AttributionTests.CreateGppGdbSettings(SupportedArchitecture.x86, "GppMingw86", "GdbMingw86", SupportedDebugger.Gdb_MinGW);
+        private static readonly ITestSettings Settings_ClangLldbX64 =
+            AttributionTests.CreateClangLldbSettings(SupportedArchitecture.x64, "Clang", "Lldb");
+        private static readonly ITestSettings Settings_ClangLldbX86 =
+            AttributionTests.CreateClangLldbSettings(SupportedArchitecture.x86, "Clang", "Lldb");
+
+        #endregion
+    }
+}

--- a/test/DebuggerTesting/Utilities/ArgumentBuilder.cs
+++ b/test/DebuggerTesting/Utilities/ArgumentBuilder.cs
@@ -1,0 +1,131 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Text;
+
+namespace DebuggerTesting.Utilities
+{
+    /// <summary>
+    /// A class that builds an arguments string
+    /// </summary>
+    public class ArgumentBuilder
+    {
+        #region Constructor
+
+        /// <summary>
+        /// Constructs a new argument builder
+        /// </summary>
+        /// <param name="prefix">String to use in front of the name portion of an argument.</param>
+        /// <param name="suffix">String to use in between the name and value portions of an argument.</param>
+        public ArgumentBuilder(string prefix, string suffix)
+        {
+            this.builder = new StringBuilder();
+            this.prefix = prefix;
+            this.suffix = suffix;
+        }
+
+        #endregion
+
+        #region Methods
+
+        /// <summary>
+        /// Appends an argument value to the builder
+        /// </summary>
+        public void AppendArgument(string value)
+        {
+            if (!String.IsNullOrWhiteSpace(value))
+            {
+                this.builder.Append(" ");
+                this.builder.Append(value);
+            }
+        }
+
+        /// <summary>
+        /// Appends an argument value with surrounding quotes to the builder
+        /// </summary>
+        public void AppendArgumentQuoted(string value)
+        {
+            if (!String.IsNullOrWhiteSpace(value))
+                this.AppendArgument("\"" + value + "\"");
+        }
+
+        /// <summary>
+        /// Appends an argument name to the builder
+        /// </summary>
+        private void AppendName(string name)
+        {
+            Parameter.ThrowIfNullOrWhiteSpace(name, nameof(name));
+
+            builder.Append(" ");
+            if (!String.IsNullOrEmpty(this.prefix))
+            {
+                builder.Append(this.prefix);
+            }
+            builder.Append(name);
+        }
+
+        /// <summary>
+        /// Appends an argument name and value to the builder
+        /// </summary>
+        public void AppendNamedArgument(string name, string value, string overrideSuffix = null)
+        {
+            Parameter.ThrowIfNullOrWhiteSpace(name, nameof(name));
+
+            this.AppendName(name);
+            if (!String.IsNullOrWhiteSpace(value))
+            {
+                string suffix = overrideSuffix ?? this.suffix;
+                if (!String.IsNullOrEmpty(suffix))
+                {
+                    builder.Append(suffix);
+                }
+                this.builder.Append(value);
+            }
+        }
+
+        /// <summary>
+        /// Appends an argument name and value with surrounding quotes to the builder
+        /// </summary>
+        public void AppendNamedArgumentQuoted(string name, string value, string overrideSuffix = null)
+        {
+            Parameter.ThrowIfNullOrWhiteSpace(name, nameof(name));
+
+            if (!String.IsNullOrWhiteSpace(value))
+                this.AppendNamedArgument(name, ArgumentBuilder.MakeQuoted(value), overrideSuffix);
+        }
+
+        public static string MakeQuotedIfRequired(string value)
+        {
+            if (value.Contains("\"") || value.Contains("'") || value.Contains(" "))
+                return MakeQuoted(value);
+            return value;
+        }
+
+        public static string MakeQuoted(string value)
+        {
+            if (null == value)
+                return null;
+
+            return "\"" + value.Replace("\"", "\\\"") + "\"";
+        }
+
+        /// <summary>
+        /// Renders the argument string from the builder
+        /// </summary>
+        public override string ToString()
+        {
+            return this.builder?.ToString().Trim();
+        }
+
+        #endregion
+
+        #region Fields
+
+        private StringBuilder builder = null;
+        private string prefix = null;
+        private string suffix = null;
+
+        #endregion
+    }
+}

--- a/test/DebuggerTesting/Utilities/AssemblyExtensions.cs
+++ b/test/DebuggerTesting/Utilities/AssemblyExtensions.cs
@@ -1,0 +1,29 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Reflection;
+
+namespace DebuggerTesting.Utilities
+{
+    public static class AssemblyExtensions
+    {
+        #region Methods
+
+#if !CORECLR
+
+        /// <summary>
+        /// Gets the path of the <see cref="Assembly"/>.
+        /// </summary>
+        public static string GetPath(this Assembly assembly)
+        {
+            Parameter.ThrowIfNull(assembly, nameof(assembly));
+
+            return Uri.UnescapeDataString(new UriBuilder(assembly.Location).Path);
+        }
+
+#endif
+
+        #endregion
+    }
+}

--- a/test/DebuggerTesting/Utilities/DisposableHelper.cs
+++ b/test/DebuggerTesting/Utilities/DisposableHelper.cs
@@ -1,0 +1,53 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace DebuggerTesting.Utilities
+{
+    public static class DisposableHelper
+    {
+        /// <summary>
+        /// Calls dispose on the object if it implements IDisposable.
+        /// Ignores a null object.
+        /// </summary>
+        public static void SafeDispose(object o)
+        {
+            SafeDispose(o as IDisposable);
+        }
+
+        /// <summary>
+        /// Calls dispose on the object.
+        /// Ignores a null object.
+        /// </summary>
+        public static void SafeDispose(this IDisposable o)
+        {
+            o?.Dispose();
+        }
+
+        /// <summary>
+        /// Calls dispose on all the objects in the collection that implement IDisposable.
+        /// Ignores any null values.
+        /// </summary>
+        public static void SafeDisposeAll(IEnumerable objects)
+        {
+            SafeDisposeAll(objects?.OfType<IDisposable>());
+        }
+
+        /// <summary>
+        /// Calls dispose on all the objects in the collection.
+        /// Ignores any null values.
+        /// </summary>
+        public static void SafeDisposeAll(this IEnumerable<IDisposable> objects)
+        {
+            if (objects == null)
+                return;
+
+            foreach (IDisposable o in objects)
+                SafeDispose(o);
+        }
+    }
+}

--- a/test/DebuggerTesting/Utilities/DisposableObject.cs
+++ b/test/DebuggerTesting/Utilities/DisposableObject.cs
@@ -1,0 +1,74 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+
+namespace DebuggerTesting
+{
+    /// <summary>
+    /// Base class for disposable objects.
+    /// </summary>
+    public abstract class DisposableObject : IDisposable
+    {
+        #region Constructor
+
+        protected DisposableObject()
+        {
+        }
+
+        #endregion
+
+        #region Destructor
+
+        ~DisposableObject()
+        {
+            if (!this.IsDisposed)
+            {
+                this.Dispose(isDisposing: false);
+            }
+        }
+
+        #endregion
+
+        #region IDisposable Members
+
+        public void Dispose()
+        {
+            UDebug.Assert(!this.IsDisposed, "This was already disposed");
+            if (!this.IsDisposed)
+            {
+                this.Dispose(isDisposing: true);
+                GC.SuppressFinalize(this);
+            }
+        }
+
+        #endregion
+
+        #region Methods
+
+        protected virtual void Dispose(bool isDisposing)
+        {
+            this.IsDisposed = true;
+        }
+
+        /// <summary>
+        /// Throws an exception if the object is disposed.
+        /// </summary>
+        protected void VerifyNotDisposed()
+        {
+            if (this.IsDisposed)
+                throw new ObjectDisposedException(this.GetType().FullName);
+        }
+
+        #endregion
+
+        #region Properties
+
+        /// <summary>
+        /// Gets a value indicating whether the object is disposed.
+        /// </summary>
+        public bool IsDisposed { get; private set; }
+
+        #endregion
+    }
+}

--- a/test/DebuggerTesting/Utilities/EnumerableExtensions.cs
+++ b/test/DebuggerTesting/Utilities/EnumerableExtensions.cs
@@ -1,0 +1,15 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Collections.Generic;
+
+namespace DebuggerTesting.Utilities
+{
+    public static class EnumerableExtensions
+    {
+        public static ISet<TKey> ToKeySet<TKey, TValue>(this IDictionary<TKey, TValue> dictionary)
+        {
+            return new HashSet<TKey>(dictionary.Keys);
+        }
+    }
+}

--- a/test/DebuggerTesting/Utilities/FileUtilities.cs
+++ b/test/DebuggerTesting/Utilities/FileUtilities.cs
@@ -1,0 +1,44 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.IO;
+
+namespace DebuggerTesting.Utilities
+{
+    internal class FileUtilities
+    {
+        public static void DirectoryCopy(string sourceDirName, string destDirName, bool copySubDirs)
+        {
+            // Get the subdirectories for the specified directory.
+            DirectoryInfo sourceDir = new DirectoryInfo(sourceDirName);
+
+            if (!sourceDir.Exists)
+            {
+                throw new DirectoryNotFoundException(
+                    "Source directory does not exist or could not be found: "
+                    + sourceDirName);
+            }
+
+            // If the destination directory doesn't exist, create it.
+            if (!Directory.Exists(destDirName))
+            {
+                Directory.CreateDirectory(destDirName);
+            }
+
+            // Get the files in the directory and copy them to the new location.
+            foreach (FileInfo file in sourceDir.GetFiles())
+            {
+                file.CopyTo(Path.Combine(destDirName, file.Name), overwrite: true);
+            }
+
+            // If copying subdirectories, copy them and their contents to new location.
+            if (copySubDirs)
+            {
+                foreach (DirectoryInfo subdir in sourceDir.GetDirectories())
+                {
+                    DirectoryCopy(subdir.FullName, Path.Combine(destDirName, subdir.Name), copySubDirs);
+                }
+            }
+        }
+    }
+}

--- a/test/DebuggerTesting/Utilities/HashUtilities.cs
+++ b/test/DebuggerTesting/Utilities/HashUtilities.cs
@@ -1,0 +1,32 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace DebuggerTesting.Utilities
+{
+    internal static class HashUtilities
+    {
+        #region Methods
+
+        public static int CombineHashCodes(int h1, int h2)
+        {
+            return (h1 << 5) + h1 ^ h2;
+        }
+
+        internal static int CombineHashCodes(int h1, int h2, int h3)
+        {
+            return HashUtilities.CombineHashCodes(HashUtilities.CombineHashCodes(h1, h2), h3);
+        }
+
+        internal static int CombineHashCodes(int h1, int h2, int h3, int h4)
+        {
+            return HashUtilities.CombineHashCodes(HashUtilities.CombineHashCodes(h1, h2), HashUtilities.CombineHashCodes(h3, h4));
+        }
+
+        internal static int CombineHashCodes(int h1, int h2, int h3, int h4, int h5)
+        {
+            return HashUtilities.CombineHashCodes(HashUtilities.CombineHashCodes(h1, h2, h3, h4), h5);
+        }
+
+        #endregion
+    }
+}

--- a/test/DebuggerTesting/Utilities/Parameter.cs
+++ b/test/DebuggerTesting/Utilities/Parameter.cs
@@ -1,0 +1,222 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Diagnostics;
+using System.Globalization;
+using System.Reflection;
+
+namespace DebuggerTesting
+{
+    [DebuggerStepThrough]
+    public static class Parameter
+    {
+        #region NotOfType
+
+        /// <summary>
+        /// Throws ArgumentException if the value is not of the specified type.
+        /// </summary>
+        public static void ThrowIfNotOfType<T>(object value, string paramName, bool allowNull = false)
+        {
+            AssertIfNotOfType<T>(value, paramName, allowNull);
+            if (IsNotOfType<T>(value, allowNull))
+                throw new ArgumentException(string.Empty, paramName);
+        }
+
+        /// <summary>
+        /// Assert if the value is not of the specified type.
+        /// </summary>
+        [DebuggerHidden]
+        [Conditional("DEBUG")]
+        public static void AssertIfNotOfType<T>(object value, string paramName, bool allowNull = false)
+        {
+            if (IsNotOfType<T>(value, allowNull))
+                ParameterAssert("Parameter {0} not of type {1}", paramName, typeof(T).Name);
+        }
+
+        public static void AssertIfNotOfType<T>(Type type, string paramName)
+        {
+            Parameter.AssertIfNull(type, paramName);
+            if (!typeof(T).GetTypeInfo().IsAssignableFrom(type.GetTypeInfo()))
+                ParameterAssert("Parameter {0} does not implement {1}", paramName, typeof(T).Name);
+        }
+
+        private static bool IsNotOfType<T>(object value, bool allowNull)
+        {
+            return (null == value && !allowNull) || (null != value && !(value is T));
+        }
+
+        #endregion
+
+        #region NullOrWhiteSpace
+
+        /// <summary>
+        /// Throws ArgumentNullException if the value is null or is white space.
+        /// </summary>
+        public static void ThrowIfNullOrWhiteSpace(string value, string paramName)
+        {
+            AssertIfNullOrWhiteSpace(value, paramName);
+            if (IsNullOrWhiteSpace(value))
+                throw new ArgumentNullException(paramName);
+        }
+
+        /// <summary>
+        /// Assert if the value is null or is white space.
+        /// </summary>
+        [DebuggerHidden]
+        [Conditional("DEBUG")]
+        public static void AssertIfNullOrWhiteSpace(string value, string paramName)
+        {
+            if (IsNullOrWhiteSpace(value))
+                ParameterAssert("Parameter {0} is null or white space.", paramName);
+        }
+
+        private static bool IsNullOrWhiteSpace(string value)
+        {
+            return String.IsNullOrWhiteSpace(value);
+        }
+
+        #endregion
+
+        #region Null
+
+        /// <summary>
+        /// Throws ArgumentNullException if the value is null.
+        /// </summary>
+        public static void ThrowIfNull<T>(T value, string paramName)
+            where T : class
+        {
+            AssertIfNull(value, paramName);
+            if (IsNull(value))
+                throw new ArgumentNullException(paramName);
+        }
+
+        /// <summary>
+        /// Assert if the value is null.
+        /// </summary>
+        [DebuggerHidden]
+        [Conditional("DEBUG")]
+        public static void AssertIfNull<T>(T value, string paramName)
+            where T : class
+        {
+            if (IsNull(value))
+                ParameterAssert("Parameter {0} is null.", paramName);
+        }
+
+        private static bool IsNull<T>(T value)
+            where T : class
+        {
+            return null == value;
+        }
+
+        #endregion
+
+        #region IsInvalid
+
+        /// <summary>
+        /// Throws ArgumentNullException if the value matches an invalid value.
+        /// </summary>
+        public static void ThrowIfIsInvalid<T>(T value, T invalidValue, string paramName)
+            where T : struct
+        {
+            AssertIfIsInvalid(value, invalidValue, paramName);
+            if (IsInvalid(value, invalidValue))
+                throw new ArgumentNullException(paramName);
+        }
+
+        /// <summary>
+        /// Assert if the value matches an invalid value.
+        /// </summary>
+        [DebuggerHidden]
+        [Conditional("DEBUG")]
+        public static void AssertIfIsInvalid<T>(T value, T invalidValue, string paramName)
+            where T : struct
+        {
+            if (IsInvalid(value, invalidValue))
+                ParameterAssert("Parameter {0} is invalid value.", paramName);
+        }
+
+        private static bool IsInvalid<T>(T value, T invalidValue)
+        {
+            return object.Equals(value, invalidValue);
+        }
+
+        #endregion
+
+        #region OutOfRange
+
+        /// <summary>
+        /// Throw ArgumentOutOfRangeException if value is not between minValue and maxValue inclusively.
+        /// </summary>
+        public static void ThrowIfOutOfRange(int value, int minValue, int maxValue, string paramName)
+        {
+            AssertIfOutOfRange(value, minValue, maxValue, paramName);
+            if (IsOutOfRange(value, minValue, maxValue))
+                throw new ArgumentOutOfRangeException(paramName);
+        }
+
+        /// <summary>
+        /// Assert if value is not between minValue and maxValue inclusively.
+        /// </summary>
+        [DebuggerHidden]
+        [Conditional("DEBUG")]
+        public static void AssertIfOutOfRange(int value, int minValue, int maxValue, string paramName)
+        {
+            if (IsOutOfRange(value, minValue, maxValue))
+                ParameterAssert("Parameter {0} is out of range. Should be between {1} and {2}.", paramName, minValue, maxValue);
+        }
+
+        private static bool IsOutOfRange(int value, int minValue, int maxValue)
+        {
+            return value < minValue || value > maxValue;
+        }
+
+        #endregion
+
+        #region NotPositive
+
+        /// <summary>
+        /// Throws ArgumentOutOfRangeException if the value is not a negative or zero.
+        /// </summary>
+        public static void ThrowIfNegativeOrZero(int value, string paramName)
+        {
+            AssertIfNegativeOrZero(value, paramName);
+            if (IsNegativeOrZero(value))
+                throw new ArgumentOutOfRangeException(paramName);
+        }
+
+        /// <summary>
+        /// Assert if the value is not a negative or zero.
+        /// </summary>
+        [DebuggerHidden]
+        [Conditional("DEBUG")]
+        public static void AssertIfNegativeOrZero(int value, string paramName)
+        {
+            if (IsNegativeOrZero(value))
+                ParameterAssert("Parameter Error: Parameter {0} is not positive.", paramName);
+        }
+
+        private static bool IsNegativeOrZero(int value)
+        {
+            return value <= 0;
+        }
+
+        #endregion
+
+        #region ParameterAssert
+
+        [DebuggerHidden]
+        [Conditional("DEBUG")]
+        private static void ParameterAssert(string format, params object[] parameters)
+        {
+            string message = "Parameter Error: ";
+            if (!string.IsNullOrEmpty(format))
+                message += string.Format(CultureInfo.InvariantCulture, format, parameters);
+
+            Debug.WriteLine(message);
+            Debug.Fail(message);
+        }
+
+        #endregion
+    }
+}

--- a/test/DebuggerTesting/Utilities/PlatformUtilities.cs
+++ b/test/DebuggerTesting/Utilities/PlatformUtilities.cs
@@ -1,0 +1,114 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Collections.Generic;
+using System.Collections.Specialized;
+using System.Diagnostics;
+using System.Reflection;
+using System.Runtime.InteropServices;
+
+namespace DebuggerTesting.Utilities
+{
+    public static class PlatformUtilities
+    {
+        private enum RuntimePlatform
+        {
+            Unset = 0,
+            Unknown,
+            Windows,
+            MacOSX,
+            Unix,
+        }
+
+        private static RuntimePlatform _runtimePlatform;
+
+        private static RuntimePlatform GetRuntimePlatform()
+        {
+            if (_runtimePlatform == RuntimePlatform.Unset)
+            {
+                _runtimePlatform = CalculateRuntimePlatform();
+            }
+            return _runtimePlatform;
+        }
+
+        private static RuntimePlatform CalculateRuntimePlatform()
+        {
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+            {
+                return RuntimePlatform.Windows;
+            }
+            else if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
+            {
+                return RuntimePlatform.MacOSX;
+            }
+            else if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
+            {
+                return RuntimePlatform.Unix;
+            }
+            return RuntimePlatform.Unknown;
+        }
+
+        /*
+         * Is this Windows?
+         */
+        public static bool IsWindows
+        {
+            get
+            {
+                return GetRuntimePlatform() == RuntimePlatform.Windows;
+            }
+        }
+
+        /*
+         * Is this OS X?
+         */
+        public static bool IsOSX
+        {
+            get
+            {
+                return GetRuntimePlatform() == RuntimePlatform.MacOSX;
+            }
+        }
+
+        /*
+         * Is this Linux?
+         */
+        public static bool IsLinux
+        {
+            get
+            {
+                return GetRuntimePlatform() == RuntimePlatform.Unix;
+            }
+        }
+
+        public static bool Is64Bit
+        {
+            get
+            {
+                return true;
+            }
+        }
+
+        // Abstract API call to add an environment variable to a new process
+        public static void SetEnvironmentVariable(this ProcessStartInfo processStartInfo, string key, string value)
+        {
+            processStartInfo.Environment[key] = value;
+        }
+
+        // Abstract API call to add an environment variable to a new process
+        public static string GetEnvironmentVariable(this ProcessStartInfo processStartInfo, string key)
+        {
+            if (processStartInfo.Environment.ContainsKey(key))
+                return processStartInfo.Environment[key];
+            return null;
+        }
+
+        // Abstract API call to Marshal.SizeOf
+        public static int MarshalSizeOf<T>()
+        {
+            return Marshal.SizeOf<T>();
+        }
+    }
+}
+

--- a/test/DebuggerTesting/Utilities/ProcessHelper.cs
+++ b/test/DebuggerTesting/Utilities/ProcessHelper.cs
@@ -1,0 +1,289 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
+using DebuggerTesting.Utilities.Windows;
+using System.IO;
+using System.ComponentModel;
+
+namespace DebuggerTesting.Utilities
+{
+    public static class ProcessHelper
+    {
+        #region Methods
+
+        public static void AddToPath(this Process process, string value)
+        {
+            string existingPath = PlatformUtilities.GetEnvironmentVariable(process.StartInfo, "Path");
+            string newPath = string.IsNullOrWhiteSpace(existingPath) ?
+                                value :
+                                existingPath + ";" + value;
+            PlatformUtilities.SetEnvironmentVariable(process.StartInfo, "Path", newPath);
+        }
+
+        /// <summary>
+        /// Creates a ProcessStartInfo object from a file name and arguments
+        /// </summary>
+        public static ProcessStartInfo CreateProcessStartInfo(string fileName, string arguments)
+        {
+            Parameter.ThrowIfNull(fileName, nameof(fileName));
+
+            ProcessStartInfo startInfo = new ProcessStartInfo();
+#if !CORECLR
+            startInfo.WindowStyle = ProcessWindowStyle.Hidden;
+#endif
+            startInfo.FileName = fileName;
+            startInfo.Arguments = arguments;
+            startInfo.UseShellExecute = false;
+            startInfo.RedirectStandardOutput = true;
+            startInfo.RedirectStandardError = true;
+            startInfo.CreateNoWindow = true;
+            startInfo.WorkingDirectory = Path.GetDirectoryName(fileName);
+
+            return startInfo;
+        }
+
+        /// <summary>
+        /// Creates a Process object initialized with a ProcessStartInfo object
+        /// </summary>
+        public static Process CreateProcess(ProcessStartInfo startInfo)
+        {
+            Parameter.ThrowIfNull(startInfo, nameof(startInfo));
+
+            Process process = new Process();
+            process.StartInfo = startInfo;
+            return process;
+        }
+
+        /// <summary>
+        /// Creates a Process object from a file name and arguments
+        /// </summary>
+        public static Process CreateProcess(string fileName, string arguments)
+        {
+            return ProcessHelper.CreateProcess(ProcessHelper.CreateProcessStartInfo(fileName, arguments));
+        }
+
+        /// <summary>
+        /// Provides a way to assure a process will is closed or killed when dispose is called
+        /// </summary>
+        public static IDisposable ProcessCleanup(ILoggingComponent logger, Process p)
+        {
+            return new ProcessCleanupHelper(logger, p);
+        }
+
+        #region ProcessCleanupHelper Class
+
+        private sealed class ProcessCleanupHelper : DisposableObject
+        {
+            ILoggingComponent logger;
+            Process process;
+
+            public ProcessCleanupHelper(ILoggingComponent logger, Process process)
+            {
+                this.logger = logger;
+                this.process = process;
+            }
+
+            protected override void Dispose(bool isDisposing)
+            {
+                if (isDisposing)
+                {
+                    if (this.process != null)
+                    {
+                        int killCount = ProcessHelper.KillProcess(process, recurse: true);
+                        if (killCount > 0)
+                        {
+                            this.logger.WriteLine("Killed {0} debuggee process(es).", killCount);
+                        }
+                        this.process.Dispose();
+                        this.process = null;
+                    }
+                }
+
+                base.Dispose(isDisposing);
+            }
+        }
+
+        #endregion
+
+        /// <summary>
+        /// Kills a process and child processes if requested
+        /// </summary>
+        /// <param name="process">The process to kill</param>
+        /// <param name="recurse">True to kill child processes</param>
+        /// <returns>The count of processes killed</returns>
+        public static int KillProcess(Process process, bool recurse = false)
+        {
+            return KillProcess(process.Id, recurse);
+        }
+
+        /// <summary>
+        /// Kills a process and child processes if requested
+        /// </summary>
+        /// <param name="processId">The process to kill</param>
+        /// <param name="recurse">True to kill child processes</param>
+        /// <returns>The count of processes killed</returns>
+        public static int KillProcess(int processId, bool recurse = false)
+        {
+            if (recurse)
+            {
+                int killCount = 0;
+                int[] childProcessIds = ProcessHelper.FindChildProcesses(processId);
+                killCount += ProcessHelper.KillProcess(processId, recurse: false);
+                foreach (int childProcessId in childProcessIds)
+                {
+                    killCount += ProcessHelper.KillProcess(childProcessId, recurse: true);
+                }
+                return killCount;
+            }
+            else
+            {
+                if (!IsProcessRunning(processId))
+                {
+                    return 0;
+                }
+
+                // This can fail, but don't want to raise an exception in the dispose that hides the root error.
+                try
+                {
+                    Kill(processId);
+                    return 1;
+                }
+                catch (Exception)
+                {
+                    return 0;
+                }
+            }
+        }
+
+        public static bool IsProcessRunning(int processId)
+        {
+            if (PlatformUtilities.IsLinux || PlatformUtilities.IsOSX)
+            {
+                return UnixNativeMethods.GetPGid(processId) >= 0;
+            }
+            else if (PlatformUtilities.IsWindows)
+            {
+                try
+                {
+                    return !TryGetProcessById(processId)?.HasExited ?? false;
+                }
+                catch (Exception)
+                {
+                    return false;
+                }
+            }
+            else
+            {
+                throw new NotSupportedException();
+            }
+        }
+
+        private static void Kill(int processId)
+        {
+            if (PlatformUtilities.IsLinux || PlatformUtilities.IsOSX)
+            {
+                const int sigkill = 9;
+                UnixNativeMethods.Kill(processId, sigkill);
+            }
+            else if (PlatformUtilities.IsWindows)
+            {
+                try
+                {
+                    TryGetProcessById(processId)?.Kill();
+                }
+                catch (Exception) { }
+            }
+            else
+            {
+                throw new NotSupportedException();
+            }
+        }
+
+        /// <summary>
+        /// Trys to get a Process from a process id. Returns null if the process doesn't exist.
+        /// </summary>
+        private static Process TryGetProcessById(int processId)
+        {
+            try
+            {
+                return Process.GetProcessById(processId);
+            }
+            catch (ArgumentException)
+            {
+                return null;
+            }
+        }
+
+        /// <summary>
+        /// Try to get child processes by using 'pgrep -P ##'
+        /// NOTE: This command is not on OSX 10.7 and earlier
+        /// </summary>
+        private static int[] FindChildProcesses(int parentProcessId)
+        {
+            try
+            {
+                return ProcessHelper.FindChildProcessIds(parentProcessId)
+                    .Select((id) => id)
+                    .ToArray();
+            }
+            catch (Exception)
+            {
+                return new int[] { };
+            }
+        }
+
+        private static IEnumerable<int> FindChildProcessIds(int id)
+        {
+            if (PlatformUtilities.IsLinux || PlatformUtilities.IsOSX)
+            {
+                List<int> childProcessIds = new List<int>(1);
+                string pgrepArgs = "-P {0}".FormatInvariantWithArgs(id);
+
+                using (Process pgrepProcess = ProcessHelper.CreateProcess("pgrep", pgrepArgs))
+                {
+                    pgrepProcess.Start();
+                    pgrepProcess.WaitForExit();
+
+                    string childLine;
+                    while ((childLine = pgrepProcess.StandardOutput.ReadLine()) != null)
+                    {
+                        int childProcessId = childLine.ToInt() ?? -1;
+                        if (childProcessId > 0)
+                        {
+                            childProcessIds.Add(childProcessId);
+                        }
+                    }
+                    return childProcessIds;
+                }
+            }
+            else if (PlatformUtilities.IsWindows)
+            {
+                // Find all processes that are parented by the specified id
+                return from p in Process.GetProcesses()
+                       where WindowsProcessNativeMethods.GetParentProcessId(p.Id) == id
+                       select p.Id;
+            }
+            throw new NotSupportedException();
+        }
+
+        public static void InvokeIfAlive(this Process process, Action action)
+        {
+            if (!process.HasExited)
+            {
+                lock (process)
+                {
+                    if (!process.HasExited)
+                    {
+                        action();
+                    }
+                }
+            }
+        }
+
+        #endregion
+    }
+}

--- a/test/DebuggerTesting/Utilities/StringExtensions.cs
+++ b/test/DebuggerTesting/Utilities/StringExtensions.cs
@@ -1,0 +1,103 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+using System.Text;
+
+namespace DebuggerTesting
+{
+    public static class StringExtensions
+    {
+        /// <summary>
+        /// Formats the format string with the given arguments using the current culture.
+        /// </summary>
+        public static string FormatWithArgs(this string format, params object[] args)
+        {
+            return format.FormatWithArgs(CultureInfo.CurrentCulture, args);
+        }
+
+        /// <summary>
+        /// Formats the format string with the given arguments using the invariant culture.
+        /// </summary>
+        public static string FormatInvariantWithArgs(this string format, params object[] args)
+        {
+            return format.FormatWithArgs(CultureInfo.InvariantCulture, args);
+        }
+
+        /// <summary>
+        /// Formats the format string with the given arguments using the given culture.
+        /// </summary>
+        private static string FormatWithArgs(this string format, IFormatProvider provider, params object[] args)
+        {
+            return String.Format(provider, format, args);
+        }
+
+        /// <summary>
+        /// Determines if string has ASCII characters only.
+        /// </summary>
+        public static bool HasAsciiOnly(this string value)
+        {
+            if (String.IsNullOrEmpty(value))
+                return true;
+
+            return value.All(c => c <= 0x7F);
+        }
+
+        /// <summary>
+        /// Converts a string to its base64 representation using the given encoding.
+        /// </summary>
+        public static string ToBase64String(this string value, Encoding encoding)
+        {
+            Parameter.ThrowIfNull(encoding, nameof(encoding));
+
+            if (String.IsNullOrEmpty(value))
+                return value;
+
+            return Convert.ToBase64String(encoding.GetBytes(value));
+        }
+
+        /// <summary>
+        /// Creates a string representation of the contents of the dictionary.
+        /// Returns a line for each entry in the format "key=value"
+        /// </summary>
+        public static string ToReadableString<TKey, TValue>(this IDictionary<TKey, TValue> dictionary, string prefix = null)
+        {
+            if (dictionary == null || dictionary.Count == 0)
+                return string.Empty;
+
+            // Creates an aggregate that accumulates in a string builder
+            return dictionary.Aggregate(
+                new StringBuilder(),
+                (sb, x) => sb.AppendFormat(CultureInfo.InvariantCulture, "{0}{1}={2}", prefix, x.Key, x.Value).AppendLine(),
+                sb => sb.ToString());
+        }
+
+        /// <summary>
+        /// Parses a string to int. If the string is not a valid int, this converts to null
+        /// </summary>
+        public static int? ToInt(this string value)
+        {
+            int x;
+            if (int.TryParse(value, out x))
+                return x;
+            else
+                return null;
+        }
+
+        /// <summary>
+        /// Parses a string to bool. If the string is not a valid bool, this converts to null
+        /// </summary>
+        public static bool? ToBool(this string value)
+        {
+            bool x;
+            if (bool.TryParse(value, out x))
+                return x;
+            else
+                return null;
+        }
+
+    }
+}

--- a/test/DebuggerTesting/Utilities/SupportedArchitectureExtensions.cs
+++ b/test/DebuggerTesting/Utilities/SupportedArchitectureExtensions.cs
@@ -1,0 +1,29 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+
+namespace DebuggerTesting.Utilities
+{
+    public static class SupportedArchitectureExtensions
+    {
+        #region Methods
+
+        public static string ToArchitectureString(this SupportedArchitecture architecture)
+        {
+            switch (architecture)
+            {
+                case SupportedArchitecture.x86:
+                    return "x86";
+                case SupportedArchitecture.x64:
+                    return "x64";
+                case SupportedArchitecture.arm:
+                    return "arm";
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(architecture));
+            }
+        }
+
+        #endregion
+    }
+}

--- a/test/DebuggerTesting/Utilities/UDebug.cs
+++ b/test/DebuggerTesting/Utilities/UDebug.cs
@@ -1,0 +1,471 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Globalization;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using System.Text;
+using System.Text.RegularExpressions;
+
+namespace DebuggerTesting
+{
+    public enum DebugUIResult
+    {
+        Unset = 0,
+        Debug,
+        Ignore,
+        IgnoreAll,
+        EndProcess,
+    }
+
+    public interface IDebugFailUI
+    {
+        DebugUIResult ShowFailure(string message, string callLocation, string exception, string callStack);
+    }
+
+    public static class UDebug
+    {
+
+        [Conditional("DEBUG")]
+        [DebuggerHidden]
+        public static void Assert(bool condition, string format, params string[] parameters)
+        {
+            if (!condition)
+                UDebug.Fail(format, parameters);
+        }
+
+        [Conditional("DEBUG")]
+        [DebuggerHidden]
+        public static void AssertNotNull<T>(T value, string format, params string[] parameters)
+            where T : class
+        {
+            if (value == null)
+                UDebug.Fail(format, parameters);
+        }
+
+        [Conditional("DEBUG")]
+        [DebuggerHidden]
+        public static void AssertNotNullOrEmpty(string value, string format, params string[] parameters)
+        {
+            if (string.IsNullOrEmpty(value))
+                UDebug.Fail(format, parameters);
+        }
+
+        [Conditional("DEBUG")]
+        [DebuggerHidden]
+        public static void AssertService<T>(T service)
+            where T : class
+        {
+            if (service == null)
+                UDebug.Fail("Service {0} could not be loaded.", typeof(T).Name);
+        }
+
+        [Conditional("DEBUG")]
+        [DebuggerHidden]
+        public static void Fail(string format, params object[] parameters)
+        {
+            UDebug.Fail(null, format, parameters);
+        }
+
+        [Conditional("DEBUG")]
+        [DebuggerHidden]
+        public static void Fail(Exception ex)
+        {
+            UDebug.Fail(ex, string.Empty);
+        }
+
+        [Conditional("DEBUG")]
+        [DebuggerHidden]
+        public static void Fail(string message)
+        {
+            UDebug.Fail((Exception)null, message);
+        }
+
+        private static bool? showFailUI;
+
+        private static bool? ShowFailUI
+        {
+            get
+            {
+                return showFailUI;
+            }
+            set
+            {
+                // Only allow the value to be set once.
+                if (null == showFailUI)
+                    showFailUI = value;
+            }
+        }
+
+        [DebuggerHidden]
+        [Conditional("DEBUG")]
+        public static void Fail(Exception ex, string format, params string[] parameters)
+        {
+#if DEBUG
+            string message = null;
+            string exception = null;
+            string callStack = null;
+
+            if (!string.IsNullOrEmpty(format))
+                message = string.Format(CultureInfo.InvariantCulture, format, parameters);
+
+            if (ex != null)
+            {
+                exception = ExceptionToString(ex, 0, false);
+                callStack = ExceptionToCallStack(ex);
+            }
+
+            FailInternal(message, exception, callStack);
+#endif
+        }
+
+        [DebuggerHidden]
+        [Conditional("DEBUG")]
+        private static void FailInternal(string message, string exception = null, string callStack = null)
+        {
+#if DEBUG
+
+            if (callStack == null)
+            {
+                callStack = GetCurrentCallStack();
+            }
+
+            string callLocation = GetFirstUserFrame();
+
+            if (false != ShowFailUI)
+            {
+                message = message ?? string.Empty;
+                message = "Failure: " + message;
+
+                // Are we logging to a file?
+                string logFile = Environment.GetEnvironmentVariable("vsassert");
+                if (string.IsNullOrEmpty(logFile))
+                {
+                    ShowFailureInternal(message, callLocation, exception, callStack);
+                }
+                else
+                {
+                    using (StreamWriter file = File.AppendText(logFile))
+                    {
+                        file.WriteLine(message);
+                    }
+                }
+            }
+            else
+                throw new Exception(message);
+#endif
+        }
+
+#if DEBUG
+        private static HashSet<string> IgnoreTable = new HashSet<string>();
+
+        /// <summary>
+        /// A way to override default Debug Fail UI
+        /// </summary>
+        public static IDebugFailUI DebugFailUI { get; set; }
+
+        [DebuggerStepThrough]
+        [DebuggerHidden]
+        private static void ShowFailureInternal(string message, string callLocation, string exception, string callStack)
+        {
+            if (IgnoreTable.Contains(callLocation))
+                return;
+
+            message = message ?? string.Empty;
+
+            if (DebugFailUI == null)
+                DebugFailUI = new DefaultDebugFailUI();
+            DebugUIResult result = DebugUIResult.Ignore;
+
+            try
+            {
+                result = DebugFailUI.ShowFailure(message, callLocation, exception, callStack);
+            }
+            catch (InvalidOperationException)
+            { }
+
+            switch (result)
+            {
+                case DebugUIResult.Debug:
+                    if (!Debugger.IsAttached)
+                    {
+                        Debugger.Launch();
+                    }
+                    Debugger.Break();
+                    break;
+                case DebugUIResult.EndProcess:
+                    // Kill the process
+                    Process.GetCurrentProcess().Kill();
+                    break;
+                case DebugUIResult.IgnoreAll:
+                    if (!string.IsNullOrWhiteSpace(callLocation))
+                        IgnoreTable.Add(callLocation);
+                    break;
+            }
+        }
+
+        [DebuggerHidden]
+        private static string ExceptionToCallStack(Exception ex)
+        {
+            return ExceptionToCallStack(ex, 0);
+        }
+
+        [DebuggerHidden]
+        private static string ExceptionToCallStack(Exception ex, int depth = 0)
+        {
+            StringBuilder sb = new StringBuilder();
+
+            // Runtime Invoke may put the callstack information in the Data dictionary.
+            if (ex.Data.Contains("CustomStackTrace"))
+            {
+                string stackTrace = ex.Data["CustomStackTrace"] as string;
+                if (!string.IsNullOrEmpty(stackTrace))
+                {
+                    sb.Append(ex.GetType().Name); // Name of the exception type
+                    sb.AppendLine(" Call Stack (from thread): ");
+                    foreach (var line in stackTrace.Split(new string[] { " at " }, StringSplitOptions.RemoveEmptyEntries))
+                    {
+                        string trimLine = line.Trim();
+                        if (!string.IsNullOrEmpty(trimLine))
+                        {
+                            sb.Append("        ");
+                            sb.AppendLine(trimLine);
+                        }
+                    }
+                }
+            }
+
+            // The stack trace of where the exception was raised (not where the assert was raised)
+            if (!string.IsNullOrEmpty(ex.StackTrace))
+            {
+                sb.Append(ex.GetType().Name); // Name of the exception type
+                sb.AppendLine(" Call Stack: ");
+                foreach (var line in ex.StackTrace.Split(new string[] { " at " }, StringSplitOptions.RemoveEmptyEntries))
+                {
+                    string trimLine = line.Trim();
+                    if (!string.IsNullOrEmpty(trimLine))
+                    {
+                        sb.AppendLine(trimLine);
+                    }
+                }
+            }
+
+            // Provide more information on common exceptions
+            DetailedExceptionHelper(sb, ex, depth, string.Empty);
+
+            // The inner exceptions
+            if (ex.InnerException != null)
+            {
+                string innerCallStack = ExceptionToCallStack(ex.InnerException, depth + 1);
+                if (!string.IsNullOrEmpty(innerCallStack))
+                {
+                    sb.AppendLine();
+                    sb.Append(innerCallStack);
+                }
+            }
+
+            return sb.ToString();
+        }
+
+#endif //DEBUG
+
+        [DebuggerHidden]
+        public static string ExceptionToString(Exception ex)
+        {
+            return ExceptionToString(ex, 0, true);
+        }
+
+        /// <summary>
+        /// Converts an exception to a string that contains more useful
+        /// information than the default ex.ToString()
+        /// </summary>
+        [DebuggerHidden]
+        private static string ExceptionToString(Exception ex, int depth, bool showCallStack)
+        {
+            if (ex == null)
+                return string.Empty;
+
+            string padding = new string(' ', depth * 4);
+
+            StringBuilder sb = new StringBuilder();
+            sb.Append(padding);
+            sb.Append(ex.GetType().Name); // Name of the exception type
+            sb.Append(": ");
+
+            // The message
+            string message = AddPadding(ex.Message, padding);
+            if (!string.IsNullOrEmpty(message))
+            {
+                sb.AppendLine(message);
+            }
+            else
+            {
+                sb.AppendLine();
+            }
+
+            if (showCallStack)
+            {
+                // The stack trace of where the exception was raised (not where the assert was raised)
+                if (!string.IsNullOrEmpty(ex.StackTrace))
+                {
+                    sb.AppendLine();
+                    foreach (var line in ex.StackTrace.Split(new string[] { " at " }, StringSplitOptions.RemoveEmptyEntries))
+                    {
+                        string trimLine = line.Trim();
+                        if (!string.IsNullOrEmpty(trimLine))
+                        {
+                            sb.AppendLine(trimLine);
+                        }
+                    }
+                }
+            }
+
+            // Provide more information on common exceptions
+            DetailedExceptionHelper(sb, ex, depth, padding);
+
+            // The inner exceptions
+            if (ex.InnerException != null)
+            {
+                sb.Append(padding);
+                sb.AppendLine("Inner Exception: ");
+                sb.Append(ExceptionToString(ex.InnerException, depth + 1, showCallStack: false));
+            }
+
+            return sb.ToString();
+        }
+
+        // Provide more information on common exceptions
+        private static void DetailedExceptionHelper(StringBuilder sb, Exception ex, int depth, string padding)
+        {
+            // Reflection type loads occur a lot in this code, so give more info
+            // on why they failed
+            if (ex is ReflectionTypeLoadException)
+            {
+                foreach (var exLoader in (ex as ReflectionTypeLoadException).LoaderExceptions.Take(5))
+                {
+                    sb.AppendLine();
+                    sb.Append(padding);
+                    sb.AppendLine("Loader exception: ");
+                    sb.Append(ExceptionToString(exLoader, depth + 1, showCallStack: false));
+                }
+            }
+            else if (ex is FileNotFoundException)
+            {
+                FileNotFoundException exception = (FileNotFoundException)ex;
+                bool hasFileName = !String.IsNullOrEmpty(exception.FileName);
+                bool hasFusionLog = false;
+#if !CORECLR
+                hasFusionLog = !String.IsNullOrEmpty(exception.FusionLog);
+#endif
+                if (hasFileName || hasFusionLog)
+                {
+                    sb.AppendLine();
+                    if (hasFileName)
+                    {
+                        sb.Append(padding);
+                        sb.Append("File: ");
+                        sb.AppendLine(exception.FileName);
+                    }
+#if !CORECLR
+                    if (hasFusionLog)
+                    {
+                        sb.Append(padding);
+                        sb.Append("Fusion log: ");
+                        sb.AppendLine(exception.FusionLog);
+                    }
+#endif
+                }
+            }
+            else if (ex is AggregateException)
+            {
+                AggregateException exception = (AggregateException)ex;
+                if (exception.InnerExceptions != null)
+                {
+                    foreach (var exInner in exception.InnerExceptions.Take(5))
+                    {
+                        sb.AppendLine();
+                        sb.Append(padding);
+                        sb.AppendLine("Aggregate exception: ");
+                        sb.Append(ExceptionToString(exInner, depth + 1, showCallStack: false));
+                    }
+                }
+            }
+        }
+
+        // Add padding before new lines to make indents consistent
+        private static string AddPadding(string message, string padding)
+        {
+            message = message.Trim();
+            // Change tabs to spaces
+            message = Regex.Replace(message, "\t", "    ");
+
+            // Handle any kind of new line that is spewed out of an exception
+            // Change everything to '\n' first, then back to NewLine (AKA \r\n, AKA CRLF)
+            message = Regex.Replace(message, Environment.NewLine, "\n");
+            message = Regex.Replace(message, "\r", "\n");
+            message = Regex.Replace(message, "\n", Environment.NewLine + padding);
+            return message;
+        }
+
+
+#if DEBUG
+
+        static readonly private Type[] ClassesToIgnore = {
+            typeof(UDebug),
+            typeof(Parameter),
+            typeof(DefaultDebugFailUI),
+            typeof(Environment)
+        };
+
+        [DebuggerHidden]
+        private static string GetFirstUserFrame()
+        {
+            return GetCurrentCallStack(justFirstLine: true);
+        }
+
+        [DebuggerHidden]
+        private static string GetCurrentCallStack()
+        {
+            return GetCurrentCallStack(justFirstLine: false);
+        }
+
+        [DebuggerHidden]
+        private static string GetCurrentCallStack(bool justFirstLine)
+        {
+            // Use the Environment.StackTrace API to get the stack trace.
+            IEnumerable<string> frames = Environment.StackTrace.Split(new string[] { Environment.NewLine }, StringSplitOptions.RemoveEmptyEntries);
+            foreach (Type ignoreType in ClassesToIgnore)
+            {
+                frames = frames.Where(x => x.IndexOf(ignoreType.FullName, StringComparison.OrdinalIgnoreCase) < 0);
+            }
+
+            // Remove " at " part of string
+            frames = frames.Select(x => x.Substring(6).Trim());
+
+            if (justFirstLine)
+                return frames.FirstOrDefault() ?? string.Empty;
+
+            return string.Join(Environment.NewLine, frames) ?? string.Empty;
+        }
+
+#endif
+    }
+
+#if DEBUG
+    /// <summary>
+    /// Implements the Debug Fail UI for the UDebug class
+    /// </summary>
+    internal class DefaultDebugFailUI : IDebugFailUI
+    {
+        DebugUIResult IDebugFailUI.ShowFailure(string message, string callLocation, string exception, string callStack)
+        {
+            Debug.Fail(exception + ": " + message, callStack);
+            return DebugUIResult.Ignore;
+        }
+    }
+#endif //DEBUG
+}

--- a/test/DebuggerTesting/Utilities/UnixNativeMethods.cs
+++ b/test/DebuggerTesting/Utilities/UnixNativeMethods.cs
@@ -1,0 +1,24 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Runtime.InteropServices;
+
+namespace DebuggerTesting.Utilities
+{
+    internal class UnixNativeMethods
+    {
+        private const string Libc = "libc";
+
+        [DllImport(Libc, EntryPoint = "kill", SetLastError = true)]
+        internal static extern int Kill(int pid, int mode);
+
+        [DllImport(Libc, EntryPoint = "mkfifo", SetLastError = true)]
+        internal static extern int MkFifo(byte[] name, int mode);
+
+        [DllImport(Libc, EntryPoint = "geteuid", SetLastError = true)]
+        internal static extern uint GetEUid();
+
+        [DllImport(Libc, EntryPoint = "getpgid", SetLastError = true)]
+        internal static extern int GetPGid(int pid);
+    }
+}

--- a/test/DebuggerTesting/Utilities/Windows/WindowsProcessNativeMethods.cs
+++ b/test/DebuggerTesting/Utilities/Windows/WindowsProcessNativeMethods.cs
@@ -1,0 +1,116 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Globalization;
+using System.Runtime.InteropServices;
+
+namespace DebuggerTesting.Utilities.Windows
+{
+    /// <summary>
+    /// P/Invoke APIs to get process information
+    /// </summary>
+    internal static class WindowsProcessNativeMethods
+    {
+        #region CreateToolhelp32Snapshot
+
+        [Flags]
+        private enum SnapshotFlags : uint
+        {
+            Inherit = 0x80000000,
+            All = (HeapList | Process | Thread | Module | Module32),
+            HeapList = 0x00000001,
+            Process = 0x00000002,
+            Thread = 0x00000004,
+            Module = 0x00000008,
+            Module32 = 0x00000010,
+        }
+
+        [DllImport("kernel32.dll", SetLastError = true)]
+        private static extern IntPtr CreateToolhelp32Snapshot([In] SnapshotFlags flags, [In] uint processId);
+
+        #endregion
+
+        #region Process32
+
+        [StructLayout(LayoutKind.Sequential)]
+        private struct ProcessEntry32
+        {
+            public ProcessEntry32(uint? size) : this()
+            {
+                this.size = size ?? (uint)PlatformUtilities.MarshalSizeOf<ProcessEntry32>();
+            }
+
+            const int MAX_PATH = 260;
+            public uint size;
+            public uint unused;
+            public uint processId;
+            public UIntPtr defaultHeapId;
+            public uint moduleId;
+            public uint cntThreads;
+            public uint parentProcessId;
+            public int pcPriClassBase;
+            public uint flags;
+            [MarshalAs(UnmanagedType.ByValTStr, SizeConst = MAX_PATH)]
+            public string exeFile;
+        }
+
+        private const int ERROR_NO_MORE_FILES = 18;
+
+        [DllImport("kernel32.dll", SetLastError = true)]
+        [return: MarshalAs(UnmanagedType.Bool)]
+        private static extern bool Process32First([In] IntPtr snapshot, [In, Out] ref ProcessEntry32 processEntry);
+
+        [DllImport("kernel32.dll", SetLastError = true)]
+        [return: MarshalAs(UnmanagedType.Bool)]
+        private static extern bool Process32Next([In] IntPtr snapshot, [In, Out] ref ProcessEntry32 processEntry);
+
+        private static ProcessEntry32 Process32First(IntPtr snapshot)
+        {
+            ProcessEntry32 processEntry = new ProcessEntry32(size: null);
+            if (!Process32First(snapshot, ref processEntry))
+            {
+                int error = Marshal.GetLastWin32Error();
+                if (error != ERROR_NO_MORE_FILES)
+                    throw new InvalidOperationException("Win32 Error 0x" + error.ToString("X8", CultureInfo.InvariantCulture));
+            }
+            return processEntry;
+        }
+
+        #endregion
+
+        #region CloseHandle
+
+        [DllImport("kernel32", SetLastError = true)]
+        [return: MarshalAs(UnmanagedType.Bool)]
+        private static extern bool CloseHandle([In] IntPtr handle);
+
+        #endregion
+
+        /// <summary>
+        /// Gets the parent process id
+        /// </summary>
+        public static int? GetParentProcessId(int processId)
+        {
+            IntPtr snapshot = IntPtr.Zero;
+            try
+            {
+                snapshot = CreateToolhelp32Snapshot(SnapshotFlags.Process, 0);
+                ProcessEntry32 processEntry = Process32First(snapshot);
+                do
+                {
+                    if (processEntry.processId == processId)
+                        return (int)processEntry.parentProcessId;
+                } while (Process32Next(snapshot, ref processEntry));
+            }
+            catch (Exception)
+            { }
+            finally
+            {
+                if (snapshot != IntPtr.Zero)
+                    CloseHandle(snapshot);
+            }
+            return null;
+        }
+    }
+}

--- a/test/DebuggerTesting/Utilities/XmlHelper.cs
+++ b/test/DebuggerTesting/Utilities/XmlHelper.cs
@@ -1,0 +1,61 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Diagnostics.CodeAnalysis;
+using System.Globalization;
+using System.Xml;
+using System.Xml.Linq;
+
+namespace DebuggerTesting.Utilities
+{
+    public static class XmlHelper
+    {
+#if CORECLR
+        [SuppressMessage("Microsoft.Security.Xml", "CA3053:UseXmlSecureResolver", Justification = "XmlResolver property does not exist in CoreCLR.")]
+#endif
+        public static XmlReader CreateXmlReader(string uri)
+        {
+            XmlReaderSettings settings = new XmlReaderSettings();
+            settings.ConformanceLevel = ConformanceLevel.Document;
+            settings.DtdProcessing = DtdProcessing.Prohibit;
+#if !CORECLR
+            settings.XmlResolver = null;
+#endif
+            return XmlReader.Create(uri, settings);
+        }
+
+        public static string GetAttributeValue(this XElement element, string attributeName)
+        {
+            return element.Attribute(attributeName)?.Value;
+        }
+
+        public static TEnum GetAttributeEnum<TEnum>(this XElement element, string attributeName)
+            where TEnum : struct
+        {
+            string attributeValue = GetAttributeValue(element, attributeName);
+            TEnum value;
+            if (!Enum.TryParse(attributeValue, true, out value))
+                throw new ArgumentOutOfRangeException(nameof(attributeValue), "Unhandled " + typeof(TEnum).Name + " value " + attributeValue);
+            return value;
+        }
+
+        public static bool? GetAttributeValueAsBool(this XElement element, string attributeName)
+        {
+            string value = element.GetAttributeValue(attributeName);
+            if (string.IsNullOrEmpty(value))
+                return null;
+
+            return bool.Parse(value);
+        }
+
+        public static double? GetAttributeValueAsDouble(this XElement element, string attributeName)
+        {
+            string value = element.GetAttributeValue(attributeName);
+            if (string.IsNullOrEmpty(value))
+                return null;
+
+            return double.Parse(value, CultureInfo.InvariantCulture);
+        }
+    }
+}


### PR DESCRIPTION
This PR migrates over DebuggerTesting, CppTests, and DebugAdapterRunner to the MIEngine repository. 

- Debugger Testing is the infrastructure used to build c++ debuggee projects and let tests know which debugger to run. 
- CppTests holds the debuggees, configurations, and tests to run aganist.
- DebugAdapterRunner is a tool to help compare Request/Responses for the DebugAdapterProtocol (DAP).

These test projects are added under MIEngine_Root/test and are added to the MIDebugEngine.sln.
It will output it in `$(MIEngineRoot)bin\DebugAdapterProtocolTests\$(Configuration)`

Aside: Added the build props to the MIDebugEngine.sln too. 

TODO: Handling CrossPlatform builds, updating the releases, and running tests. 