### PR TITLE
Resolves: Add GitHub Codespaces configuration

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,7 @@
+FROM mcr.microsoft.com/vscode/devcontainers/dotnet:0.201.7-5.0
+
+# Install gcc, g++ and make
+RUN sudo apt update && \
+    sudo apt install build-essential -y
+
+# Built with ❤ by [Pipeline Foundation](https://pipeline.foundation)

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -12,16 +12,14 @@
 		// GitHub specific
 		"eamodio.gitlens",
 		"cschleiden.vscode-github-actions",
-		"redhat.vscode-yaml",
+		"ms-azure-devops.azure-pipelines",
 		"bierner.markdown-preview-github-styles",
 		"ban.spellright",
 		// .NET specific
 		"ms-dotnettools.csharp",
 		"VisualStudioExptTeam.vscodeintellicode",
 		"ms-vscode.powershell",
-		"jmrog.vscode-nuget-package-manager",
-		// CPP specific
-    		"ms-vscode.cpptools"
+		"jmrog.vscode-nuget-package-manager"
 	],
 	"postCreateCommand": "",
   	"build": {

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -20,13 +20,13 @@
 		"VisualStudioExptTeam.vscodeintellicode",
 		"ms-vscode.powershell",
 		"jmrog.vscode-nuget-package-manager",
-    // CPP specific
-    "ms-vscode.cpptools"
+		// CPP specific
+    		"ms-vscode.cpptools"
 	],
 	"postCreateCommand": "",
-  "build": {
-    "dockerfile": "Dockerfile"
-  }
+  	"build": {
+    		"dockerfile": "Dockerfile"
+  	}
 }
 
 // Built with ❤ by [Pipeline Foundation](https://pipeline.foundation)

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,32 @@
+{
+	"name": "MIEngine Codespace",
+	"settings": {
+		"workbench.colorTheme": "Default Dark+",
+		"terminal.integrated.defaultProfile.linux": "pwsh"
+	},
+	"extensions": [
+		// VS Code specific
+		"coenraads.bracket-pair-colorizer",
+		"vscode-icons-team.vscode-icons",
+		"editorconfig.editorconfig",
+		// GitHub specific
+		"eamodio.gitlens",
+		"cschleiden.vscode-github-actions",
+		"redhat.vscode-yaml",
+		"bierner.markdown-preview-github-styles",
+		"ban.spellright",
+		// .NET specific
+		"ms-dotnettools.csharp",
+		"VisualStudioExptTeam.vscodeintellicode",
+		"ms-vscode.powershell",
+		"jmrog.vscode-nuget-package-manager",
+    // CPP specific
+    "ms-vscode.cpptools"
+	],
+	"postCreateCommand": "",
+  "build": {
+    "dockerfile": "Dockerfile"
+  }
+}
+
+// Built with ❤ by [Pipeline Foundation](https://pipeline.foundation)


### PR DESCRIPTION
- ready-to-start GitHub Codespaces configuration with all necessary tooling

- in addition, it provides basic tools for:
  - .NET development
  - C/C++ development
  - GitHub support
  - overall more pleasant VS Code experience
  
The configuration consists of:

- `"settings":` - a list of VS Code settings to be applied automatically after the Codespace container is created (.editorconfig overrides these)
  - `"workbench.colorTheme": "Default Dark+"` - sets the theme of the VS Code workbench to the `Default Dark+` theme
  - `"terminal.integrated.defaultProfile.linux": "pwsh"` - sets the default VS Code terminal to PowerShell Core

- `extensions:` - a list of VS Code extensions that are automatically installed after the Codespace container is created
  - `"coenraads.bracket-pair-colorizer"` - sets different colors for each nested pair of brackets
  - `"vscode-icons-team.vscode-icons"` - provides a huge set of icons for the VS Code explorer
  - `"editorconfig.editorconfig"` - attempts to override user/workspace settings with those in the .editorconfig
  - `"eamodio.gitlens"` - provides git information directly inside the code
  - `"cschleiden.vscode-github-actions"` and `"redhat.vscode-yaml"` - provide YAML and GitHub Actions support
  - `"bierner.markdown-preview-github-styles"` and `"ban.spellright"` - provide assistance with writing Markdown documentation
  - `"ms-dotnettools.csharp"` and `"VisualStudioExptTeam.vscodeintellicode"` - provide basic Visual Studio tooling
  - `"ms-vscode.powershell"` - provides the functionality of Windows PowerShell ISE inside VS Code
  - `"jmrog.vscode-nuget-package-manager"` - provides use of the NuGet library through the Command Palette
  - `"ms-vscode.cpptools"` - adds language support for C/C++ to Visual Studio Code, including features such as IntelliSense and debugging.

  
- `"postCreateCommand"` - is a string of commands separated by `&&` that execute after the container has been built and the source code has been cloned

- `"build"` - declares the Docker configuration that the container would use to run.

- `Dockerfile`:
  - `"mcr.microsoft.com/vscode/devcontainers/dotnet:0.201.7-5.0"` - the Codespace container runs from an Ubuntu 20.04 image with .NET Core SDK installed (`0.201.7` is the latest .NET Core SDK Docker image tagged version)
  - Additional installed tools:
    - Build essentials package

This GitHub Codespace configuration can also be used locally with the [Remote - Containers](https://marketplace.visualstudio.com/items?itemName=ms-vscode-remote.remote-containers) extension for VS Code. It automatically creates and runs a Docker container based on the `devcontainer.json` configuration inside the repo, so anyone could work on the project from any computer, without the need to install anything other than VS Code and Docker.

Resolves #1189 
