### PR TITLE
Add WSL port supplier

### DIFF
--- a/src/MIDebugEngine/Microsoft.MIDebugEngine.pkgdef
+++ b/src/MIDebugEngine/Microsoft.MIDebugEngine.pkgdef
@@ -52,6 +52,8 @@
 "0"="{3FDDF14E-E758-4695-BE0C-7509920432C9}"
 ; Docker Port Supplier
 "1"="{A2BBC114-47E4-473F-A49C-69EE89711243}"
+; WSL Port supplier
+"2"="{267B1341-AC92-44DC-94DF-2EE4205DD17E}"
 
 [$RootKey$\OpenFolder\Settings\VSWorkspaceSettings\{EA6637C6-17DF-45B5-A183-0951C54243BC}]
 @="$PackageFolder$\OpenFolderSchema.json"

--- a/src/SSHDebugPS/AD7/AD7PortSupplier.cs
+++ b/src/SSHDebugPS/AD7/AD7PortSupplier.cs
@@ -17,7 +17,7 @@ namespace Microsoft.SSHDebugPS
 
         public abstract int AddPort(IDebugPortRequest2 request, out IDebugPort2 port);
 
-        public int CanAddPort()
+        public virtual int CanAddPort()
         {
             return HR.S_OK;
         }

--- a/src/SSHDebugPS/Docker/DockerConnection.cs
+++ b/src/SSHDebugPS/Docker/DockerConnection.cs
@@ -99,14 +99,14 @@ namespace Microsoft.SSHDebugPS.Docker
 
         #endregion
 
-        private string _containerName;
+        private readonly string _containerName;
         private readonly DockerExecutionManager _dockerExecutionManager;
-
-        internal new DockerContainerTransportSettings TransportSettings => (DockerContainerTransportSettings)base.TransportSettings;
+        private readonly DockerContainerTransportSettings _settings;
 
         public DockerConnection(DockerContainerTransportSettings settings, Connection outerConnection, string name)
-            : base(settings, outerConnection, name)
+            : base(outerConnection, name)
         {
+            _settings = settings;
             _containerName = settings.ContainerName;
             _dockerExecutionManager = new DockerExecutionManager(settings, outerConnection);
         }
@@ -125,7 +125,7 @@ namespace Microsoft.SSHDebugPS.Docker
             }
 
             var commandRunner = GetExecCommandRunner(commandText, handleRawOutput: runInShell == false);
-            asyncCommand = new DockerAsyncCommand(commandRunner, callback);
+            asyncCommand = new PipeAsyncCommand(commandRunner, callback);
         }
 
         public override void CopyFile(string sourcePath, string destinationPath)
@@ -142,11 +142,11 @@ namespace Microsoft.SSHDebugPS.Docker
             {
                 tmpFile = "/tmp" + "/" + StringResources.CopyFile_TempFilePrefix + Guid.NewGuid();
                 OuterConnection.CopyFile(sourcePath, tmpFile);
-                settings = new DockerCopySettings(TransportSettings, tmpFile, destinationPath);
+                settings = new DockerCopySettings(_settings, tmpFile, destinationPath);
             }
             else
             {
-                settings = new DockerCopySettings(TransportSettings, sourcePath, destinationPath);
+                settings = new DockerCopySettings(_settings, sourcePath, destinationPath);
             }
 
             ICommandRunner runner = GetCommandRunner(settings);
@@ -186,46 +186,12 @@ namespace Microsoft.SSHDebugPS.Docker
         // Base implementation was evaluating '$HOME' on the host machine and not the client machine, causing the home directory to be wrong.
         public override string GetUserHomeDirectory()
         {
-            string command = "eval echo '~'";
-            string commandOutput;
-            string errorMessage;
-            ExecuteCommand(command, Timeout.Infinite, throwOnFailure: true, commandOutput: out commandOutput, errorMessage: out errorMessage);
-
-            return commandOutput;
-        }
-
-        // Execute a command and wait for a response. No more interaction
-        public override void ExecuteSyncCommand(string commandDescription, string commandText, out string commandOutput, int timeout, out int exitCode)
-        {
-            int exit = -1;
-            string output = string.Empty;
-
-            var settings = new DockerExecSettings(TransportSettings, commandText, runInShell: false, makeInteractive: false);
-            var runner = GetCommandRunner(settings, true);
-
-            string dockerCommand = "{0} {1}".FormatInvariantWithArgs(settings.Command, settings.CommandArgs);
-            string waitMessage = StringResources.WaitingOp_ExecutingCommand.FormatCurrentCultureWithArgs(commandDescription);
-            string errorMessage;
-            VS.VSOperationWaiter.Wait(waitMessage, true, (cancellationToken) =>
-            {
-                if (OuterConnection != null)
-                {
-                    exit = OuterConnection.ExecuteCommand(dockerCommand, timeout, out output, out errorMessage);
-                }
-                else
-                {
-                    //local exec command
-                    exit = ExecuteCommand(commandText, timeout, out output, out errorMessage);
-                }
-            });
-
-            exitCode = exit;
-            commandOutput = output;
+            return ExecuteCommand("eval echo '~'", Timeout.Infinite);
         }
 
         private ICommandRunner GetExecCommandRunner(string commandText, bool handleRawOutput = false)
         {
-            var execSettings = new DockerExecSettings(this.TransportSettings, commandText, handleRawOutput);
+            var execSettings = new DockerExecSettings(this._settings, commandText, handleRawOutput);
 
             return GetCommandRunner(execSettings, handleRawOutput: handleRawOutput);
         }

--- a/src/SSHDebugPS/Docker/DockerExecutionManager.cs
+++ b/src/SSHDebugPS/Docker/DockerExecutionManager.cs
@@ -49,7 +49,7 @@ namespace Microsoft.SSHDebugPS.Docker
 
     internal class DockerExecutionManager
     {
-        private DockerAsyncCommand _currentCommand;
+        private PipeAsyncCommand _currentCommand;
 
         private Connection _outerConnection = null;
         private DockerContainerTransportSettings _baseSettings;
@@ -88,7 +88,7 @@ namespace Microsoft.SSHDebugPS.Docker
             using (ICommandRunner commandRunner = GetExecCommandRunner(commandText, runInShell, makeInteractive))
             {
                 ShellCommandCallback commandCallback = new ShellCommandCallback(_commandCompleteEvent);
-                DockerAsyncCommand command = new DockerAsyncCommand(commandRunner, commandCallback);
+                PipeAsyncCommand command = new PipeAsyncCommand(commandRunner, commandCallback);
 
                 try
                 {

--- a/src/SSHDebugPS/LocalProcessAsyncRunner.cs
+++ b/src/SSHDebugPS/LocalProcessAsyncRunner.cs
@@ -1,0 +1,123 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Threading;
+using System.Threading.Tasks;
+using SysProcess = System.Diagnostics.Process;
+
+namespace Microsoft.SSHDebugPS
+{
+    readonly struct ProcessResult
+    {
+        public int ExitCode { get; }
+        public IList<string> StdOut { get; }
+        public IList<string> StdErr { get; }
+
+        public ProcessResult(int exitCode, IList<string> stdOut, IList<string> stdErr)
+        {
+            this.ExitCode = exitCode;
+            this.StdOut = stdOut;
+            this.StdErr = stdErr;
+        }
+    };
+
+    internal static class LocalProcessAsyncRunner
+    {
+        public static Task<ProcessResult> ExecuteProcessAsync(ProcessStartInfo startInfo, CancellationToken cancellationToken)
+        {
+            bool isComplete = false;
+            var taskCompletionSource = new TaskCompletionSource<ProcessResult>();
+            CancellationTokenRegistration cancellationTokenRegistration = new CancellationTokenRegistration();
+            List<string> stdOut = new List<string>();
+            List<string> stdError = new List<string>();
+            SysProcess process = null;
+
+            void Process_Exited(object sender, EventArgs e)
+            {
+                // Briefly take this lock to make sure that we had a chance to finish initialization, and to guard 'isComplete'
+                lock (taskCompletionSource)
+                {
+                    if (isComplete)
+                    {
+                        return; // already canceled
+                    }
+                    isComplete = true;
+                }
+
+                cancellationTokenRegistration.Dispose();
+                process.Exited -= Process_Exited;
+
+                // Wait for any output handlers to flush
+                process.WaitForExit();
+
+                int exitCode = process.ExitCode;
+                process.Close();
+
+                taskCompletionSource.SetResult(new ProcessResult(exitCode, stdOut, stdError));
+            }
+
+            void OnCancel()
+            {
+                // Briefly take this lock to make sure that we had a chance to finish initialization, and to guard 'isComplete'
+                lock (taskCompletionSource)
+                {
+                    if (isComplete)
+                    {
+                        return; // process already exited
+                    }
+                    isComplete = true;
+                }
+
+                taskCompletionSource.SetCanceled();
+                process.Exited -= Process_Exited;
+
+                try
+                {
+                    process.Kill();
+                }
+                catch (Exception)
+                { }
+
+                process.Close();
+            }
+            
+            lock (taskCompletionSource)
+            {
+                cancellationTokenRegistration = cancellationToken.Register(OnCancel);
+                process = new SysProcess();
+                process.StartInfo = startInfo;
+                process.EnableRaisingEvents = true;
+                process.Exited += Process_Exited;
+
+                process.OutputDataReceived += (sender, e) =>
+                {
+                    if (e.Data == null)
+                    {
+                        return; // ignore end-of-stream
+                    }
+
+                    stdOut.Add(e.Data);
+                };
+
+                process.ErrorDataReceived += (sender, e) =>
+                {
+                    if (e.Data == null)
+                    {
+                        return; // ignore end-of-stream
+                    }
+
+                    stdError.Add(e.Data);
+                };
+
+                process.Start();
+                process.BeginOutputReadLine();
+                process.BeginErrorReadLine();
+            }
+
+            return taskCompletionSource.Task;
+        }
+    }
+}

--- a/src/SSHDebugPS/Microsoft.SSHDebugPS.pkgdef
+++ b/src/SSHDebugPS/Microsoft.SSHDebugPS.pkgdef
@@ -7,6 +7,10 @@
 "PortPickerCLSID"="{91BDF293-E6A0-49C4-B033-6F36CFC4FF98}"
 "Name"="Docker (Linux Container)"
 
+[$RootKey$\AD7Metrics\PortSupplier\{267B1341-AC92-44DC-94DF-2EE4205DD17E}]
+"CLSID"="{B8587A49-00BD-4DEE-94B9-6EBF49003E04}"
+"Name"="Windows Subsystem for Linux (WSL)"
+
 [$RootKey$\CLSID\{1326FB0D-EA51-4F90-BEDF-5948588B0FE1}]
 "Assembly"="Microsoft.SSHDebugPS"
 "Class"="Microsoft.SSHDebugPS.SSH.SSHPortSupplier"
@@ -34,6 +38,12 @@
 [$RootKey$\CLSID\{AE75778B-70E8-4F53-B3FE-59E048D3D01B}]
 "Assembly"="Microsoft.SSHDebugPS"
 "Class"="Microsoft.SSHDebugPS.Docker.DockerWindowsPortPicker"
+"InprocServer32"="$WinDir$\SYSTEM32\MSCOREE.DLL"
+"CodeBase"="$PackageFolder$\Microsoft.SSHDebugPS.dll"
+
+[$RootKey$\CLSID\{B8587A49-00BD-4DEE-94B9-6EBF49003E04}]
+"Assembly"="Microsoft.SSHDebugPS"
+"Class"="Microsoft.SSHDebugPS.WSL.WSLPortSupplier"
 "InprocServer32"="$WinDir$\SYSTEM32\MSCOREE.DLL"
 "CodeBase"="$PackageFolder$\Microsoft.SSHDebugPS.dll"
 

--- a/src/SSHDebugPS/PipeAsyncCommand.cs
+++ b/src/SSHDebugPS/PipeAsyncCommand.cs
@@ -6,14 +6,14 @@ using System.Text;
 using System.Threading;
 using Microsoft.VisualStudio.Debugger.Interop.UnixPortSupplier;
 
-namespace Microsoft.SSHDebugPS.Docker
+namespace Microsoft.SSHDebugPS
 {
-    internal class DockerAsyncCommand : IDebugUnixShellAsyncCommand
+    internal class PipeAsyncCommand : IDebugUnixShellAsyncCommand
     {
         private ICommandRunner _runner;
         private IDebugUnixShellCommandCallback _callback;
-        private StringBuilder _errorBuilder = new StringBuilder();
-        public DockerAsyncCommand(ICommandRunner runner, IDebugUnixShellCommandCallback callback)
+        private readonly StringBuilder _errorBuilder = new StringBuilder();
+        public PipeAsyncCommand(ICommandRunner runner, IDebugUnixShellCommandCallback callback)
         {
             _callback = callback;
             _runner = runner;

--- a/src/SSHDebugPS/SSH/SSHConnection.cs
+++ b/src/SSHDebugPS/SSH/SSHConnection.cs
@@ -87,12 +87,6 @@ namespace Microsoft.SSHDebugPS.SSH
             }
         }
 
-        public override void ExecuteSyncCommand(string commandDescription, string commandText, out string commandOutput, int timeout, out int exitCode)
-        {
-            string errorMessage;
-            exitCode = ExecuteCommand(commandText, timeout, out commandOutput, out errorMessage);
-        }
-
         public override int ExecuteCommand(string commandText, int timeout, out string commandOutput, out string errorMessage)
         {
             INonHostedCommand command = _remoteSystem.Shell.ExecuteCommand(commandText, timeout);

--- a/src/SSHDebugPS/StringResources.Designer.cs
+++ b/src/SSHDebugPS/StringResources.Designer.cs
@@ -290,6 +290,42 @@ namespace Microsoft.SSHDebugPS {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Unable to enumerate installed GNU/Linux distributions. wsl.exe exited with code {0} (0x{0:X8}). More information may be available in the output window..
+        /// </summary>
+        internal static string Error_WSLEnumDistrosFailed_Args1 {
+            get {
+                return ResourceManager.GetString("Error_WSLEnumDistrosFailed_Args1", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to &apos;{0} {1}&apos; failed and wrote the following text to standard error:.
+        /// </summary>
+        internal static string Error_WSLExecErrorOut_Args2 {
+            get {
+                return ResourceManager.GetString("Error_WSLExecErrorOut_Args2", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Unable to use the Windows Subsystem for Linux (WSL) transport. No GNU/Linux distributions are installed..
+        /// </summary>
+        internal static string Error_WSLNoDistros {
+            get {
+                return ResourceManager.GetString("Error_WSLNoDistros", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Windows Subsystem for Linux (WSL) is not installed on this computer..
+        /// </summary>
+        internal static string Error_WSLNotInstalled {
+            get {
+                return ResourceManager.GetString("Error_WSLNotInstalled", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Enter credentials to connect to {0}.
         /// </summary>
         internal static string HeaderTextFormat {
@@ -326,6 +362,15 @@ namespace Microsoft.SSHDebugPS {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to {0} Transport.
+        /// </summary>
+        internal static string TransportTitle_Args1 {
+            get {
+                return ResourceManager.GetString("TransportTitle_Args1", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to &lt;username&gt;.
         /// </summary>
         internal static string UserName_PlaceHolder {
@@ -340,6 +385,15 @@ namespace Microsoft.SSHDebugPS {
         internal static string WaitingOp_Connecting {
             get {
                 return ResourceManager.GetString("WaitingOp_Connecting", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Enumerating installed GNU/Linux distributions....
+        /// </summary>
+        internal static string WaitingOp_EnumeratingWSLDistros {
+            get {
+                return ResourceManager.GetString("WaitingOp_EnumeratingWSLDistros", resourceCulture);
             }
         }
         
@@ -376,6 +430,33 @@ namespace Microsoft.SSHDebugPS {
         internal static string WaitingOp_MakeDirectory {
             get {
                 return ResourceManager.GetString("WaitingOp_MakeDirectory", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to The Windows Subsystem for Linux (WSL) connection type allows Visual Studio to attach to local GNU/Linux processes..
+        /// </summary>
+        internal static string WSL_PSDescription {
+            get {
+                return ResourceManager.GetString("WSL_PSDescription", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Windows Subsystem for Linux (WSL).
+        /// </summary>
+        internal static string WSL_PSName {
+            get {
+                return ResourceManager.GetString("WSL_PSName", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to The installed version of Windows Subsystem for Linux (WSL) is incompatible with Visual Studio&apos;s attach support. Please upgrade to WSL version 2 or newer..
+        /// </summary>
+        internal static string WSL_V2Required {
+            get {
+                return ResourceManager.GetString("WSL_V2Required", resourceCulture);
             }
         }
     }

--- a/src/SSHDebugPS/StringResources.resx
+++ b/src/SSHDebugPS/StringResources.resx
@@ -242,4 +242,35 @@ Error:
   <data name="WaitingOp_MakeDirectory" xml:space="preserve">
     <value>Creating directory on remote system...</value>
   </data>
+  <data name="WSL_PSDescription" xml:space="preserve">
+    <value>The Windows Subsystem for Linux (WSL) connection type allows Visual Studio to attach to local GNU/Linux processes.</value>
+  </data>
+  <data name="WSL_PSName" xml:space="preserve">
+    <value>Windows Subsystem for Linux (WSL)</value>
+  </data>
+  <data name="Error_WSLNotInstalled" xml:space="preserve">
+    <value>Windows Subsystem for Linux (WSL) is not installed on this computer.</value>
+  </data>
+  <data name="WaitingOp_EnumeratingWSLDistros" xml:space="preserve">
+    <value>Enumerating installed GNU/Linux distributions...</value>
+  </data>
+  <data name="Error_WSLEnumDistrosFailed_Args1" xml:space="preserve">
+    <value>Unable to enumerate installed GNU/Linux distributions. wsl.exe exited with code {0} (0x{0:X8}). More information may be available in the output window.</value>
+    <comment>{0} is the exit code number</comment>
+  </data>
+  <data name="Error_WSLExecErrorOut_Args2" xml:space="preserve">
+    <value>'{0} {1}' failed and wrote the following text to standard error:</value>
+    <comment>{0} is the path to wsl.exe
+{1} is the arguments to it</comment>
+  </data>
+  <data name="Error_WSLNoDistros" xml:space="preserve">
+    <value>Unable to use the Windows Subsystem for Linux (WSL) transport. No GNU/Linux distributions are installed.</value>
+  </data>
+  <data name="TransportTitle_Args1" xml:space="preserve">
+    <value>{0} Transport</value>
+    <comment>{0} is 'SSH', 'Docker', 'Windows Subsystem for Linux (WSL)'</comment>
+  </data>
+  <data name="WSL_V2Required" xml:space="preserve">
+    <value>The installed version of Windows Subsystem for Linux (WSL) is incompatible with Visual Studio's attach support. Please upgrade to WSL version 2 or newer.</value>
+  </data>
 </root>

--- a/src/SSHDebugPS/WSL/WSLCommandLine.cs
+++ b/src/SSHDebugPS/WSL/WSLCommandLine.cs
@@ -1,0 +1,144 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Microsoft.SSHDebugPS.Utilities;
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.Text;
+using System.Text.RegularExpressions;
+using System.Threading;
+using System.Threading.Tasks;
+using ThreadHelper = Microsoft.VisualStudio.Shell.ThreadHelper;
+using static Microsoft.VisualStudio.Shell.VsTaskLibraryHelper;
+using System.Linq;
+
+namespace Microsoft.SSHDebugPS.WSL
+{
+    internal static class WSLCommandLine
+    {
+        static string s_exePath;
+        public static string ExePath
+        {
+            get
+            {
+                if (s_exePath == null)
+                    throw new InvalidOperationException();
+
+                return s_exePath;
+            }
+        }
+
+        public static void EnsureInitialized()
+        {
+            if (s_exePath == null)
+            {
+                string path = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.Windows), Environment.Is64BitProcess ? "System32" : "sysnative", "wsl.exe");
+                if (!File.Exists(path))
+                {
+                    throw new WSLException(StringResources.Error_WSLNotInstalled);
+                }
+
+                s_exePath = path;
+            }
+        }
+
+        public static ProcessStartInfo GetExecStartInfo(string distroName, string commandText)
+        {
+            return GetWSLStartInfo(GetExecCommandLineArgs(distroName, commandText), Encoding.UTF8);
+        }
+
+        public static string GetExecCommandLineArgs(string distroName, string commandText)
+        {
+            return FormattableString.Invariant($"-d {distroName} -- {commandText}");
+        }
+
+        public static IEnumerable<string> GetInstalledDistros()
+        {
+            HashSet<string> distributions = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+
+            ThreadHelper.JoinableTaskFactory.Run(StringResources.WaitingOp_EnumeratingWSLDistros, async (progress, cancellationToken) =>
+            {
+                ProcessStartInfo startInfo = GetWSLStartInfo("-l -v", Encoding.Unicode);
+
+                ProcessResult processResult = await LocalProcessAsyncRunner.ExecuteProcessAsync(startInfo, cancellationToken);
+                if (processResult.ExitCode != 0)
+                {
+                    const int NoDistrosExitCode = -1;
+                    if (processResult.ExitCode == NoDistrosExitCode)
+                    {
+                        // Older versions of wsl don't like the '-v' and will also fail with -1 for that reason. Check if this is why we are seeing the failure
+                        ProcessResult retryResult = await LocalProcessAsyncRunner.ExecuteProcessAsync(GetWSLStartInfo("-l", Encoding.Unicode), cancellationToken);
+
+                        // If the exit code is still NoDistros then they really don't have any distros
+                        if (retryResult.ExitCode == NoDistrosExitCode)
+                        {
+                            throw new WSLException(StringResources.Error_WSLNoDistros);
+                        }
+                        // For any other code, they don't have WSL 2 installed.
+                        else
+                        {
+                            throw new WSLException(StringResources.WSL_V2Required);
+                        }
+                    }
+                    else
+                    {
+                        if (processResult.StdErr.Count > 0)
+                        {
+                            VsOutputWindowWrapper.WriteLine(StringResources.Error_WSLExecErrorOut_Args2.FormatCurrentCultureWithArgs(startInfo.FileName, startInfo.Arguments));
+                            foreach (string line in processResult.StdErr)
+                            {
+                                VsOutputWindowWrapper.WriteLine("\t" + line);
+                            }
+                        }
+
+                        throw new WSLException(StringResources.Error_WSLEnumDistrosFailed_Args1.FormatCurrentCultureWithArgs(processResult.ExitCode));
+                    }
+                }
+
+                // Parse the installed distributions
+                /* Ouput looks like:
+                    NAME                   STATE           VERSION
+                * Ubuntu                 Stopped         2
+                    docker-desktop-data    Running         2
+                    docker-desktop         Running         2
+                */
+                Regex distributionRegex = new Regex(@"^\*?\s+(?<name>\S+)\s");
+                foreach (string line in processResult.StdOut.Skip(1))
+                {
+                    Match match = distributionRegex.Match(line);
+                    if (match.Success)
+                    {
+                        string distroName = match.Groups["name"].Value;
+                        if (distroName.StartsWith("docker-desktop", StringComparison.OrdinalIgnoreCase))
+                        {
+                            continue;
+                        }
+
+                        distributions.Add(distroName);
+                    }
+                }
+            });
+            if (distributions.Count == 0)
+            {
+                throw new WSLException(StringResources.Error_WSLNoDistros);
+            }
+
+            return distributions;
+        }
+
+        private static ProcessStartInfo GetWSLStartInfo(string args, Encoding encoding)
+        {
+            return new ProcessStartInfo(s_exePath, args)
+            {
+                UseShellExecute = false,
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                CreateNoWindow = true,
+                StandardOutputEncoding = encoding,
+                StandardErrorEncoding = encoding
+            };
+        }
+    }
+}

--- a/src/SSHDebugPS/WSL/WSLConnection.cs
+++ b/src/SSHDebugPS/WSL/WSLConnection.cs
@@ -1,0 +1,131 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Microsoft.VisualStudio.Debugger.Interop.UnixPortSupplier;
+using System.Collections.Generic;
+using System;
+using System.Text;
+using System.Threading;
+using SysProcess = System.Diagnostics.Process;
+using System.Threading.Tasks;
+
+namespace Microsoft.SSHDebugPS.WSL
+{
+    internal class WSLConnection : PipeConnection
+    {
+        public WSLConnection(string distribution) : base(outerConnection:null, name: distribution)
+        {
+        }
+
+        /// <inheritdoc/>
+        public override int ExecuteCommand(string commandText, int timeout, out string commandOutput, out string errorMessage)
+        {
+            using (var cancellationTokenSource = new CancellationTokenSource())
+            {
+                Task<ProcessResult> task = LocalProcessAsyncRunner.ExecuteProcessAsync(WSLCommandLine.GetExecStartInfo(this.Name, commandText), cancellationTokenSource.Token);
+                if (!task.Wait(timeout))
+                {
+                    cancellationTokenSource.Cancel();
+                    throw new TimeoutException();
+                }
+
+                ProcessResult result = task.Result;
+                commandOutput = string.Join("\n", result.StdOut);
+                errorMessage = string.Join("\n", result.StdErr);
+                return result.ExitCode;
+            }
+        }
+
+        /// <inheritdoc/>
+        public override void BeginExecuteAsyncCommand(string commandText, bool runInShell, IDebugUnixShellCommandCallback callback, out IDebugUnixShellAsyncCommand asyncCommand)
+        {
+            if (IsClosed)
+            {
+                throw new ObjectDisposedException(nameof(WSLConnection));
+            }
+
+            string args = WSLCommandLine.GetExecCommandLineArgs(this.Name, commandText);
+            ICommandRunner commandRunner = LocalCommandRunner.CreateInstance(handleRawOutput: runInShell == false, WSLCommandLine.ExePath, args);
+            asyncCommand = new PipeAsyncCommand(commandRunner, callback);
+        }
+
+        /// <inheritdoc/>
+        public override void CopyFile(string sourcePath, string destinationPath)
+        {
+            bool IsFullyQualifiedWindowsLocalPath(string path)
+            {
+                if (path == null)
+                    return false;
+
+                if (path.Length < 3)
+                    return false;
+
+                char driveLetter = sourcePath[0];
+                bool isDriveLetter = (driveLetter >= 'a' && driveLetter <= 'z') || (driveLetter >= 'A' && driveLetter <= 'Z');
+                if (!isDriveLetter)
+                {
+                    return false;
+                }
+
+                if (sourcePath[1] != ':')
+                {
+                    return false;
+                }
+
+                char slash = sourcePath[2];
+                if (slash != '\\' && slash != '/')
+                {
+                    return false;
+                }
+
+                return true;
+            }
+
+            if (!IsFullyQualifiedWindowsLocalPath(sourcePath))
+            {
+                throw new ArgumentOutOfRangeException(nameof(sourcePath));
+            }
+
+            StringBuilder commandBuilder = new StringBuilder();
+            commandBuilder.Append("cp /mnt/");
+            commandBuilder.Append(char.ToLowerInvariant(sourcePath[0]));
+
+            // Append all the other characters of the path with special handling for backslash and space
+            for (int c = 2; c < sourcePath.Length; c++)
+            {
+                char ch = sourcePath[c];
+                switch (ch)
+                {
+                    case '\\':
+                        commandBuilder.Append('/');
+                        break;
+
+                    case ' ':
+                        commandBuilder.Append(@"\ ");
+                        break;
+
+                    default:
+                        commandBuilder.Append(ch);
+                        break;
+                }
+            }
+
+            commandBuilder.Append(' ');
+            commandBuilder.Append(destinationPath);
+
+            this.ExecuteCommand(commandBuilder.ToString(), Timeout.Infinite);
+        }
+
+        /// <inheritdoc/>
+        public override bool IsLinux()
+        {
+            return true;
+        }
+
+        /// <inheritdoc/>
+        public override bool IsOSX()
+        {
+            return false;
+        }
+    }
+}

--- a/src/SSHDebugPS/WSL/WSLException.cs
+++ b/src/SSHDebugPS/WSL/WSLException.cs
@@ -1,0 +1,24 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Runtime.Serialization;
+
+namespace Microsoft.SSHDebugPS.WSL
+{
+    [Serializable]
+    internal class WSLException : Exception
+    {
+        public WSLException(string message) : base(message)
+        {
+        }
+
+        public WSLException(string message, Exception innerException) : base(message, innerException)
+        {
+        }
+
+        protected WSLException(SerializationInfo info, StreamingContext context) : base(info, context)
+        {
+        }
+    }
+}

--- a/src/SSHDebugPS/WSL/WSLPort.cs
+++ b/src/SSHDebugPS/WSL/WSLPort.cs
@@ -1,0 +1,16 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Microsoft.SSHDebugPS.WSL
+{
+    internal class WSLPort : AD7Port
+    {
+        public WSLPort(AD7PortSupplier portSupplier, string name, bool isInAddPort)
+            : base(portSupplier, name, isInAddPort) { }
+
+        protected override Connection GetConnectionInternal()
+        {
+            return new WSLConnection(Name);
+        }
+    }
+}

--- a/src/SSHDebugPS/WSL/WSLPortSupplier.cs
+++ b/src/SSHDebugPS/WSL/WSLPortSupplier.cs
@@ -1,0 +1,84 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
+using System.Runtime.InteropServices;
+using Microsoft.VisualStudio;
+using Microsoft.VisualStudio.Debugger.Interop;
+using Microsoft.VisualStudio.Shell;
+using Microsoft.VisualStudio.Shell.Interop;
+
+namespace Microsoft.SSHDebugPS.WSL
+{
+    [ComVisible(true)]
+    [Guid("B8587A49-00BD-4DEE-94B9-6EBF49003E04")]
+    internal class WSLPortSupplier : AD7PortSupplier
+    {
+        private readonly Guid _Id = new Guid("267B1341-AC92-44DC-94DF-2EE4205DD17E");
+
+        protected override Guid Id { get { return _Id; } }
+        protected override string Name { get { return StringResources.WSL_PSName; } }
+        protected override string Description { get { return StringResources.WSL_PSDescription; } }
+        IEnumerable<string> _distros;
+
+        public WSLPortSupplier() : base()
+        {
+        }
+
+        public override int CanAddPort()
+        {
+            // Indicate that ports cannot be added
+            return HR.S_FALSE;
+        }
+
+        public override int CanPersistPorts()
+        {
+            // Opt-out of the SDM remembering ports
+            return HR.S_OK;
+        }
+
+        public override int EnumPorts(out IEnumDebugPorts2 ppEnum)
+        {
+            ThreadHelper.ThrowIfNotOnUIThread();
+
+            if (_distros == null)
+            {
+                IVsUIShell shell = Package.GetGlobalService(typeof(SVsUIShell)) as IVsUIShell;
+
+                try
+                {
+                    WSLCommandLine.EnsureInitialized();
+                    _distros = WSLCommandLine.GetInstalledDistros();
+                }
+                catch (Exception ex)
+                {
+                    shell.SetErrorInfo(ex.HResult, ex.Message, 0, null, null);
+                    shell.ReportErrorInfo(ex.HResult);
+                    ppEnum = null;
+                    return VSConstants.E_ABORT;
+                }
+            }
+
+            WSLPort[] ports = _distros.Select(name => new WSLPort(this, name, isInAddPort: false)).ToArray();
+            ppEnum = new AD7PortEnum(ports);
+            return HR.S_OK;
+        }
+
+        public override int EnumPersistedPorts(BSTR_ARRAY portNames, out IEnumDebugPorts2 portEnum)
+        {
+            // This should never be called since CanPersistPorts returns S_OK
+            Debug.Fail("Why is EnumPersistedPorts called?");
+            throw new NotImplementedException();
+        }
+        public override int AddPort(IDebugPortRequest2 request, out IDebugPort2 port)
+        {
+            // This should never be called
+            Debug.Fail("Why is AddPort called?");
+            throw new NotImplementedException();
+        }
+    }
+
+}


### PR DESCRIPTION
This PR adds a port supplier for WSL. This enables attaching to processes running in a WSL distro for both .NET (vsdbg) and GDB debugging.

I also cleaned up the SSHDebugPS code a bit:
* Connection now has two overloads of ExecuteCommand that do one of the following. Fixed most call sites to use whichever one they were intending:
     * Throw if the exit code is non-zero
     -or-
     * Return the exit code
* Connection no longer needlessly implements IDebugUnixShellPort
* Added a much cleaner local command runner

### Testing

Verified both native and .NET attach worked to an Ubuntu 20.04 WSL image.