### PR TITLE
Add osxlauncherhelper for macOS

### DIFF
--- a/eng/pipelines/steps/PublishOpenDebugAD7.yml
+++ b/eng/pipelines/steps/PublishOpenDebugAD7.yml
@@ -35,6 +35,10 @@ steps:
 
 # macOS Steps since we need to harden and sign the binary.
 - ${{ if startsWith(parameters.RuntimeID, 'osx-') }}:
+  - script:
+      copy ${{ parameters.SignedBinariesFolder }}\Release\vscode\osxlaunchhelper.scpt $(Build.StagingDirectory)\${{ parameters.RuntimeID }}\debugAdapters\bin\.
+    displayName: "Copy osxlaunchhelper.scpt"
+
   - template: ../tasks/PublishPipelineArtifact.yml
     parameters:
       displayName: 'Publish Unsigned ${{ parameters.RuntimeID }}'


### PR DESCRIPTION
The published version of macOS OpenDebugAD7 does not bring along the osxlauncherhelper.scpt when running `dotnet publish`, 

This PR adds a step to copy it to the release folder. 