### PR TITLE
Add Telemetry for FrameworkVersion

### DIFF
--- a/src/OpenDebugAD7/AD7DebugSession.cs
+++ b/src/OpenDebugAD7/AD7DebugSession.cs
@@ -141,6 +141,15 @@ namespace OpenDebugAD7
             m_logger.Write(LoggingCategory.Telemetry, eventName, propertiesDictionary);
         }
 
+        private static string GetFrameworkVersionAttributeValue()
+        {
+            var attribute = typeof(object).Assembly.GetCustomAttribute(typeof(System.Reflection.AssemblyFileVersionAttribute)) as AssemblyFileVersionAttribute;
+            if (attribute == null)
+                return string.Empty;
+
+            return attribute.Version;
+        }
+
         private ProtocolException CreateProtocolExceptionAndLogTelemetry(string telemetryEventName, int error, string message)
         {
             DebuggerTelemetry.ReportError(telemetryEventName, error);
@@ -959,6 +968,7 @@ namespace OpenDebugAD7
                 }
 
                 properties.Add(DebuggerTelemetry.TelemetryMIMode, mimode);
+                properties.Add(DebuggerTelemetry.TelemetryFrameworkVersion, GetFrameworkVersionAttributeValue());
 
                 DebuggerTelemetry.ReportTimedEvent(telemetryEventName, DateTime.Now - launchStartTime, properties);
 
@@ -1146,6 +1156,7 @@ namespace OpenDebugAD7
 
                 var properties = new Dictionary<string, object>(StringComparer.Ordinal);
                 properties.Add(DebuggerTelemetry.TelemetryMIMode, mimode);
+                properties.Add(DebuggerTelemetry.TelemetryFrameworkVersion, GetFrameworkVersionAttributeValue());
 
                 DebuggerTelemetry.ReportTimedEvent(telemetryEventName, DateTime.Now - attachStartTime, properties);
                 success = true;

--- a/src/OpenDebugAD7/Telemetry/DebuggerTelemetry.cs
+++ b/src/OpenDebugAD7/Telemetry/DebuggerTelemetry.cs
@@ -42,12 +42,10 @@ namespace OpenDebugAD7
         private const string TelemetryEngineVersion = "EngineVersion";
         private const string TelemetryHostVersion = "HostVersion";
         private const string TelemetryAdapterId = "AdapterId";
-        private const string TelemetryFrameworkVersion = "FrameworkVersion";
         private string _engineName;
         private string _engineVersion;
         private string _hostVersion;
         private string _adapterId;
-        private string _frameworkVersion;
 
         // Specific telemetry properties
         public const string TelemetryIsCoreDump = TelemetryLaunchEventName + ".IsCoreDump";
@@ -57,6 +55,7 @@ namespace OpenDebugAD7
         public const string TelemetryVisualizerFileUsed = "VisualizerFileUsed";
         public const string TelemetrySourceFileMappings = "SourceFileMappings";
         public const string TelemetryMIMode = "MIMode";
+        public const string TelemetryFrameworkVersion = "FrameworkVersion";
         public const string TelemetryStackFrameId = TelemetryExecuteInConsole + ".StackFrameId";
 
         private DebuggerTelemetry(Action<DebugEvent> callback, TypeInfo engineType, TypeInfo hostType, string adapterId)
@@ -67,7 +66,6 @@ namespace OpenDebugAD7
             _engineName = engineType.Namespace;
             _engineVersion = GetVersionAttributeValue(engineType);
             _hostVersion = GetVersionAttributeValue(hostType);
-            _frameworkVersion = GetFrameworkVersionAttributeValue();
             _adapterId = adapterId;
         }
 
@@ -213,7 +211,6 @@ namespace OpenDebugAD7
             properties[TelemetryEngineVersion] = _engineVersion;
             properties[TelemetryHostVersion] = _hostVersion;
             properties[TelemetryAdapterId] = _adapterId;
-            properties[TelemetryFrameworkVersion] = _frameworkVersion;
 
             properties.Merge(eventProperties);
 
@@ -258,15 +255,6 @@ namespace OpenDebugAD7
         private static string GetVersionAttributeValue(TypeInfo engineType)
         {
             var attribute = engineType.Assembly.GetCustomAttribute(typeof(System.Reflection.AssemblyFileVersionAttribute)) as AssemblyFileVersionAttribute;
-            if (attribute == null)
-                return string.Empty;
-
-            return attribute.Version;
-        }
-
-        private static string GetFrameworkVersionAttributeValue()
-        {
-            var attribute = typeof(object).Assembly.GetCustomAttribute(typeof(System.Reflection.AssemblyFileVersionAttribute)) as AssemblyFileVersionAttribute;
             if (attribute == null)
                 return string.Empty;
 

--- a/src/OpenDebugAD7/Telemetry/DebuggerTelemetry.cs
+++ b/src/OpenDebugAD7/Telemetry/DebuggerTelemetry.cs
@@ -42,10 +42,12 @@ namespace OpenDebugAD7
         private const string TelemetryEngineVersion = "EngineVersion";
         private const string TelemetryHostVersion = "HostVersion";
         private const string TelemetryAdapterId = "AdapterId";
+        private const string TelemetryFrameworkVersion = "FrameworkVersion";
         private string _engineName;
         private string _engineVersion;
         private string _hostVersion;
         private string _adapterId;
+        private string _frameworkVersion;
 
         // Specific telemetry properties
         public const string TelemetryIsCoreDump = TelemetryLaunchEventName + ".IsCoreDump";
@@ -65,6 +67,7 @@ namespace OpenDebugAD7
             _engineName = engineType.Namespace;
             _engineVersion = GetVersionAttributeValue(engineType);
             _hostVersion = GetVersionAttributeValue(hostType);
+            _frameworkVersion = GetFrameworkVersionAttributeValue();
             _adapterId = adapterId;
         }
 
@@ -210,6 +213,7 @@ namespace OpenDebugAD7
             properties[TelemetryEngineVersion] = _engineVersion;
             properties[TelemetryHostVersion] = _hostVersion;
             properties[TelemetryAdapterId] = _adapterId;
+            properties[TelemetryFrameworkVersion] = _frameworkVersion;
 
             properties.Merge(eventProperties);
 
@@ -254,6 +258,15 @@ namespace OpenDebugAD7
         private static string GetVersionAttributeValue(TypeInfo engineType)
         {
             var attribute = engineType.Assembly.GetCustomAttribute(typeof(System.Reflection.AssemblyFileVersionAttribute)) as AssemblyFileVersionAttribute;
+            if (attribute == null)
+                return string.Empty;
+
+            return attribute.Version;
+        }
+
+        private static string GetFrameworkVersionAttributeValue()
+        {
+            var attribute = typeof(object).Assembly.GetCustomAttribute(typeof(System.Reflection.AssemblyFileVersionAttribute)) as AssemblyFileVersionAttribute;
             if (attribute == null)
                 return string.Empty;
 


### PR DESCRIPTION
This PR will add Telemetry to see which version of .NET customers are using to help determine if a majority of customers are still on v4.6.2.