### PR TITLE
Enable InvariantGlobalization for OpenDebugAD7

### DIFF
--- a/src/OpenDebugAD7/OpenDebugAD7.csproj
+++ b/src/OpenDebugAD7/OpenDebugAD7.csproj
@@ -20,8 +20,10 @@
     <!--
       For non-Windows platforms, .NET Core depends on libicu for data about locales and international settings.
       GDB does not support localization so neither does OpenDebugAD7 or MICore.
+
+      Condition: If we are building on linux, set invariant globalization. If we are publishing for linux (non-Windows and non-macOS), also set invariant globalization.
     -->
-    <InvariantGlobalization Condition="$([MSBuild]::IsOSPlatform('linux'))">true</InvariantGlobalization>
+    <InvariantGlobalization Condition="$([MSBuild]::IsOSPlatform('linux')) OR ('$(RuntimeIdentifier)' != '' AND !$(RuntimeIdentifier.StartsWith('win')) AND !$(RuntimeIdentifier.StartsWith('osx')))">true</InvariantGlobalization>
 
     <IsPublishable>true</IsPublishable>
 

--- a/src/OpenDebugAD7/OpenDebugAD7.csproj
+++ b/src/OpenDebugAD7/OpenDebugAD7.csproj
@@ -17,6 +17,12 @@
     <TargetFramework>net5.0</TargetFramework>
     <Prefer32Bit>false</Prefer32Bit>
 
+    <!--
+      For non-Windows platforms, .NET Core depends on libicu for data about locales and international settings.
+      GDB does not support localization so neither does OpenDebugAD7 or MICore.
+    -->
+    <InvariantGlobalization Condition="!$([MSBuild]::IsOSPlatform('windows'))">true</InvariantGlobalization>
+
     <IsPublishable>true</IsPublishable>
 
     <!-- F5 OpenDebugAD7.exe if OpenDebugAD7 is the startup project. -->

--- a/src/OpenDebugAD7/OpenDebugAD7.csproj
+++ b/src/OpenDebugAD7/OpenDebugAD7.csproj
@@ -21,7 +21,7 @@
       For non-Windows platforms, .NET Core depends on libicu for data about locales and international settings.
       GDB does not support localization so neither does OpenDebugAD7 or MICore.
     -->
-    <InvariantGlobalization Condition="!$([MSBuild]::IsOSPlatform('windows'))">true</InvariantGlobalization>
+    <InvariantGlobalization Condition="$([MSBuild]::IsOSPlatform('linux'))">true</InvariantGlobalization>
 
     <IsPublishable>true</IsPublishable>
 


### PR DESCRIPTION
Starting OpenDebugAD7 on Alpine will cause the error message:
> Process terminated. Couldn't find a valid ICU package installed on the system.

OpenDebugAD7 does not support Localization so we will enable InvariantGlobalization. 