### PR TITLE
Add Test Case for DataBreakpoints

### DIFF
--- a/src/OpenDebugAD7/AD7DebugSession.cs
+++ b/src/OpenDebugAD7/AD7DebugSession.cs
@@ -2435,7 +2435,7 @@ namespace OpenDebugAD7
                     // We don't have a parent object. Default to using top stack frame
                     if (m_frameHandles == null || !m_frameHandles.TryGetFirst(out IDebugStackFrame2 frame))
                     {
-                        response.Description = string.Format(CultureInfo.CurrentCulture, AD7Resources.Error_DataBreakpointInfoFail, AD7Resources.Error_NoParentObject);
+                        throw new ProtocolException(string.Format(CultureInfo.CurrentCulture, AD7Resources.Error_DataBreakpointInfoFail, AD7Resources.Error_NoParentObject));
                     }
                     else
                     {
@@ -2450,7 +2450,7 @@ namespace OpenDebugAD7
                     eb.CheckHR(hr);
                     if (!string.IsNullOrEmpty(errorMessage))
                     {
-                        response.Description = string.Format(CultureInfo.CurrentCulture, AD7Resources.Error_DataBreakpointInfoFail, errorMessage);
+                        throw new ProtocolException(string.Format(CultureInfo.CurrentCulture, AD7Resources.Error_DataBreakpointInfoFail, errorMessage));
                     }
                     else
                     {
@@ -2461,21 +2461,21 @@ namespace OpenDebugAD7
                         response.AccessTypes = new List<DataBreakpointAccessType>() { DataBreakpointAccessType.Write };
                     }
                 }
-                else if (response.Description == null)
+                else
                 {
-                    response.Description = string.Format(CultureInfo.CurrentCulture, AD7Resources.Error_DataBreakpointInfoFail, AD7Resources.Error_ChildPropertyNotFound);
+                    throw new ProtocolException(string.Format(CultureInfo.CurrentCulture, AD7Resources.Error_DataBreakpointInfoFail, AD7Resources.Error_ChildPropertyNotFound));
                 }
+
+                responder.SetResponse(response);
             }
             catch (Exception ex)
             {
                 if (ex is AD7Exception ad7ex)
                     response.Description = ad7ex.Message;
+                else if (ex is ProtocolException peEx)
+                    responder.SetError(peEx);
                 else
-                    response.Description = string.Format(CultureInfo.CurrentCulture, AD7Resources.Error_DataBreakpointInfoFail, "");
-            }
-            finally
-            {
-                responder.SetResponse(response);
+                    responder.SetError(new ProtocolException(string.Format(CultureInfo.CurrentCulture, AD7Resources.Error_DataBreakpointInfoFail, "")));
             }
         }
 

--- a/test/CppTests/Tests/BreakpointTests.cs
+++ b/test/CppTests/Tests/BreakpointTests.cs
@@ -474,14 +474,8 @@ namespace CppTests.Tests
                 {
                     IFrameInspector mainFrame = inspector.Stack.First();
                     string value = mainFrame.GetVariable("total").Value;
-                    if (double.TryParse(value, out double result))
-                    {
-                        Assert.Equal(1.0, result);
-                    }
-                    else
-                    {
-                        Assert.Fail("Unable to get a valid value of type double.");
-                    }
+                    Assert.True(double.TryParse(value, out double result));
+                    Assert.Equal(1.0, result);
                 }
 
                 // Delete data breakpoint

--- a/test/CppTests/Tests/BreakpointTests.cs
+++ b/test/CppTests/Tests/BreakpointTests.cs
@@ -473,7 +473,15 @@ namespace CppTests.Tests
                 using (IThreadInspector inspector = runner.GetThreadInspector())
                 {
                     IFrameInspector mainFrame = inspector.Stack.First();
-                    Assert.Equal("1.0", mainFrame.GetVariable("total").Value);
+                    string value = mainFrame.GetVariable("total").Value;
+                    if (double.TryParse(value, out double result))
+                    {
+                        Assert.Equal(1.0, result);
+                    }
+                    else
+                    {
+                        Assert.Fail("Unable to get a valid value of type double.");
+                    }
                 }
 
                 // Delete data breakpoint

--- a/test/DebuggerTesting/OpenDebug/Commands/DataBreakpointInfoCommand.cs
+++ b/test/DebuggerTesting/OpenDebug/Commands/DataBreakpointInfoCommand.cs
@@ -1,0 +1,42 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using DebuggerTesting.Compilation;
+using DebuggerTesting.OpenDebug.Commands.Responses;
+using Newtonsoft.Json;
+
+namespace DebuggerTesting.OpenDebug.Commands
+{
+
+    #region DataBreakpointsInfoCommandArgs
+
+    public sealed class DataBreakpointsInfoCommandArgs : JsonValue
+    {
+        public int? variableReference;
+        public string name;
+    }
+
+    #endregion
+
+    public class DataBreakpointsInfoCommand : CommandWithResponse<DataBreakpointsInfoCommandArgs, DataBreakpointsInfoResponseValue>
+    {
+        public DataBreakpointsInfoCommand() : base("dataBreakpointInfo")
+        {
+        }
+
+        public DataBreakpointsInfoCommand(string name) :
+            this()
+        {
+            this.Args.name = name;
+        }
+
+        public override string ToString()
+        {
+            return "{0} ({1})".FormatInvariantWithArgs(base.ToString(), this.Args.name);
+        }
+    }
+}

--- a/test/DebuggerTesting/OpenDebug/Commands/Responses/DataBreakpointInfoResponseValue.cs
+++ b/test/DebuggerTesting/OpenDebug/Commands/Responses/DataBreakpointInfoResponseValue.cs
@@ -1,0 +1,17 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace DebuggerTesting.OpenDebug.Commands.Responses
+{
+    public sealed class DataBreakpointsInfoResponseValue : CommandResponseValue
+    {
+        public sealed class Body
+        {
+            public string dataId;
+            public string description;
+            public string[] accessTypes;
+            public bool canPersist;
+        }
+        public Body body = new Body();
+    }
+}

--- a/test/DebuggerTesting/OpenDebug/Commands/Responses/SetDataBreakpointsResponse.cs
+++ b/test/DebuggerTesting/OpenDebug/Commands/Responses/SetDataBreakpointsResponse.cs
@@ -1,0 +1,21 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace DebuggerTesting.OpenDebug.Commands.Responses
+{
+    public sealed class SetDataBreakpointsResponseValue : CommandResponseValue
+    {
+        public sealed class Body
+        {
+            public sealed class Breakpoint
+            {
+                public int? id;
+                public bool? verified;
+                public int? line;
+                public string message;
+            }
+            public Breakpoint[] breakpoints;
+        }
+        public Body body = new Body();
+    }
+}

--- a/test/DebuggerTesting/OpenDebug/Commands/SetDataBreakpointsCommand.cs
+++ b/test/DebuggerTesting/OpenDebug/Commands/SetDataBreakpointsCommand.cs
@@ -1,0 +1,105 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using DebuggerTesting.Compilation;
+using DebuggerTesting.OpenDebug.Commands.Responses;
+using Newtonsoft.Json;
+
+namespace DebuggerTesting.OpenDebug.Commands
+{
+
+    #region SetBreakpointsCommandArgs
+
+    public sealed class SetDataBreakpointsCommandArgs : JsonValue
+    {
+        public sealed class DataBreakpoint
+        {
+            public DataBreakpoint(string dataId, string accessTypes, string condition, string hitCondition)
+            {
+                this.dataId = dataId;
+                this.accessTypes = accessTypes;
+                this.condition = condition;
+                this.hitCondition = hitCondition;
+            }
+
+            public string dataId;
+
+            [JsonProperty(DefaultValueHandling = DefaultValueHandling.Ignore)]
+            public string accessTypes;
+
+            [JsonProperty(DefaultValueHandling = DefaultValueHandling.Ignore)]
+            public string condition;
+
+            [JsonProperty(DefaultValueHandling = DefaultValueHandling.Ignore)]
+            public string hitCondition;
+        }
+        public DataBreakpoint[] breakpoints;
+    }
+
+    #endregion
+
+    #region SourceBreakpoints
+
+    /// <summary>
+    /// Contains information on all the breakpoints for a source file
+    /// </summary>
+    public sealed class DataBreakpoints
+    {
+        private List<SetDataBreakpointsCommandArgs.DataBreakpoint> breakpoints;
+
+        public DataBreakpoints()
+        {
+            this.breakpoints = new List<SetDataBreakpointsCommandArgs.DataBreakpoint>();
+        }
+
+        public DataBreakpoints(params string[] dataIds)
+    : this()
+        {
+            foreach (string dataId in dataIds)
+            {
+                this.Add(dataId);
+            }
+        }
+
+        public DataBreakpoints Add(string dataId, string accessType = "write", string condition = null, string hitCondition = null)
+        {
+            this.breakpoints.Add(new SetDataBreakpointsCommandArgs.DataBreakpoint(dataId, accessType, condition, null));
+            return this;
+        }
+
+        public DataBreakpoints Remove(string dataId)
+        {
+            this.breakpoints.RemoveAll(bp => String.Equals(bp.dataId, dataId, StringComparison.Ordinal));
+            return this;
+        }
+
+        internal IList<SetDataBreakpointsCommandArgs.DataBreakpoint> Breakpoints
+        {
+            get { return this.breakpoints; }
+        }
+    }
+
+    #endregion
+
+    public class SetDataBreakpointsCommand : CommandWithResponse<SetDataBreakpointsCommandArgs, SetDataBreakpointsResponseValue>
+    {
+        public SetDataBreakpointsCommand() : base("setDataBreakpoints")
+        {
+        }
+
+        public SetDataBreakpointsCommand(DataBreakpoints dataBreakpoints) :
+            this()
+        {
+            this.Args.breakpoints = dataBreakpoints.Breakpoints.ToArray();
+        }
+
+        public override string ToString()
+        {
+            return "{0} ({1})".FormatInvariantWithArgs(base.ToString(), String.Join(", ", this.Args.breakpoints.Select(bp => bp.dataId)));
+        }
+    }
+}

--- a/test/DebuggerTesting/OpenDebug/Extensions/DebuggerRunnerExtensions.cs
+++ b/test/DebuggerTesting/OpenDebug/Extensions/DebuggerRunnerExtensions.cs
@@ -212,6 +212,16 @@ namespace DebuggerTesting.OpenDebug.Extensions
             return runner.RunCommand(new SetInstructionBreakpointsCommand(breakpoints));
         }
 
+        public static DataBreakpointsInfoResponseValue DataBreakpointInfo(this IDebuggerRunner runner, string name)
+        {
+            return runner.RunCommand(new DataBreakpointsInfoCommand(name));
+        }
+
+        public static SetDataBreakpointsResponseValue SetDataBreakpoints(this IDebuggerRunner runner, DataBreakpoints breakpoints)
+        {
+            return runner.RunCommand(new SetDataBreakpointsCommand(breakpoints));
+        }
+
         public static string[] CompletionsRequest(this IDebuggerRunner runner, string text)
         {
             CompletionItem[] completionItems = runner.RunCommand(new CompletionsCommand(null, text, 0, null))?.body?.targets;


### PR DESCRIPTION
Added a test case for data breakpoints for GDB
- Added command and response for SetDataBreakpoint and DataBreakpointInfo

Also fixed an issue where we would fail in DataBreakpointInfo but still return a successful response.