### PR TITLE
Add 'All Exceptions' for ExceptionFilter in OpenDebugAD7

### DIFF
--- a/build/package_versions.settings.targets
+++ b/build/package_versions.settings.targets
@@ -3,7 +3,7 @@
         <Microsoft_VisualStudio_Debugger_Interop_Portable_Version>1.0.1</Microsoft_VisualStudio_Debugger_Interop_Portable_Version>
         <Microsoft_VisualStudio_Interop_Version>17.0.0-previews-1-31410-258</Microsoft_VisualStudio_Interop_Version>
         <Newtonsoft_Json_Version>12.0.2</Newtonsoft_Json_Version>
-        <Microsoft_VisualStudio_Shared_VSCodeDebugProtocol_Version>16.9.50204.1</Microsoft_VisualStudio_Shared_VSCodeDebugProtocol_Version>
+        <Microsoft_VisualStudio_Shared_VSCodeDebugProtocol_Version>17.0.50801.1</Microsoft_VisualStudio_Shared_VSCodeDebugProtocol_Version>
 
         <!-- Test Packages -->
         <Microsoft_NET_Test_Sdk_Version>16.7.1</Microsoft_NET_Test_Sdk_Version>

--- a/src/DebugEngineHost.VSCode/VSCode/ExceptionBreakpointFilter.cs
+++ b/src/DebugEngineHost.VSCode/VSCode/ExceptionBreakpointFilter.cs
@@ -45,12 +45,13 @@ namespace Microsoft.DebugEngineHost.VSCode
         [JsonRequired]
         public string conditionDescription { get; set; }
 
+        [JsonRequired]
+        public Guid categoryId { get; set; }
+
         /// <summary>
         /// The default state for the button
         /// </summary>
         public bool @default { get; set; }
-
-        public Guid categoryId { get; set; }
 
         [JsonIgnore]
         public enum_EXCEPTION_STATE State { get; set; } = enum_EXCEPTION_STATE.EXCEPTION_STOP_SECOND_CHANCE | enum_EXCEPTION_STATE.EXCEPTION_STOP_FIRST_CHANCE | enum_EXCEPTION_STATE.EXCEPTION_STOP_USER_FIRST_CHANCE;

--- a/src/DebugEngineHost.VSCode/VSCode/ExceptionBreakpointFilter.cs
+++ b/src/DebugEngineHost.VSCode/VSCode/ExceptionBreakpointFilter.cs
@@ -46,6 +46,12 @@ namespace Microsoft.DebugEngineHost.VSCode
             }
         }
 
+        [JsonRequired]
+        public bool supportsCondition { get; set; }
+
+        [JsonRequired]
+        public string conditionDescription { get; set; }
+
         /// <summary>
         /// The default state for the button
         /// </summary>

--- a/src/DebugEngineHost.VSCode/VSCode/ExceptionBreakpointFilter.cs
+++ b/src/DebugEngineHost.VSCode/VSCode/ExceptionBreakpointFilter.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using Microsoft.VisualStudio.Debugger.Interop;
 using Newtonsoft.Json;
 using System;
 using System.Diagnostics;
@@ -13,9 +14,6 @@ namespace Microsoft.DebugEngineHost.VSCode
     /// </summary>
     sealed public class ExceptionBreakpointFilter
     {
-        public const string Filter_All = "all";
-        public const string Filter_UserUnhandled = "user-unhandled";
-
         private string _filter;
 
         /// <summary>
@@ -25,7 +23,7 @@ namespace Microsoft.DebugEngineHost.VSCode
         public string label { get; set; }
 
         /// <summary>
-        /// The identifier for this filter. Currently this should be 'all' or 'user-unhandled'
+        /// The identifier for this filter.
         /// </summary>
         [JsonRequired]
         public string filter
@@ -37,11 +35,6 @@ namespace Microsoft.DebugEngineHost.VSCode
 
             set
             {
-                if (value != Filter_All && value != Filter_UserUnhandled)
-                {
-                    Debug.Fail("Invalid ExceptionBreakpointFilter");
-                    throw new ArgumentOutOfRangeException("filter");
-                }
                 _filter = value;
             }
         }
@@ -56,5 +49,11 @@ namespace Microsoft.DebugEngineHost.VSCode
         /// The default state for the button
         /// </summary>
         public bool @default { get; set; }
+
+        public Guid categoryId { get; set; }
+
+        [JsonIgnore]
+        public enum_EXCEPTION_STATE State { get; set; } = enum_EXCEPTION_STATE.EXCEPTION_STOP_SECOND_CHANCE | enum_EXCEPTION_STATE.EXCEPTION_STOP_FIRST_CHANCE | enum_EXCEPTION_STATE.EXCEPTION_STOP_USER_FIRST_CHANCE;
+
     }
 }

--- a/src/DebugEngineHost.VSCode/VSCode/ExceptionSettings.cs
+++ b/src/DebugEngineHost.VSCode/VSCode/ExceptionSettings.cs
@@ -6,6 +6,9 @@ using Newtonsoft.Json;
 using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
+using System.Diagnostics;
+using System.Globalization;
+using System.Linq;
 
 namespace Microsoft.DebugEngineHost.VSCode
 {
@@ -52,8 +55,25 @@ namespace Microsoft.DebugEngineHost.VSCode
         {
         }
 
+#if DEBUG
+        internal void ValidateExceptionFilters()
+        {
+            foreach (ExceptionBreakpointFilter filter in _exceptionFilters)
+            {
+                // Make sure that the category GUID was listed in the config file. 
+                if (!_categories.Where(c => c.Id == filter.categoryId).Any())
+                {
+                    Debug.Fail(string.Format(CultureInfo.InvariantCulture, "Missing category '{0}' from configuration file.", filter.categoryId));
+                }
+            }
+        }
+#endif
+
         internal void MakeReadOnly()
         {
+#if DEBUG
+            ValidateExceptionFilters();
+#endif
             _categories = new ReadOnlyCollection<CategoryConfiguration>(_categories);
             _exceptionFilters = new ReadOnlyCollection<ExceptionBreakpointFilter>(_exceptionFilters);
         }

--- a/src/MIDebugEngine/Engine.Impl/DebuggedProcess.cs
+++ b/src/MIDebugEngine/Engine.Impl/DebuggedProcess.cs
@@ -1189,9 +1189,9 @@ namespace Microsoft.MIDebugEngine
                     bplist.AddRange(bkpt);
                     _callback.OnBreakpoint(thread, bplist.AsReadOnly());
                 }
-                else if (ExceptionManager.TryGetExceptionBreakpoint(bkptno, out string exceptionName, out Guid exceptionCategoryGuid)) // exception breakpoint hit
+                else if (ExceptionManager.TryGetExceptionBreakpoint(bkptno, addr, frame, out string exceptionName, out string description, out Guid exceptionCategoryGuid)) // exception breakpoint hit
                 {
-                    _callback.OnException(thread, exceptionName, "", 0, exceptionCategoryGuid, ExceptionBreakpointStates.BreakThrown);
+                    _callback.OnException(thread, exceptionName, description, 0, exceptionCategoryGuid, ExceptionBreakpointStates.BreakThrown);
                 }
                 else if (!this.EntrypointHit)
                 {

--- a/src/MIDebugEngine/Engine.Impl/ExceptionManager.cs
+++ b/src/MIDebugEngine/Engine.Impl/ExceptionManager.cs
@@ -308,19 +308,27 @@ namespace Microsoft.MIDebugEngine
                     exceptionName = categorySettings.CurrentRules.FirstOrDefault(pair => pair.Value == breakpointNumber).Key;
                     if (exceptionName != null)
                     {
+                        // The string to use when displaying which exception caused the breakpoint to hit.
+                        // It is empty if it uses the category name
+                        string displayException = string.Empty;
+
                         if (exceptionName.Length < 1 || exceptionName == "*") // if exceptionName is "*", the exceptions category is selected
                         {
                             exceptionName = categorySettings.CategoryName;
+                        }
+                        else
+                        {
+                            displayException = string.Format(CultureInfo.InvariantCulture, " '{0}'", exceptionName);
                         }
 
                         string functionName = frame?.TryFindString("func");
                         if (string.IsNullOrWhiteSpace(functionName))
                         {
-                            exceptionDescription = string.Format(CultureInfo.CurrentCulture, ResourceStrings.Exception_Thrown, address);
+                            exceptionDescription = string.Format(CultureInfo.CurrentCulture, ResourceStrings.Exception_Thrown, displayException, address);
                         }
                         else
                         {
-                            exceptionDescription = string.Format(CultureInfo.CurrentCulture, ResourceStrings.Exception_Thrown_with_Source, address, functionName);
+                            exceptionDescription = string.Format(CultureInfo.CurrentCulture, ResourceStrings.Exception_Thrown_with_Source, displayException, address, functionName);
                         }
 
                         exceptionCategoryGuid = CppExceptionCategoryGuid;

--- a/src/MIDebugEngine/Engine.Impl/ExceptionManager.cs
+++ b/src/MIDebugEngine/Engine.Impl/ExceptionManager.cs
@@ -294,9 +294,10 @@ namespace Microsoft.MIDebugEngine
             }
         }
 
-        public bool TryGetExceptionBreakpoint(string bkptno, out string exceptionName, out Guid exceptionCategoryGuid)
+        public bool TryGetExceptionBreakpoint(string bkptno, ulong address, TupleValue frame, out string exceptionName, out string exceptionDescription, out Guid exceptionCategoryGuid)
         {
-            exceptionName = null;
+            exceptionName = string.Empty;
+            exceptionDescription = string.Empty;
             exceptionCategoryGuid = Guid.Empty;
             ExceptionCategorySettings categorySettings;
             if (_categoryMap.TryGetValue(CppExceptionCategoryGuid, out categorySettings))
@@ -311,6 +312,17 @@ namespace Microsoft.MIDebugEngine
                         {
                             exceptionName = categorySettings.CategoryName;
                         }
+
+                        string functionName = frame?.TryFindString("func");
+                        if (string.IsNullOrWhiteSpace(functionName))
+                        {
+                            exceptionDescription = string.Format(CultureInfo.CurrentCulture, ResourceStrings.Exception_Thrown, address);
+                        }
+                        else
+                        {
+                            exceptionDescription = string.Format(CultureInfo.CurrentCulture, ResourceStrings.Exception_Thrown_with_Source, address, functionName);
+                        }
+
                         exceptionCategoryGuid = CppExceptionCategoryGuid;
                         return true;
 

--- a/src/MIDebugEngine/ResourceStrings.Designer.cs
+++ b/src/MIDebugEngine/ResourceStrings.Designer.cs
@@ -158,7 +158,7 @@ namespace Microsoft.MIDebugEngine {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Exception thrown at 0x{0:X}..
+        ///   Looks up a localized string similar to Exception{0} thrown at 0x{1:X}..
         /// </summary>
         internal static string Exception_Thrown {
             get {
@@ -167,7 +167,7 @@ namespace Microsoft.MIDebugEngine {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Exception thrown at 0x{0:X} in {1}..
+        ///   Looks up a localized string similar to Exception{0} thrown at 0x{1:X} in {2}..
         /// </summary>
         internal static string Exception_Thrown_with_Source {
             get {

--- a/src/MIDebugEngine/ResourceStrings.Designer.cs
+++ b/src/MIDebugEngine/ResourceStrings.Designer.cs
@@ -158,6 +158,24 @@ namespace Microsoft.MIDebugEngine {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Exception thrown at 0x{0:X}..
+        /// </summary>
+        internal static string Exception_Thrown {
+            get {
+                return ResourceManager.GetString("Exception_Thrown", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Exception thrown at 0x{0:X} in {1}..
+        /// </summary>
+        internal static string Exception_Thrown_with_Source {
+            get {
+                return ResourceManager.GetString("Exception_Thrown_with_Source", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Error while updating exception settings. {0}.
         /// </summary>
         internal static string ExceptionSettingsError {

--- a/src/MIDebugEngine/ResourceStrings.resx
+++ b/src/MIDebugEngine/ResourceStrings.resx
@@ -263,11 +263,11 @@ See https://aka.ms/miengine-gdb-troubleshooting for details.</value>
 </value>
   </data>
   <data name="Exception_Thrown" xml:space="preserve">
-    <value>Exception thrown at 0x{0:X}.</value>
-    <comment>0 = address</comment>
+    <value>Exception{0} thrown at 0x{1:X}.</value>
+    <comment>0 = optional exception name, 1 = address</comment>
   </data>
   <data name="Exception_Thrown_with_Source" xml:space="preserve">
-    <value>Exception thrown at 0x{0:X} in {1}.</value>
-    <comment>0 = address, 1 = exception file</comment>
+    <value>Exception{0} thrown at 0x{1:X} in {2}.</value>
+    <comment>0 = optional exception name, 1 = address, 2 = exception file</comment>
   </data>
 </root>

--- a/src/MIDebugEngine/ResourceStrings.resx
+++ b/src/MIDebugEngine/ResourceStrings.resx
@@ -262,4 +262,12 @@ See https://aka.ms/miengine-gdb-troubleshooting for details.</value>
     <value>Warning: Exceptions are not supported in this scenario.
 </value>
   </data>
+  <data name="Exception_Thrown" xml:space="preserve">
+    <value>Exception thrown at 0x{0:X}.</value>
+    <comment>0 = address</comment>
+  </data>
+  <data name="Exception_Thrown_with_Source" xml:space="preserve">
+    <value>Exception thrown at 0x{0:X} in {1}.</value>
+    <comment>0 = address, 1 = exception file</comment>
+  </data>
 </root>

--- a/src/OpenDebugAD7/AD7Resources.Designer.cs
+++ b/src/OpenDebugAD7/AD7Resources.Designer.cs
@@ -207,6 +207,15 @@ namespace OpenDebugAD7 {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to ERROR: &apos;{0}&apos; is an invalid exception condition.
+        /// </summary>
+        internal static string Error_Invalid_Exception_Condition {
+            get {
+                return ResourceManager.GetString("Error_Invalid_Exception_Condition", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to DNX runtime process exited unexpectedly with error code {0}..
         /// </summary>
         internal static string Error_LaunchFailedNoError {

--- a/src/OpenDebugAD7/AD7Resources.Designer.cs
+++ b/src/OpenDebugAD7/AD7Resources.Designer.cs
@@ -207,7 +207,7 @@ namespace OpenDebugAD7 {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to ERROR: &apos;{0}&apos; is an invalid exception condition.
+        ///   Looks up a localized string similar to ERROR: &apos;{0}&apos; is an invalid exception condition. See https://aka.ms/VSCode-Cpp-ExceptionSettings for more information..
         /// </summary>
         internal static string Error_Invalid_Exception_Condition {
             get {

--- a/src/OpenDebugAD7/AD7Resources.Designer.cs
+++ b/src/OpenDebugAD7/AD7Resources.Designer.cs
@@ -117,6 +117,15 @@ namespace OpenDebugAD7 {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to &apos;{0}&apos; is not a supported exception filter..
+        /// </summary>
+        internal static string Error_FilterOption_Not_Supported {
+            get {
+                return ResourceManager.GetString("Error_FilterOption_Not_Supported", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Breakpoint Error: function &quot;{0}&quot;, {1}.
         /// </summary>
         internal static string Error_FunctionBreakpoint {

--- a/src/OpenDebugAD7/AD7Resources.resx
+++ b/src/OpenDebugAD7/AD7Resources.resx
@@ -304,4 +304,8 @@
   <data name="Error_UnableToSetInstructionBreakpoint" xml:space="preserve">
     <value>Error setting instruction breakpoint: {0}</value>
   </data>
+  <data name="Error_FilterOption_Not_Supported" xml:space="preserve">
+    <value>'{0}' is not a supported exception filter.</value>
+    <comment>{0} is the name of the exception filter.</comment>
+  </data>
 </root>

--- a/src/OpenDebugAD7/AD7Resources.resx
+++ b/src/OpenDebugAD7/AD7Resources.resx
@@ -308,4 +308,8 @@
     <value>'{0}' is not a supported exception filter.</value>
     <comment>{0} is the name of the exception filter.</comment>
   </data>
+  <data name="Error_Invalid_Exception_Condition" xml:space="preserve">
+    <value>ERROR: '{0}' is an invalid exception condition</value>
+    <comment>{0} is the exception condition</comment>
+  </data>
 </root>

--- a/src/OpenDebugAD7/AD7Resources.resx
+++ b/src/OpenDebugAD7/AD7Resources.resx
@@ -309,7 +309,7 @@
     <comment>{0} is the name of the exception filter.</comment>
   </data>
   <data name="Error_Invalid_Exception_Condition" xml:space="preserve">
-    <value>ERROR: '{0}' is an invalid exception condition</value>
+    <value>ERROR: '{0}' is an invalid exception condition. See https://aka.ms/VSCode-Cpp-ExceptionSettings for more information.</value>
     <comment>{0} is the exception condition</comment>
   </data>
 </root>

--- a/src/OpenDebugAD7/LanguageUtilities.cs
+++ b/src/OpenDebugAD7/LanguageUtilities.cs
@@ -21,8 +21,6 @@ namespace OpenDebugAD7
                 return false;
             }
 
-            string[] parts = identifier.Split();
-
             /*
              * Most languages require the first character in the indentifier not be a number.
              * 
@@ -33,7 +31,7 @@ namespace OpenDebugAD7
              * - Python
              */
             string digits = "0123456789";
-            if (digits.Contains(parts[0], StringComparison.Ordinal))
+            if (digits.Contains(identifier[0], StringComparison.Ordinal))
             {
                 return false;
             }

--- a/src/OpenDebugAD7/LanguageUtilities.cs
+++ b/src/OpenDebugAD7/LanguageUtilities.cs
@@ -1,0 +1,53 @@
+﻿// // Copyright (c) Microsoft. All rights reserved.
+// // Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Linq;
+
+namespace OpenDebugAD7
+{
+    internal static class LanguageUtilities
+    {
+        /// <summary>
+        /// This method does a simple validation on the input 'identifier'.
+        /// </summary>
+        /// <param name="identifier">the identifier to validate</param>
+        /// <returns>'true' if this is a valid identifier name. 'false' if otherwise.</returns>
+        public static bool IsValidIdentifier(string identifier)
+        {
+            // Check to see if identifier is null or blank.
+            if (string.IsNullOrWhiteSpace(identifier))
+            {
+                return false;
+            }
+
+            string[] parts = identifier.Split();
+
+            /*
+             * Most languages require the first character in the indentifier not be a number.
+             * 
+             * Languages:
+             * - C
+             * - C++
+             * - Rust
+             * - Python
+             */
+            string digits = "0123456789";
+            if (digits.Contains(parts[0], StringComparison.Ordinal))
+            {
+                return false;
+            }
+
+            /*
+             * Check to see if we got an '=' if the user is trying to do a 
+             * comparison on a non-existant psuedo variable like 'name'.
+             */
+            if (identifier.Where(c => c == '=').Any())
+            {
+                return false;
+            }
+
+            return true;
+        }
+    }
+}

--- a/src/OpenDebugAD7/cppdbg.ad7Engine.json
+++ b/src/OpenDebugAD7/cppdbg.ad7Engine.json
@@ -13,8 +13,10 @@
     ],
     "exceptionBreakpointFilters": [
       {
-        "label": "All Exceptions",
-        "filter": "all"
+        "label": "All C++ Exceptions",
+        "filter": "all",
+        "supportsCondition": true,
+        "conditionDescription": "std::out_of_range,std::invalid_argument"
       }
     ]
   }

--- a/src/OpenDebugAD7/cppdbg.ad7Engine.json
+++ b/src/OpenDebugAD7/cppdbg.ad7Engine.json
@@ -16,7 +16,8 @@
         "label": "All C++ Exceptions",
         "filter": "all",
         "supportsCondition": true,
-        "conditionDescription": "std::out_of_range,std::invalid_argument"
+        "conditionDescription": "std::out_of_range,std::invalid_argument",
+        "categoryId": "3A12D0B7-C26C-11D0-B442-00A0244A1DD2"
       }
     ]
   }

--- a/src/OpenDebugAD7/cppdbg.ad7Engine.json
+++ b/src/OpenDebugAD7/cppdbg.ad7Engine.json
@@ -7,8 +7,14 @@
   "exceptionSettings": {
     "categories": [
       {
-        "name": "CppExceptionCategory",
+        "name": "C++ Exceptions",
         "id": "3A12D0B7-C26C-11D0-B442-00A0244A1DD2"
+      }
+    ],
+    "exceptionBreakpointFilters": [
+      {
+        "label": "All Exceptions",
+        "filter": "all"
       }
     ]
   }

--- a/test/CppTests/Tests/ExceptionTests.cs
+++ b/test/CppTests/Tests/ExceptionTests.cs
@@ -284,6 +284,7 @@ namespace CppTests.Tests
         [Theory]
         [DependsOnTest(nameof(CompileExceptionDebuggee))]
         [RequiresTestSettings]
+        [UnsupportedDebugger(SupportedDebugger.Lldb, SupportedArchitecture.x86 | SupportedArchitecture.x64)]
         public void SetAllExceptionBreakpointTest(ITestSettings settings)
         {
             this.TestPurpose("This test checks to see if we can hit an exception breakpoint.");
@@ -327,6 +328,7 @@ namespace CppTests.Tests
 
         [Theory]
         [DependsOnTest(nameof(CompileExceptionDebuggee))]
+        [UnsupportedDebugger(SupportedDebugger.Lldb, SupportedArchitecture.x86 | SupportedArchitecture.x64)]
         [RequiresTestSettings]
         public void SetConditionExceptionBreakpointTest(ITestSettings settings)
         {
@@ -349,7 +351,7 @@ namespace CppTests.Tests
                 {
                     new ExceptionFilterOptions()
                     {
-                        condition = "std::exception",
+                        condition = "std::out_of_range",
                         filterId = "all"
                     }
                 };

--- a/test/CppTests/Tests/ExceptionTests.cs
+++ b/test/CppTests/Tests/ExceptionTests.cs
@@ -328,7 +328,10 @@ namespace CppTests.Tests
 
         [Theory]
         [DependsOnTest(nameof(CompileExceptionDebuggee))]
-        [UnsupportedDebugger(SupportedDebugger.Lldb, SupportedArchitecture.x86 | SupportedArchitecture.x64)]
+        // TODO: Re-enable SupportedDebugger.Gdb_MinGW when updated past 10.x in CI.
+        // Current issue is that it reports "did not find exception probe (does libstdcxx have SDT probes)?" and does not evaluate
+        // the condition.
+        [UnsupportedDebugger(SupportedDebugger.Lldb | SupportedDebugger.Gdb_MinGW, SupportedArchitecture.x86 | SupportedArchitecture.x64)]
         [RequiresTestSettings]
         public void SetConditionExceptionBreakpointTest(ITestSettings settings)
         {

--- a/test/DebuggerTesting/OpenDebug/Commands/SetExceptionBreakpointsCommand.cs
+++ b/test/DebuggerTesting/OpenDebug/Commands/SetExceptionBreakpointsCommand.cs
@@ -3,9 +3,16 @@
 
 namespace DebuggerTesting.OpenDebug.Commands
 {
+    public sealed class ExceptionFilterOptions : JsonValue
+    {
+        public string filterId;
+        public string condition;
+    }
+
     public sealed class SetExceptionBreakpointsCommandArgs : JsonValue
     {
         public string[] filters;
+        public ExceptionFilterOptions[] filterOptions;
     }
 
     public class SetExceptionBreakpointsCommand : Command<SetExceptionBreakpointsCommandArgs>
@@ -13,10 +20,14 @@ namespace DebuggerTesting.OpenDebug.Commands
         public const string FilterUserUnhandler = "user-unhandled";
         public const string FilterAll = "all";
 
-        public SetExceptionBreakpointsCommand(params string[] filters)
+        public SetExceptionBreakpointsCommand(string[] filters, ExceptionFilterOptions[] filterOptions)
            : base("setExceptionBreakpoints")
         {
-            this.Args.filters = (filters.Length > 0) ? filters : new string[] { FilterUserUnhandler };
+            if (filters != null)
+            {
+                this.Args.filters = (filters.Length > 0) ? filters : new string[] { FilterUserUnhandler };
+            }
+            this.Args.filterOptions = filterOptions;
         }
     }
 }

--- a/test/DebuggerTesting/OpenDebug/Extensions/DebuggerRunnerExtensions.cs
+++ b/test/DebuggerTesting/OpenDebug/Extensions/DebuggerRunnerExtensions.cs
@@ -197,9 +197,9 @@ namespace DebuggerTesting.OpenDebug.Extensions
             return runner.RunCommand(new SetBreakpointsCommand(sourceBreakpoints));
         }
 
-        public static void SetExceptionBreakpoints(this IDebuggerRunner runner, params string[] filters)
+        public static void SetExceptionBreakpoints(this IDebuggerRunner runner, string[] filters, ExceptionFilterOptions[] filterOptions)
         {
-                runner.RunCommand(new SetExceptionBreakpointsCommand(filters));
+            runner.RunCommand(new SetExceptionBreakpointsCommand(filters, filterOptions));
         }
 
         public static SetBreakpointsResponseValue SetFunctionBreakpoints(this IDebuggerRunner runner, FunctionBreakpoints breakpoints)


### PR DESCRIPTION
This PR adds an exception filter in the VS Code window "All Exceptions".

When checked, any exception thrown will be stopped at as a breakpoint.
![image](https://user-images.githubusercontent.com/3953714/145901344-65c591ea-8b7a-4293-9c05-2f6155f514e4.png)

This PR also updates the exception description for the AD7Exception
event. The description will indicate the address and function that it
was thrown.

**Image of `All C++ Exceptions` check**
![image](https://user-images.githubusercontent.com/3953714/145901353-c7e6c16b-1284-4c61-94cc-75792671cb10.png)

**Image of `All C++ Exceptions` with a condition**
![image](https://user-images.githubusercontent.com/3953714/146095805-d7a1303b-0e92-4b49-886c-3780d426bd33.png)

**Image of a specific exception in Visual Studio 2022**
![image](https://user-images.githubusercontent.com/3953714/146096539-3a554fb5-8861-4a17-aee3-50619163b3b8.png)


TODO: 
- [ ] Update https://github.com/microsoft/vscode-cpptools/blob/main/Documentation/Debugger/ExceptionSettings.md 