### PR TITLE
Fix GitHub Action Test runs

### DIFF
--- a/.github/workflows/Build-And-Test.yml
+++ b/.github/workflows/Build-And-Test.yml
@@ -195,7 +195,7 @@ jobs:
       if: ${{ always() }}
       with:
         name: linux_x64_results
-        path: ${{ github.workspace }}/bin/DebugAdapterProtocolTests/Debug/CppTests/results*.trx
+        path: ${{ github.workspace }}/bin/DebugAdapterProtocolTests/Debug/CppTests/results.trx
 
   osx_build:
     runs-on: macos-latest
@@ -210,11 +210,6 @@ jobs:
       with:
         dotnet-version: 6.0.x
 
-    # BSD grep will fail on -o and -P. Install GNU Grep
-    - run: |
-        brew install grep
-        echo 'export PATH="/usr/local/opt/grep/libexec/gnubin:$PATH"' >> .bash_profile
-
     - name: Build
       run: dotnet build ${{ github.workspace }}/src/MIDebugEngine-Unix.sln
 
@@ -222,7 +217,6 @@ jobs:
         ${{ github.workspace }}/eng/Scripts/CI-Build.sh
 
     - run: |
-        [ -f .bash_profile ] && source .bash_profile
         ${{ github.workspace }}/eng/Scripts/CI-Test.sh
 
     - name: 'Upload Test Results'
@@ -230,4 +224,4 @@ jobs:
       if: ${{ always() }}
       with:
         name: osx_x64_results
-        path: ${{ github.workspace }}/bin/DebugAdapterProtocolTests/Debug/CppTests/results*.trx
+        path: ${{ github.workspace }}/bin/DebugAdapterProtocolTests/Debug/CppTests/results.trx

--- a/.github/workflows/Build-And-Test.yml
+++ b/.github/workflows/Build-And-Test.yml
@@ -85,6 +85,57 @@ jobs:
         install: >-
           mingw-w64-x86_64-toolchain
 
+    # As of Nov 8, 2021, mingw-w64-x86_64-toolchain-11.1.x
+    # causes GDB to return "During startup program exited with code 0xc0000139"
+    # Downgrade to working toolchain (04-May-2021)
+    # TODO: Remove this task when there is a newer version of toolchain than 11.1.x
+    - shell: msys2 {0}
+      name: Downgrade toolchain to 10.x
+      run: |
+        # Download GDB
+        DOWNLOAD_DOWNGRADED_GDB_PATH='${{ github.workspace }}/mingw-w64-x86_64-gdb-10.2-2-any.pkg.tar.zst'
+        DOWNLOAD_DOWNGRADED_GDB_PATH=${DOWNLOAD_DOWNGRADED_GDB_PATH//\\//}
+        wget -O ${DOWNLOAD_DOWNGRADED_GDB_PATH} http://repo.msys2.org/mingw/x86_64/mingw-w64-x86_64-gdb-10.2-2-any.pkg.tar.zst
+
+        # Download GCC
+        DOWNLOAD_DOWNGRADED_GCC_PATH='${{ github.workspace }}/mingw-w64-x86_64-gcc-10.3.0-8-any.pkg.tar.zst'
+        DOWNLOAD_DOWNGRADED_GCC_PATH=${DOWNLOAD_DOWNGRADED_GCC_PATH//\\//}
+        wget -O ${DOWNLOAD_DOWNGRADED_GCC_PATH} http://repo.msys2.org/mingw/x86_64/mingw-w64-x86_64-gcc-10.3.0-8-any.pkg.tar.zst
+
+        # Download GCC Lib
+        DOWNLOAD_DOWNGRADED_GCCLIB_PATH='${{ github.workspace }}/mingw-w64-x86_64-gcc-libs-10.3.0-8-any.pkg.tar.zst'
+        DOWNLOAD_DOWNGRADED_GCCLIB_PATH=${DOWNLOAD_DOWNGRADED_GCCLIB_PATH//\\//}
+        wget -O ${DOWNLOAD_DOWNGRADED_GCCLIB_PATH} http://repo.msys2.org/mingw/x86_64/mingw-w64-x86_64-gcc-libs-10.3.0-8-any.pkg.tar.zst
+
+        # Download GCC Ada
+        DOWNLOAD_DOWNGRADED_ADA_PATH='${{ github.workspace }}/mingw-w64-x86_64-gcc-ada-10.3.0-8-any.pkg.tar.zst'
+        DOWNLOAD_DOWNGRADED_ADA_PATH=${DOWNLOAD_DOWNGRADED_ADA_PATH//\\//}
+        wget -O ${DOWNLOAD_DOWNGRADED_ADA_PATH} http://repo.msys2.org/mingw/x86_64/mingw-w64-x86_64-gcc-ada-10.3.0-8-any.pkg.tar.zst
+
+        # Download GCC Fortran
+        DOWNLOAD_DOWNGRADED_FORTRAN_PATH='${{ github.workspace }}/mingw-w64-x86_64-gcc-fortran-10.3.0-8-any.pkg.tar.zst'
+        DOWNLOAD_DOWNGRADED_FORTRAN_PATH=${DOWNLOAD_DOWNGRADED_FORTRAN_PATH//\\//}
+        wget -O ${DOWNLOAD_DOWNGRADED_FORTRAN_PATH} http://repo.msys2.org/mingw/x86_64/mingw-w64-x86_64-gcc-fortran-10.3.0-8-any.pkg.tar.zst
+
+        # Download GCC Libfortran
+        DOWNLOAD_DOWNGRADED_LIBFORTRAN_PATH='${{ github.workspace }}/mingw-w64-x86_64-gcc-libgfortran-10.3.0-8-any.pkg.tar.zst'
+        DOWNLOAD_DOWNGRADED_LIBFORTRAN_PATH=${DOWNLOAD_DOWNGRADED_LIBFORTRAN_PATH//\\//}
+        wget -O ${DOWNLOAD_DOWNGRADED_LIBFORTRAN_PATH} http://repo.msys2.org/mingw/x86_64/mingw-w64-x86_64-gcc-libgfortran-10.3.0-8-any.pkg.tar.zst
+
+        # Download GCC Obj-C
+        DOWNLOAD_DOWNGRADED_OBJC_PATH='${{ github.workspace }}/mingw-w64-x86_64-gcc-objc-10.3.0-8-any.pkg.tar.zst'
+        DOWNLOAD_DOWNGRADED_OBJC_PATH=${DOWNLOAD_DOWNGRADED_OBJC_PATH//\\//}
+        wget -O ${DOWNLOAD_DOWNGRADED_OBJC_PATH} http://repo.msys2.org/mingw/x86_64/mingw-w64-x86_64-gcc-objc-10.3.0-8-any.pkg.tar.zst
+
+        # Download GCC libgccjit
+        DOWNLOAD_DOWNGRADED_LIBGCCJIT_PATH='${{ github.workspace }}/mingw-w64-x86_64-libgccjit-10.3.0-8-any.pkg.tar.zst'
+        DOWNLOAD_DOWNGRADED_LIBGCCJIT_PATH=${DOWNLOAD_DOWNGRADED_LIBGCCJIT_PATH//\\//}
+        wget -O ${DOWNLOAD_DOWNGRADED_LIBGCCJIT_PATH} http://repo.msys2.org/mingw/x86_64/mingw-w64-x86_64-libgccjit-10.3.0-8-any.pkg.tar.zst
+
+        # Install
+        pacman -U --noconfirm $DOWNLOAD_DOWNGRADED_GDB_PATH $DOWNLOAD_DOWNGRADED_GCC_PATH $DOWNLOAD_DOWNGRADED_GCCLIB_PATH $DOWNLOAD_DOWNGRADED_ADA_PATH $DOWNLOAD_DOWNGRADED_FORTRAN_PATH $DOWNLOAD_DOWNGRADED_LIBFORTRAN_PATH $DOWNLOAD_DOWNGRADED_OBJC_PATH $DOWNLOAD_DOWNGRADED_LIBGCCJIT_PATH
+
+    
     - shell: msys2 {0}
       name: Gather c++ toolchain paths
       run: |
@@ -94,7 +145,8 @@ jobs:
         gdb --version
 
 
-    - run: >
+    - run: |
+        set PATH="%PATH%;D:\a\_temp\msys64\mingw64\bin\"
         dotnet test ${{ github.workspace }}\bin\DebugAdapterProtocolTests\Debug\CppTests\CppTests.dll --logger "trx;LogFileName=${{ github.workspace }}\bin\DebugAdapterProtocolTests\Debug\CppTests\results.trx"
 
     - name: 'Upload Test Results'
@@ -143,7 +195,7 @@ jobs:
       if: ${{ always() }}
       with:
         name: linux_x64_results
-        path: ${{ github.workspace }}/bin/DebugAdapterProtocolTests/Debug/CppTests/results.trx
+        path: ${{ github.workspace }}/bin/DebugAdapterProtocolTests/Debug/CppTests/results*.trx
 
   osx_build:
     runs-on: macos-latest
@@ -158,6 +210,10 @@ jobs:
       with:
         dotnet-version: 6.0.x
 
+    - run: |
+        brew install grep
+        echo 'export PATH="/usr/local/opt/grep/libexec/gnubin:$PATH"' >> .bash_profile
+
     - name: Build
       run: dotnet build ${{ github.workspace }}/src/MIDebugEngine-Unix.sln
 
@@ -165,6 +221,7 @@ jobs:
         ${{ github.workspace }}/eng/Scripts/CI-Build.sh
 
     - run: |
+        [ -f .bash_profile ] && source .bash_profile
         ${{ github.workspace }}/eng/Scripts/CI-Test.sh
 
     - name: 'Upload Test Results'
@@ -172,4 +229,4 @@ jobs:
       if: ${{ always() }}
       with:
         name: osx_x64_results
-        path: ${{ github.workspace }}/bin/DebugAdapterProtocolTests/Debug/CppTests/results.trx
+        path: ${{ github.workspace }}/bin/DebugAdapterProtocolTests/Debug/CppTests/results*.trx

--- a/.github/workflows/Build-And-Test.yml
+++ b/.github/workflows/Build-And-Test.yml
@@ -210,6 +210,7 @@ jobs:
       with:
         dotnet-version: 6.0.x
 
+    # BSD grep will fail on -o and -P. Install GNU Grep
     - run: |
         brew install grep
         echo 'export PATH="/usr/local/opt/grep/libexec/gnubin:$PATH"' >> .bash_profile

--- a/eng/Scripts/CI-Test.sh
+++ b/eng/Scripts/CI-Test.sh
@@ -41,7 +41,7 @@ counter=0
 while [ $counter -lt 3 ]
 do
     echo -e "Retry $counter for $filter"
-    if [ ! "$(dotnet test "$RootDir"/bin/DebugAdapterProtocolTests/Debug/CppTests/CppTests.dll --logger "trx;LogFileName=$RootDir/bin/DebugAdapterProtocolTests/Debug/CppTests/results-$counter.trx" --filter "$filter" > /dev/null 2>&1)" ]
+    if [ "$(dotnet test "$RootDir"/bin/DebugAdapterProtocolTests/Debug/CppTests/CppTests.dll --logger "trx;LogFileName=$RootDir/bin/DebugAdapterProtocolTests/Debug/CppTests/results-$counter.trx" --filter "$filter" > /dev/null 2>&1)" ]
     then
         echo "Tests failed on rerun #$counter".
         exit $exitcode

--- a/eng/Scripts/CI-Test.sh
+++ b/eng/Scripts/CI-Test.sh
@@ -19,33 +19,4 @@ if [ ! -f "$RootDir/bin/DebugAdapterProtocolTests/Debug/CppTests/config.xml" ]; 
     fi
 fi
 
-# Adapted from https://www.cazzulino.com/dotnet-test-retry.html
-exitcode=0
-dotnet test "$RootDir"/bin/DebugAdapterProtocolTests/Debug/CppTests/CppTests.dll --logger "trx;LogFileName=$RootDir/bin/DebugAdapterProtocolTests/Debug/CppTests/results.trx" | tee ./output.log
-# run test and forward output also to a file in addition to stdout (tee command)
-# capture dotnet test exit status, different from tee
-exitcode=${PIPESTATUS[0]}
-if [ "$exitcode" == 0 ]
-then
-    exit 0
-fi
-# Get failed test names, join as DisplayName=TEST with |, remove trailing |.
-filter=$(grep -o -P '(?<=\sFailed\sCppTests.Tests.)\w*' < ./output.log | awk 'BEGIN { ORS="|" } { print("DisplayName~" $0) }' | grep -o -P '.*(?=\|$)')
-if [ -z "$filter" ] && [ "$(uname)" = "Darwin" ]; then
-    echo -e "Failed to set a filter. Make sure you are using GNU grep from homebrew."
-    exit 1
-fi
-
-# Make sure the next 3 runs are clean for the failing tests.
-counter=0
-while [ $counter -lt 3 ]
-do
-    echo -e "Retry $counter for $filter"
-    if [ ! "$(dotnet test "$RootDir"/bin/DebugAdapterProtocolTests/Debug/CppTests/CppTests.dll --logger "trx;LogFileName=$RootDir/bin/DebugAdapterProtocolTests/Debug/CppTests/results-$counter.trx" --filter "$filter" > /dev/null 2>&1)" ]
-    then
-        echo "Tests failed on rerun #$counter".
-        exit $exitcode
-    fi
-    ((counter++))
-done
-exit 0
+dotnet test "$RootDir"/bin/DebugAdapterProtocolTests/Debug/CppTests/CppTests.dll --logger "trx;LogFileName=$RootDir/bin/DebugAdapterProtocolTests/Debug/CppTests/results.trx"

--- a/eng/Scripts/CI-Test.sh
+++ b/eng/Scripts/CI-Test.sh
@@ -19,4 +19,30 @@ if [ ! -f "$RootDir/bin/DebugAdapterProtocolTests/Debug/CppTests/config.xml" ]; 
     fi
 fi
 
-dotnet test "$RootDir"/bin/DebugAdapterProtocolTests/Debug/CppTests/CppTests.dll --logger "trx;LogFileName=$RootDir/bin/DebugAdapterProtocolTests/Debug/CppTests/results.trx"
+# Adapted from https://www.cazzulino.com/dotnet-test-retry.html
+counter=0
+exitcode=0
+while [ $counter -lt 6 ]
+do
+    if [ "$filter" ]
+    then
+        echo -e "Retry $counter for $filter"
+        dotnet test "$RootDir"/bin/DebugAdapterProtocolTests/Debug/CppTests/CppTests.dll --logger "trx;LogFileName=$RootDir/bin/DebugAdapterProtocolTests/Debug/CppTests/results-$counter.trx" --filter "$filter" | tee ./output.log
+    else
+        dotnet test "$RootDir"/bin/DebugAdapterProtocolTests/Debug/CppTests/CppTests.dll --logger "trx;LogFileName=$RootDir/bin/DebugAdapterProtocolTests/Debug/CppTests/results.trx" | tee ./output.log
+    fi
+    # run test and forward output also to a file in addition to stdout (tee command)
+    # capture dotnet test exit status, different from tee
+    exitcode=${PIPESTATUS[0]}
+    if [ "$exitcode" == 0 ]
+    then
+        exit 0
+    fi
+    # cat output, get failed test names, join as DisplayName=TEST with |, remove trailing |.
+    filter=$(grep -o -P '(?<=\sFailed\s)\w*' < ./output.log | awk 'BEGIN { ORS="|" } { print("DisplayName=" $0) }' | grep -o -P '.*(?=\|$)')
+    if [ -z "$filter" ] && [ "$(uname)" = "Darwin" ]; then
+        echo -e "Failed to set a filter. Make sure you are using GNU grep from homebrew."
+    fi
+    ((counter++))
+done
+exit "$exitcode"

--- a/eng/Scripts/CI-Test.sh
+++ b/eng/Scripts/CI-Test.sh
@@ -41,7 +41,7 @@ counter=0
 while [ $counter -lt 3 ]
 do
     echo -e "Retry $counter for $filter"
-    if [ "$(dotnet test "$RootDir"/bin/DebugAdapterProtocolTests/Debug/CppTests/CppTests.dll --logger "trx;LogFileName=$RootDir/bin/DebugAdapterProtocolTests/Debug/CppTests/results-$counter.trx" --filter "$filter" > /dev/null 2>&1)" ]
+    if [ ! "$(dotnet test "$RootDir"/bin/DebugAdapterProtocolTests/Debug/CppTests/CppTests.dll --logger "trx;LogFileName=$RootDir/bin/DebugAdapterProtocolTests/Debug/CppTests/results-$counter.trx" --filter "$filter" > /dev/null 2>&1)" ]
     then
         echo "Tests failed on rerun #$counter".
         exit $exitcode

--- a/eng/Scripts/CI-Test.sh
+++ b/eng/Scripts/CI-Test.sh
@@ -30,7 +30,7 @@ then
     exit 0
 fi
 # Get failed test names, join as DisplayName=TEST with |, remove trailing |.
-filter=$(grep -o -P '(?<=\sFailed\s)\w*' < ./output.log | awk 'BEGIN { ORS="|" } { print("DisplayName=" $0) }' | grep -o -P '.*(?=\|$)')
+filter=$(grep -o -P '(?<=\sFailed\sCppTests.Tests.)\w*' < ./output.log | awk 'BEGIN { ORS="|" } { print("DisplayName~" $0) }' | grep -o -P '.*(?=\|$)')
 if [ -z "$filter" ] && [ "$(uname)" = "Darwin" ]; then
     echo -e "Failed to set a filter. Make sure you are using GNU grep from homebrew."
     exit 1

--- a/eng/Scripts/CI-Test.sh
+++ b/eng/Scripts/CI-Test.sh
@@ -20,28 +20,32 @@ if [ ! -f "$RootDir/bin/DebugAdapterProtocolTests/Debug/CppTests/config.xml" ]; 
 fi
 
 # Adapted from https://www.cazzulino.com/dotnet-test-retry.html
-counter=0
 exitcode=0
-while [ $counter -lt 6 ]
+dotnet test "$RootDir"/bin/DebugAdapterProtocolTests/Debug/CppTests/CppTests.dll --logger "trx;LogFileName=$RootDir/bin/DebugAdapterProtocolTests/Debug/CppTests/results.trx" | tee ./output.log
+# run test and forward output also to a file in addition to stdout (tee command)
+# capture dotnet test exit status, different from tee
+exitcode=${PIPESTATUS[0]}
+if [ "$exitcode" == 0 ]
+then
+    exit 0
+fi
+# Get failed test names, join as DisplayName=TEST with |, remove trailing |.
+filter=$(grep -o -P '(?<=\sFailed\s)\w*' < ./output.log | awk 'BEGIN { ORS="|" } { print("DisplayName=" $0) }' | grep -o -P '.*(?=\|$)')
+if [ -z "$filter" ] && [ "$(uname)" = "Darwin" ]; then
+    echo -e "Failed to set a filter. Make sure you are using GNU grep from homebrew."
+    exit 1
+fi
+
+# Make sure the next 3 runs are clean for the failing tests.
+counter=0
+while [ $counter -lt 3 ]
 do
-    if [ "$filter" ]
+    echo -e "Retry $counter for $filter"
+    dotnet test "$RootDir"/bin/DebugAdapterProtocolTests/Debug/CppTests/CppTests.dll --logger "trx;LogFileName=$RootDir/bin/DebugAdapterProtocolTests/Debug/CppTests/results-$counter.trx" --filter "$filter" > /dev/null 2>&1
+    if [ "$exitcode" != 0 ]
     then
-        echo -e "Retry $counter for $filter"
-        dotnet test "$RootDir"/bin/DebugAdapterProtocolTests/Debug/CppTests/CppTests.dll --logger "trx;LogFileName=$RootDir/bin/DebugAdapterProtocolTests/Debug/CppTests/results-$counter.trx" --filter "$filter" | tee ./output.log
-    else
-        dotnet test "$RootDir"/bin/DebugAdapterProtocolTests/Debug/CppTests/CppTests.dll --logger "trx;LogFileName=$RootDir/bin/DebugAdapterProtocolTests/Debug/CppTests/results.trx" | tee ./output.log
-    fi
-    # run test and forward output also to a file in addition to stdout (tee command)
-    # capture dotnet test exit status, different from tee
-    exitcode=${PIPESTATUS[0]}
-    if [ "$exitcode" == 0 ]
-    then
-        exit 0
-    fi
-    # cat output, get failed test names, join as DisplayName=TEST with |, remove trailing |.
-    filter=$(grep -o -P '(?<=\sFailed\s)\w*' < ./output.log | awk 'BEGIN { ORS="|" } { print("DisplayName=" $0) }' | grep -o -P '.*(?=\|$)')
-    if [ -z "$filter" ] && [ "$(uname)" = "Darwin" ]; then
-        echo -e "Failed to set a filter. Make sure you are using GNU grep from homebrew."
+        echo "Tests failed on rerun #$counter".
+        exit "$exitcode"
     fi
     ((counter++))
 done

--- a/eng/Scripts/CI-Test.sh
+++ b/eng/Scripts/CI-Test.sh
@@ -41,12 +41,11 @@ counter=0
 while [ $counter -lt 3 ]
 do
     echo -e "Retry $counter for $filter"
-    dotnet test "$RootDir"/bin/DebugAdapterProtocolTests/Debug/CppTests/CppTests.dll --logger "trx;LogFileName=$RootDir/bin/DebugAdapterProtocolTests/Debug/CppTests/results-$counter.trx" --filter "$filter" > /dev/null 2>&1
-    if [ "$exitcode" != 0 ]
+    if [ ! "$(dotnet test "$RootDir"/bin/DebugAdapterProtocolTests/Debug/CppTests/CppTests.dll --logger "trx;LogFileName=$RootDir/bin/DebugAdapterProtocolTests/Debug/CppTests/results-$counter.trx" --filter "$filter" > /dev/null 2>&1)" ]
     then
         echo "Tests failed on rerun #$counter".
-        exit "$exitcode"
+        exit $exitcode
     fi
     ((counter++))
 done
-exit "$exitcode"
+exit 0

--- a/src/MICore/Transports/PipeTransport.cs
+++ b/src/MICore/Transports/PipeTransport.cs
@@ -177,7 +177,7 @@ namespace MICore
 
                 try
                 {
-                    _writer.Close();
+                    _writer?.Close();
                 }
                 catch (IOException)
                 {


### PR DESCRIPTION
This PR revert "Remove downgrade to GNU toolchain (#1298)" since
machines seem to be flaky on which versions of GDB we get.

This reverts commit 8d70a37d2243862eccba70a6226bf684708871c7.

We also introduce retry logic for dotnet test on flaky tests.

Also does a null check on writer.close since that seems to be the cause
of most tests failing when disconnecting.