### PR TITLE
Disable / Fix tests for cppvsdbg

### DIFF
--- a/test/CppTests/Tests/BreakpointTests.cs
+++ b/test/CppTests/Tests/BreakpointTests.cs
@@ -157,6 +157,7 @@ namespace CppTests.Tests
         [Theory]
         [DependsOnTest(nameof(CompileKitchenSinkForBreakpointTests))]
         [RequiresTestSettings]
+        [UnsupportedDebugger(SupportedDebugger.VsDbg, SupportedArchitecture.x86 | SupportedArchitecture.x64)]
         public void LineLogBreakpointsBasic(ITestSettings settings)
         {
             this.TestPurpose("Tests basic operation of line breakpoints with a LogPoint");
@@ -429,6 +430,7 @@ namespace CppTests.Tests
         [RequiresTestSettings]
         // lldb-mi does not support -break-watch
         [UnsupportedDebugger(SupportedDebugger.Lldb, SupportedArchitecture.x64 | SupportedArchitecture.x86)]
+        [UnsupportedDebugger(SupportedDebugger.VsDbg, SupportedArchitecture.x86 | SupportedArchitecture.x64)]
         public void DataBreakpointTest(ITestSettings settings)
         {
             this.TestPurpose("Tests that data breakpoints work");

--- a/test/CppTests/Tests/ExceptionTests.cs
+++ b/test/CppTests/Tests/ExceptionTests.cs
@@ -285,6 +285,7 @@ namespace CppTests.Tests
         [DependsOnTest(nameof(CompileExceptionDebuggee))]
         [RequiresTestSettings]
         [UnsupportedDebugger(SupportedDebugger.Lldb, SupportedArchitecture.x86 | SupportedArchitecture.x64)]
+        [UnsupportedDebugger(SupportedDebugger.VsDbg, SupportedArchitecture.x86 | SupportedArchitecture.x64)]
         public void SetAllExceptionBreakpointTest(ITestSettings settings)
         {
             this.TestPurpose("This test checks to see if we can hit an exception breakpoint.");
@@ -332,6 +333,7 @@ namespace CppTests.Tests
         // Current issue is that it reports "did not find exception probe (does libstdcxx have SDT probes)?" and does not evaluate
         // the condition.
         [UnsupportedDebugger(SupportedDebugger.Lldb | SupportedDebugger.Gdb_MinGW, SupportedArchitecture.x86 | SupportedArchitecture.x64)]
+        [UnsupportedDebugger(SupportedDebugger.VsDbg, SupportedArchitecture.x86 | SupportedArchitecture.x64)]
         [RequiresTestSettings]
         public void SetConditionExceptionBreakpointTest(ITestSettings settings)
         {

--- a/test/CppTests/Tests/ExpressionTests.cs
+++ b/test/CppTests/Tests/ExpressionTests.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.Linq;
 using DebuggerTesting;
 using DebuggerTesting.Compilation;
@@ -497,7 +498,11 @@ namespace CppTests.Tests
 
                     this.Comment("Set myint=9000 as hex.");
                     string hexVal = runner.SetExpression("myint", "9000", currentFrame.Id, new ValueFormat { hex = true });
-                    Assert.Equal("0x2328", hexVal);
+                    // Validate that it starts with 0x
+                    Assert.StartsWith("0x", hexVal);
+                    // Convert hex value back to decimal and compare they are equal.
+                    Assert.True(int.TryParse(hexVal.Substring(2), NumberStyles.AllowHexSpecifier, CultureInfo.InvariantCulture, out int result));
+                    Assert.Equal(9000, result);
                 }
 
                 this.Comment("Continue to run to exist.");


### PR DESCRIPTION
Disable LogPoint tests and data breakpoint tests for Cppvsdbg
Disable Exception tests for cppvsdbg since they are very specific for cppdbg.
Updated SetExpression since cppvsdbg returns leading zeros.