### PR TITLE
Visual Studio: add support for custom UI visualizers

### DIFF
--- a/IL/Microsoft.Internal.VisualStudio.Interop.il
+++ b/IL/Microsoft.Internal.VisualStudio.Interop.il
@@ -918,4 +918,64 @@
 			.get instance class [mscorlib]System.Array Microsoft.Internal.VisualStudio.Shell.Interop.IVsTelemetryPropertyBag::get_AllPropertyNames()
 		}
 	}
+	.class public interface abstract import IVsExtensionManagerPrivate
+	{
+		.custom instance void [mscorlib]System.Runtime.InteropServices.GuidAttribute::.ctor(string) = { string('753E55C6-E779-4A7A-BCD1-FD87181D52C0') }
+		.custom instance void [mscorlib]System.Runtime.InteropServices.InterfaceTypeAttribute::.ctor(valuetype [mscorlib]System.Runtime.InteropServices.ComInterfaceType) = { int32(1) }
+		.method public virtual hidebysig newslot abstract 
+			instance int32 GetEnabledExtensionContentLocations([in] string marshal(lpwstr) szContentTypeName, [in] uint32 cContentLocations, [out] string[] marshal(bstr[ + 1]) rgbstrContentLocations, [out] string[] marshal(bstr[ + 1]) rgbstrUniqueExtensionStrings, [out] uint32& pcContentLocations)
+			preservesig internalcall 
+		{
+			.param [1]
+			.custom instance void [mscorlib]System.Runtime.InteropServices.ComAliasNameAttribute::.ctor(string) = { string('OLE.LPCWSTR') }
+			.param [2]
+			.custom instance void [mscorlib]System.Runtime.InteropServices.ComAliasNameAttribute::.ctor(string) = { string('OLE.ULONG') }
+			.param [5]
+			.custom instance void [mscorlib]System.Runtime.InteropServices.ComAliasNameAttribute::.ctor(string) = { string('OLE.ULONG') }
+		}
+		.method public virtual hidebysig newslot abstract 
+			instance int32 GetEnabledExtensionContentLocationsWithNames([in] string marshal(lpwstr) szContentTypeName, [in] uint32 cContentLocations, [out] string[] marshal(bstr[ + 1]) rgbstrContentLocations, [out] string[] marshal(bstr[ + 1]) rgbstrUniqueExtensionStrings, [out] string[] marshal(bstr[ + 1]) rgbstrExtensionNames, [out] uint32& pcContentLocations)
+			preservesig internalcall 
+		{
+			.param [1]
+			.custom instance void [mscorlib]System.Runtime.InteropServices.ComAliasNameAttribute::.ctor(string) = { string('OLE.LPCWSTR') }
+			.param [2]
+			.custom instance void [mscorlib]System.Runtime.InteropServices.ComAliasNameAttribute::.ctor(string) = { string('OLE.ULONG') }
+			.param [6]
+			.custom instance void [mscorlib]System.Runtime.InteropServices.ComAliasNameAttribute::.ctor(string) = { string('OLE.ULONG') }
+		}
+		.method public virtual hidebysig newslot abstract 
+			instance int32 GetDisabledExtensionContentLocations([in] string marshal(lpwstr) szContentTypeName, [in] uint32 cContentLocations, [out] string[] marshal(bstr[ + 1]) rgbstrContentLocations, [out] string[] marshal(bstr[ + 1]) rgbstrUniqueExtensionStrings, [out] uint32& pcContentLocations)
+			preservesig internalcall 
+		{
+			.param [1]
+			.custom instance void [mscorlib]System.Runtime.InteropServices.ComAliasNameAttribute::.ctor(string) = { string('OLE.LPCWSTR') }
+			.param [2]
+			.custom instance void [mscorlib]System.Runtime.InteropServices.ComAliasNameAttribute::.ctor(string) = { string('OLE.ULONG') }
+			.param [5]
+			.custom instance void [mscorlib]System.Runtime.InteropServices.ComAliasNameAttribute::.ctor(string) = { string('OLE.ULONG') }
+		}
+		.method public virtual hidebysig newslot abstract 
+			instance int32 GetLastConfigurationChange([out] valuetype [mscorlib]System.DateTime[] marshal([]) pTimestamp)
+			preservesig internalcall 
+		{
+		}
+		.method public virtual hidebysig newslot abstract 
+			instance int32 LogAllInstalledExtensions()
+			preservesig internalcall 
+		{
+		}
+		.method public virtual hidebysig newslot abstract 
+			instance int32 GetUniqueExtensionString([in] string marshal(lpwstr) szExtensionIdentifier, [out] string& marshal(bstr) pbstrUniqueString)
+			preservesig internalcall 
+		{
+			.param [1]
+			.custom instance void [mscorlib]System.Runtime.InteropServices.ComAliasNameAttribute::.ctor(string) = { string('OLE.LPCWSTR') }
+		}
+	}
+	.class public interface abstract import SVsExtensionManager
+	{
+		.custom instance void [mscorlib]System.Runtime.InteropServices.GuidAttribute::.ctor(string) = { string('316F4DE6-3CA4-4F0D-B003-962D28F65238') }
+		.custom instance void [mscorlib]System.Runtime.InteropServices.InterfaceTypeAttribute::.ctor(valuetype [mscorlib]System.Runtime.InteropServices.ComInterfaceType) = { int32(1) }
+	}
 }

--- a/src/DebugEngineHost.Stub/DebugEngineHost.ref.cs
+++ b/src/DebugEngineHost.Stub/DebugEngineHost.ref.cs
@@ -395,6 +395,16 @@ public sealed class HostLogger
         }
 
         /// <summary>
+        /// Searches the extension manager for natvis files, invoking the loader on any which are found.
+        /// </summary>
+        /// <param name="loader">Natvis loader method to invoke</param>
+        [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Naming", "CA1704:IdentifiersShouldBeSpelledCorrectly", MessageId = "Natvis")]
+        public static void FindNatvisInVSIX(NatvisLoader loader)
+        {
+            throw new NotImplementedException();
+        }
+
+        /// <summary>
         /// Return the solution's root directory, null if no solution
         /// </summary>
         public static string FindSolutionRoot()

--- a/src/DebugEngineHost.Stub/DebugEngineHost.ref.cs
+++ b/src/DebugEngineHost.Stub/DebugEngineHost.ref.cs
@@ -385,21 +385,11 @@ public sealed class HostLogger
         public delegate void NatvisLoader(string path);
 
         /// <summary>
-        /// Searches the solution for natvis files, invoking the loader on any which are found.
+        /// Searches the solution and VSIXs for natvis files, invoking the loader on any which are found.
         /// </summary>
         /// <param name="loader">Natvis loader method to invoke</param>
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Naming", "CA1704:IdentifiersShouldBeSpelledCorrectly", MessageId = "Natvis")]
-        public static void FindNatvisInSolution(NatvisLoader loader)
-        {
-            throw new NotImplementedException();
-        }
-
-        /// <summary>
-        /// Searches the extension manager for natvis files, invoking the loader on any which are found.
-        /// </summary>
-        /// <param name="loader">Natvis loader method to invoke</param>
-        [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Naming", "CA1704:IdentifiersShouldBeSpelledCorrectly", MessageId = "Natvis")]
-        public static void FindNatvisInVSIX(NatvisLoader loader)
+        public static void FindNatvis(NatvisLoader loader)
         {
             throw new NotImplementedException();
         }

--- a/src/DebugEngineHost.Stub/Shared/Microsoft.VisualStudio.Debugger.Interop.MI.cs
+++ b/src/DebugEngineHost.Stub/Shared/Microsoft.VisualStudio.Debugger.Interop.MI.cs
@@ -1,0 +1,24 @@
+﻿// // Copyright (c) Microsoft. All rights reserved.
+// // Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Runtime.InteropServices;
+
+namespace Microsoft.VisualStudio.Debugger.Interop.MI
+{
+    /// <summary>
+    /// IDebugProperty for MIEngine
+    /// </summary>
+    [ComImport()]
+    [ComVisible(true)]
+    [Guid("27F5EFAF-9DBA-4AC0-A456-1F97E50F3CDA")]
+    [InterfaceType(1)]
+    public interface IDebugMIEngineProperty
+    {
+        /// <summary> 
+        /// Get the expression context for the property
+        /// </summary>
+        [PreserveSig]
+        int GetExpressionContext([Out, MarshalAs(UnmanagedType.Interface)] out IDebugExpressionContext2 ppExpressionContext);
+    }
+}

--- a/src/DebugEngineHost.VSCode/DebugEngineHost.VSCode.csproj
+++ b/src/DebugEngineHost.VSCode/DebugEngineHost.VSCode.csproj
@@ -22,6 +22,7 @@
 
   <ItemGroup Label="Compile Shared Interfaces">
     <Compile Include="$(MIEngineRoot)\src\DebugEngineHost.Stub\Shared\Microsoft.VisualStudio.Debugger.Interop.DAP.cs" />
+    <Compile Include="..\DebugEngineHost.Stub\Shared\Microsoft.VisualStudio.Debugger.Interop.MI.cs" Link="Microsoft.VisualStudio.Debugger.Interop.MI.cs" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/DebugEngineHost.VSCode/HostNatvisProject.cs
+++ b/src/DebugEngineHost.VSCode/HostNatvisProject.cs
@@ -14,6 +14,11 @@ namespace Microsoft.DebugEngineHost
             // In-solution natvis is not supported for VS Code now, so do nothing.
         }
 
+        public static void FindNatvisInVSIX(NatvisLoader loader)
+        {
+            // VSIX natvis is not supported for VS Code now, so do nothing.
+        }
+
         public static string FindSolutionRoot()
         {
             // This was added in MIEngine to support breakpoint sourcefile mapping. 

--- a/src/DebugEngineHost.VSCode/HostNatvisProject.cs
+++ b/src/DebugEngineHost.VSCode/HostNatvisProject.cs
@@ -9,14 +9,9 @@ namespace Microsoft.DebugEngineHost
     {
         public delegate void NatvisLoader(string path);
 
-        public static void FindNatvisInSolution(NatvisLoader loader)
+        public static void FindNatvis(NatvisLoader loader)
         {
             // In-solution natvis is not supported for VS Code now, so do nothing.
-        }
-
-        public static void FindNatvisInVSIX(NatvisLoader loader)
-        {
-            // VSIX natvis is not supported for VS Code now, so do nothing.
         }
 
         public static string FindSolutionRoot()

--- a/src/DebugEngineHost/DebugEngineHost.csproj
+++ b/src/DebugEngineHost/DebugEngineHost.csproj
@@ -28,7 +28,6 @@
 
   <ItemGroup Label="Compile Shared Interfaces">
     <Compile Include="$(MIEngineRoot)\src\DebugEngineHost.Stub\Shared\Microsoft.VisualStudio.Debugger.Interop.DAP.cs" />
-    <Compile Remove="E:\MIEngine\\src\DebugEngineHost.Stub\Shared\Microsoft.VisualStudio.Debugger.Interop.MI.cs" />
     <Compile Include="$(MIEngineRoot)\src\DebugEngineHost.Stub\Shared\Microsoft.VisualStudio.Debugger.Interop.MI.cs" />
   </ItemGroup>
 

--- a/src/DebugEngineHost/DebugEngineHost.csproj
+++ b/src/DebugEngineHost/DebugEngineHost.csproj
@@ -28,6 +28,8 @@
 
   <ItemGroup Label="Compile Shared Interfaces">
     <Compile Include="$(MIEngineRoot)\src\DebugEngineHost.Stub\Shared\Microsoft.VisualStudio.Debugger.Interop.DAP.cs" />
+    <Compile Remove="E:\MIEngine\\src\DebugEngineHost.Stub\Shared\Microsoft.VisualStudio.Debugger.Interop.MI.cs" />
+    <Compile Include="$(MIEngineRoot)\src\DebugEngineHost.Stub\Shared\Microsoft.VisualStudio.Debugger.Interop.MI.cs" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/DebugEngineHost/HostNatvisProject.cs
+++ b/src/DebugEngineHost/HostNatvisProject.cs
@@ -30,41 +30,24 @@ namespace Microsoft.DebugEngineHost
         public delegate void NatvisLoader(string path);
 
         /// <summary>
-        /// Searches the solution for natvis files, invoking the loader on any which are found.
+        /// Searches the solution and VSIXs for natvis files, invoking the loader on any which are found.
         /// </summary>
         /// <param name="loader">Natvis loader method to invoke</param>
-        public static void FindNatvisInSolution(NatvisLoader loader)
+        public static void FindNatvis(NatvisLoader loader)
         {
             List<string> paths = new List<string>();
             try
             {
-                ThreadHelper.JoinableTaskFactory.Run(async () =>
-                    await Internal.FindNatvisInSolutionImplAsync(paths)
-                );
+                ThreadHelper.JoinableTaskFactory.Run(async () => {
+                    await Internal.FindNatvisInSolutionImplAsync(paths);
+                    Internal.FindNatvisInVSIXImpl(paths);
+                });
             }
             catch (Exception)
             {
             }
             paths.ForEach((s) => loader(s));
         }
-
-        /// <summary>
-        /// Queries the extension manager for natvis files, invoking the loader on any which are found.
-        /// </summary>
-        /// <param name="loader">Natvis loader method to invoke</param>
-        public static void FindNatvisInVSIX(NatvisLoader loader)
-        {
-            List<string> paths = new List<string>();
-            try
-            {
-                Internal.FindNatvisInVSIXImpl(paths);
-            }
-            catch (Exception)
-            {
-            }
-            paths.ForEach((s) => loader(s));
-        }
-
 
         public static string FindSolutionRoot()
         {

--- a/src/DebugEngineHost/HostNatvisProject.cs
+++ b/src/DebugEngineHost/HostNatvisProject.cs
@@ -232,10 +232,7 @@ namespace Microsoft.DebugEngineHost
                     var hr = pem.GetEnabledExtensionContentLocations(name, contentLocations, rgbstrContentLocations, rgbstrUniqueStrings, out var actualContentLocations);
                     if (hr == VSConstants.S_OK && actualContentLocations > 0)
                     {
-                        for (var i = 0; i < actualContentLocations; ++i)
-                        {
-                            paths.Add(rgbstrContentLocations[i]);
-                        }
+                        paths.AddRange(rgbstrContentLocations);
                     }
                 }
             }

--- a/src/MIDebugEngine/Engine.Impl/Variables.cs
+++ b/src/MIDebugEngine/Engine.Impl/Variables.cs
@@ -88,6 +88,8 @@ namespace Microsoft.MIDebugEngine
         public enum_DEBUGPROP_INFO_FLAGS PropertyInfoFlags { get; set; }
         private string DisplayHint { get; set; }
         public bool IsPreformatted { get; set; }
+        public List<(string, int)> UIVisualizers { get; } = null;
+
 
         static readonly Lazy<Regex> s_addressPattern = new Lazy<Regex>(() => new Regex(@"^(0x[0-9a-fA-F]+)\b"));
 

--- a/src/MIDebugEngine/Engine.Impl/Variables.cs
+++ b/src/MIDebugEngine/Engine.Impl/Variables.cs
@@ -88,8 +88,6 @@ namespace Microsoft.MIDebugEngine
         public enum_DEBUGPROP_INFO_FLAGS PropertyInfoFlags { get; set; }
         private string DisplayHint { get; set; }
         public bool IsPreformatted { get; set; }
-        public List<(string, int)> UIVisualizers { get; } = null;
-
 
         static readonly Lazy<Regex> s_addressPattern = new Lazy<Regex>(() => new Regex(@"^(0x[0-9a-fA-F]+)\b"));
 

--- a/src/MIDebugEngine/Natvis.Impl/Natvis.cs
+++ b/src/MIDebugEngine/Natvis.Impl/Natvis.cs
@@ -91,6 +91,18 @@ namespace Microsoft.MIDebugEngine.Natvis
         }
     }
 
+    internal struct VisualizerId
+    {
+        public string Name { get; }
+        public int Id { get; }
+
+        public VisualizerId(string name,int id)
+        {
+            this.Name = name;
+            this.Id = id;
+        }
+    };
+
     public class Natvis
     {
         private class AliasInfo
@@ -135,13 +147,13 @@ namespace Microsoft.MIDebugEngine.Natvis
             public VisualizerType Visualizer { get; private set; }
             public Dictionary<string, string> ScopedNames { get; private set; }
 
-            public IEnumerable<(string,int)> GetUIVisualizers()
+            public VisualizerId[] GetUIVisualizers()
             {
                 return this.Visualizer.Items.Where((i) => i is UIVisualizerItemType).Select(i =>
                   {
                       var visualizer = (UIVisualizerItemType)i;
-                      return (visualizer.ServiceId, visualizer.Id);
-                  });
+                      return new VisualizerId(visualizer.ServiceId, visualizer.Id);
+                  }).ToArray();
             }
 
             public VisualizerInfo(VisualizerType viz, TypeName name)
@@ -194,8 +206,7 @@ namespace Microsoft.MIDebugEngine.Natvis
         {
             try
             {
-                HostNatvisProject.FindNatvisInSolution((s) => LoadFile(s));
-                HostNatvisProject.FindNatvisInVSIX((s) => LoadFile(s));
+                HostNatvisProject.FindNatvis((s) => LoadFile(s));
             }
             catch (FileNotFoundException)
             {
@@ -346,7 +357,7 @@ namespace Microsoft.MIDebugEngine.Natvis
             }
         }
 
-        internal (string value, IEnumerable<(string, int)> uiVisualizers) FormatDisplayString(IVariableInformation variable)
+        internal (string value, VisualizerId[] uiVisualizers) FormatDisplayString(IVariableInformation variable)
         {
             VisualizerInfo visualizer = null;
             try

--- a/src/MIDebugEngine/Natvis.Impl/Natvis.cs
+++ b/src/MIDebugEngine/Natvis.Impl/Natvis.cs
@@ -9,6 +9,7 @@ using System;
 using System.Collections.Generic;
 using System.Globalization;
 using System.IO;
+using System.Linq;
 using System.Reflection;
 using System.Text;
 using System.Text.RegularExpressions;
@@ -74,7 +75,7 @@ namespace Microsoft.MIDebugEngine.Natvis
     internal class VisualizerWrapper : SimpleWrapper
     {
         public readonly Natvis.VisualizerInfo Visualizer;
-        private bool _isVisualizerView;
+        private readonly bool _isVisualizerView;
 
         public VisualizerWrapper(string name, AD7Engine engine, IVariableInformation underlyingVariable, Natvis.VisualizerInfo viz, bool isVisualizerView)
             : base(name, engine, underlyingVariable)
@@ -118,6 +119,7 @@ namespace Microsoft.MIDebugEngine.Natvis
         {
             public List<TypeInfo> Visualizers { get; private set; }
             public List<AliasInfo> Aliases { get; private set; }
+            public List<UIVisualizerType> UIVisualizers { get; set; } = null;
             public readonly AutoVisualizer Environment;
 
             public FileInfo(AutoVisualizer env)
@@ -132,6 +134,15 @@ namespace Microsoft.MIDebugEngine.Natvis
         {
             public VisualizerType Visualizer { get; private set; }
             public Dictionary<string, string> ScopedNames { get; private set; }
+
+            public IEnumerable<(string,int)> GetUIVisualizers()
+            {
+                return this.Visualizer.Items.Where((i) => i is UIVisualizerItemType).Select(i =>
+                  {
+                      var visualizer = (UIVisualizerItemType)i;
+                      return (visualizer.ServiceId, visualizer.Id);
+                  });
+            }
 
             public VisualizerInfo(VisualizerType viz, TypeName name)
             {
@@ -184,6 +195,7 @@ namespace Microsoft.MIDebugEngine.Natvis
             try
             {
                 HostNatvisProject.FindNatvisInSolution((s) => LoadFile(s));
+                HostNatvisProject.FindNatvisInVSIX((s) => LoadFile(s));
             }
             catch (FileNotFoundException)
             {
@@ -315,6 +327,12 @@ namespace Microsoft.MIDebugEngine.Natvis
                                 }
                             }
                         }
+
+                        if (autoVis.UIVisualizer != null)
+                        {
+                            f.UIVisualizers = autoVis.UIVisualizer.ToList();
+                        }
+
                         _typeVisualizers.Add(f);
                     }
                     return autoVis != null;
@@ -328,8 +346,9 @@ namespace Microsoft.MIDebugEngine.Natvis
             }
         }
 
-        internal string FormatDisplayString(IVariableInformation variable)
+        internal (string value, IEnumerable<(string, int)> uiVisualizers) FormatDisplayString(IVariableInformation variable)
         {
+            VisualizerInfo visualizer = null;
             try
             {
                 _depth++;
@@ -340,10 +359,10 @@ namespace Microsoft.MIDebugEngine.Natvis
                         || (ShowDisplayStrings == DisplayStringsState.ForVisualizedItems && variable.IsVisualized)) &&
                         !variable.IsPreformatted)
                     {
-                        VisualizerInfo visualizer = FindType(variable);
+                        visualizer = FindType(variable);
                         if (visualizer == null)
                         {
-                            return variable.Value;
+                            return (variable.Value, null);
                         }
 
                         Cache.Add(variable);    // vizualized value has been displayed
@@ -357,7 +376,7 @@ namespace Microsoft.MIDebugEngine.Natvis
                                 {
                                     continue;
                                 }
-                                return FormatValue(display.Value, variable, visualizer.ScopedNames);
+                                return (FormatValue(display.Value, variable, visualizer.ScopedNames), visualizer.GetUIVisualizers());
                             }
                         }
                     }
@@ -373,7 +392,7 @@ namespace Microsoft.MIDebugEngine.Natvis
             {
                 _depth--;
             }
-            return variable.Value;
+            return (variable.Value, visualizer?.GetUIVisualizers());
         }
 
         private IVariableInformation GetVisualizationWrapper(IVariableInformation variable)
@@ -442,6 +461,21 @@ namespace Microsoft.MIDebugEngine.Natvis
                 variable = new VariableInformation(expr, expr, frame.ThreadContext, frame.Engine, frame.Thread);
             }
             return variable;
+        }
+
+        internal string GetUIVisualizerName(string serviceId, int id)
+        {
+            string result = string.Empty;
+            this._typeVisualizers.ForEach((f)=>
+            {
+                UIVisualizerType uiViz;
+                if ((uiViz = f.UIVisualizers?.FirstOrDefault((u) => u.ServiceId == serviceId && u.Id == id)) != null)
+                {
+                    result = uiViz.MenuName;
+                }
+            });
+
+            return result;
         }
 
         private delegate IVariableInformation Traverse(IVariableInformation node);
@@ -1080,7 +1114,7 @@ namespace Microsoft.MIDebugEngine.Natvis
             string processedExpr = ReplaceNamesInExpression(expression, variable, scopedNames);
             IVariableInformation expressionVariable = new VariableInformation(processedExpr, variable, _process.Engine, null);
             expressionVariable.SyncEval();
-            return FormatDisplayString(expressionVariable);
+            return FormatDisplayString(expressionVariable).value;
         }
     }
 }


### PR DESCRIPTION
Add support for natvis UIVisualizers and VSIX defined natvis. 
1. At startup (when VS hosted debugging) the host queries VS for VSIX defined natvis files and adds those to the set searched for visualizers.
2. UIVisualizer natvis elements are parsed and returned with property values when they are found.