### PR TITLE
Fix Windows Path check in MapCurrentSrcToCompileTimeSrc

### DIFF
--- a/src/MIDebugEngine/Engine.Impl/DebuggedProcess.cs
+++ b/src/MIDebugEngine/Engine.Impl/DebuggedProcess.cs
@@ -2248,7 +2248,7 @@ namespace Microsoft.MIDebugEngine
                             continue;   // match didn't end at a directory separator, not actually a match
                         }
                         compilerSrc = Path.Combine(e.CompileTimePath, file);    // map to the compiled location
-                        if (compilerSrc.IndexOf('\\') > 0)
+                        if (compilerSrc.IndexOf('\\') != -1)
                         {
                             compilerSrc = PlatformUtilities.WindowsPathToUnixPath(compilerSrc); // use Unix notation for the compiled path
                         }


### PR DESCRIPTION
If a user had `\\` at the start of their `compilerSrc` string, we would
incorrectly detect that the string does not contain any windows paths 
since IndexOf would return 0.

Docs from IndexOf:
> The zero-based index position of value if that character is found, or -1 if it is not

This PR fixes the IndexOf check to see if it returned `-1` instead of `> 0`

Related: https://github.com/microsoft/vscode-cpptools/issues/8696