### PR TITLE
Move runtime to .NET 6

### DIFF
--- a/.github/workflows/Build-And-Test.yml
+++ b/.github/workflows/Build-And-Test.yml
@@ -29,7 +29,7 @@ jobs:
     - name: Install .NET Core
       uses: actions/setup-dotnet@v1
       with:
-        dotnet-version: 5.0.x
+        dotnet-version: 6.0.x
 
     - name: Setup MSBuild.exe
       uses: microsoft/setup-msbuild@v1.0.2
@@ -61,7 +61,7 @@ jobs:
     - name: Install .NET Core
       uses: actions/setup-dotnet@v1
       with:
-        dotnet-version: 5.0.x
+        dotnet-version: 6.0.x
 
     - name: Setup MSBuild.exe
       uses: microsoft/setup-msbuild@v1.0.2
@@ -166,7 +166,7 @@ jobs:
     - name: Install .NET Core
       uses: actions/setup-dotnet@v1
       with:
-        dotnet-version: 5.0.x
+        dotnet-version: 6.0.x
 
     - name: Build
       run: dotnet build ${{ github.workspace }}/src/MIDebugEngine-Unix.sln
@@ -207,7 +207,7 @@ jobs:
     - name: Install .NET Core
       uses: actions/setup-dotnet@v1
       with:
-        dotnet-version: 5.0.x
+        dotnet-version: 6.0.x
 
     - name: Build
       run: dotnet build ${{ github.workspace }}/src/MIDebugEngine-Unix.sln

--- a/src/MakePIAPortable/MakePIAPortable.csproj
+++ b/src/MakePIAPortable/MakePIAPortable.csproj
@@ -15,14 +15,14 @@
   </PropertyGroup>
 
   <ItemGroup Label="ILDasm NuGet Package">
-    <PackageReference Include="runtime.win-x64.Microsoft.NETCore.ILDAsm" Version="5.0.0" GeneratePathProperty="true" Condition="$([MSBuild]::IsOSPlatform('windows'))" />
-    <PackageReference Include="runtime.linux-x64.Microsoft.NETCore.ILDAsm" Version="5.0.0" GeneratePathProperty="true" Condition="$([MSBuild]::IsOSPlatform('linux'))" />
-    <PackageReference Include="runtime.osx-x64.Microsoft.NETCore.ILDAsm" Version="5.0.0" GeneratePathProperty="true" Condition="$([MSBuild]::IsOSPlatform('osx'))" />
+    <PackageReference Include="runtime.win-x64.Microsoft.NETCore.ILDAsm" Version="6.0.0" GeneratePathProperty="true" Condition="$([MSBuild]::IsOSPlatform('windows'))" />
+    <PackageReference Include="runtime.linux-x64.Microsoft.NETCore.ILDAsm" Version="6.0.0" GeneratePathProperty="true" Condition="$([MSBuild]::IsOSPlatform('linux'))" />
+    <PackageReference Include="runtime.osx-x64.Microsoft.NETCore.ILDAsm" Version="6.0.0" GeneratePathProperty="true" Condition="$([MSBuild]::IsOSPlatform('osx'))" />
   </ItemGroup>
 
   <ItemGroup Label="ILAsm NuGet Package">
-    <PackageReference Include="runtime.linux-x64.Microsoft.NETCore.ILAsm" Version="5.0.0" GeneratePathProperty="true" Condition="$([MSBuild]::IsOSPlatform('linux'))" />
-    <PackageReference Include="runtime.osx-x64.Microsoft.NETCore.ILAsm" Version="5.0.0" GeneratePathProperty="true" Condition="$([MSBuild]::IsOSPlatform('osx'))" />
+    <PackageReference Include="runtime.linux-x64.Microsoft.NETCore.ILAsm" Version="6.0.0" GeneratePathProperty="true" Condition="$([MSBuild]::IsOSPlatform('linux'))" />
+    <PackageReference Include="runtime.osx-x64.Microsoft.NETCore.ILAsm" Version="6.0.0" GeneratePathProperty="true" Condition="$([MSBuild]::IsOSPlatform('osx'))" />
   </ItemGroup>
 
   <!-- Keep in sync with ..\..\build\Debugger.PIAs.NonPortable.Packages.settings.targets -->

--- a/src/OpenDebugAD7/OpenDebugAD7.csproj
+++ b/src/OpenDebugAD7/OpenDebugAD7.csproj
@@ -14,7 +14,7 @@
     <OutputPath>$(MIDefaultOutputPath)\vscode</OutputPath>
     <OutputType>Exe</OutputType>
     <DropSubDir>vscode</DropSubDir>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
 
     <!--
       For non-Windows platforms, .NET Core depends on libicu for data about locales and international settings.

--- a/src/tools/MakePIAPortableTool/MakePIAPortableTool.csproj
+++ b/src/tools/MakePIAPortableTool/MakePIAPortableTool.csproj
@@ -4,7 +4,7 @@
   
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
 
     <OutputPath>$(MIDefaultOutputPath)tools</OutputPath>
     <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>

--- a/test/CppTests/CppTests.csproj
+++ b/test/CppTests/CppTests.csproj
@@ -2,7 +2,7 @@
   <Import Project="..\..\build\debuggertesting.settings.targets" />
 
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
 
     <IsPackable>false</IsPackable>
 

--- a/test/CppTests/CppTests.nuspec
+++ b/test/CppTests/CppTests.nuspec
@@ -14,10 +14,10 @@
     <copyright>© Microsoft Corporation. All rights reserved.</copyright>
   </metadata>
   <files>
-    <file src="$binRoot$CppTests.dll" target="lib\net5.0" />
-    <file src="$binRoot$CppTests.pdb" target="lib\net5.0" />
-    <file src="$binRoot$DebuggerTesting.dll" target="lib\net5.0" />
-    <file src="$binRoot$DebuggerTesting.pdb" target="lib\net5.0" />
+    <file src="$binRoot$CppTests.dll" target="lib\net6.0" />
+    <file src="$binRoot$CppTests.pdb" target="lib\net6.0" />
+    <file src="$binRoot$DebuggerTesting.dll" target="lib\net6.0" />
+    <file src="$binRoot$DebuggerTesting.pdb" target="lib\net6.0" />
     <file src="$binRoot$contentFiles\**\*" target="contentFiles" />
   </files>
 </package>

--- a/test/DebugAdapterRunner/DebugAdapterRunner.csproj
+++ b/test/DebugAdapterRunner/DebugAdapterRunner.csproj
@@ -4,7 +4,7 @@
   <PropertyGroup>
     <AssemblyName>dar</AssemblyName>
     <RootNamespace>DebugAdapterRunner</RootNamespace>
-    <TargetFramework>netcoreapp5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup Label="Package References">

--- a/test/DebugAdapterRunner/DebugAdapterRunner.nuspec
+++ b/test/DebugAdapterRunner/DebugAdapterRunner.nuspec
@@ -18,7 +18,7 @@
     </dependencies>
   </metadata>
   <files>
-    <file src="$binRoot$dar.dll" target="lib\net5.0" />
-    <file src="$binRoot$dar.pdb" target="lib\net5.0" />
+    <file src="$binRoot$dar.dll" target="lib\net6.0" />
+    <file src="$binRoot$dar.pdb" target="lib\net6.0" />
   </files>
 </package>

--- a/test/DebuggerTesting/DebuggerTesting.csproj
+++ b/test/DebuggerTesting/DebuggerTesting.csproj
@@ -2,7 +2,7 @@
   <Import Project="..\..\build\debuggertesting.settings.targets" />
 
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
 
     <IsPackable>false</IsPackable>
   </PropertyGroup>


### PR DESCRIPTION
This PR converts MIEngine and associated project to move from .NET 5 to .NET 6