### PR TITLE
Support vaguely named variables in VariableManager's cache

### DIFF
--- a/src/OpenDebugAD7/VariableManager.cs
+++ b/src/OpenDebugAD7/VariableManager.cs
@@ -35,7 +35,7 @@ namespace OpenDebugAD7
         // NOTE: ((VariablesReference | IDebugStackFrame2), Name) -> IDebugProperty2
         private readonly Dictionary<Tuple<object, string>, IDebugProperty2> m_variableProperties;
 
-        public static string VariableNameFormat = "{0} #{1}";
+        public const string VariableNameFormat = "{0} #{1}";
 
         internal VariableManager()
         {

--- a/src/OpenDebugAD7/VariableManager.cs
+++ b/src/OpenDebugAD7/VariableManager.cs
@@ -32,24 +32,21 @@ namespace OpenDebugAD7
         // NOTE: The value being stored can be a VariableScope or a VariableEvaluationData
         private readonly HandleCollection<Object> m_variableHandles;
 
-        // NOTE: (VariableReference, ChildName) -> IDebugProperty2
-        private readonly Dictionary<Tuple<int, string>, IDebugProperty2> m_variablesChildren;
+        // NOTE: ((VariablesReference | IDebugStackFrame2), Name) -> IDebugProperty2
+        private readonly Dictionary<Tuple<object, string>, IDebugProperty2> m_variableProperties;
 
-        // NOTE: (Frame, Name) -> IDebugProperty2
-        private readonly Dictionary<Tuple<IDebugStackFrame2, string>, IDebugProperty2> m_framesVariables;
+        public static string VariableNameFormat = "{0} #{1}";
 
         internal VariableManager()
         {
             m_variableHandles = new HandleCollection<Object>();
-            m_variablesChildren = new Dictionary<Tuple<int, string>, IDebugProperty2>();
-            m_framesVariables = new Dictionary<Tuple<IDebugStackFrame2, string>, IDebugProperty2>();
+            m_variableProperties = new Dictionary<Tuple<object, string>, IDebugProperty2>();
         }
 
         internal void Reset()
         {
             m_variableHandles.Reset();
-            m_variablesChildren.Clear();
-            m_framesVariables.Clear();
+            m_variableProperties.Clear();
         }
 
         internal Boolean IsEmpty()
@@ -57,14 +54,9 @@ namespace OpenDebugAD7
             return m_variableHandles.IsEmpty;
         }
 
-        internal bool TryGetProperty((int, string) key, out IDebugProperty2 prop)
+        internal bool TryGetProperty((object, string) key, out IDebugProperty2 prop)
         {
-            return m_variablesChildren.TryGetValue(Tuple.Create(key.Item1, key.Item2), out prop);
-        }
-
-        internal bool TryGetProperty((IDebugStackFrame2, string) key, out IDebugProperty2 prop)
-        {
-            return m_framesVariables.TryGetValue(Tuple.Create(key.Item1, key.Item2), out prop);
+            return m_variableProperties.TryGetValue(Tuple.Create(key.Item1, key.Item2), out prop);
         }
 
         internal bool TryGet(int handle, out object value)
@@ -77,14 +69,9 @@ namespace OpenDebugAD7
             return m_variableHandles.Create(scope);
         }
 
-        public void AddChildVariable(int parentHandle, DEBUG_PROPERTY_INFO propInfo)
+        public void AddVariableProperty((object, string) key, IDebugProperty2 prop)
         {
-            m_variablesChildren.TryAdd(Tuple.Create(parentHandle, propInfo.bstrName), propInfo.pProperty);
-        }
-
-        public void AddFrameVariable(IDebugStackFrame2 frame, DEBUG_PROPERTY_INFO propInfo)
-        {
-            m_framesVariables.TryAdd(Tuple.Create(frame, propInfo.bstrName), propInfo.pProperty);
+            m_variableProperties[Tuple.Create(key.Item1, key.Item2)] = prop;
         }
 
         internal Variable CreateVariable(IDebugProperty2 property, enum_DEBUGPROP_INFO_FLAGS propertyInfoFlags)


### PR DESCRIPTION
Better fix for https://github.com/microsoft/vscode-cpptools/issues/8760

Improves on https://github.com/microsoft/MIEngine/pull/1271 by storing duplicate variable names as "{name} #{uniqueNumber}".

So, if you have 2 variables named `a`, you would get `a` and `a #2` in the variables window.

![image](https://user-images.githubusercontent.com/10853283/152408173-7a5941db-4e01-41d7-bcc8-3a4a0241a755.png)

This also simplifies VariableManager's cache into one dictionary.
