### PR TITLE
Data breakpoints in OpenDebugAD7

### DIFF
--- a/src/DebugEngineHost.VSCode/HostMarshal.cs
+++ b/src/DebugEngineHost.VSCode/HostMarshal.cs
@@ -4,6 +4,7 @@
 using Microsoft.DebugEngineHost.VSCode;
 using Microsoft.VisualStudio.Debugger.Interop;
 using System;
+using System.Runtime.InteropServices;
 
 namespace Microsoft.DebugEngineHost
 {
@@ -110,7 +111,7 @@ namespace Microsoft.DebugEngineHost
         /// <returns></returns>
         public static string GetDataBreakpointStringForIntPtr(IntPtr stringId)
         {
-            throw new NotImplementedException();
+            return Marshal.PtrToStringBSTR(stringId);
         }
 
         /// <summary>
@@ -120,7 +121,7 @@ namespace Microsoft.DebugEngineHost
         /// <returns>IntPtr to a BSTR which can be returned to VS.</returns>
         public static IntPtr GetIntPtrForDataBreakpointAddress(string address)
         {
-            throw new NotImplementedException();
+            return Marshal.StringToBSTR(address);
         }
 
         /// <summary>

--- a/src/DebugEngineHost.VSCode/VSCode/EngineConfiguration.cs
+++ b/src/DebugEngineHost.VSCode/VSCode/EngineConfiguration.cs
@@ -33,6 +33,7 @@ namespace Microsoft.DebugEngineHost.VSCode
         private bool _conditionalBP;
         private bool _functionBP;
         private bool _clipboardContext;
+        private bool _dataBP;
 
         // NOTE: CoreCLR doesn't support providing a code base when loading assemblies. So all debug engines
         // must be placed in the directory of OpenDebugAD7.exe
@@ -72,6 +73,12 @@ namespace Microsoft.DebugEngineHost.VSCode
         { 
             get { return _clipboardContext; } 
             set { SetProperty(out _clipboardContext, value); }
+        }
+
+        public bool DataBP
+        {
+            get { return _dataBP; }
+            set { SetProperty(out _dataBP, value); }
         }
 
 

--- a/src/MIDebugEngine/AD7.Impl/AD7PendingBreakpoint.cs
+++ b/src/MIDebugEngine/AD7.Impl/AD7PendingBreakpoint.cs
@@ -292,9 +292,6 @@ namespace Microsoft.MIDebugEngine
             {
                 if (e.GetBaseException() is InvalidCoreDumpOperationException)
                     return AD7_HRESULT.E_CRASHDUMP_UNSUPPORTED;
-                else if (e.GetBaseException() is ArgumentException && (enum_BP_LOCATION_TYPE)_bpRequestInfo.bpLocation.bpLocationType == enum_BP_LOCATION_TYPE.BPLT_DATA_STRING)
-                    // handle invalid data bp address/size
-                    return Constants.E_FAIL;
                 else
                     return EngineUtils.UnexpectedException(e);
             }
@@ -323,6 +320,11 @@ namespace Microsoft.MIDebugEngine
                 //replaced by the real mi debugger error text
                 this.SetError(new AD7ErrorBreakpoint(this, ResourceStrings.LongBind, enum_BP_ERROR_TYPE.BPET_SEV_LOW | enum_BP_ERROR_TYPE.BPET_TYPE_WARNING), true);
                 return Constants.S_FALSE;
+            }
+            else if (this._BPError != null)
+            {
+                // Ran into some sort of error
+                return Constants.E_FAIL;
             }
             else
             {
@@ -367,7 +369,16 @@ namespace Microsoft.MIDebugEngine
                 }
                 else
                 {
-                    bindResult = await PendingBreakpoint.Bind(_address, _size, _engine.DebuggedProcess, _condition, this);
+                    try
+                    {
+                        bindResult = await PendingBreakpoint.Bind(_address, _size, _engine.DebuggedProcess, _condition, this);
+                    }
+                    catch (ArgumentException ex)
+                    {
+                        // There was an error binding at the address with the specified size. This could happen if the size is greater
+                        // than the max size a data bp can watch.
+                        bindResult = new PendingBreakpoint.BindResult(ex.Message);
+                    }
                 }
 
                 lock (_boundBreakpoints)

--- a/src/MIDebugEngine/AD7.Impl/AD7PendingBreakpoint.cs
+++ b/src/MIDebugEngine/AD7.Impl/AD7PendingBreakpoint.cs
@@ -3,7 +3,6 @@
 
 using MICore;
 using Microsoft.DebugEngineHost;
-using Microsoft.MIDebugEngine.Natvis;
 using Microsoft.VisualStudio.Debugger.Interop;
 using System;
 using System.Collections.Generic;

--- a/src/MIDebugEngine/AD7.Impl/AD7PendingBreakpoint.cs
+++ b/src/MIDebugEngine/AD7.Impl/AD7PendingBreakpoint.cs
@@ -3,6 +3,7 @@
 
 using MICore;
 using Microsoft.DebugEngineHost;
+using Microsoft.MIDebugEngine.Natvis;
 using Microsoft.VisualStudio.Debugger.Interop;
 using System;
 using System.Collections.Generic;
@@ -292,6 +293,9 @@ namespace Microsoft.MIDebugEngine
             {
                 if (e.GetBaseException() is InvalidCoreDumpOperationException)
                     return AD7_HRESULT.E_CRASHDUMP_UNSUPPORTED;
+                else if (e.GetBaseException() is ArgumentException && (enum_BP_LOCATION_TYPE)_bpRequestInfo.bpLocation.bpLocationType == enum_BP_LOCATION_TYPE.BPLT_DATA_STRING)
+                    // handle invalid data bp address/size
+                    return Constants.E_FAIL;
                 else
                     return EngineUtils.UnexpectedException(e);
             }

--- a/src/MIDebugEngine/AD7.Impl/AD7Property.cs
+++ b/src/MIDebugEngine/AD7.Impl/AD7Property.cs
@@ -161,11 +161,12 @@ namespace Microsoft.MIDebugEngine
 
                     // Create property array
                     DEBUG_PROPERTY_INFO[] properties = new DEBUG_PROPERTY_INFO[propertyCount];
-                    for (int i = 0; i < children.Length; i++)
+                    for (int i = 0, j = 0; i < children.Length; i++)
                     {
                         if (fitsFilter == null || fitsFilter[i])
                         {
-                            properties[i] = (new AD7Property(_engine, children[i])).ConstructDebugPropertyInfo(dwFields);
+                            properties[j] = (new AD7Property(_engine, children[i])).ConstructDebugPropertyInfo(dwFields);
+                            ++j; // increment j if we fit filter, this allows us to traverse "properties" array properly.
                         }
                     }
                     ppEnum = new AD7PropertyEnum(properties);
@@ -466,7 +467,7 @@ namespace Microsoft.MIDebugEngine
         {
             try
             {
-                pbstrAddress = _variableInformation.Address() + "," + _variableInformation.FullName();
+                pbstrAddress = _variableInformation.Address();
                 pSize = _variableInformation.Size();
                 pbstrDisplayName = _variableInformation.FullName();
                 pbstrError = "";

--- a/src/MIDebugEngine/AD7.Impl/AD7Property.cs
+++ b/src/MIDebugEngine/AD7.Impl/AD7Property.cs
@@ -1,7 +1,6 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using EnvDTE;
 using Microsoft.VisualStudio.Debugger.Interop;
 using System;
 using System.Diagnostics;
@@ -151,7 +150,7 @@ namespace Microsoft.MIDebugEngine
                         fitsFilter = new bool[children.Length];
                         for (int i = 0; i < children.Length; i++)
                         {
-                            fitsFilter[i] = string.Compare(children[i].Name, pszNameFilter, StringComparison.Ordinal) == 0;
+                            fitsFilter[i] = string.Equals(children[i].Name, pszNameFilter, StringComparison.Ordinal);
                             if (!fitsFilter[i])
                             {
                                 propertyCount--;
@@ -467,7 +466,7 @@ namespace Microsoft.MIDebugEngine
         {
             try
             {
-                pbstrAddress = _variableInformation.Address();
+                pbstrAddress = _variableInformation.Address() + "," + _variableInformation.FullName();
                 pSize = _variableInformation.Size();
                 pbstrDisplayName = _variableInformation.FullName();
                 pbstrError = "";

--- a/src/OpenDebugAD7/AD7DebugSession.cs
+++ b/src/OpenDebugAD7/AD7DebugSession.cs
@@ -3478,14 +3478,14 @@ namespace OpenDebugAD7
                         }
                         else // data bp
                         {
+                            string outputMsg = string.Format(CultureInfo.CurrentCulture, AD7Resources.Error_InvalidDataBreakpoint, errorMsg);
                             bp = new Breakpoint()
                             {
                                 Verified = false,
                                 Id = (int)ad7BPRequest.Id,
                                 Line = 0,
-                                Message = errorMsg
+                                Message = outputMsg
                             };
-                            string outputMsg = string.Format(CultureInfo.CurrentCulture, AD7Resources.Error_DataBreakpointInfoFail, errorMsg);
                             m_logger.WriteLine(LoggingCategory.DebuggerError, outputMsg);
                         }
 

--- a/src/OpenDebugAD7/AD7DebugSession.cs
+++ b/src/OpenDebugAD7/AD7DebugSession.cs
@@ -2413,7 +2413,7 @@ namespace OpenDebugAD7
             catch (Exception ex)
             {
                 if (ex is AD7Exception ad7ex)
-                    response.Description = string.Format(CultureInfo.CurrentCulture, AD7Resources.Error_DataBreakpointInfoFail, ad7ex.Message);
+                    response.Description = ad7ex.Message;
                 else
                     response.Description = string.Format(CultureInfo.CurrentCulture, AD7Resources.Error_DataBreakpointInfoFail, "");
             }

--- a/src/OpenDebugAD7/AD7DebugSession.cs
+++ b/src/OpenDebugAD7/AD7DebugSession.cs
@@ -52,8 +52,6 @@ namespace OpenDebugAD7
         private Dictionary<string, IDebugPendingBreakpoint2> m_functionBreakpoints;
         private Dictionary<ulong, IDebugPendingBreakpoint2> m_instructionBreakpoints;
         private Dictionary<string, IDebugPendingBreakpoint2> m_dataBreakpoints;
-        private static string s_errorInvalidAmountOfDataBreakpointsMessage = "You may have requested too many hardware breakpoints/watchpoints";
-        private bool m_tooManyDataBreakpoints = false;
 
         private List<string> m_exceptionBreakpoints;
         private readonly HandleCollection<IDebugStackFrame2> m_frameHandles;
@@ -226,12 +224,7 @@ namespace OpenDebugAD7
                 {
                     m_logger.SetLoggingConfiguration(LoggingCategory.EngineLogging, engineLogging.Value);
                     HostLogger.EnableHostLogging();
-                    HostLogger.Instance.LogCallback = (s) =>
-                    {
-                        if (s.Contains(s_errorInvalidAmountOfDataBreakpointsMessage, StringComparison.InvariantCulture))
-                            m_tooManyDataBreakpoints = true;
-                        m_logger.WriteLine(LoggingCategory.EngineLogging, s);
-                    };
+                    HostLogger.Instance.LogCallback = s => m_logger.WriteLine(LoggingCategory.EngineLogging, s);
                 }
 
                 bool? trace = logging.GetValueAsBool("trace");
@@ -3324,11 +3317,6 @@ namespace OpenDebugAD7
 
             string exceptionDescription;
             exceptionEvent.GetExceptionDescription(out exceptionDescription);
-            if (m_tooManyDataBreakpoints)
-            {
-                exceptionDescription += " " + string.Format(CultureInfo.CurrentCulture, AD7Resources.Error_InvalidAmountOfDataBreakpoints);
-                m_tooManyDataBreakpoints = false;
-            }
 
             FireStoppedEvent(pThread, StoppedEvent.ReasonValue.Exception, exceptionDescription);
         }

--- a/src/OpenDebugAD7/AD7DebugSession.cs
+++ b/src/OpenDebugAD7/AD7DebugSession.cs
@@ -905,6 +905,7 @@ namespace OpenDebugAD7
                 SupportsSetVariable = true,
                 SupportsFunctionBreakpoints = m_engineConfiguration.FunctionBP,
                 SupportsConditionalBreakpoints = m_engineConfiguration.ConditionalBP,
+                SupportsDataBreakpoints = true,
                 ExceptionBreakpointFilters = filters,
                 SupportsExceptionFilterOptions = filters.Any(),
                 SupportsClipboardContext = m_engineConfiguration.ClipboardContext,

--- a/src/OpenDebugAD7/AD7DebugSession.cs
+++ b/src/OpenDebugAD7/AD7DebugSession.cs
@@ -1,5 +1,4 @@
-﻿
-// Copyright (c) Microsoft. All rights reserved.
+﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
@@ -2724,8 +2723,7 @@ namespace OpenDebugAD7
                 if (!m_functionBreakpoints.ContainsKey(b.Name))
                 {
                     IDebugPendingBreakpoint2 pendingBp;
-                    AD7FunctionPosition functionPosition = new AD7FunctionPosition(b.Name);
-                    AD7BreakPointRequest pBPRequest = new AD7BreakPointRequest(functionPosition);
+                    AD7BreakPointRequest pBPRequest = new AD7BreakPointRequest(b.Name);
 
                     int hr = m_engine.CreatePendingBreakpoint(pBPRequest, out pendingBp);
 

--- a/src/OpenDebugAD7/AD7DebugSession.cs
+++ b/src/OpenDebugAD7/AD7DebugSession.cs
@@ -52,6 +52,8 @@ namespace OpenDebugAD7
         private Dictionary<string, IDebugPendingBreakpoint2> m_functionBreakpoints;
         private Dictionary<ulong, IDebugPendingBreakpoint2> m_instructionBreakpoints;
         private Dictionary<string, IDebugPendingBreakpoint2> m_dataBreakpoints;
+        private static string s_errorInvalidAmountOfDataBreakpointsMessage = "You may have requested too many hardware breakpoints/watchpoints";
+        private bool m_tooManyDataBreakpoints = false;
 
         private List<string> m_exceptionBreakpoints;
         private readonly HandleCollection<IDebugStackFrame2> m_frameHandles;
@@ -224,7 +226,12 @@ namespace OpenDebugAD7
                 {
                     m_logger.SetLoggingConfiguration(LoggingCategory.EngineLogging, engineLogging.Value);
                     HostLogger.EnableHostLogging();
-                    HostLogger.Instance.LogCallback = s => m_logger.WriteLine(LoggingCategory.EngineLogging, s);
+                    HostLogger.Instance.LogCallback = (s) =>
+                    {
+                        if (s.Contains(s_errorInvalidAmountOfDataBreakpointsMessage, StringComparison.InvariantCulture))
+                            m_tooManyDataBreakpoints = true;
+                        m_logger.WriteLine(LoggingCategory.EngineLogging, s);
+                    };
                 }
 
                 bool? trace = logging.GetValueAsBool("trace");
@@ -3317,6 +3324,11 @@ namespace OpenDebugAD7
 
             string exceptionDescription;
             exceptionEvent.GetExceptionDescription(out exceptionDescription);
+            if (m_tooManyDataBreakpoints)
+            {
+                exceptionDescription += " " + string.Format(CultureInfo.CurrentCulture, AD7Resources.Error_InvalidAmountOfDataBreakpoints);
+                m_tooManyDataBreakpoints = false;
+            }
 
             FireStoppedEvent(pThread, StoppedEvent.ReasonValue.Exception, exceptionDescription);
         }

--- a/src/OpenDebugAD7/AD7Impl/AD7BreakPointRequest.cs
+++ b/src/OpenDebugAD7/AD7Impl/AD7BreakPointRequest.cs
@@ -25,7 +25,7 @@ namespace OpenDebugAD7.AD7Impl
 
         public IDebugMemoryContext2 MemoryContext {  get; private set; }
 
-        public string DataId { get; private set; }
+        public string DataAddress { get; private set; }
         public uint DataSize { get; private set; }
 
         // Used for Releasing the MemoryContext.
@@ -51,10 +51,11 @@ namespace OpenDebugAD7.AD7Impl
             FunctionPosition = functionPosition;
         }
 
-        public AD7BreakPointRequest(string dataId)
+        // Data breakpoint constructor
+        public AD7BreakPointRequest(string address, uint size)
         {
-            DataId = dataId;
-            DataSize = 
+            DataAddress = address;
+            DataSize = size;
         }
 
         public AD7BreakPointRequest(IDebugMemoryContext2 memoryContext)
@@ -76,7 +77,7 @@ namespace OpenDebugAD7.AD7Impl
             {
                 pBPLocationType[0] = enum_BP_LOCATION_TYPE.BPLT_CODE_CONTEXT;
             }
-            else if (DataId != null)
+            else if (DataAddress != null)
             {
                 pBPLocationType[0] = enum_BP_LOCATION_TYPE.BPLT_DATA_STRING;
             }
@@ -105,10 +106,10 @@ namespace OpenDebugAD7.AD7Impl
                     MemoryContextIntPtr = HostMarshal.RegisterCodeContext(MemoryContext as IDebugCodeContext2);
                     pBPRequestInfo[0].bpLocation.unionmember1 = MemoryContextIntPtr;
                 }
-                else if (DataId != null)
+                else if (DataAddress != null)
                 {
                     pBPRequestInfo[0].bpLocation.bpLocationType = (uint)enum_BP_LOCATION_TYPE.BPLT_DATA_STRING;
-                    pBPRequestInfo[0].bpLocation.unionmember3 = HostMarshal.GetIntPtrForDataBreakpointAddress(DataId);
+                    pBPRequestInfo[0].bpLocation.unionmember3 = HostMarshal.GetIntPtrForDataBreakpointAddress(DataAddress);
                     pBPRequestInfo[0].bpLocation.unionmember4 = (IntPtr)DataSize;
                 }
             }

--- a/src/OpenDebugAD7/AD7Impl/AD7BreakPointRequest.cs
+++ b/src/OpenDebugAD7/AD7Impl/AD7BreakPointRequest.cs
@@ -34,7 +34,7 @@ namespace OpenDebugAD7.AD7Impl
         public IntPtr MemoryContextIntPtr { get; private set;  }
 
         // Unique identifier for breakpoint when communicating with VSCode
-        public uint Id { get; private set; } = GetNextBreakpointId();
+        public uint Id { get; } = GetNextBreakpointId();
 
         // Bind result from IDebugBreakpointErrorEvent2 or IDebugBreakpointBoundEvent2
         public Breakpoint BindResult { get; set; }

--- a/src/OpenDebugAD7/AD7Impl/AD7BreakPointRequest.cs
+++ b/src/OpenDebugAD7/AD7Impl/AD7BreakPointRequest.cs
@@ -54,6 +54,7 @@ namespace OpenDebugAD7.AD7Impl
         public AD7BreakPointRequest(string dataId)
         {
             DataId = dataId;
+            DataSize = 
         }
 
         public AD7BreakPointRequest(IDebugMemoryContext2 memoryContext)

--- a/src/OpenDebugAD7/AD7Impl/AD7BreakPointRequest.cs
+++ b/src/OpenDebugAD7/AD7Impl/AD7BreakPointRequest.cs
@@ -46,9 +46,9 @@ namespace OpenDebugAD7.AD7Impl
             Id = GetNextBreakpointId();
         }
 
-        public AD7BreakPointRequest(AD7FunctionPosition functionPosition)
+        public AD7BreakPointRequest(string functionName)
         {
-            FunctionPosition = functionPosition;
+            FunctionPosition = new AD7FunctionPosition(functionName);
         }
 
         // Data breakpoint constructor

--- a/src/OpenDebugAD7/AD7Impl/AD7BreakPointRequest.cs
+++ b/src/OpenDebugAD7/AD7Impl/AD7BreakPointRequest.cs
@@ -34,7 +34,7 @@ namespace OpenDebugAD7.AD7Impl
         public IntPtr MemoryContextIntPtr { get; private set;  }
 
         // Unique identifier for breakpoint when communicating with VSCode
-        public uint Id { get; private set; }
+        public uint Id { get; private set; } = GetNextBreakpointId();
 
         // Bind result from IDebugBreakpointErrorEvent2 or IDebugBreakpointBoundEvent2
         public Breakpoint BindResult { get; set; }
@@ -43,7 +43,6 @@ namespace OpenDebugAD7.AD7Impl
         {
             DocumentPosition = new AD7DocumentPosition(config, path, line);
             Condition = condition;
-            Id = GetNextBreakpointId();
         }
 
         public AD7BreakPointRequest(string functionName)

--- a/src/OpenDebugAD7/AD7Resources.Designer.cs
+++ b/src/OpenDebugAD7/AD7Resources.Designer.cs
@@ -216,15 +216,6 @@ namespace OpenDebugAD7 {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to You may have requested too many hardware breakpoints/watchpoints..
-        /// </summary>
-        internal static string Error_InvalidAmountOfDataBreakpoints {
-            get {
-                return ResourceManager.GetString("Error_InvalidAmountOfDataBreakpoints", resourceCulture);
-            }
-        }
-        
-        /// <summary>
         ///   Looks up a localized string similar to DNX runtime process exited unexpectedly with error code {0}..
         /// </summary>
         internal static string Error_LaunchFailedNoError {

--- a/src/OpenDebugAD7/AD7Resources.Designer.cs
+++ b/src/OpenDebugAD7/AD7Resources.Designer.cs
@@ -243,6 +243,15 @@ namespace OpenDebugAD7 {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Unable to set data breakpoint: {0}.
+        /// </summary>
+        internal static string Error_InvalidDataBreakpoint {
+            get {
+                return ResourceManager.GetString("Error_InvalidDataBreakpoint", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to DNX runtime process exited unexpectedly with error code {0}..
         /// </summary>
         internal static string Error_LaunchFailedNoError {

--- a/src/OpenDebugAD7/AD7Resources.Designer.cs
+++ b/src/OpenDebugAD7/AD7Resources.Designer.cs
@@ -61,6 +61,15 @@ namespace OpenDebugAD7 {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to When &apos;{0}&apos; changes ({1} bytes).
+        /// </summary>
+        internal static string DataBreakpointDisplayString {
+            get {
+                return ResourceManager.GetString("DataBreakpointDisplayString", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Execute debugger commands using &quot;-exec &lt;command&gt;&quot;, for example &quot;-exec info registers&quot; will list registers in use (when GDB is the debugger).
         /// </summary>
         internal static string DebugConsoleStartMessage {
@@ -75,6 +84,15 @@ namespace OpenDebugAD7 {
         internal static string DebuggerDisconnectMessage {
             get {
                 return ResourceManager.GetString("DebuggerDisconnectMessage", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Unable to find child property..
+        /// </summary>
+        internal static string Error_ChildPropertyNotFound {
+            get {
+                return ResourceManager.GetString("Error_ChildPropertyNotFound", resourceCulture);
             }
         }
         
@@ -104,6 +122,15 @@ namespace OpenDebugAD7 {
         internal static string Error_CorruptingException {
             get {
                 return ResourceManager.GetString("Error_CorruptingException", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Unable to get info for data breakpoint. {0}.
+        /// </summary>
+        internal static string Error_DataBreakpointInfoFail {
+            get {
+                return ResourceManager.GetString("Error_DataBreakpointInfoFail", resourceCulture);
             }
         }
         
@@ -241,6 +268,15 @@ namespace OpenDebugAD7 {
         internal static string Error_MissingOutParam {
             get {
                 return ResourceManager.GetString("Error_MissingOutParam", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Unable to get parent object: No scope or variable found..
+        /// </summary>
+        internal static string Error_NoParentObject {
+            get {
+                return ResourceManager.GetString("Error_NoParentObject", resourceCulture);
             }
         }
         

--- a/src/OpenDebugAD7/AD7Resources.Designer.cs
+++ b/src/OpenDebugAD7/AD7Resources.Designer.cs
@@ -216,6 +216,15 @@ namespace OpenDebugAD7 {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to You may have requested too many hardware breakpoints/watchpoints..
+        /// </summary>
+        internal static string Error_InvalidAmountOfDataBreakpoints {
+            get {
+                return ResourceManager.GetString("Error_InvalidAmountOfDataBreakpoints", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to DNX runtime process exited unexpectedly with error code {0}..
         /// </summary>
         internal static string Error_LaunchFailedNoError {

--- a/src/OpenDebugAD7/AD7Resources.resx
+++ b/src/OpenDebugAD7/AD7Resources.resx
@@ -312,4 +312,7 @@
     <value>ERROR: '{0}' is an invalid exception condition. See https://aka.ms/VSCode-Cpp-ExceptionSettings for more information.</value>
     <comment>{0} is the exception condition</comment>
   </data>
+  <data name="Error_InvalidAmountOfDataBreakpoints" xml:space="preserve">
+    <value>You may have requested too many hardware breakpoints/watchpoints.</value>
+  </data>
 </root>

--- a/src/OpenDebugAD7/AD7Resources.resx
+++ b/src/OpenDebugAD7/AD7Resources.resx
@@ -312,7 +312,4 @@
     <value>ERROR: '{0}' is an invalid exception condition. See https://aka.ms/VSCode-Cpp-ExceptionSettings for more information.</value>
     <comment>{0} is the exception condition</comment>
   </data>
-  <data name="Error_InvalidAmountOfDataBreakpoints" xml:space="preserve">
-    <value>You may have requested too many hardware breakpoints/watchpoints.</value>
-  </data>
 </root>

--- a/src/OpenDebugAD7/AD7Resources.resx
+++ b/src/OpenDebugAD7/AD7Resources.resx
@@ -327,4 +327,8 @@
   <data name="Error_ChildPropertyNotFound" xml:space="preserve">
     <value>Unable to find child property.</value>
   </data>
+  <data name="Error_InvalidDataBreakpoint" xml:space="preserve">
+    <value>Unable to set data breakpoint: {0}</value>
+    <comment>{0} is the reason</comment>
+  </data>
 </root>

--- a/src/OpenDebugAD7/AD7Resources.resx
+++ b/src/OpenDebugAD7/AD7Resources.resx
@@ -312,4 +312,19 @@
     <value>ERROR: '{0}' is an invalid exception condition. See https://aka.ms/VSCode-Cpp-ExceptionSettings for more information.</value>
     <comment>{0} is the exception condition</comment>
   </data>
+  <data name="Error_DataBreakpointInfoFail" xml:space="preserve">
+    <value>Unable to get info for data breakpoint. {0}</value>
+    <comment>{0} is the reason (could be exception condition)</comment>
+  </data>
+  <data name="Error_NoParentObject" xml:space="preserve">
+    <value>Unable to get parent object: No scope or variable found.</value>
+    <comment>{0} is a number, {1} is the property name</comment>
+  </data>
+  <data name="DataBreakpointDisplayString" xml:space="preserve">
+    <value>When '{0}' changes ({1} bytes)</value>
+    <comment>{0} is the variable name, {1} is a number (size of the variable)</comment>
+  </data>
+  <data name="Error_ChildPropertyNotFound" xml:space="preserve">
+    <value>Unable to find child property.</value>
+  </data>
 </root>

--- a/src/OpenDebugAD7/VariableManager.cs
+++ b/src/OpenDebugAD7/VariableManager.cs
@@ -77,22 +77,14 @@ namespace OpenDebugAD7
             return m_variableHandles.Create(scope);
         }
 
-        public void AddChildVariable(int parentHandle, IDebugProperty2 prop)
+        public void AddChildVariable(int parentHandle, DEBUG_PROPERTY_INFO propInfo)
         {
-            var propInfo = new DEBUG_PROPERTY_INFO[1];
-            prop.GetPropertyInfo(enum_DEBUGPROP_INFO_FLAGS.DEBUGPROP_INFO_NAME, Constants.EvaluationRadix, Constants.EvaluationTimeout, null, 0, propInfo);
-            string name = propInfo[0].bstrName;
-
-            m_variablesChildren.Add(Tuple.Create(parentHandle, name), prop);
+            m_variablesChildren.Add(Tuple.Create(parentHandle, propInfo.bstrName), propInfo.pProperty);
         }
 
-        public void AddFrameVariable(IDebugStackFrame2 frame, IDebugProperty2 prop)
+        public void AddFrameVariable(IDebugStackFrame2 frame, DEBUG_PROPERTY_INFO propInfo)
         {
-            var propInfo = new DEBUG_PROPERTY_INFO[1];
-            prop.GetPropertyInfo(enum_DEBUGPROP_INFO_FLAGS.DEBUGPROP_INFO_NAME, Constants.EvaluationRadix, Constants.EvaluationTimeout, null, 0, propInfo);
-            string name = propInfo[0].bstrName;
-
-            m_framesVariables.Add(Tuple.Create(frame, name), prop);
+            m_framesVariables.Add(Tuple.Create(frame, propInfo.bstrName), propInfo.pProperty);
         }
 
         internal Variable CreateVariable(IDebugProperty2 property, enum_DEBUGPROP_INFO_FLAGS propertyInfoFlags)

--- a/src/OpenDebugAD7/VariableManager.cs
+++ b/src/OpenDebugAD7/VariableManager.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
+using System.Collections.Generic;
 using Microsoft.DebugEngineHost.VSCode;
 using Microsoft.VisualStudio.Debugger.Interop;
 using Microsoft.VisualStudio.Shared.VSCodeDebugProtocol.Messages;
@@ -31,19 +32,39 @@ namespace OpenDebugAD7
         // NOTE: The value being stored can be a VariableScope or a VariableEvaluationData
         private readonly HandleCollection<Object> m_variableHandles;
 
+        // NOTE: (VariableReference, ChildName) -> IDebugProperty2
+        private readonly Dictionary<Tuple<int, string>, IDebugProperty2> m_variablesChildren;
+
+        // NOTE: (Frame, Name) -> IDebugProperty2
+        private readonly Dictionary<Tuple<IDebugStackFrame2, string>, IDebugProperty2> m_framesVariables;
+
         internal VariableManager()
         {
             m_variableHandles = new HandleCollection<Object>();
+            m_variablesChildren = new Dictionary<Tuple<int, string>, IDebugProperty2>();
+            m_framesVariables = new Dictionary<Tuple<IDebugStackFrame2, string>, IDebugProperty2>();
         }
 
         internal void Reset()
         {
             m_variableHandles.Reset();
+            m_variablesChildren.Clear();
+            m_framesVariables.Clear();
         }
 
         internal Boolean IsEmpty()
         {
             return m_variableHandles.IsEmpty;
+        }
+
+        internal bool TryGetProperty((int, string) key, out IDebugProperty2 prop)
+        {
+            return m_variablesChildren.TryGetValue(Tuple.Create(key.Item1, key.Item2), out prop);
+        }
+
+        internal bool TryGetProperty((IDebugStackFrame2, string) key, out IDebugProperty2 prop)
+        {
+            return m_framesVariables.TryGetValue(Tuple.Create(key.Item1, key.Item2), out prop);
         }
 
         internal bool TryGet(int handle, out object value)
@@ -54,6 +75,24 @@ namespace OpenDebugAD7
         internal int Create(VariableScope scope)
         {
             return m_variableHandles.Create(scope);
+        }
+
+        public void AddChildVariable(int parentHandle, IDebugProperty2 prop)
+        {
+            var propInfo = new DEBUG_PROPERTY_INFO[1];
+            prop.GetPropertyInfo(enum_DEBUGPROP_INFO_FLAGS.DEBUGPROP_INFO_NAME, Constants.EvaluationRadix, Constants.EvaluationTimeout, null, 0, propInfo);
+            string name = propInfo[0].bstrName;
+
+            m_variablesChildren.Add(Tuple.Create(parentHandle, name), prop);
+        }
+
+        public void AddFrameVariable(IDebugStackFrame2 frame, IDebugProperty2 prop)
+        {
+            var propInfo = new DEBUG_PROPERTY_INFO[1];
+            prop.GetPropertyInfo(enum_DEBUGPROP_INFO_FLAGS.DEBUGPROP_INFO_NAME, Constants.EvaluationRadix, Constants.EvaluationTimeout, null, 0, propInfo);
+            string name = propInfo[0].bstrName;
+
+            m_framesVariables.Add(Tuple.Create(frame, name), prop);
         }
 
         internal Variable CreateVariable(IDebugProperty2 property, enum_DEBUGPROP_INFO_FLAGS propertyInfoFlags)

--- a/src/OpenDebugAD7/cppdbg.ad7Engine.json
+++ b/src/OpenDebugAD7/cppdbg.ad7Engine.json
@@ -3,6 +3,7 @@
   "engineClassName": "Microsoft.MIDebugEngine.AD7Engine",
   "conditionalBP": true,
   "functionBP": true,
+  "dataBP": true,
   "clipboardContext": true,
   "exceptionSettings": {
     "categories": [


### PR DESCRIPTION
This PR implements `DataBreakpointInfo` and `SetDataBreakpoints` for OpenDebugAD7's debug session as a part of the [Debug Adapter Protocol (DAP)](https://microsoft.github.io/debug-adapter-protocol/specification).

Notes:
1. Refactors most of `HandleEvaluateRequestAsync` into a `TryEvaluate` function that `DataBreakpointInfo` can use for evaluating a variable to find it's address/size (gotten via `IDebugProperty160.GetDataBreakpointInfo160`).
2. Makes `AD7Property.EnumChildren` support filtering with the child's name (specified [here with pszNameFilter](https://docs.microsoft.com/en-us/visualstudio/extensibility/debugger/reference/idebugproperty2-enumchildren?view=vs-2022))
3. Supports `BPLT_DATA_STRING` in `AD7BreakpointRequest` (returns the proper address/size).
4. The DataId passed to/from VS Code as part of both DAP functions is "{address},{size}"

Potential problems/things to improve:
1. If users have too many data breakpoints, then we receive an exception that GDB can't continue the debuggee process and we display a very mysterious error message: "Debugger was unable to continue the process."
2. If a variable size is too big to set a data breakpoint on, then we simply don't display the "Break When Value Changes" context menu item. It might be worthwhile in the future to say why it doesn't display.
3. Add test :)