### PR TITLE
Fix PlatformUtilities methods

### DIFF
--- a/src/MICore/PlatformUtilities.cs
+++ b/src/MICore/PlatformUtilities.cs
@@ -32,17 +32,19 @@ namespace MICore
 
         private static RuntimePlatform CalculateRuntimePlatform()
         {
-            switch (Environment.OSVersion.Platform)
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
             {
-                case PlatformID.Win32NT:
-                    return RuntimePlatform.Windows;
-                case PlatformID.Unix:
-                    return RuntimePlatform.Unix;
-                case PlatformID.MacOSX:
-                    return RuntimePlatform.MacOSX;
-                default:
-                    return RuntimePlatform.Unknown;
+                return RuntimePlatform.Windows;
             }
+            else if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
+            {
+                return RuntimePlatform.MacOSX;
+            }
+            else if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
+            {
+                return RuntimePlatform.Unix;
+            }
+            return RuntimePlatform.Unknown;
         }
 
 

--- a/test/CppTests/Tests/EnvironmentTests.cs
+++ b/test/CppTests/Tests/EnvironmentTests.cs
@@ -51,7 +51,8 @@ namespace CppTests.Tests
         [DependsOnTest(nameof(CompileKitchenSinkForEnvironmentTests))]
         [RequiresTestSettings]
         // Need to support 'runInTerminal' request.
-        [UnsupportedDebugger(SupportedDebugger.VsDbg, SupportedArchitecture.x86 | SupportedArchitecture.x64)]
+        // Re-enable lldb for test machines
+        [UnsupportedDebugger(SupportedDebugger.VsDbg | SupportedDebugger.Lldb, SupportedArchitecture.x86 | SupportedArchitecture.x64)]
         public void EnvironmentVariablesBasicNewTerminal(ITestSettings settings)
         {
             this.TestPurpose("Tests basic operation of environment variables using a new terminal window");
@@ -72,7 +73,8 @@ namespace CppTests.Tests
         [DependsOnTest(nameof(CompileKitchenSinkForEnvironmentTests))]
         [RequiresTestSettings]
         // Need to support 'runInTerminal' request.
-        [UnsupportedDebugger(SupportedDebugger.VsDbg, SupportedArchitecture.x86 | SupportedArchitecture.x64)]
+        // Re-enable lldb for test machines
+        [UnsupportedDebugger(SupportedDebugger.VsDbg | SupportedDebugger.Lldb, SupportedArchitecture.x86 | SupportedArchitecture.x64)]
         public void EnvironmentVariablesUndefinedNewTerminal(ITestSettings settings)
         {
             this.TestPurpose("Tests environment variables that are undefined using a new terminal window");

--- a/test/CppTests/Tests/EnvironmentTests.cs
+++ b/test/CppTests/Tests/EnvironmentTests.cs
@@ -136,7 +136,8 @@ namespace CppTests.Tests
         [DependsOnTest(nameof(CompileKitchenSinkForEnvironmentTests))]
         [RequiresTestSettings]
         // Need to support 'runInTerminal' request.
-        [UnsupportedDebugger(SupportedDebugger.VsDbg, SupportedArchitecture.x86 | SupportedArchitecture.x64)]
+        // darwin-debug does not support spaces in environment variables
+        [UnsupportedDebugger(SupportedDebugger.VsDbg | SupportedDebugger.Lldb, SupportedArchitecture.x86 | SupportedArchitecture.x64)]
         public void EnvironmentVariablesSpacesNewTerminal(ITestSettings settings)
         {
             this.TestPurpose("Tests environment variables that include a space in a new terminal window");


### PR DESCRIPTION
Use 'RuntimeInformation.IsOSPlatform' instead of
'Environment.OSVersion.Platform'

Environment.OSVersion.Platform on .NET 5 is returning 'Unix' for macOS
which is causing a bunch of our cases to not work.

Tested RuntimeInformation.IsOSPlatform(OSPlatform.Windows) on net472 on
Windows and it returns true.