### PR TITLE
Allow passwords in ssh connection strings

### DIFF
--- a/src/SSHDebugPS/StringResources.Designer.cs
+++ b/src/SSHDebugPS/StringResources.Designer.cs
@@ -19,7 +19,7 @@ namespace Microsoft.SSHDebugPS {
     // class via a tool like ResGen or Visual Studio.
     // To add or remove a member, edit your .ResX file then rerun ResGen
     // with the /str option, or rebuild your VS project.
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "16.0.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "17.0.0.0")]
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     internal class StringResources {
@@ -335,11 +335,33 @@ namespace Microsoft.SSHDebugPS {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Accept Host Key.
+        /// </summary>
+        internal static string HostKeyCaption {
+            get {
+                return ResourceManager.GetString("HostKeyCaption", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to &lt;hostname&gt;.
         /// </summary>
         internal static string HostName_PlaceHolder {
             get {
                 return ResourceManager.GetString("HostName_PlaceHolder", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to The authenticity of the host &apos;{0}&apos; needs to be established.
+        ///
+        ///&apos;{1}&apos; key fingerprint is &apos;{2}&apos;. 
+        ///
+        ///Would you like to continue connecting?.
+        /// </summary>
+        internal static string NewHostKeyMessage {
+            get {
+                return ResourceManager.GetString("NewHostKeyMessage", resourceCulture);
             }
         }
         

--- a/src/SSHDebugPS/StringResources.resx
+++ b/src/SSHDebugPS/StringResources.resx
@@ -273,4 +273,15 @@ Error:
   <data name="WSL_V2Required" xml:space="preserve">
     <value>The installed version of Windows Subsystem for Linux (WSL) is incompatible with Visual Studio's attach support. Please upgrade to WSL version 2 or newer.</value>
   </data>
+  <data name="HostKeyCaption" xml:space="preserve">
+    <value>Accept Host Key</value>
+  </data>
+  <data name="NewHostKeyMessage" xml:space="preserve">
+    <value>The authenticity of the host '{0}' needs to be established.
+
+'{1}' key fingerprint is '{2}'. 
+
+Would you like to continue connecting?</value>
+    <comment>{0} is a hostname, {1} is a key name, {2} is a fingerprint key value</comment>
+  </data>
 </root>

--- a/src/SSHDebugTests/SSHConnectionStringTests.cs
+++ b/src/SSHDebugTests/SSHConnectionStringTests.cs
@@ -46,9 +46,9 @@ namespace SSHDebugTests
             ipv6TestStrings.Add(
                 new ConnectionStringTestItem()
                 {
-                    // valid with custom username
+                    // valid with username:password
                     rawConnectionString = "test:user@[1234::6:7:8]",
-                    expectedUsername = "test:user",
+                    expectedUsername = "test",
                     expectedHostname = "[1234::6:7:8]",
                     expectedPort = ConnectionManager.DefaultSSHPort
                 });
@@ -144,6 +144,15 @@ namespace SSHDebugTests
                     expectedHostname = "10.10.10.10",
                     expectedPort = ConnectionManager.DefaultSSHPort
                 });
+            ipv4TestStrings.Add(
+                 new ConnectionStringTestItem()
+                 {
+                     // valid username no port with password
+                     rawConnectionString = "user:pass@10.10.10.10",
+                     expectedUsername = "user",
+                     expectedHostname = "10.10.10.10",
+                     expectedPort = ConnectionManager.DefaultSSHPort
+                 });
             ipv4TestStrings.Add(
                 new ConnectionStringTestItem()
                 {

--- a/src/SSHDebugTests/SSHConnectionStringTests.cs
+++ b/src/SSHDebugTests/SSHConnectionStringTests.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections.Generic;
 using System.Globalization;
+using System.Security;
 using Microsoft.SSHDebugPS;
 using Microsoft.SSHDebugPS.Utilities;
 using Xunit;
@@ -174,7 +175,7 @@ namespace SSHDebugTests
             string username;
             string hostname;
             int port;
-            ConnectionManager.ParseSSHConnectionString(item.rawConnectionString, out username, out hostname, out port);
+            ConnectionManager.ParseSSHConnectionString(item.rawConnectionString, out username, out SecureString password, out hostname, out port);
 
             Assert.True(item.expectedUsername.Equals(username, StringComparison.Ordinal), _comparisonErrorStringFormat.FormatInvariantWithArgs("UserName", item.expectedUsername, username));
             Assert.True(item.expectedHostname.Equals(hostname, StringComparison.Ordinal), _comparisonErrorStringFormat.FormatInvariantWithArgs("Hostname", item.expectedHostname, hostname));

--- a/src/SSHDebugTests/SSHConnectionStringTests.cs
+++ b/src/SSHDebugTests/SSHConnectionStringTests.cs
@@ -17,6 +17,7 @@ namespace SSHDebugTests
         {
             internal string rawConnectionString;
             internal string expectedUsername;
+            internal string expectedPassword;
             internal string expectedHostname;
             internal int expectedPort;
         }
@@ -31,6 +32,7 @@ namespace SSHDebugTests
                     // valid
                     rawConnectionString = "testuser@[1:2:3:4:5:6:7:8]:24",
                     expectedUsername = "testuser",
+                    expectedPassword = null,
                     expectedHostname = "[1:2:3:4:5:6:7:8]",
                     expectedPort = 24
                 });
@@ -40,6 +42,7 @@ namespace SSHDebugTests
                     // valid with no port
                     rawConnectionString = "testuser@[1:2:3:4:5:6:7:8]",
                     expectedUsername = "testuser",
+                    expectedPassword = null,
                     expectedHostname = "[1:2:3:4:5:6:7:8]",
                     expectedPort = ConnectionManager.DefaultSSHPort
                 });
@@ -49,6 +52,7 @@ namespace SSHDebugTests
                     // valid with username:password
                     rawConnectionString = "test:user@[1234::6:7:8]",
                     expectedUsername = "test",
+                    expectedPassword = "user",
                     expectedHostname = "[1234::6:7:8]",
                     expectedPort = ConnectionManager.DefaultSSHPort
                 });
@@ -58,6 +62,7 @@ namespace SSHDebugTests
                     // Valid with large port
                     rawConnectionString = "[1:2:3:4:5:6:7:8]:12345",
                     expectedUsername = StringResources.UserName_PlaceHolder,
+                    expectedPassword = null,
                     expectedHostname = "[1:2:3:4:5:6:7:8]",
                     expectedPort = 12345
                 });
@@ -67,6 +72,7 @@ namespace SSHDebugTests
                     // Invalid format
                     rawConnectionString = "testuser@:8",
                     expectedUsername = StringResources.UserName_PlaceHolder,
+                    expectedPassword = null,
                     expectedHostname = StringResources.HostName_PlaceHolder,
                     expectedPort = ConnectionManager.DefaultSSHPort
                 });
@@ -76,6 +82,7 @@ namespace SSHDebugTests
                     // Invalid string (just port)
                     rawConnectionString = ":8",
                     expectedUsername = StringResources.UserName_PlaceHolder,
+                    expectedPassword = null,
                     expectedHostname = StringResources.HostName_PlaceHolder,
                     expectedPort = ConnectionManager.DefaultSSHPort
                 });
@@ -85,6 +92,7 @@ namespace SSHDebugTests
                     // Empty String
                     rawConnectionString = string.Empty,
                     expectedUsername = StringResources.UserName_PlaceHolder,
+                    expectedPassword = null,
                     expectedHostname = StringResources.HostName_PlaceHolder,
                     expectedPort = ConnectionManager.DefaultSSHPort
                 });
@@ -94,6 +102,7 @@ namespace SSHDebugTests
                     // Invalid port
                     rawConnectionString = "[1:2:3:4:5:6:7:8]:123456",
                     expectedUsername = StringResources.UserName_PlaceHolder,
+                    expectedPassword = null,
                     expectedHostname = StringResources.HostName_PlaceHolder,
                     expectedPort = ConnectionManager.DefaultSSHPort
                 });
@@ -114,6 +123,7 @@ namespace SSHDebugTests
                     // valid no username
                     rawConnectionString = "192.168.1.1:156",
                     expectedUsername = StringResources.UserName_PlaceHolder,
+                    expectedPassword = null,
                     expectedHostname = "192.168.1.1",
                     expectedPort = 156
                 });
@@ -123,6 +133,7 @@ namespace SSHDebugTests
                     // valid username with port
                     rawConnectionString = "customUser@192.168.1.1:65354",
                     expectedUsername = "customUser",
+                    expectedPassword = null,
                     expectedHostname = "192.168.1.1",
                     expectedPort = 65354
                 });
@@ -132,6 +143,7 @@ namespace SSHDebugTests
                     // valid no username, Large port
                     rawConnectionString = "192.168.1.1:" + (ushort.MaxValue).ToString("d", CultureInfo.InvariantCulture),
                     expectedUsername = StringResources.UserName_PlaceHolder,
+                    expectedPassword = null,
                     expectedHostname = "192.168.1.1",
                     expectedPort = ushort.MaxValue
                 });
@@ -141,6 +153,7 @@ namespace SSHDebugTests
                     // valid username no port
                     rawConnectionString = "user@10.10.10.10",
                     expectedUsername = "user",
+                    expectedPassword = null,
                     expectedHostname = "10.10.10.10",
                     expectedPort = ConnectionManager.DefaultSSHPort
                 });
@@ -150,6 +163,7 @@ namespace SSHDebugTests
                      // valid username no port with password
                      rawConnectionString = "user:pass@10.10.10.10",
                      expectedUsername = "user",
+                     expectedPassword = "pass",
                      expectedHostname = "10.10.10.10",
                      expectedPort = ConnectionManager.DefaultSSHPort
                  });
@@ -159,6 +173,7 @@ namespace SSHDebugTests
                     // Invalid port
                     rawConnectionString = "192.168.1.1:123456",
                     expectedUsername = StringResources.UserName_PlaceHolder,
+                    expectedPassword = null,
                     expectedHostname = StringResources.HostName_PlaceHolder,
                     expectedPort = ConnectionManager.DefaultSSHPort
                 });
@@ -168,6 +183,7 @@ namespace SSHDebugTests
                     // Invalid address
                     rawConnectionString = "1%92.168.1.1:23",
                     expectedUsername = StringResources.UserName_PlaceHolder,
+                    expectedPassword = null,
                     expectedHostname = StringResources.HostName_PlaceHolder,
                     expectedPort = ConnectionManager.DefaultSSHPort
                 });
@@ -189,6 +205,28 @@ namespace SSHDebugTests
             Assert.True(item.expectedUsername.Equals(username, StringComparison.Ordinal), _comparisonErrorStringFormat.FormatInvariantWithArgs("UserName", item.expectedUsername, username));
             Assert.True(item.expectedHostname.Equals(hostname, StringComparison.Ordinal), _comparisonErrorStringFormat.FormatInvariantWithArgs("Hostname", item.expectedHostname, hostname));
             Assert.True(item.expectedPort == port, _comparisonErrorStringFormat.FormatInvariantWithArgs("Port", item.expectedPort, port));
+            if (item.expectedPassword == null)
+            {
+                Assert.True(password == null);
+            }
+            else
+            {
+                string passwordString = StringFromSecureString(password);
+                Assert.True(item.expectedPassword.Equals(passwordString, StringComparison.Ordinal), _comparisonErrorStringFormat.FormatInvariantWithArgs("Password", item.expectedPassword, passwordString)); 
+            }
+        }
+
+        private static string StringFromSecureString(SecureString secString)
+        {
+            if (secString == null)
+            {
+                return null;
+            }
+
+            IntPtr bstr = System.Runtime.InteropServices.Marshal.SecureStringToBSTR(secString);
+            string value = System.Runtime.InteropServices.Marshal.PtrToStringBSTR(bstr);
+            System.Runtime.InteropServices.Marshal.FreeBSTR(bstr);
+            return value;
         }
     }
 }


### PR DESCRIPTION
Supports an Office scenario for attaching to a process running somewhere in a pool of servers. Such connections are temporary; they do not get added to the Connection Manager.