### PR TITLE
Added PostRemoteConnectCommands (#1181)

### DIFF
--- a/src/MICore/JsonLaunchOptions.cs
+++ b/src/MICore/JsonLaunchOptions.cs
@@ -97,6 +97,12 @@ namespace MICore.Json.LaunchOptions
         public List<SetupCommand> SetupCommands { get; protected set; }
 
         /// <summary>
+        /// One or more commands to execute in order to setup underlying debugger after debugger has been attached. i.e. flashing and resetting the board
+        /// </summary>
+        [JsonProperty("postRemoteConnectCommands", DefaultValueHandling = DefaultValueHandling.Ignore)]
+        public List<SetupCommand> PostRemoteConnectCommands { get; protected set; }
+
+        /// <summary>
         /// Explicitly control whether hardware breakpoints are used. If an optional limit is provided, additionally restrict the number of hardware breakpoints for remote targets. Example: "hardwareBreakpoints": { "require": true, "limit": 5 }.
         /// </summary>
         [JsonProperty("hardwareBreakpoints", DefaultValueHandling = DefaultValueHandling.Ignore)]
@@ -360,6 +366,7 @@ namespace MICore.Json.LaunchOptions
         {
             this.Args = new List<string>();
             this.SetupCommands = new List<SetupCommand>();
+            this.PostRemoteConnectCommands = new List<SetupCommand>();
             this.CustomLaunchSetupCommands = new List<SetupCommand>();
             this.Environment = new List<Environment>();
             this.SourceFileMap = new Dictionary<string, object>();
@@ -372,6 +379,7 @@ namespace MICore.Json.LaunchOptions
             string targetArchitecture = null,
             string cwd = null,
             List<SetupCommand> setupCommands = null,
+            List<SetupCommand> postRemoteConnectCommands = null,
             List<SetupCommand> customLaunchSetupCommands = null,
             LaunchCompleteCommand? launchCompleteCommand = null,
             string visualizerFile = null,
@@ -402,6 +410,7 @@ namespace MICore.Json.LaunchOptions
             this.TargetArchitecture = targetArchitecture;
             this.Cwd = cwd;
             this.SetupCommands = setupCommands;
+            this.PostRemoteConnectCommands = postRemoteConnectCommands;
             this.CustomLaunchSetupCommands = customLaunchSetupCommands;
             this.LaunchCompleteCommand = launchCompleteCommand;
             this.VisualizerFile = visualizerFile;

--- a/src/MICore/LaunchOptions.cs
+++ b/src/MICore/LaunchOptions.cs
@@ -1060,6 +1060,24 @@ namespace MICore
             }
         }
 
+        private ReadOnlyCollection<LaunchCommand> _postRemoteConnectCommands;
+
+        /// <summary>
+        /// [Required] Additional commands used to setup debugging once the remote connection has been made. May be an empty collection
+        /// </summary>
+        public ReadOnlyCollection<LaunchCommand> PostRemoteConnectCommands
+        {
+            get { return _postRemoteConnectCommands; }
+            set
+            {
+                if (value == null)
+                    throw new ArgumentNullException("PostRemoteConnectCommands");
+
+                VerifyCanModifyProperty(nameof(PostRemoteConnectCommands));
+                _postRemoteConnectCommands = value;
+            }
+        }
+
 
         private ReadOnlyCollection<LaunchCommand> _customLaunchSetupCommands;
 
@@ -1416,6 +1434,7 @@ namespace MICore
 
             options.ProcessId = processId;
             options.SetupCommands = new ReadOnlyCollection<LaunchCommand>(new LaunchCommand[] { });
+            options.PostRemoteConnectCommands = new ReadOnlyCollection<LaunchCommand>(new LaunchCommand[] { });
             if (attachOptions != null)
             {
                 options.Merge(attachOptions);
@@ -1753,6 +1772,7 @@ namespace MICore
             }
 
             this.SetupCommands = LaunchCommand.CreateCollection(options.SetupCommands);
+            this.PostRemoteConnectCommands = LaunchCommand.CreateCollection(options.PostRemoteConnectCommands);
 
             this.RequireHardwareBreakpoints = options.HardwareBreakpointInfo?.Require ?? false;
             this.HardwareBreakpointLimit = options.HardwareBreakpointInfo?.Limit ?? 0;

--- a/src/MIDebugEngine/Engine.Impl/DebuggedProcess.cs
+++ b/src/MIDebugEngine/Engine.Impl/DebuggedProcess.cs
@@ -746,6 +746,8 @@ namespace Microsoft.MIDebugEngine
                         commands.Add(new LaunchCommand("-target-attach " + _launchOptions.ProcessId.Value.ToString(CultureInfo.InvariantCulture), ignoreFailures: false, failureHandler: failureHandler));
                     }
 
+                    commands.AddRange(_launchOptions.PostRemoteConnectCommands);
+
                     if (this.MICommandFactory.Mode == MIMode.Lldb)
                     {
                         // LLDB finishes attach in break mode. Gdb does finishes in run mode. Issue a continue in lldb to match the gdb behavior
@@ -824,13 +826,13 @@ namespace Microsoft.MIDebugEngine
                         if (!string.IsNullOrWhiteSpace(destination))
                         {
                             commands.Add(new LaunchCommand("-target-select remote " + destination, string.Format(CultureInfo.CurrentCulture, ResourceStrings.ConnectingMessage, destination)));
-
                             if (localLaunchOptions.RequireHardwareBreakpoints && localLaunchOptions.HardwareBreakpointLimit > 0) {
                                 commands.Add(new LaunchCommand(string.Format(CultureInfo.InvariantCulture, "-interpreter-exec console \"set remote hardware-breakpoint-limit {0}\"", localLaunchOptions.HardwareBreakpointLimit.ToString(CultureInfo.InvariantCulture))));
                             }
                         }
 
                     }
+                    commands.AddRange(_launchOptions.PostRemoteConnectCommands);
 
                     // Environment variables are set for the debuggee only with the modes that support that
                     foreach (EnvironmentEntry envEntry in _launchOptions.Environment)

--- a/src/MIDebugPackage/OpenFolderSchema.json
+++ b/src/MIDebugPackage/OpenFolderSchema.json
@@ -120,6 +120,10 @@
                   "$ref": "#/definitions/cpp_schema/definitions/launchSetupCommands"
                 }
               },
+              "postRemoteConnectCommands": {
+                "type": "array",
+                "description": "One or more commands to execute after the connection has been made, in order to set up the remote connection."
+              },
               "customLaunchSetupCommands": {
                 "type": "array",
                 "description": "If provided, this replaces the default commands used to launch a target with some other commands. \nFor example, this can be \"-target-attach\" in order to attach to a target process. \nAn empty command list replaces the launch commands with nothing, which can be useful if the debugger is being provided launch options as command line options. \nExample: \"customLaunchSetupCommands\": [ { \"text\": \"target-run\", \"description\": \"run target\", \"ignoreFailures\": false }].",


### PR DESCRIPTION
* Added PostRemoteConnectCommands

Added these in order to allow for commands that could be executed after
the remote connection (i.e to gdb) to be made. For example, flashing the
board and/or resetting the board.

* relocated commands.add to catch all cases

* white space

Co-authored-by: Andrew Wang <waan@microsoft.com>