### PR TITLE
Fix linux CI Build

### DIFF
--- a/.github/workflows/Build-And-Test.yml
+++ b/.github/workflows/Build-And-Test.yml
@@ -172,6 +172,7 @@ jobs:
       run: dotnet build ${{ github.workspace }}/src/MIDebugEngine-Unix.sln
 
     - run: |
+        sudo apt update
         sudo apt-get install gdb g++ -y
         which g++
         which gdb


### PR DESCRIPTION
This pr adds `sudo apt update` to make the `sudo apt-get install` succeed.