### PR TITLE
Bug 1447876: Local window variable value can not be synchronized with…

### DIFF
--- a/src/MIDebugEngine/AD7.Impl/AD7StackFrame.cs
+++ b/src/MIDebugEngine/AD7.Impl/AD7StackFrame.cs
@@ -22,7 +22,6 @@ namespace Microsoft.MIDebugEngine
 
         private string _functionName;
         private MITextPosition _textPosition;
-        private bool _hasGottenLocalsAndParams = false;
         private uint _radix;
         private AD7MemoryAddress _codeCxt;
         private AD7DocumentContext _documentCxt;
@@ -249,7 +248,7 @@ namespace Microsoft.MIDebugEngine
                     await Engine.UpdateRadixAsync(radix);
                 });
             }
-            if (_textPosition != null && (!_hasGottenLocalsAndParams || radix != _radix))
+            if (_textPosition != null && radix != _radix)
             {
                 _radix = radix;
                 List<VariableInformation> localsAndParameters = null;
@@ -271,8 +270,6 @@ namespace Microsoft.MIDebugEngine
                         _locals.Add(vi);
                     }
                 }
-
-                _hasGottenLocalsAndParams = true;
             }
         }
 
@@ -399,15 +396,6 @@ namespace Microsoft.MIDebugEngine
                     guidFilter == AD7Guids.guidFilterLocals ||
                     guidFilter == AD7Guids.guidFilterLocalsPlusArgs)
                 {
-                    /*
-                    Question: do we want to filter on guidFilter?
-
-                    if (guidFilter == AD7Guids.guidFilterLocalsPlusArgs)
-                    {
-                        _hasGottenLocalsAndParams = false;
-                    }
-                    */
-                    _hasGottenLocalsAndParams = false;
                     EnsureLocalsAndParameters();
                 }
 

--- a/src/MIDebugEngine/AD7.Impl/AD7StackFrame.cs
+++ b/src/MIDebugEngine/AD7.Impl/AD7StackFrame.cs
@@ -399,6 +399,15 @@ namespace Microsoft.MIDebugEngine
                     guidFilter == AD7Guids.guidFilterLocals ||
                     guidFilter == AD7Guids.guidFilterLocalsPlusArgs)
                 {
+                    /*
+                    Question: do we want to filter on guidFilter?
+
+                    if (guidFilter == AD7Guids.guidFilterLocalsPlusArgs)
+                    {
+                        _hasGottenLocalsAndParams = false;
+                    }
+                    */
+                    _hasGottenLocalsAndParams = false;
                     EnsureLocalsAndParameters();
                 }
 

--- a/src/MIDebugEngine/AD7.Impl/AD7StackFrame.cs
+++ b/src/MIDebugEngine/AD7.Impl/AD7StackFrame.cs
@@ -244,29 +244,27 @@ namespace Microsoft.MIDebugEngine
                     await Engine.UpdateRadixAsync(radix);
                 });
             }
-            //if (_textPosition != null && radix != _radix)
-            //{
-            _radix = radix;
-            List<VariableInformation> localsAndParameters = null;
-            Engine.DebuggedProcess.WorkerThread.RunOperation(async () =>
+            if (_textPosition != null)
             {
-                localsAndParameters = await Engine.DebuggedProcess.GetLocalsAndParameters(Thread, ThreadContext);
-            });
+                _radix = radix;
+                List<VariableInformation> localsAndParameters = null;
+                Engine.DebuggedProcess.WorkerThread.RunOperation(async () =>
+                {
+                    localsAndParameters = await Engine.DebuggedProcess.GetLocalsAndParameters(Thread, ThreadContext);
+                });
 
-            parameters.Clear();
-            locals.Clear();
-            foreach (VariableInformation vi in localsAndParameters)
-            {
-                if (vi.IsParameter)
+                foreach (VariableInformation vi in localsAndParameters)
                 {
-                    parameters.Add(vi);
-                }
-                else
-                {
-                    locals.Add(vi);
+                    if (vi.IsParameter)
+                    {
+                        parameters.Add(vi);
+                    }
+                    else
+                    {
+                        locals.Add(vi);
+                    }
                 }
             }
-            //}
         }
 
         // Construct an instance of IEnumDebugPropertyInfo2 for the combined locals and parameters.
@@ -286,7 +284,7 @@ namespace Microsoft.MIDebugEngine
 
             if (parameters  != null)
             {
-                elementsReturned += (uint)parameters .Count;
+                elementsReturned += (uint)parameters.Count;
             }
             DEBUG_PROPERTY_INFO[] propInfo = new DEBUG_PROPERTY_INFO[elementsReturned];
 
@@ -301,7 +299,7 @@ namespace Microsoft.MIDebugEngine
 
             if (parameters  != null)
             {
-                for (int i = 0; i < parameters .Count; i++)
+                for (int i = 0; i < parameters.Count; i++)
                 {
                     AD7Property property = new AD7Property(Engine, parameters [i]);
                     propInfo[localsLength + i] = property.ConstructDebugPropertyInfo(dwFields);
@@ -314,7 +312,7 @@ namespace Microsoft.MIDebugEngine
         // Construct an instance of IEnumDebugPropertyInfo2 for the locals collection only.
         private void CreateLocalProperties(enum_DEBUGPROP_INFO_FLAGS dwFields, out uint elementsReturned, out IEnumDebugPropertyInfo2 enumObject)
         {
-            GetLocalsAndParameters(out List<VariableInformation> locals, out List<VariableInformation> parameters);
+            GetLocalsAndParameters(out List<VariableInformation> locals, out _);
 
             elementsReturned = (uint)locals.Count;
             DEBUG_PROPERTY_INFO[] propInfo = new DEBUG_PROPERTY_INFO[locals.Count];
@@ -331,10 +329,10 @@ namespace Microsoft.MIDebugEngine
         // Construct an instance of IEnumDebugPropertyInfo2 for the parameters collection only.
         private void CreateParameterProperties(enum_DEBUGPROP_INFO_FLAGS dwFields, out uint elementsReturned, out IEnumDebugPropertyInfo2 enumObject)
         {
-            GetLocalsAndParameters(out List<VariableInformation> locals, out List<VariableInformation> parameters);
+            GetLocalsAndParameters(out _, out List<VariableInformation> parameters);
 
-            elementsReturned = (uint)parameters .Count;
-            DEBUG_PROPERTY_INFO[] propInfo = new DEBUG_PROPERTY_INFO[parameters .Count];
+            elementsReturned = (uint)parameters.Count;
+            DEBUG_PROPERTY_INFO[] propInfo = new DEBUG_PROPERTY_INFO[parameters.Count];
 
             for (int i = 0; i < propInfo.Length; i++)
             {
@@ -392,15 +390,6 @@ namespace Microsoft.MIDebugEngine
 
             try
             {
-                if (guidFilter == AD7Guids.guidFilterAllLocals ||
-                    guidFilter == AD7Guids.guidFilterAllLocalsPlusArgs ||
-                    guidFilter == AD7Guids.guidFilterArgs ||
-                    guidFilter == AD7Guids.guidFilterLocals ||
-                    guidFilter == AD7Guids.guidFilterLocalsPlusArgs)
-                {
-                    GetLocalsAndParameters(out List<VariableInformation> locals, out List<VariableInformation> parameters);
-                }
-
                 if (guidFilter == AD7Guids.guidFilterLocalsPlusArgs ||
                         guidFilter == AD7Guids.guidFilterAllLocalsPlusArgs ||
                         guidFilter == AD7Guids.guidFilterAllLocals)


### PR DESCRIPTION
… Immediate window value change

We want `_hasGottenLocalsAndParams` to be false when the user modifies the value of a Locals variable in the Immediate window. By resetting `_hasGottenLocalsAndParams` to its default value before the call to `EnsureLocalsAndParameters()`, the Locals variable values are updated correctly.

**Note: there is a very noticeable lag to the change in the Locals window for the current implementation.**

**Before**
![image](https://user-images.githubusercontent.com/60245970/160914405-db66dd74-d2f0-40f2-a652-311b29390536.png)

**After**
![image](https://user-images.githubusercontent.com/60245970/160915228-88dee66a-f3eb-42f0-95df-e727dddc241a.png)
