### PR TITLE
Bug 1452506: The word "Refresh" disappears after moving the cursor over it in Docker(Linux Container) testing

### DIFF
--- a/src/SSHDebugPS/UI/ContainerPickerDialogWindow.xaml
+++ b/src/SSHDebugPS/UI/ContainerPickerDialogWindow.xaml
@@ -195,7 +195,7 @@
             <Setter Property="Background"
                     Value="Transparent" />
             <Setter Property="Foreground"
-                    Value="{DynamicResource {x:Static platformui:EnvironmentColors.ControlLinkTextBrushKey}}" />
+                    Value="{StaticResource {x:Static SystemColors.ControlTextBrushKey}}" />
             <Setter Property="Margin"
                     Value="0" />
             <Setter Property="Padding"
@@ -225,12 +225,12 @@
                             <Trigger Property="IsFocused"
                                      Value="True">
                                 <Setter Property="Foreground"
-                                        Value="{DynamicResource {x:Static platformui:EnvironmentColors.ControlLinkTextHoverBrushKey}}" />
+                                        Value="{StaticResource {x:Static SystemColors.ControlTextBrushKey}}" />
                             </Trigger>
                             <Trigger Property="IsMouseOver"
                                      Value="True">
                                 <Setter Property="Foreground"
-                                        Value="{DynamicResource {x:Static platformui:EnvironmentColors.ControlLinkTextHoverBrushKey}}" />
+                                        Value="{StaticResource {x:Static SystemColors.ControlTextBrushKey}}" />
                                 <Setter TargetName="accessText"
                                         Property="TextDecorations"
                                         Value="Underline" />
@@ -240,13 +240,13 @@
                             <Trigger Property="IsPressed"
                                      Value="True">
                                 <Setter Property="Foreground"
-                                        Value="{DynamicResource {x:Static platformui:EnvironmentColors.ControlLinkTextPressedBrushKey}}" />
+                                        Value="{StaticResource {x:Static SystemColors.ControlTextBrushKey}}" />
                             </Trigger>
                             <!-- None of our links should be disabled, but keep the style just in case -->
                             <Trigger Property="IsEnabled"
                                      Value="False">
                                 <Setter Property="Foreground"
-                                        Value="{DynamicResource {x:Static platformui:EnvironmentColors.PanelHyperlinkDisabledBrushKey}}" />
+                                        Value="{StaticResource {x:Static SystemColors.ControlTextBrushKey}}" />
                                 <!--
                                 When more than one active trigger set the same property,
                                 the last trigger wins.  Thus, we also set the decoration

--- a/src/SSHDebugPS/UI/ContainerPickerDialogWindow.xaml
+++ b/src/SSHDebugPS/UI/ContainerPickerDialogWindow.xaml
@@ -195,7 +195,7 @@
             <Setter Property="Background"
                     Value="Transparent" />
             <Setter Property="Foreground"
-                    Value="{StaticResource {x:Static SystemColors.ControlTextBrushKey}}" />
+                    Value="{DynamicResource {x:Static platformui:EnvironmentColors.ControlLinkTextBrushKey}}" />
             <Setter Property="Margin"
                     Value="0" />
             <Setter Property="Padding"
@@ -225,12 +225,12 @@
                             <Trigger Property="IsFocused"
                                      Value="True">
                                 <Setter Property="Foreground"
-                                        Value="{StaticResource {x:Static SystemColors.ControlTextBrushKey}}" />
+                                        Value="{DynamicResource {x:Static platformui:EnvironmentColors.ControlLinkTextBrushKey}}" />
                             </Trigger>
                             <Trigger Property="IsMouseOver"
                                      Value="True">
                                 <Setter Property="Foreground"
-                                        Value="{StaticResource {x:Static SystemColors.ControlTextBrushKey}}" />
+                                        Value="{DynamicResource {x:Static platformui:EnvironmentColors.ControlLinkTextBrushKey}}" />
                                 <Setter TargetName="accessText"
                                         Property="TextDecorations"
                                         Value="Underline" />
@@ -240,13 +240,13 @@
                             <Trigger Property="IsPressed"
                                      Value="True">
                                 <Setter Property="Foreground"
-                                        Value="{StaticResource {x:Static SystemColors.ControlTextBrushKey}}" />
+                                        Value="{DynamicResource {x:Static platformui:EnvironmentColors.ControlLinkTextBrushKey}}" />
                             </Trigger>
                             <!-- None of our links should be disabled, but keep the style just in case -->
                             <Trigger Property="IsEnabled"
                                      Value="False">
                                 <Setter Property="Foreground"
-                                        Value="{StaticResource {x:Static SystemColors.ControlTextBrushKey}}" />
+                                        Value="{DynamicResource {x:Static platformui:EnvironmentColors.PanelHyperlinkDisabledBrushKey}}" />
                                 <!--
                                 When more than one active trigger set the same property,
                                 the last trigger wins.  Thus, we also set the decoration


### PR DESCRIPTION
### No Hover

**Before:**
![image](https://user-images.githubusercontent.com/60245970/148455676-e2c84743-201f-4b05-a108-17afb5430927.png)

**After:**
![image](https://user-images.githubusercontent.com/60245970/148456086-c5421273-a82d-4d26-9f4c-bc04c484fb82.png)

### On Hover

**Before:**
![image](https://user-images.githubusercontent.com/60245970/148455724-b805810e-6d69-4dbd-888b-99f017a88ef6.png)

**After:**
![image](https://user-images.githubusercontent.com/60245970/148456223-40f82f11-6e4f-4494-b44b-a7f517c76018.png)