### PR TITLE
Fix for duplicate variable names causing debugging crash

### DIFF
--- a/src/OpenDebugAD7/VariableManager.cs
+++ b/src/OpenDebugAD7/VariableManager.cs
@@ -79,24 +79,13 @@ namespace OpenDebugAD7
 
         public void AddChildVariable(int parentHandle, DEBUG_PROPERTY_INFO propInfo)
         {
-            try
-            {
-                m_variablesChildren.Add(Tuple.Create(parentHandle, propInfo.bstrName), propInfo.pProperty);
-            }
-            catch (Exception ex)
-            {
-            }
+            m_variablesChildren.TryAdd(Tuple.Create(parentHandle, propInfo.bstrName), propInfo.pProperty);
         }
 
         public void AddFrameVariable(IDebugStackFrame2 frame, DEBUG_PROPERTY_INFO propInfo)
         {
-            try
-            {
-                m_framesVariables.Add(Tuple.Create(frame, propInfo.bstrName), propInfo.pProperty);
-            }
-            catch (Exception ex)
-            {
-            }
+
+            m_framesVariables.TryAdd(Tuple.Create(frame, propInfo.bstrName), propInfo.pProperty);
         }
 
         internal Variable CreateVariable(IDebugProperty2 property, enum_DEBUGPROP_INFO_FLAGS propertyInfoFlags)

--- a/src/OpenDebugAD7/VariableManager.cs
+++ b/src/OpenDebugAD7/VariableManager.cs
@@ -79,12 +79,24 @@ namespace OpenDebugAD7
 
         public void AddChildVariable(int parentHandle, DEBUG_PROPERTY_INFO propInfo)
         {
-            m_variablesChildren.Add(Tuple.Create(parentHandle, propInfo.bstrName), propInfo.pProperty);
+            try
+            {
+                m_variablesChildren.Add(Tuple.Create(parentHandle, propInfo.bstrName), propInfo.pProperty);
+            }
+            catch (Exception ex)
+            {
+            }
         }
 
         public void AddFrameVariable(IDebugStackFrame2 frame, DEBUG_PROPERTY_INFO propInfo)
         {
-            m_framesVariables.Add(Tuple.Create(frame, propInfo.bstrName), propInfo.pProperty);
+            try
+            {
+                m_framesVariables.Add(Tuple.Create(frame, propInfo.bstrName), propInfo.pProperty);
+            }
+            catch (Exception ex)
+            {
+            }
         }
 
         internal Variable CreateVariable(IDebugProperty2 property, enum_DEBUGPROP_INFO_FLAGS propertyInfoFlags)

--- a/src/OpenDebugAD7/VariableManager.cs
+++ b/src/OpenDebugAD7/VariableManager.cs
@@ -84,7 +84,6 @@ namespace OpenDebugAD7
 
         public void AddFrameVariable(IDebugStackFrame2 frame, DEBUG_PROPERTY_INFO propInfo)
         {
-
             m_framesVariables.TryAdd(Tuple.Create(frame, propInfo.bstrName), propInfo.pProperty);
         }
 


### PR DESCRIPTION
Issue: https://github.com/microsoft/vscode-cpptools/issues/8760

I didn't account for multiple variables with the same name in the same stack frame. This converts the VariableManager's cache methods to use Dictionary.TryAdd().

This does introduce a new bug: If you set a data breakpoint on a variable with the same name as another in the same stack frame, then it _could_ be set on the other variable instead of the one you've selected. This is a very small bug that requires us to either:

1. Not allow data breakpoints on variables where they share a name with another variable in the same frame.
2. Tweak VS Code to send us something more descriptive than just the variable name in a DataBreakpointInfo request.