### PR TITLE
Publish win-x86 and remove prefer32bit

### DIFF
--- a/eng/pipelines/steps/PublishOpenDebugAD7.yml
+++ b/eng/pipelines/steps/PublishOpenDebugAD7.yml
@@ -6,15 +6,17 @@ parameters:
 steps:
 - script: |
     dotnet publish $(Build.SourcesDirectory)\src\OpenDebugAD7\OpenDebugAD7.csproj -c ${{ parameters.Configuration }} -r ${{ parameters.RuntimeID }} --self-contained -o $(Build.StagingDirectory)\${{ parameters.RuntimeID }}\debugAdapters\bin
+    copy ${{ parameters.SignedBinariesFolder }}\Release\vscode\OpenDebugAD7.dll "$(Build.StagingDirectory)\${{ parameters.RuntimeID }}\debugAdapters\bin\.
     copy ${{ parameters.SignedBinariesFolder }}\Release\vscode\Microsoft.DebugEngineHost.dll $(Build.StagingDirectory)\${{ parameters.RuntimeID }}\debugAdapters\bin\.
     copy ${{ parameters.SignedBinariesFolder }}\Release\Microsoft.MIDebugEngine.dll $(Build.StagingDirectory)\${{ parameters.RuntimeID }}\debugAdapters\bin\.
     copy ${{ parameters.SignedBinariesFolder }}\Release\Microsoft.MICore.dll $(Build.StagingDirectory)\${{ parameters.RuntimeID }}\debugAdapters\bin\.
   displayName: "Publish OpenDebugAD7 ${{ parameters.RuntimeID }}"
 
-# Windows Steps for signing OpenDebugAD7.dll and OpenDebugAD7.exe, copying over WindowsDebugLauncher.exe, and verify the windows binaries.
+# Windows Steps for signing OpenDebugAD7.exe, copying over WindowsDebugLauncher.exe, and verify the windows binaries.
 - ${{ if startsWith(parameters.RuntimeID, 'win') }}:
   - template: ../tasks/MSBuild.yml
     parameters:
+      DisplayName: "Sign OpenDebugAD7.exe"
       solution: $(Build.SourcesDirectory)\src\OpenDebugAD7\OpenDebugAD7.csproj
       configuration: ${{ parameters.Configuration }}
       msbuildArguments: '/t:SignPublishedFiles /p:PublishPath=$(Build.StagingDirectory)\${{ parameters.RuntimeID }}\debugAdapters\bin'
@@ -24,7 +26,7 @@ steps:
 
   - script: |
       copy ${{ parameters.SignedBinariesFolder }}\Release\vscode\WindowsDebugLauncher.exe $(Build.StagingDirectory)\${{ parameters.RuntimeID }}\debugAdapters\bin\.
-    displayName: "Copy OpenDebugAD7.exe and WindowsDebugLauncher.exe"
+    displayName: "Copy WindowsDebugLauncher.exe"
 
   - template: ../tasks/SignVerify.yml
     parameters:

--- a/eng/pipelines/steps/PublishOpenDebugAD7.yml
+++ b/eng/pipelines/steps/PublishOpenDebugAD7.yml
@@ -6,16 +6,23 @@ parameters:
 steps:
 - script: |
     dotnet publish $(Build.SourcesDirectory)\src\OpenDebugAD7\OpenDebugAD7.csproj -c ${{ parameters.Configuration }} -r ${{ parameters.RuntimeID }} --self-contained -o $(Build.StagingDirectory)\${{ parameters.RuntimeID }}\debugAdapters\bin
-    copy ${{ parameters.SignedBinariesFolder }}\Release\vscode\OpenDebugAD7.dll "$(Build.StagingDirectory)\${{ parameters.RuntimeID }}\debugAdapters\bin\.
     copy ${{ parameters.SignedBinariesFolder }}\Release\vscode\Microsoft.DebugEngineHost.dll $(Build.StagingDirectory)\${{ parameters.RuntimeID }}\debugAdapters\bin\.
     copy ${{ parameters.SignedBinariesFolder }}\Release\Microsoft.MIDebugEngine.dll $(Build.StagingDirectory)\${{ parameters.RuntimeID }}\debugAdapters\bin\.
     copy ${{ parameters.SignedBinariesFolder }}\Release\Microsoft.MICore.dll $(Build.StagingDirectory)\${{ parameters.RuntimeID }}\debugAdapters\bin\.
   displayName: "Publish OpenDebugAD7 ${{ parameters.RuntimeID }}"
 
-# Windows Steps for copying over OpenDebugAD7.exe, WindowsDebugLauncher.exe, and verify the windows binaries.
+# Windows Steps for signing OpenDebugAD7.dll and OpenDebugAD7.exe, copying over WindowsDebugLauncher.exe, and verify the windows binaries.
 - ${{ if startsWith(parameters.RuntimeID, 'win') }}:
+  - template: ../tasks/MSBuild.yml
+    parameters:
+      solution: $(Build.SourcesDirectory)\src\OpenDebugAD7\OpenDebugAD7.csproj
+      configuration: ${{ parameters.Configuration }}
+      msbuildArguments: '/t:SignPublishedFiles /p:PublishPath=$(Build.StagingDirectory)\${{ parameters.RuntimeID }}\debugAdapters\bin'
+      env: { 
+        "SIGN_TYPE": "$(SignType)" 
+      } 
+
   - script: |
-      copy ${{ parameters.SignedBinariesFolder }}\Release\vscode\OpenDebugAD7.exe $(Build.StagingDirectory)\${{ parameters.RuntimeID }}\debugAdapters\bin\.
       copy ${{ parameters.SignedBinariesFolder }}\Release\vscode\WindowsDebugLauncher.exe $(Build.StagingDirectory)\${{ parameters.RuntimeID }}\debugAdapters\bin\.
     displayName: "Copy OpenDebugAD7.exe and WindowsDebugLauncher.exe"
 

--- a/eng/pipelines/templates/VSCode-release.template.yml
+++ b/eng/pipelines/templates/VSCode-release.template.yml
@@ -1,6 +1,6 @@
 ---
 parameters:
-  rids: ["win7-x86", "win-x64", "win10-arm64", "osx-x64", "linux-x64", "linux-arm", "linux-arm64", "linux-musl-x64" ]
+  rids: ["win-x86", "win10-arm64", "osx-x64", "linux-x64", "linux-arm", "linux-arm64", "linux-musl-x64" ]
 
 steps:
 - checkout: self

--- a/src/DebugEngineHost.VSCode/DebugEngineHost.VSCode.csproj
+++ b/src/DebugEngineHost.VSCode/DebugEngineHost.VSCode.csproj
@@ -18,7 +18,6 @@
     <OutputPath>$(MIDefaultOutputPath)\vscode</OutputPath>
     <DropSubDir>vscode</DropSubDir>
     <TargetFramework>netstandard2.0</TargetFramework>
-    <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
 
   <ItemGroup Label="Compile Shared Interfaces">

--- a/src/MICore/MICore.csproj
+++ b/src/MICore/MICore.csproj
@@ -17,7 +17,6 @@
     would take a fair amount of work.-->
     <NoWarn>$(NoWarn);1591</NoWarn>
     <TargetFramework>netstandard2.0</TargetFramework>
-    <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <ItemGroup>
     <None Include="SGEN_SHA2_SIGNATUREKEY" />

--- a/src/MIDebugEngine/MIDebugEngine.csproj
+++ b/src/MIDebugEngine/MIDebugEngine.csproj
@@ -12,7 +12,6 @@
     <ProjectTypeGuids>{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
     <OutputPath>$(MIDefaultOutputPath)</OutputPath>
     <TargetFramework>netstandard2.0</TargetFramework>
-    <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/OpenDebugAD7/OpenDebugAD7.csproj
+++ b/src/OpenDebugAD7/OpenDebugAD7.csproj
@@ -89,4 +89,41 @@
       <OutputType>Exe</OutputType>
     </PropertyGroup>
   </Target>
+
+  <!-- 
+    Run Target to Sign Published Files if we have:
+    1. The Microbuild Tools 
+    2. On Windows without an RID or targeting Windows RIDs
+
+    This target needs to be run directly with /t and /p:PublishPath needs to be set.
+  -->
+  <Target Name="SignPublishedFiles" BeforeTargets="" AfterTargets="">
+    <Error 
+      Condition="'$(PkgMicrosoft_VisualStudioEng_MicroBuild_Core)'=='' and '$(Lab)'!='false' and '$(TEST_LAB_BUILD)'=='' and '$(BUILD_BUILDURI)'!=''" 
+      Text="Microsoft.VisualStudioEng.MicroBuild.Core needs to be added as a PackageReference for SignFiles." 
+    />
+    <Error Condition="'$(PublishPath)'==''" Text="PublishPath needs to be set for SignPublishedFiles target." />
+
+    <ItemGroup>
+      <PublishFileToSign Include="$(PublishPath)\OpenDebugAD7.dll" />
+      <PublishFileToSign Include="$(PublishPath)\OpenDebugAD7.exe" />
+    </ItemGroup>
+
+    <ItemGroup Condition="'$(SIGN_TYPE)' == 'real'">
+      <!-- Real Signed -->
+      <PublishedFilesToSign Include="@(PublishFileToSign)">
+        <Authenticode>Microsoft400</Authenticode>
+        <StrongName>StrongNameSHA2</StrongName>
+      </PublishedFilesToSign>
+    </ItemGroup>
+
+    <ItemGroup Condition="'$(SIGN_TYPE)' != 'real'">
+    <!-- Test Signed -->
+      <PublishedFilesToSign Include="@(PublishFileToSign)">
+        <Authenticode>Microsoft400</Authenticode>
+      </PublishedFilesToSign>
+    </ItemGroup>
+
+    <SignFiles Files="@(PublishedFilesToSign)" Type="$(SIGN_TYPE)" BinariesDirectory="$(OutputPath)" IntermediatesDirectory="$(IntermediateOutputPath)" ESRPSigning="$(ESRPSigning)" UseBearerToken="$(UseBearerToken)" />
+  </Target>
 </Project>

--- a/src/OpenDebugAD7/OpenDebugAD7.csproj
+++ b/src/OpenDebugAD7/OpenDebugAD7.csproj
@@ -15,7 +15,6 @@
     <OutputType>Exe</OutputType>
     <DropSubDir>vscode</DropSubDir>
     <TargetFramework>net5.0</TargetFramework>
-    <Prefer32Bit>false</Prefer32Bit>
 
     <!--
       For non-Windows platforms, .NET Core depends on libicu for data about locales and international settings.

--- a/src/OpenDebugAD7/OpenDebugAD7.csproj
+++ b/src/OpenDebugAD7/OpenDebugAD7.csproj
@@ -124,6 +124,6 @@
       </PublishedFilesToSign>
     </ItemGroup>
 
-    <SignFiles Files="@(PublishedFilesToSign)" Type="$(SIGN_TYPE)" BinariesDirectory="$(OutputPath)" IntermediatesDirectory="$(IntermediateOutputPath)" ESRPSigning="$(ESRPSigning)" UseBearerToken="$(UseBearerToken)" />
+    <SignFiles Files="@(PublishedFilesToSign)" Type="$(SIGN_TYPE)" BinariesDirectory="$(PublishPath)" IntermediatesDirectory="$(IntermediateOutputPath)" ESRPSigning="$(ESRPSigning)" UseBearerToken="$(UseBearerToken)" />
   </Target>
 </Project>

--- a/src/OpenDebugAD7/OpenDebugAD7.csproj
+++ b/src/OpenDebugAD7/OpenDebugAD7.csproj
@@ -74,7 +74,6 @@
   <ItemGroup Label="Drop Files">
     <DropSignedFile Include="$(OutputPath)\OpenDebugAD7.dll" />
     <DropUnsignedFile Include="$(OutputPath)\OpenDebugAD7.pdb" />
-    <DropSignedFile Condition="$([MSBuild]::IsOSPlatform('windows')) AND ('$(RuntimeIdentifier)' == '' OR $(RuntimeIdentifier.Contains('win')))" Include="$(OutputPath)\OpenDebugAD7.exe" />
     <!-- We will build OpenDebugAD7 via publish for non-windows -->
     <DropThirdPartySignedFile Include="$(OutputPath)\Newtonsoft.Json.dll" />
     <DropUnsignedFile Include="$(OutputPath)\Microsoft.VisualStudio.Shared.VSCodeDebugProtocol.dll" />

--- a/src/OpenDebugAD7/OpenDebugAD7.csproj
+++ b/src/OpenDebugAD7/OpenDebugAD7.csproj
@@ -105,7 +105,6 @@
     <Error Condition="'$(PublishPath)'==''" Text="PublishPath needs to be set for SignPublishedFiles target." />
 
     <ItemGroup>
-      <PublishFileToSign Include="$(PublishPath)\OpenDebugAD7.dll" />
       <PublishFileToSign Include="$(PublishPath)\OpenDebugAD7.exe" />
     </ItemGroup>
 


### PR DESCRIPTION
Remove win7-x86 and win-x64 publish and only publish win-x86 since
OpenDebugAD7 will just run as 32-bit.