### PR TITLE
fix 2nd echo processing with lldb

### DIFF
--- a/src/MICore/Debugger.cs
+++ b/src/MICore/Debugger.cs
@@ -1253,10 +1253,10 @@ namespace MICore
                         {
                             WaitingOperationDescriptor waitingOperation;
                             if (_waitingOperations.TryGetValue(id, out waitingOperation) &&
-                                !waitingOperation.EchoReceived &&
                                 line == waitingOperation.Command)
                             {
                                 // This is just the echo. Ignore.
+                                // Sometimes with lldb we are seeing 2 command echos 
                                 waitingOperation.EchoReceived = true;
                                 return;
                             }
@@ -1267,6 +1267,7 @@ namespace MICore
                 switch (c)
                 {
                     case '~':
+                    case '@':
                         OnDebuggeeOutput(noprefix);         // Console stream
                         break;
                     case '^':


### PR DESCRIPTION
Fixing VS bug 1496172. Writing app output to an alternate tty is not supported by lldb so the output arrives via the MI connection prefaced by '@'. The MI engine did not recognize that prefix so put out the line with the '@' to the debug window. At that point lldb begins echoing each command line twice. This seems like an lldb bug. To work around it the MIEngine now accepts multiple echos.
