### PR TITLE
Support SSH by project systems

### DIFF
--- a/src/SSHDebugPS/AD7/AD7Process.cs
+++ b/src/SSHDebugPS/AD7/AD7Process.cs
@@ -44,6 +44,8 @@ namespace Microsoft.SSHDebugPS
             _flags = psProcess.Flags;
         }
 
+        public uint Id => _processId;
+
         public int Attach(IDebugEventCallback2 pCallback, Guid[] rgguidSpecificEngines, uint celtSpecificEngines, int[] rghrEngineAttach)
         {
             throw new NotImplementedException();

--- a/src/SSHDebugPS/HR.cs
+++ b/src/SSHDebugPS/HR.cs
@@ -13,6 +13,7 @@ namespace Microsoft.SSHDebugPS
         public const int E_NOTIMPL = unchecked((int)0x80004001);
         public const int E_REMOTE_CONNECT_USER_CANCELED = unchecked((int)0x80040758);
         public const int E_FAIL = unchecked((int)0x80004005);
+        public const int E_PROCESS_DESTROYED = unchecked((int)0x80040070);
 
         public static void Check(int hr)
         {


### PR DESCRIPTION
This PR makes a tweak to the SSH port supplier so that attaches with LaunchDebugTragets will work. To do so SSHDebugPS needed to implement IDebugPort2.GetProcess.

### Testing
- [x] Verified that an example VS package can attach using the below code
- [x] Verified that a regular SSH attach still works and doesn't use `GetProcess`

#### Example code to programmatically attach

```C#
    var debugTargets = new VsDebugTargetInfo4[1];

    Guid guidDebugEngine = new Guid("EF9CD3BB-2C0E-41AD-B54C-63006BC09D19"); // .NET Core SSH/WSL/Docker Attach GUID
    ref VsDebugTargetInfo4 vsDebugTargetInfo = ref debugTargets[0];
    vsDebugTargetInfo.dlo = (uint)DEBUG_LAUNCH_OPERATION.DLO_AlreadyRunning;
    vsDebugTargetInfo.bstrExe = "CsCon1"; // Replace with real value
    vsDebugTargetInfo.bstrPortName = "greggm@localhost:2222"; // Replace with real value
    // From https://github.com/microsoft/MIEngine/blob/main/src/SSHDebugPS/Microsoft.SSHDebugPS.pkgdef
    vsDebugTargetInfo.guidPortSupplier = new Guid("3FDDF14E-E758-4695-BE0C-7509920432C9");
    vsDebugTargetInfo.pDebugEngines = (IntPtr)(&guidDebugEngine);
    vsDebugTargetInfo.dwDebugEngineCount = 1;
    vsDebugTargetInfo.dwProcessId = 248; // Replace with real value

    var debugger = (IVsDebugger4)Package.GetGlobalService(typeof(SVsShellDebugger));
    debugger.LaunchDebugTargets4(1, debugTargets, new VsDebugTargetProcessInfo[1]);
```