### PR TITLE
Add threadId to thread name

### DIFF
--- a/src/OpenDebugAD7/AD7DebugSession.cs
+++ b/src/OpenDebugAD7/AD7DebugSession.cs
@@ -9,6 +9,7 @@ using System.Globalization;
 using System.IO;
 using System.Linq;
 using System.Reflection;
+using System.Text.RegularExpressions;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.DebugEngineHost;
@@ -2043,11 +2044,24 @@ namespace OpenDebugAD7
             }
 
             // iterate over the collection asking the engine for the name
-            foreach (var pair in threads)
+            foreach ((int id, IDebugThread2 thread) in threads)
             {
-                string name;
-                pair.Value.GetName(out name);
-                response.Threads.Add(new OpenDebugThread(pair.Key, name));
+                string name = null;
+
+                if (thread != null && thread.GetName(out name) == HRConstants.S_OK)
+                {
+                    // Append the thread id as a suffix unless the engine is already including it
+                    if (thread.GetThreadId(out uint threadId) == HRConstants.S_OK)
+                    {
+                        string threadIdDecimal = threadId.ToString(CultureInfo.InvariantCulture);
+                        if (!Regex.IsMatch(name, string.Concat("\b", threadIdDecimal, "\b")))
+                        {
+                            name = string.Concat(name, " [", threadIdDecimal, "]");
+                        }
+                    }
+                }
+
+                response.Threads.Add(new OpenDebugThread(id, name));
             }
 
             responder.SetResponse(response);

--- a/src/OpenDebugAD7/AD7DebugSession.cs
+++ b/src/OpenDebugAD7/AD7DebugSession.cs
@@ -2046,22 +2046,32 @@ namespace OpenDebugAD7
             // iterate over the collection asking the engine for the name
             foreach ((int id, IDebugThread2 thread) in threads)
             {
-                string name = null;
-
-                if (thread != null && thread.GetName(out name) == HRConstants.S_OK)
+                if (thread != null)
                 {
-                    // Append the thread id as a suffix unless the engine is already including it
-                    if (thread.GetThreadId(out uint threadId) == HRConstants.S_OK)
+                    if (thread.GetName(out string name) == HRConstants.S_OK)
                     {
-                        string threadIdDecimal = threadId.ToString(CultureInfo.InvariantCulture);
-                        if (!Regex.IsMatch(name, string.Concat("\b", threadIdDecimal, "\b")))
+                        // Append the thread id as a suffix unless the engine is already including it
+                        if (thread.GetThreadId(out uint threadId) == HRConstants.S_OK)
                         {
-                            name = string.Concat(name, " [", threadIdDecimal, "]");
+                            string threadIdDecimal = threadId.ToString(CultureInfo.InvariantCulture);
+                            if (!Regex.IsMatch(name, string.Concat("\b", threadIdDecimal, "\b")))
+                            {
+                                name = string.Concat(name, " [", threadIdDecimal, "]");
+                            }
+                        }
+                        else
+                        {
+                            // We did not get a thread id. Skip adding to list.
+                            continue;
                         }
                     }
-                }
+                    else
+                    {
+                        name = null;
+                    }
 
-                response.Threads.Add(new OpenDebugThread(id, name));
+                    response.Threads.Add(new OpenDebugThread(id, name));
+                }
             }
 
             responder.SetResponse(response);


### PR DESCRIPTION
This PR adds a threadId to the Threads response to help users see what
the thread is in the CallStacks view.

**Old:**
![image](https://user-images.githubusercontent.com/3953714/160193295-e9c1fcb9-8865-4e90-b0d0-e837e7c84dc0.png)

**New:**
![image](https://user-images.githubusercontent.com/3953714/160193238-b5c3d68b-9d4d-4530-931d-9e5516105f6f.png)
