### PR TITLE
Fix Zip Structure

### DIFF
--- a/eng/pipelines/steps/PublishOpenDebugAD7.yml
+++ b/eng/pipelines/steps/PublishOpenDebugAD7.yml
@@ -5,22 +5,22 @@ parameters:
 
 steps:
 - script: |
-    dotnet publish $(Build.SourcesDirectory)\src\OpenDebugAD7\OpenDebugAD7.csproj -c ${{ parameters.Configuration }} -r ${{ parameters.RuntimeID }} --self-contained -o $(Build.StagingDirectory)\debugAdapters\${{ parameters.RuntimeID }}
-    copy ${{ parameters.SignedBinariesFolder }}\Release\vscode\OpenDebugAD7.dll "$(Build.StagingDirectory)\debugAdapters\${{ parameters.RuntimeID }}\.
-    copy ${{ parameters.SignedBinariesFolder }}\Release\vscode\Microsoft.DebugEngineHost.dll $(Build.StagingDirectory)\debugAdapters\${{ parameters.RuntimeID }}\.
-    copy ${{ parameters.SignedBinariesFolder }}\Release\Microsoft.MIDebugEngine.dll $(Build.StagingDirectory)\debugAdapters\${{ parameters.RuntimeID }}\.
-    copy ${{ parameters.SignedBinariesFolder }}\Release\Microsoft.MICore.dll $(Build.StagingDirectory)\debugAdapters\${{ parameters.RuntimeID }}\.
+    dotnet publish $(Build.SourcesDirectory)\src\OpenDebugAD7\OpenDebugAD7.csproj -c ${{ parameters.Configuration }} -r ${{ parameters.RuntimeID }} --self-contained -o $(Build.StagingDirectory)\${{ parameters.RuntimeID }}\debugAdapters\bin
+    copy ${{ parameters.SignedBinariesFolder }}\Release\vscode\OpenDebugAD7.dll "$(Build.StagingDirectory)\${{ parameters.RuntimeID }}\debugAdapters\bin\.
+    copy ${{ parameters.SignedBinariesFolder }}\Release\vscode\Microsoft.DebugEngineHost.dll $(Build.StagingDirectory)\${{ parameters.RuntimeID }}\debugAdapters\bin\.
+    copy ${{ parameters.SignedBinariesFolder }}\Release\Microsoft.MIDebugEngine.dll $(Build.StagingDirectory)\${{ parameters.RuntimeID }}\debugAdapters\bin\.
+    copy ${{ parameters.SignedBinariesFolder }}\Release\Microsoft.MICore.dll $(Build.StagingDirectory)\${{ parameters.RuntimeID }}\debugAdapters\bin\.
   displayName: "Publish OpenDebugAD7 ${{ parameters.RuntimeID }}"
 
 # Windows Steps for copying over the exe and verify the windows binaries.
-- ${{ if startsWith(parameters.RuntimeID, 'win-') }}:
+- ${{ if startsWith(parameters.RuntimeID, 'win') }}:
   - script: |
-      copy ${{ parameters.SignedBinariesFolder }}\Release\vscode\OpenDebugAD7.exe $(Build.StagingDirectory)\debugAdapters\${{ parameters.RuntimeID }}\.
+      copy ${{ parameters.SignedBinariesFolder }}\Release\vscode\OpenDebugAD7.exe $(Build.StagingDirectory)\${{ parameters.RuntimeID }}\debugAdapters\bin\.
     displayName: "Copy OpenDebugAD7.exe"
 
   - template: ../tasks/SignVerify.yml
     parameters:
-      TargetFolders: $(Build.StagingDirectory)\debugAdapters\${{ parameters.RuntimeID }}\.
+      TargetFolders: $(Build.StagingDirectory)\${{ parameters.RuntimeID }}\debugAdapters\bin\.
       ExcludeSNVerify: true # Ignore CrossGen'ed .NET binaries
 
 # macOS Steps since we need to harden and sign the binary.
@@ -28,13 +28,13 @@ steps:
   - template: ../tasks/PublishPipelineArtifact.yml
     parameters:
       displayName: 'Publish Unsigned ${{ parameters.RuntimeID }}'
-      path: '$(Build.StagingDirectory)\debugAdapters\${{ parameters.RuntimeID }}'
+      path: '$(Build.StagingDirectory)\${{ parameters.RuntimeID }}'
       artifactName: 'unsigned_${{ parameters.RuntimeID }}_binaries'  
 
 # Publishing for non-macOS
 - ${{ if not(startsWith(parameters.RuntimeID, 'osx-')) }}:
   - powershell: |
-      Compress-Archive -Path $(Build.StagingDirectory)\debugAdapters\${{ parameters.RuntimeID }}\* -DestinationPath $(Build.StagingDirectory)\zips\${{ parameters.RuntimeID }}.zip
+      Compress-Archive -Path $(Build.StagingDirectory)\${{ parameters.RuntimeID }}\debugAdapters -DestinationPath $(Build.StagingDirectory)\zips\${{ parameters.RuntimeID }}.zip
     displayName: "Create ${{ parameters.RuntimeID}}.zip"  
 
   - template: ../tasks/PublishPipelineArtifact.yml

--- a/eng/pipelines/templates/VSCode-codesign-osx.template.yml
+++ b/eng/pipelines/templates/VSCode-codesign-osx.template.yml
@@ -9,14 +9,14 @@ steps:
     artifact: 'unsigned_osx-x64_binaries'
 
 - script: |
-    echo "#[command] codesign -s - -f --entitlements $(Build.SourcesDirectory)/eng/Signing/macOS/debugger-entitlements.plist $(Pipeline.Workspace)/Artifacts/OpenDebugAD7"
-    codesign -s - -f --entitlements $(Build.SourcesDirectory)/eng/Signing/macOS/debugger-entitlements.plist $(Pipeline.Workspace)/Artifacts/OpenDebugAD7
-    
-    echo "#[command] cd $(Pipeline.Workspace)/Artifacts/"
-    cd $(Pipeline.Workspace)/Artifacts/
+    echo "#[command] codesign -s - -f --entitlements $(Build.SourcesDirectory)/eng/Signing/macOS/debugger-entitlements.plist $(Pipeline.Workspace)/Artifacts/debugAdapters/bin/OpenDebugAD7"
+    codesign -s - -f --entitlements $(Build.SourcesDirectory)/eng/Signing/macOS/debugger-entitlements.plist $(Pipeline.Workspace)/Artifacts/debugAdapters/bin/OpenDebugAD7
 
-    echo "#[command] zip -r $(Pipeline.Workspace)/osx-x64.zip *"
-    zip -r $(Pipeline.Workspace)/osx-x64.zip *
+    echo "#[command] cd $(Pipeline.Workspace)/Artifacts/"
+    cd $(Pipeline.Workspace)/Artifacts
+
+    echo "#[command] zip -r $(Pipeline.Workspace)/osx-x64.zip ./debugAdapters"
+    zip -r $(Pipeline.Workspace)/osx-x64.zip ./debugAdapters
 
 - template: ../tasks/PublishPipelineArtifact.yml
   parameters:


### PR DESCRIPTION
vscode-cpptools expects OpenDebugAD7 to be in debugAdapters/bin

This PR fixes the folder structure