### PR TITLE
Use pid to determine program if one is not configured for local attach

### DIFF
--- a/src/OpenDebugAD7/AD7DebugSession.cs
+++ b/src/OpenDebugAD7/AD7DebugSession.cs
@@ -1135,6 +1135,10 @@ namespace OpenDebugAD7
             SetCommonDebugSettings(responder.Arguments.ConfigurationProperties);
 
             string program = responder.Arguments.ConfigurationProperties.GetValueAsString("program");
+            if (isLocal && program == null)
+            {
+                program = Process.GetProcessById(pid).MainModule.FileName;
+            }
             string executable = null;
             bool success = false;
             try


### PR DESCRIPTION
This makes the "program" configuration optional for local attach cases. The configured program is always preferred if it is defined.

This was stemmed from a discussion over in microsoft/vscode-cpptools#5713 where another user had suggested a change like this based on feedback from one of the maintainers, but I didn't see an open pull request for it. The goal was to ultimately relax requiring the `program` configuration key to be set while debugging with local attach by pid on Linux. If this is merged, I think the C++ plugin's settings schema would also need to be altered to relax the `program` requirement.

Word of warning: I wasn't able to figure out the debug procedure for the VSCode C++ extension to verify this change, but I thought it was small enough to at least propose for discussion.

I thought I should note there is a pretty good workaround I saw in microsoft/vscode-cpptools#1272 which suggests [using the procfs](https://github.com/microsoft/vscode-cpptools/issues/1272#issuecomment-819747231) to infer the executable within VSCode's settings system.