### PR TITLE
Close pipeTransport writer on close

### DIFF
--- a/src/MICore/Transports/PipeTransport.cs
+++ b/src/MICore/Transports/PipeTransport.cs
@@ -158,6 +158,12 @@ namespace MICore
 
         public override void Close()
         {
+            if (_process != null)
+            {
+                _process.EnableRaisingEvents = false;
+                _process.Exited -= OnProcessExit;
+            }
+
             if (_writer != null)
             {
                 try
@@ -183,8 +189,6 @@ namespace MICore
 
             if (_process != null)
             {
-                _process.EnableRaisingEvents = false;
-                _process.Exited -= OnProcessExit;
                 if (_killOnClose && !_process.HasExited)
                 {
                     try

--- a/src/MICore/Transports/PipeTransport.cs
+++ b/src/MICore/Transports/PipeTransport.cs
@@ -168,6 +168,8 @@ namespace MICore
                 {
                     // Ignore errors if logout couldn't be written
                 }
+
+                _writer.Close();
             }
 
             base.Close();

--- a/src/MICore/Transports/PipeTransport.cs
+++ b/src/MICore/Transports/PipeTransport.cs
@@ -175,7 +175,14 @@ namespace MICore
                     // Ignore errors if logout couldn't be written
                 }
 
-                _writer.Close();
+                try
+                {
+                    _writer.Close();
+                }
+                catch (IOException)
+                {
+                    // There are IO Issues with the writer, ignore since its shutting down.
+                }
             }
 
             base.Close();


### PR DESCRIPTION
This PR adds `_writer.Close()` for pipeTransport when it is being
disposed. This ensures that the pipeProgram can read that the pipe has
closed and should terminate.