### PR TITLE
Add macOS ARM64 release steps

### DIFF
--- a/eng/pipelines/tasks/UseDotNet.yml
+++ b/eng/pipelines/tasks/UseDotNet.yml
@@ -1,0 +1,6 @@
+steps:
+- task: UseDotNet@2
+  displayName: 'Use .NET Core sdk'
+  inputs:
+    packageType: sdk
+    version: 6.x

--- a/eng/pipelines/templates/Build.template.yml
+++ b/eng/pipelines/templates/Build.template.yml
@@ -5,6 +5,8 @@ parameters:
 steps:
 - checkout: self
 
+- template: ../tasks/UseDotNet.yml
+
 - template: ../tasks/NuGetToolInstaller.yml
 
 - template: ../tasks/MicroBuildSigningPlugin.yml

--- a/eng/pipelines/templates/VS-release.template.yml
+++ b/eng/pipelines/templates/VS-release.template.yml
@@ -6,7 +6,7 @@ steps:
   displayName: 'Use .NET Core sdk'
   inputs:
     packageType: sdk
-    version: 5.x
+    version: 6.x
 
 - template: ../tasks/NuGetToolInstaller.yml
 

--- a/eng/pipelines/templates/VS-release.template.yml
+++ b/eng/pipelines/templates/VS-release.template.yml
@@ -2,11 +2,7 @@
 steps:
 - checkout: self
 
-- task: UseDotNet@2
-  displayName: 'Use .NET Core sdk'
-  inputs:
-    packageType: sdk
-    version: 6.x
+- template: ../tasks/UseDotNet.yml
 
 - template: ../tasks/NuGetToolInstaller.yml
 

--- a/eng/pipelines/templates/VSCode-codesign-osx.template.yml
+++ b/eng/pipelines/templates/VSCode-codesign-osx.template.yml
@@ -1,26 +1,30 @@
 ---
+parameters:
+  rids: ["osx-x64", "osx-arm64"]
+
 steps:
 - checkout: self
 
-- template: ../tasks/DownloadPipelineArtifact.yml
-  parameters:
-    displayName: 'Downloading unsigned_osx-x64_binaries'
-    path: '$(Pipeline.Workspace)/Artifacts' 
-    artifact: 'unsigned_osx-x64_binaries'
+- ${{ each rid in parameters.rids }}:
+  - template: ../tasks/DownloadPipelineArtifact.yml
+    parameters:
+      displayName: 'Downloading unsigned_${{ rid }}_binaries'
+      path: '$(Pipeline.Workspace)/Artifacts/${{ rid }}' 
+      artifact: 'unsigned_${{ rid }}_binaries'
 
-- script: |
-    echo "#[command] codesign -s - -f --entitlements $(Build.SourcesDirectory)/eng/Signing/macOS/debugger-entitlements.plist $(Pipeline.Workspace)/Artifacts/debugAdapters/bin/OpenDebugAD7"
-    codesign -s - -f --entitlements $(Build.SourcesDirectory)/eng/Signing/macOS/debugger-entitlements.plist $(Pipeline.Workspace)/Artifacts/debugAdapters/bin/OpenDebugAD7
+  - script: |
+      echo "#[command] codesign -s - -f --entitlements $(Build.SourcesDirectory)/eng/Signing/macOS/debugger-entitlements.plist $(Pipeline.Workspace)/Artifacts/${{ rid }}/debugAdapters/bin/OpenDebugAD7"
+      codesign -s - -f --entitlements $(Build.SourcesDirectory)/eng/Signing/macOS/debugger-entitlements.plist $(Pipeline.Workspace)/Artifacts/${{ rid }}/debugAdapters/bin/OpenDebugAD7
 
-    echo "#[command] cd $(Pipeline.Workspace)/Artifacts/"
-    cd $(Pipeline.Workspace)/Artifacts
+      echo "#[command] cd $(Pipeline.Workspace)/Artifacts/${{ rid }}"
+      cd $(Pipeline.Workspace)/Artifacts/${{ rid }}
 
-    echo "#[command] zip -r $(Pipeline.Workspace)/osx-x64.zip ./debugAdapters"
-    zip -r $(Pipeline.Workspace)/osx-x64.zip ./debugAdapters
+      echo "#[command] zip -r $(Pipeline.Workspace)/${{ rid }}.zip ./debugAdapters"
+      zip -r $(Pipeline.Workspace)/${{ rid }}.zip ./debugAdapters
 
-- template: ../tasks/PublishPipelineArtifact.yml
-  parameters:
-    displayName: 'Publish Binaries'
-    path: '$(Pipeline.Workspace)/osx-x64.zip'
-    artifactName: 'unsigned_osx-x64_zip'
+  - template: ../tasks/PublishPipelineArtifact.yml
+    parameters:
+      displayName: 'Publish Binaries'
+      path: '$(Pipeline.Workspace)/${{ rid }}.zip'
+      artifactName: 'unsigned_${{ rid }}_zip'
 ...

--- a/eng/pipelines/templates/VSCode-esrp-sign-osx.template.yml
+++ b/eng/pipelines/templates/VSCode-esrp-sign-osx.template.yml
@@ -1,22 +1,26 @@
 ---
+parameters:
+  rids: ["osx-x64", "osx-arm64"]
+
 steps:
 - checkout: none
 
-- template: ../tasks/DownloadPipelineArtifact.yml
-  parameters:
-    displayName: 'Downloading unsigned_osx-64_zip'
-    path: '$(Pipeline.Workspace)/Artifacts' 
-    artifact: 'unsigned_osx-x64_zip'
+- ${{ each rid in parameters.rids }}:
+  - template: ../tasks/DownloadPipelineArtifact.yml
+    parameters:
+      displayName: 'Downloading unsigned_${{ rid }}_zip'
+      path: '$(Pipeline.Workspace)/Artifacts' 
+      artifact: 'unsigned_${{ rid }}_zip'
 
-- task: MicroBuildSignMacFiles@1
-  displayName: 'ESRP Sign'
-  inputs:
-    SigningTarget: '$(Pipeline.Workspace)\Artifacts\osx-x64.zip'
-    SigningCert: 8023
+  - task: MicroBuildSignMacFiles@1
+    displayName: 'ESRP Sign'
+    inputs:
+      SigningTarget: '$(Pipeline.Workspace)\Artifacts\${{ rid }}.zip'
+      SigningCert: 8023
 
-- template: ../tasks/PublishPipelineArtifact.yml
-  parameters:
-    displayName: 'Publish Binaries'
-    path: '$(Pipeline.Workspace)\Artifacts\osx-x64.zip'
-    artifactName: 'osx-x64_zip'
+  - template: ../tasks/PublishPipelineArtifact.yml
+    parameters:
+      displayName: 'Publish Binaries'
+      path: '$(Pipeline.Workspace)\Artifacts\${{ rid }}.zip'
+      artifactName: '${{ rid }}_zip'
 ...

--- a/eng/pipelines/templates/VSCode-release.template.yml
+++ b/eng/pipelines/templates/VSCode-release.template.yml
@@ -1,6 +1,6 @@
 ---
 parameters:
-  rids: ["win-x86", "win10-arm64", "osx-x64", "linux-x64", "linux-arm", "linux-arm64", "linux-musl-x64", "linux-musl-arm64" ]
+  rids: ["win-x86", "win10-arm64", "osx-x64", "osx-arm64", "linux-x64", "linux-arm", "linux-arm64", "linux-musl-x64", "linux-musl-arm64" ]
 
 steps:
 - checkout: self
@@ -14,7 +14,7 @@ steps:
   displayName: 'Use .NET Core sdk'
   inputs:
     packageType: sdk
-    version: 5.x
+    version: 6.x
 
 - template: ../steps/BuildSolution.yml
   parameters:

--- a/eng/pipelines/templates/VSCode-release.template.yml
+++ b/eng/pipelines/templates/VSCode-release.template.yml
@@ -10,11 +10,7 @@ steps:
 
 - template: ../tasks/MicroBuildSigningPlugin.yml
 
-- task: UseDotNet@2
-  displayName: 'Use .NET Core sdk'
-  inputs:
-    packageType: sdk
-    version: 6.x
+- template: ../tasks/UseDotNet.yml
 
 - template: ../steps/BuildSolution.yml
   parameters:


### PR DESCRIPTION
This PR adds publishing osx-arm64 for OpenDebugAD7 and MIEngine.