### PR TITLE
Fix `supportsDisassembleRequest` capabilities

### DIFF
--- a/src/OpenDebugAD7/AD7DebugSession.cs
+++ b/src/OpenDebugAD7/AD7DebugSession.cs
@@ -822,7 +822,7 @@ namespace OpenDebugAD7
                 SupportsModulesRequest = true,
                 AdditionalModuleColumns = additionalModuleColumns,
                 SupportsGotoTargetsRequest = true,
-                SupportsDisassembleRequest = true,
+                SupportsDisassembleRequest = m_engine is IDebugMemoryBytesDAP,
                 SupportsValueFormattingOptions = true,
                 SupportsSteppingGranularity = true,
             };


### PR DESCRIPTION
supportsDisassembleRequest was always set to `true`. However, it depends on `GetMemoryContext` which uses IDebugMemoryDAP interfaces.