### PR TITLE
Improve messages for unknown breakpoints and watchpoints. (#1282)

### DIFF
--- a/src/MIDebugEngine/Engine.Impl/DebuggedProcess.cs
+++ b/src/MIDebugEngine/Engine.Impl/DebuggedProcess.cs
@@ -1237,7 +1237,10 @@ namespace Microsoft.MIDebugEngine
                         // This is not one of our breakpoints, so stop with a message. Possibly it
                         // was set by the user via "-exec break ...", so display the available
                         // information.
-                        _callback.OnException(thread, $"Hit breakpoint {bkptno} at 0x{addr:x}.", "", 0);
+                        string desc = String.Format(CultureInfo.CurrentCulture,
+                                                    ResourceStrings.UnknownBreakpoint,
+                                                    bkptno, addr);
+                        _callback.OnException(thread, desc, "", 0);
                     }
                 }
             }
@@ -1268,21 +1271,34 @@ namespace Microsoft.MIDebugEngine
                         // This is not one of our watchpoints, so stop with a message. Possibly it
                         // was set by the user via "-exec watch ...", so display the available
                         // information.
-                        string desc = $"Hit watchpoint {bkptno}";
+                        string desc = string.Empty;
                         string exp = wpt.TryFindString("exp");
-                        if (!string.IsNullOrEmpty(exp)) {
-                            desc += $": {exp}";
+                        if (string.IsNullOrEmpty(exp)) {
+                            desc = String.Format(CultureInfo.CurrentCulture,
+                                                 ResourceStrings.UnknownWatchpoint,
+                                                 bkptno, addr);
                         }
-                        desc += $" at 0x{addr:x}";
+                        else
+                        {
+                            desc = String.Format(CultureInfo.CurrentCulture,
+                                                 ResourceStrings.UnknownWatchpointWithExpression,
+                                                 bkptno, exp, addr);
+                        }
                         var value = results.Results.TryFind<TupleValue>("value");
                         if (value != null) {
                             string oldValue = value.TryFindString("old");
                             if (!string.IsNullOrEmpty(oldValue)) {
-                                desc += $"\nOld value = {oldValue}";
+                                desc += "\n";
+                                desc += String.Format(CultureInfo.CurrentCulture,
+                                                      ResourceStrings.UnknownWatchpointOldValue,
+                                                      oldValue);
                             }
                             string newValue = value.TryFindString("new");
                             if (!string.IsNullOrEmpty(newValue)) {
-                                desc += $"\nNew value = {newValue}";
+                                desc += "\n";
+                                desc += String.Format(CultureInfo.CurrentCulture,
+                                                      ResourceStrings.UnknownWatchpointNewValue,
+                                                      newValue);
                             }
                         }
                         _callback.OnException(thread, desc, "", 0);

--- a/src/MIDebugEngine/ResourceStrings.Designer.cs
+++ b/src/MIDebugEngine/ResourceStrings.Designer.cs
@@ -356,11 +356,56 @@ namespace Microsoft.MIDebugEngine {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Hit breakpoint {0} at 0x{1:x}..
+        /// </summary>
+        internal static string UnknownBreakpoint {
+            get {
+                return ResourceManager.GetString("UnknownBreakpoint", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to [Unknown/Just-In-Time compiled code].
         /// </summary>
         internal static string UnknownCode {
             get {
                 return ResourceManager.GetString("UnknownCode", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Hit watchpoint {0} at 0x{1:x}..
+        /// </summary>
+        internal static string UnknownWatchpoint {
+            get {
+                return ResourceManager.GetString("UnknownWatchpoint", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to New value = {0}.
+        /// </summary>
+        internal static string UnknownWatchpointNewValue {
+            get {
+                return ResourceManager.GetString("UnknownWatchpointNewValue", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Old value = {0}.
+        /// </summary>
+        internal static string UnknownWatchpointOldValue {
+            get {
+                return ResourceManager.GetString("UnknownWatchpointOldValue", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Hit watchpoint {0}: {1} at 0x{2:x}..
+        /// </summary>
+        internal static string UnknownWatchpointWithExpression {
+            get {
+                return ResourceManager.GetString("UnknownWatchpointWithExpression", resourceCulture);
             }
         }
         

--- a/src/MIDebugEngine/ResourceStrings.resx
+++ b/src/MIDebugEngine/ResourceStrings.resx
@@ -270,4 +270,24 @@ See https://aka.ms/miengine-gdb-troubleshooting for details.</value>
     <value>Exception{0} thrown at 0x{1:X} in {2}.</value>
     <comment>0 = optional exception name, 1 = address, 2 = exception file</comment>
   </data>
+  <data name="UnknownBreakpoint" xml:space="preserve">
+    <value>Hit breakpoint {0} at 0x{1:x}.</value>
+    <comment>0 = breakpoint number, 1 = address</comment>
+  </data>
+  <data name="UnknownWatchpoint" xml:space="preserve">
+    <value>Hit watchpoint {0} at 0x{1:x}.</value>
+    <comment>0 = watchpoint number, 1 = address</comment>
+  </data>
+  <data name="UnknownWatchpointWithExpression" xml:space="preserve">
+    <value>Hit watchpoint {0}: {1} at 0x{2:x}.</value>
+    <comment>0 = watchpoint number, 1 = expression, 2 = address</comment>
+  </data>
+  <data name="UnknownWatchpointOldValue" xml:space="preserve">
+    <value>Old value = {0}</value>
+    <comment>0 = old value of watchpoint</comment>
+  </data>
+  <data name="UnknownWatchpointNewValue" xml:space="preserve">
+    <value>New value = {0}</value>
+    <comment>0 = new value of watchpoint</comment>
+  </data>
 </root>


### PR DESCRIPTION
The C/C++ extension does not support all the features of GDB breakpoints and watchpoints, so users may need to set breakpoints via `-exec break ...` in the DEBUG CONSOLE, and similarly for watchpoints via `-exec watch ...`. When these are hit, include the available information in the exception message instead of just "Unknown breakpoint" or "Unknown watchpoint". Fixes #1282.

The new behaviour for unknown breakpoints and unknown watchpoints (respectively) is shown in the screenshots below.

![Screenshot from 2022-03-03 09-40-34](https://user-images.githubusercontent.com/922721/156539095-1da14406-cbc3-4694-af62-82e68caf328a.png)

![Screenshot from 2022-03-03 09-37-05](https://user-images.githubusercontent.com/922721/156539092-cf199754-54e7-4672-8957-f3c16cce8edf.png)