### PR TITLE
Added extended-remote support

### DIFF
--- a/src/IOSDebugLauncher/Launcher.cs
+++ b/src/IOSDebugLauncher/Launcher.cs
@@ -115,7 +115,7 @@ namespace IOSDebugLauncher
                 fileCommand = string.Format(CultureInfo.InvariantCulture, "-file-exec-and-symbols \"{0}\" -p ios-simulator", _launchOptions.ExePath);
             }
 
-            string targetCommand = string.Format(CultureInfo.InvariantCulture, "-target-select remote localhost:{0}", _remotePorts.IDeviceDebugServerProxyPort.ToString(CultureInfo.InvariantCulture));
+            string targetCommand = string.Format(CultureInfo.InvariantCulture, "-target-select extended-remote localhost:{0}", _remotePorts.IDeviceDebugServerProxyPort.ToString(CultureInfo.InvariantCulture));
             string breakInMainCommand = string.Format(CultureInfo.InvariantCulture, "-break-insert main");
 
             commands.Add(new LaunchCommand(fileCommand, LauncherResources.DefinePlatform));

--- a/src/IOSDebugLauncher/Launcher.cs
+++ b/src/IOSDebugLauncher/Launcher.cs
@@ -92,7 +92,7 @@ namespace IOSDebugLauncher
                     return _client.ServerCertificateValidationCallback(sender, (X509Certificate)certificate, (X509Chain)chain, sslPolicyErrors);
                 };
             }
-            
+
             debuggerLaunchOptions.TargetArchitecture = _launchOptions.TargetArchitecture;
             debuggerLaunchOptions.AdditionalSOLibSearchPath = _launchOptions.AdditionalSOLibSearchPath;
             debuggerLaunchOptions.DebuggerMIMode = MIMode.Lldb;
@@ -115,7 +115,7 @@ namespace IOSDebugLauncher
                 fileCommand = string.Format(CultureInfo.InvariantCulture, "-file-exec-and-symbols \"{0}\" -p ios-simulator", _launchOptions.ExePath);
             }
 
-            string targetCommand = string.Format(CultureInfo.InvariantCulture, "-target-select extended-remote localhost:{0}", _remotePorts.IDeviceDebugServerProxyPort.ToString(CultureInfo.InvariantCulture));
+            string targetCommand = string.Format(CultureInfo.InvariantCulture, "-target-select remote localhost:{0}", _remotePorts.IDeviceDebugServerProxyPort.ToString(CultureInfo.InvariantCulture));
             string breakInMainCommand = string.Format(CultureInfo.InvariantCulture, "-break-insert main");
 
             commands.Add(new LaunchCommand(fileCommand, LauncherResources.DefinePlatform));

--- a/src/MICore/JsonLaunchOptions.cs
+++ b/src/MICore/JsonLaunchOptions.cs
@@ -73,6 +73,12 @@ namespace MICore.Json.LaunchOptions
         public string MiDebuggerServerAddress { get; set; }
 
         /// <summary>
+        /// If true, use gdb extended-remote mode to connect to gdbserver.
+        /// </summary>
+        [JsonProperty("useExtendedRemote", DefaultValueHandling = DefaultValueHandling.Ignore)]
+        public bool? UseExtendedRemote { get; set; }
+
+        /// <summary>
         /// Optional source file mappings passed to the debug engine. Example: '{ "/original/source/path":"/current/source/path" }'
         /// </summary>
         [JsonProperty("sourceFileMap", DefaultValueHandling = DefaultValueHandling.Ignore)]
@@ -137,6 +143,7 @@ namespace MICore.Json.LaunchOptions
             string miDebuggerPath = null,
             string miDebuggerArgs = null,
             string miDebuggerServerAddress = null,
+            bool? useExtendedRemote = null,
             HardwareBreakpointInfo hardwareBreakpointInfo = null,
             Dictionary<string, object> sourceFileMap = null,
             PipeTransport pipeTransport = null,
@@ -152,6 +159,7 @@ namespace MICore.Json.LaunchOptions
             this.MiDebuggerPath = miDebuggerPath;
             this.MiDebuggerArgs = miDebuggerArgs;
             this.MiDebuggerServerAddress = miDebuggerServerAddress;
+            this.UseExtendedRemote = useExtendedRemote;
             this.ProcessId = processId;
             this.HardwareBreakpointInfo = hardwareBreakpointInfo;
             this.SourceFileMap = sourceFileMap;
@@ -390,6 +398,7 @@ namespace MICore.Json.LaunchOptions
             string miDebuggerPath = null,
             string miDebuggerArgs = null,
             string miDebuggerServerAddress = null,
+            bool? useExtendedRemote = null,
             bool? stopAtEntry = null,
             string debugServerPath = null,
             string debugServerArgs = null,
@@ -421,6 +430,7 @@ namespace MICore.Json.LaunchOptions
             this.MiDebuggerPath = miDebuggerPath;
             this.MiDebuggerArgs = miDebuggerArgs;
             this.MiDebuggerServerAddress = miDebuggerServerAddress;
+            this.UseExtendedRemote = useExtendedRemote;
             this.StopAtEntry = stopAtEntry;
             this.DebugServerPath = debugServerPath;
             this.DebugServerArgs = debugServerArgs;

--- a/src/MICore/LaunchOptions.cs
+++ b/src/MICore/LaunchOptions.cs
@@ -443,6 +443,18 @@ namespace MICore
             this.MIDebuggerArgs = MIDebuggerArgs;
         }
 
+        public LocalLaunchOptions(string MIDebuggerPath, string MIDebuggerServerAddress, bool UseExtendedRemote) :
+            this(MIDebuggerPath, MIDebuggerServerAddress)
+        {
+            this.UseExtendedRemote = UseExtendedRemote;
+        }
+
+        public LocalLaunchOptions(string MIDebuggerPath, string MIDebuggerServerAddress, string MIDebuggerArgs, bool UseExtendedRemote) :
+            this(MIDebuggerPath, MIDebuggerServerAddress, MIDebuggerArgs)
+        {
+            this.UseExtendedRemote = UseExtendedRemote;
+        }
+
         private void InitializeServerOptions(Json.LaunchOptions.LaunchOptions launchOptions)
         {
             if (!String.IsNullOrWhiteSpace(launchOptions.DebugServerPath))
@@ -533,7 +545,8 @@ namespace MICore
 
             LocalLaunchOptions localLaunchOptions = new LocalLaunchOptions(RequireAttribute(miDebuggerPath, nameof(miDebuggerPath)),
                 launchOptions.MiDebuggerServerAddress,
-                launchOptions.MiDebuggerArgs
+                launchOptions.MiDebuggerArgs,
+                launchOptions.UseExtendedRemote.GetValueOrDefault(false)
                 );
 
             // Load up common options
@@ -561,7 +574,8 @@ namespace MICore
             var options = new LocalLaunchOptions(
                 RequireAttribute(miDebuggerPath, "MIDebuggerPath"),
                 source.MIDebuggerServerAddress,
-                source.MIDebuggerArgs);
+                source.MIDebuggerArgs,
+                source.UseExtendedRemote);
             options.InitializeCommonOptions(source);
             options.InitializeServerOptions(source);
             options._useExternalConsole = source.ExternalConsole;
@@ -665,6 +679,11 @@ namespace MICore
         /// [Optional] Server address that MI Debugger server is listening to
         /// </summary>
         public string MIDebuggerServerAddress { get; private set; }
+
+        /// <summary>
+        /// [Optional] If true, use gdb extended-remote mode to connect to gdbserver.
+        /// </summary>
+        public bool UseExtendedRemote { get; private set; }
 
         /// <summary>
         /// [Optional] MI Debugger Server exe, if non-null then the MIEngine will start the debug server before starting the debugger

--- a/src/MICore/LaunchOptions.xsd
+++ b/src/MICore/LaunchOptions.xsd
@@ -230,6 +230,11 @@
               <xs:documentation>Network address of the MI Debugger Server to connect to (example: localhost:1234).</xs:documentation>
             </xs:annotation>
           </xs:attribute>
+          <xs:attribute name="UseExtendedRemote" type="xs:boolean" use="optional">
+            <xs:annotation>
+              <xs:documentation>If true, use gdb extended-remote mode to connect to gdbserver.</xs:documentation>
+            </xs:annotation>
+          </xs:attribute>
           <xs:attribute name="DebugServer" type="xs:string" use="optional">
             <xs:annotation>
               <xs:documentation>Full path to the server executable. If non-null then the MIEngine will start the server.</xs:documentation>

--- a/src/MICore/LaunchOptions.xsd.types.designer.cs
+++ b/src/MICore/LaunchOptions.xsd.types.designer.cs
@@ -575,7 +575,11 @@ namespace MICore.Xml.LaunchOptions {
         /// <remarks/>
         [System.Xml.Serialization.XmlAttributeAttribute()]
         public string MIDebuggerServerAddress;
-        
+
+        /// <remarks/>
+        [System.Xml.Serialization.XmlAttributeAttribute()]
+        public bool UseExtendedRemote;
+
         /// <remarks/>
         [System.Xml.Serialization.XmlAttributeAttribute()]
         public string DebugServer;

--- a/src/MIDebugEngine/Engine.Impl/DebuggedProcess.cs
+++ b/src/MIDebugEngine/Engine.Impl/DebuggedProcess.cs
@@ -735,25 +735,21 @@ namespace Microsoft.MIDebugEngine
                     // Allow attach after connection only in extended-remote mode
                     if (useExtendedRemote || (!useExtendedRemote && string.IsNullOrWhiteSpace(destination)))
                     {
-                        string processId = localLaunchOptions?.ProcessId.Value.ToString(CultureInfo.InvariantCulture);
-                        if (!string.IsNullOrWhiteSpace(processId))
+                        Action<string> failureHandler = (string miError) =>
                         {
-                            Action<string> failureHandler = (string miError) =>
+                            if (miError.Trim().StartsWith("ptrace:", StringComparison.OrdinalIgnoreCase))
                             {
-                                if (miError.Trim().StartsWith("ptrace:", StringComparison.OrdinalIgnoreCase))
-                                {
-                                    string message = string.Format(CultureInfo.CurrentCulture, ResourceStrings.Error_PTraceFailure, _launchOptions.ProcessId, MICommandFactory.Name, miError);
-                                    throw new LaunchErrorException(message);
-                                }
-                                else
-                                {
-                                    string message = string.Format(CultureInfo.CurrentCulture, ResourceStrings.Error_ExePathInvalid, _launchOptions.ExePath, MICommandFactory.Name, miError);
-                                    throw new LaunchErrorException(message);
-                                }
-                            };
+                                string message = string.Format(CultureInfo.CurrentCulture, ResourceStrings.Error_PTraceFailure, _launchOptions.ProcessId, MICommandFactory.Name, miError);
+                                throw new LaunchErrorException(message);
+                            }
+                            else
+                            {
+                                string message = string.Format(CultureInfo.CurrentCulture, ResourceStrings.Error_ExePathInvalid, _launchOptions.ExePath, MICommandFactory.Name, miError);
+                                throw new LaunchErrorException(message);
+                            }
+                        };
 
-                            commands.Add(new LaunchCommand("-target-attach " + processId, ignoreFailures: false, failureHandler: failureHandler));
-                        }
+                        commands.Add(new LaunchCommand("-target-attach " + _launchOptions.ProcessId.Value.ToString(CultureInfo.InvariantCulture), ignoreFailures: false, failureHandler: failureHandler));
                     }
 
                     if (_launchOptions.PostRemoteConnectCommands != null) 

--- a/src/MIDebugEngine/Engine.Impl/DebuggedProcess.cs
+++ b/src/MIDebugEngine/Engine.Impl/DebuggedProcess.cs
@@ -728,9 +728,11 @@ namespace Microsoft.MIDebugEngine
                     string destination = localLaunchOptions?.MIDebuggerServerAddress;
                     if (!string.IsNullOrWhiteSpace(destination))
                     {
-                        commands.Add(new LaunchCommand("-target-select remote " + destination, string.Format(CultureInfo.CurrentCulture, ResourceStrings.ConnectingMessage, destination)));
+                        commands.Add(new LaunchCommand("-target-select extended-remote " + destination, string.Format(CultureInfo.CurrentCulture, ResourceStrings.ConnectingMessage, destination)));
                     }
-                    else // gdbserver is already attached when using LocalLaunchOptions
+
+                    string processId = localLaunchOptions?.ProcessId.Value.ToString(CultureInfo.InvariantCulture);
+                    if (!string.IsNullOrWhiteSpace(processId))
                     {
                         Action<string> failureHandler = (string miError) =>
                         {
@@ -746,7 +748,7 @@ namespace Microsoft.MIDebugEngine
                             }
                         };
 
-                        commands.Add(new LaunchCommand("-target-attach " + _launchOptions.ProcessId.Value.ToString(CultureInfo.InvariantCulture), ignoreFailures: false, failureHandler: failureHandler));
+                        commands.Add(new LaunchCommand("-target-attach " + processId, ignoreFailures: false, failureHandler: failureHandler));
                     }
 
                     if (_launchOptions.PostRemoteConnectCommands != null) 
@@ -831,7 +833,7 @@ namespace Microsoft.MIDebugEngine
                         string destination = localLaunchOptions.MIDebuggerServerAddress;
                         if (!string.IsNullOrWhiteSpace(destination))
                         {
-                            commands.Add(new LaunchCommand("-target-select remote " + destination, string.Format(CultureInfo.CurrentCulture, ResourceStrings.ConnectingMessage, destination)));
+                            commands.Add(new LaunchCommand("-target-select extended-remote " + destination, string.Format(CultureInfo.CurrentCulture, ResourceStrings.ConnectingMessage, destination)));
                             if (localLaunchOptions.RequireHardwareBreakpoints && localLaunchOptions.HardwareBreakpointLimit > 0) {
                                 commands.Add(new LaunchCommand(string.Format(CultureInfo.InvariantCulture, "-interpreter-exec console \"set remote hardware-breakpoint-limit {0}\"", localLaunchOptions.HardwareBreakpointLimit.ToString(CultureInfo.InvariantCulture))));
                             }

--- a/src/MIDebugPackage/OpenFolderSchema.json
+++ b/src/MIDebugPackage/OpenFolderSchema.json
@@ -113,6 +113,10 @@
                 "type": "string",
                 "description": "Network address of the MI-enabled debugger server to connect to. \nExample: localhost:1234."
               },
+              "useExtendedRemote": {
+                "type": "boolean",
+                "description": "If true, use gdb extended-remote mode to connect to gdbserver."
+              },
               "setupCommands": {
                 "type": "array",
                 "description": "One or more GDB/LLDB commands to execute in order to setup the underlying debugger. \nExample: \"setupCommands\": [ { \"text\": \"-enable-pretty-printing\", \"description\": \"Enable GDB pretty printing\", \"ignoreFailures\": true }].",

--- a/src/OpenDebugAD7/AD7DebugSession.cs
+++ b/src/OpenDebugAD7/AD7DebugSession.cs
@@ -1129,6 +1129,7 @@ namespace OpenDebugAD7
             bool isPipeTransport = (pipeTransport != null);
             bool isLocal = string.IsNullOrEmpty(miDebuggerServerAddress) && !isPipeTransport;
             string mimode = responder.Arguments.ConfigurationProperties.GetValueAsString("MIMode");
+            bool useExtendedRemote = responder.Arguments.ConfigurationProperties.GetValueAsBool("useExtendedRemote").GetValueOrDefault(false);
 
             if (isLocal)
             {
@@ -1142,7 +1143,12 @@ namespace OpenDebugAD7
             {
                 string propertyCausingRemote = !string.IsNullOrEmpty(miDebuggerServerAddress) ? "miDebuggerServerAddress" : "pipeTransport";
 
-                if (isPipeTransport && (string.IsNullOrEmpty(processId) || string.IsNullOrEmpty(pipeTransport.GetValueAsString("debuggerPath"))))
+                if (!string.IsNullOrEmpty(miDebuggerServerAddress) && !string.IsNullOrEmpty(processId) && !useExtendedRemote)
+                {
+                    responder.SetError(CreateProtocolExceptionAndLogTelemetry(telemetryEventName, 1002, "attach: 'useExtendedRemote' needs to be set to true when 'processId' is used with " + propertyCausingRemote));
+                    return;
+                }
+                else if (isPipeTransport && (string.IsNullOrEmpty(processId) || string.IsNullOrEmpty(pipeTransport.GetValueAsString("debuggerPath"))))
                 {
                     responder.SetError(CreateProtocolExceptionAndLogTelemetry(telemetryEventName, 1001, "attach: properties 'processId' and 'debuggerPath' needs to be specified with " + propertyCausingRemote));
                     return;

--- a/src/OpenDebugAD7/AD7DebugSession.cs
+++ b/src/OpenDebugAD7/AD7DebugSession.cs
@@ -1142,12 +1142,7 @@ namespace OpenDebugAD7
             {
                 string propertyCausingRemote = !string.IsNullOrEmpty(miDebuggerServerAddress) ? "miDebuggerServerAddress" : "pipeTransport";
 
-                if (!string.IsNullOrEmpty(miDebuggerServerAddress) && !string.IsNullOrEmpty(processId))
-                {
-                    responder.SetError(CreateProtocolExceptionAndLogTelemetry(telemetryEventName, 1002, "attach: 'processId' cannot be used with " + propertyCausingRemote));
-                    return;
-                }
-                else if (isPipeTransport && (string.IsNullOrEmpty(processId) || string.IsNullOrEmpty(pipeTransport.GetValueAsString("debuggerPath"))))
+                if (isPipeTransport && (string.IsNullOrEmpty(processId) || string.IsNullOrEmpty(pipeTransport.GetValueAsString("debuggerPath"))))
                 {
                     responder.SetError(CreateProtocolExceptionAndLogTelemetry(telemetryEventName, 1001, "attach: properties 'processId' and 'debuggerPath' needs to be specified with " + propertyCausingRemote));
                     return;


### PR DESCRIPTION
As discussed in https://github.com/microsoft/vscode-cpptools/issues/8497, this PR introduces a way to attach to a process after making remote connection.

A launch option field "useExtendedRemote" is added, which when being set to true, extended-remote mode will be used.

A known limitation is we can't guarantee the specified PID exists. We'll probably need to add a remote process picker in the future.