### PR TITLE
EnsureSettingsUpdated returning null for Task

### DIFF
--- a/src/MIDebugEngine/Engine.Impl/ExceptionManager.cs
+++ b/src/MIDebugEngine/Engine.Impl/ExceptionManager.cs
@@ -384,7 +384,7 @@ namespace Microsoft.MIDebugEngine
                     // If we are still delaying our processing, stop delaying it
                     _updateDelayCancelSource.Cancel();
 
-                    return _updateTask;
+                    return _updateTask ?? Task.CompletedTask;
                 }
                 else if (!_initialSettingssSent && _categoryMap.Count > 0)
                 {

--- a/src/MIDebugEngine/Engine.Impl/ExceptionManager.cs
+++ b/src/MIDebugEngine/Engine.Impl/ExceptionManager.cs
@@ -379,12 +379,13 @@ namespace Microsoft.MIDebugEngine
         {
             lock (_updateLock)
             {
-                if (_updateTask != null)
+                Task updateTask = _updateTask;
+                if (updateTask != null)
                 {
                     // If we are still delaying our processing, stop delaying it
-                    _updateDelayCancelSource.Cancel();
+                    _updateDelayCancelSource?.Cancel();
 
-                    return _updateTask ?? Task.CompletedTask;
+                    return updateTask;
                 }
                 else if (!_initialSettingssSent && _categoryMap.Count > 0)
                 {
@@ -395,7 +396,7 @@ namespace Microsoft.MIDebugEngine
                     // immediately cancel the delay since we don't want one
                     _updateDelayCancelSource = new CancellationTokenSource();
                     _updateDelayCancelSource.Cancel();
-                    Task updateTask = FlushSettingsUpdates();
+                    updateTask = FlushSettingsUpdates();
                     if (!updateTask.IsCompleted)
                     {
                         _updateTask = updateTask;
@@ -405,7 +406,7 @@ namespace Microsoft.MIDebugEngine
                 else
                 {
                     // No task is running, so just return an already signaled task
-                    return Task.FromResult<object>(null);
+                    return Task.CompletedTask;
                 }
             }
         }


### PR DESCRIPTION
This is probably not the correct fix, but this solves #1297 issue. 

Although we have a null check on line 382, we are still returning `null` for `_updateTask`. 
All instances of `_updateTask` are guarded by `_updateLock` so I am not exactly sure why this is needed.

The issue is we get a setExceptions command and most likely a background thread is going to process `FlushSettingsUpdates`. At the same time, we get a continue command which fires `EnsureSettingsUpdated` but a null is returned instead of a Task which gets awaited at
https://github.com/microsoft/MIEngine/blob/8d70a37d2243862eccba70a6226bf684708871c7/src/MIDebugEngine/Engine.Impl/DebuggedProcess.cs#L1674