### PR TITLE
Fix deleting breakpoints created as pending

### DIFF
--- a/src/MIDebugEngine/AD7.Impl/AD7PendingBreakpoint.cs
+++ b/src/MIDebugEngine/AD7.Impl/AD7PendingBreakpoint.cs
@@ -321,11 +321,6 @@ namespace Microsoft.MIDebugEngine
                 this.SetError(new AD7ErrorBreakpoint(this, ResourceStrings.LongBind, enum_BP_ERROR_TYPE.BPET_SEV_LOW | enum_BP_ERROR_TYPE.BPET_TYPE_WARNING), true);
                 return Constants.S_FALSE;
             }
-            else if (this._BPError != null)
-            {
-                // Ran into some sort of error
-                return Constants.E_FAIL;
-            }
             else
             {
                 if ((enum_BP_LOCATION_TYPE)_bpRequestInfo.bpLocation.bpLocationType == enum_BP_LOCATION_TYPE.BPLT_DATA_STRING)

--- a/src/MIDebugEngine/AD7.Impl/AD7PendingBreakpoint.cs
+++ b/src/MIDebugEngine/AD7.Impl/AD7PendingBreakpoint.cs
@@ -323,17 +323,6 @@ namespace Microsoft.MIDebugEngine
             }
             else
             {
-                if ((enum_BP_LOCATION_TYPE)_bpRequestInfo.bpLocation.bpLocationType == enum_BP_LOCATION_TYPE.BPLT_DATA_STRING)
-                {
-                    lock (_engine.DebuggedProcess.DataBreakpointVariables)
-                    {
-                        string addressName = HostMarshal.GetDataBreakpointStringForIntPtr(_bpRequestInfo.bpLocation.unionmember3);
-                        if (!_engine.DebuggedProcess.DataBreakpointVariables.Contains(addressName)) // might need to expand condition
-                        {
-                            _engine.DebuggedProcess.DataBreakpointVariables.Add(addressName);
-                        }
-                    }
-                }
                 return Constants.S_OK;
             }
         }
@@ -367,6 +356,15 @@ namespace Microsoft.MIDebugEngine
                     try
                     {
                         bindResult = await PendingBreakpoint.Bind(_address, _size, _engine.DebuggedProcess, _condition, this);
+
+                        lock (_engine.DebuggedProcess.DataBreakpointVariables)
+                        {
+                            string address = AddressId ?? _address;
+                            if (!_engine.DebuggedProcess.DataBreakpointVariables.Contains(address)) // might need to expand condition
+                            {
+                                _engine.DebuggedProcess.DataBreakpointVariables.Add(address);
+                            }
+                        }
                     }
                     catch (ArgumentException ex)
                     {


### PR DESCRIPTION
This PR fixes https://github.com/microsoft/vscode-cpptools/issues/9095.
The issue is that breakpoints that are created on debug session start
have not had their module loaded yet and BoundBreakpoints will be null
and with the current check we will return E_FAIL and never cache the
breakpoint.

The original usage of this was to capture errors for data breakpoints,
but they will come through as BreakpointEvents instead of the response
of SetBreakpoints / SetDataBreakpoints.

Example of error caught by BreakpointEvent
![image](https://user-images.githubusercontent.com/3953714/161161577-f6e85311-1834-43b8-ac34-6b7c7eb34c1e.png)
