### PR TITLE
Add Tests for NatVis

### DIFF
--- a/src/MIDebugEngine/Natvis.Impl/Natvis.cs
+++ b/src/MIDebugEngine/Natvis.Impl/Natvis.cs
@@ -516,237 +516,25 @@ namespace Microsoft.MIDebugEngine.Natvis
                     IVariableInformation expr = GetExpression(item.Value, variable, visualizer.ScopedNames, item.Name);
                     children.Add(expr);
                 }
-                else if (i is ArrayItemsType)
+                else if (i is ArrayItemsType arrayItemsType)
                 {
-                    ArrayItemsType item = (ArrayItemsType)i;
-                    if (!EvalCondition(item.Condition, variable, visualizer.ScopedNames))
-                    {
-                        continue;
-                    }
-                    uint size = 0;
-                    string val = GetExpressionValue(item.Size, variable, visualizer.ScopedNames);
-                    size = MICore.Debugger.ParseUint(val, throwOnError: true);
-                    size = size > MAX_EXPAND ? MAX_EXPAND : size;   // limit expansion
-                    ValuePointerType[] vptrs = item.ValuePointer;
-                    foreach (var vp in vptrs)
-                    {
-                        if (EvalCondition(vp.Condition, variable, visualizer.ScopedNames))
-                        {
-                            IVariableInformation ptrExpr = GetExpression("*(" + vp.Value + ")", variable, visualizer.ScopedNames);
-                            string typename = ptrExpr.TypeName;
-                            if (String.IsNullOrWhiteSpace(typename))
-                            {
-                                continue;
-                            }
-                            StringBuilder arrayBuilder = new StringBuilder();
-                            arrayBuilder.Append('(');
-                            arrayBuilder.Append(typename);
-                            arrayBuilder.Append('[');
-                            arrayBuilder.Append(size);
-                            arrayBuilder.Append("])*(");
-                            arrayBuilder.Append(vp.Value);
-                            arrayBuilder.Append(')');
-                            string arrayStr = arrayBuilder.ToString();
-                            IVariableInformation arrayExpr = GetExpression(arrayStr, variable, visualizer.ScopedNames);
-                            arrayExpr.EnsureChildren();
-                            if (arrayExpr.CountChildren != 0)
-                            {
-                                children.AddRange(arrayExpr.Children);
-                            }
-                            break;
-                        }
-                    }
+                    ParseArrayItemsType(arrayItemsType, variable, visualizer, children);
                 }
-                else if (i is TreeItemsType)
+                else if (i is TreeItemsType treeItemsType)
                 {
-                    TreeItemsType item = (TreeItemsType)i;
-                    if (!EvalCondition(item.Condition, variable, visualizer.ScopedNames))
-                    {
-                        continue;
-                    }
-                    if (String.IsNullOrWhiteSpace(item.Size) || String.IsNullOrWhiteSpace(item.HeadPointer) || String.IsNullOrWhiteSpace(item.LeftPointer) ||
-                        String.IsNullOrWhiteSpace(item.RightPointer))
-                    {
-                        continue;
-                    }
-                    if (item.ValueNode == null || String.IsNullOrWhiteSpace(item.ValueNode.Value))
-                    {
-                        continue;
-                    }
-                    string val = GetExpressionValue(item.Size, variable, visualizer.ScopedNames);
-                    uint size = MICore.Debugger.ParseUint(val, throwOnError: true);
-                    size = size > MAX_EXPAND ? MAX_EXPAND : size;   // limit expansion
-                    IVariableInformation headVal = GetExpression(item.HeadPointer, variable, visualizer.ScopedNames);
-                    ulong head = MICore.Debugger.ParseAddr(headVal.Value);
-                    var content = new List<IVariableInformation>();
-                    if (head != 0 && size != 0)
-                    {
-                        headVal.EnsureChildren();
-                        Traverse goLeft = GetTraverse(item.LeftPointer, headVal);
-                        Traverse goRight = GetTraverse(item.RightPointer, headVal);
-                        Traverse getValue = null;
-                        if (item.ValueNode.Value == "this") // TODO: handle condition
-                        {
-                            getValue = (v) => v;
-                        }
-                        else if (headVal.FindChildByName(item.ValueNode.Value) != null)
-                        {
-                            getValue = (v) => v.FindChildByName(item.ValueNode.Value);
-                        }
-                        else if (GetExpression(item.ValueNode.Value, headVal, visualizer.ScopedNames) != null)
-                        {
-                            getValue = (v) => GetExpression(item.ValueNode.Value, v, visualizer.ScopedNames);
-                        }
-                        if (goLeft == null || goRight == null || getValue == null)
-                        {
-                            continue;
-                        }
-                        TraverseTree(headVal, goLeft, goRight, getValue, children, size);
-                    }
+                    ParseTreeItemsType(treeItemsType, variable, visualizer, children);
                 }
-                else if (i is LinkedListItemsType)
+                else if (i is LinkedListItemsType linkedListItemsType)
                 {
-                    // example:
-                    //    <LinkedListItems>
-                    //      <Size>m_nElements</Size>    -- optional, will go until NextPoint is 0 or == HeadPointer
-                    //      <HeadPointer>m_pHead</HeadPointer>
-                    //      <NextPointer>m_pNext</NextPointer>
-                    //      <ValueNode>m_element</ValueNode>
-                    //    </LinkedListItems>
-                    LinkedListItemsType item = (LinkedListItemsType)i;
-                    if (String.IsNullOrWhiteSpace(item.Condition))
-                    {
-                        if (!EvalCondition(item.Condition, variable, visualizer.ScopedNames))
-                            continue;
-                    }
-                    if (String.IsNullOrWhiteSpace(item.HeadPointer) || String.IsNullOrWhiteSpace(item.NextPointer))
-                    {
-                        continue;
-                    }
-                    if (String.IsNullOrWhiteSpace(item.ValueNode))
-                    {
-                        continue;
-                    }
-                    uint size = MAX_EXPAND;
-                    if (!String.IsNullOrWhiteSpace(item.Size))
-                    {
-                        string val = GetExpressionValue(item.Size, variable, visualizer.ScopedNames);
-                        size = MICore.Debugger.ParseUint(val);
-                        size = size > MAX_EXPAND ? MAX_EXPAND : size;   // limit expansion
-                    }
-                    IVariableInformation headVal = GetExpression(item.HeadPointer, variable, visualizer.ScopedNames);
-                    ulong head = MICore.Debugger.ParseAddr(headVal.Value);
-                    var content = new List<IVariableInformation>();
-                    if (head != 0 && size != 0)
-                    {
-                        headVal.EnsureChildren();
-                        Traverse goNext = GetTraverse(item.NextPointer, headVal);
-                        Traverse getValue = null;
-                        if (item.ValueNode == "this")
-                        {
-                            getValue = (v) => v;
-                        }
-                        else if (headVal.FindChildByName(item.ValueNode) != null)
-                        {
-                            getValue = (v) => v.FindChildByName(item.ValueNode);
-                        }
-                        else
-                        {
-                            var value = GetExpression(item.ValueNode, headVal, visualizer.ScopedNames);
-                            if (value != null && !value.Error)
-                            {
-                                getValue = (v) => GetExpression(item.ValueNode, v, visualizer.ScopedNames);
-                            }
-                        }
-                        if (goNext == null || getValue == null)
-                        {
-                            continue;
-                        }
-                        TraverseList(headVal, goNext, getValue, children, size, item.NoValueHeadPointer);
-                    }
+                    ParseLinkedListItemsType(linkedListItemsType, variable, visualizer, children);
                 }
-                else if (i is IndexListItemsType)
+                else if (i is IndexListItemsType indexListItemType)
                 {
-                    // example:
-                    //     <IndexListItems>
-                    //      <Size>_M_vector._M_index</Size>
-                    //      <ValueNode>*(_M_vector._M_array[$i])</ValueNode>
-                    //    </IndexListItems>
-                    IndexListItemsType item = (IndexListItemsType)i;
-                    if (!EvalCondition(item.Condition, variable, visualizer.ScopedNames))
-                    {
-                        continue;
-                    }
-                    var sizes = item.Size;
-                    uint size = 0;
-                    if (sizes == null)
-                    {
-                        continue;
-                    }
-                    foreach (var s in sizes)
-                    {
-                        if (string.IsNullOrWhiteSpace(s.Value))
-                            continue;
-                        if (EvalCondition(s.Condition, variable, visualizer.ScopedNames))
-                        {
-                            string val = GetExpressionValue(s.Value, variable, visualizer.ScopedNames);
-                            size = MICore.Debugger.ParseUint(val);
-                            size = size > MAX_EXPAND ? MAX_EXPAND : size;   // limit expansion
-                            break;
-                        }
-                    }
-                    var values = item.ValueNode;
-                    if (values == null)
-                    {
-                        continue;
-                    }
-                    foreach (var v in values)
-                    {
-                        if (string.IsNullOrWhiteSpace(v.Value))
-                            continue;
-                        if (EvalCondition(v.Condition, variable, visualizer.ScopedNames))
-                        {
-                            string processedExpr = ReplaceNamesInExpression(v.Value, variable, visualizer.ScopedNames);
-                            Dictionary<string, string> indexDic = new Dictionary<string, string>();
-                            for (uint index = 0; index < size; ++index)
-                            {
-                                indexDic["$i"] = index.ToString(CultureInfo.InvariantCulture);
-                                string finalExpr = ReplaceNamesInExpression(processedExpr, null, indexDic);
-                                IVariableInformation expressionVariable = new VariableInformation(finalExpr, variable, _process.Engine, "[" + indexDic["$i"] + "]");
-                                expressionVariable.SyncEval();
-                                children.Add(expressionVariable);
-                            }
-                            break;
-                        }
-                    }
+                    ParseIndexListItemsType(indexListItemType, variable, visualizer, children);
                 }
-                else if (i is ExpandedItemType)
+                else if (i is ExpandedItemType expandedItemType)
                 {
-                    ExpandedItemType item = (ExpandedItemType)i;
-                    // example:
-                    // <Type Name="std::auto_ptr&lt;*&gt;">
-                    //   <DisplayString>auto_ptr {*_Myptr}</DisplayString>
-                    //   <Expand>
-                    //     <ExpandedItem>_Myptr</ExpandedItem>
-                    //   </Expand>
-                    // </Type>
-                    if (item.Condition != null)
-                    {
-                        if (!EvalCondition(item.Condition, variable, visualizer.ScopedNames))
-                        {
-                            continue;
-                        }
-                    }
-                    if (String.IsNullOrWhiteSpace(item.Value))
-                    {
-                        continue;
-                    }
-                    var expand = GetExpression(item.Value, variable, visualizer.ScopedNames);
-                    var eChildren = Expand(expand);
-                    if (eChildren != null)
-                    {
-                        children.AddRange(eChildren);
-                    }
+                    ParseExpandedItemType(expandedItemType, variable, visualizer, children);
                 }
             }
             if (!(variable is VisualizerWrapper)) // don't stack wrappers
@@ -756,6 +544,238 @@ namespace Microsoft.MIDebugEngine.Natvis
                 children.Add(rawView);
             }
             return children.ToArray();
+        }
+
+        private void ParseArrayItemsType(ArrayItemsType arrayItemsType, IVariableInformation variable, VisualizerInfo visualizer, List<IVariableInformation> children)
+        {
+            if (!EvalCondition(arrayItemsType.Condition, variable, visualizer.ScopedNames))
+            {
+                return;
+            }
+            uint size = 0;
+            string val = GetExpressionValue(arrayItemsType.Size, variable, visualizer.ScopedNames);
+            size = MICore.Debugger.ParseUint(val, throwOnError: true);
+            size = size > MAX_EXPAND ? MAX_EXPAND : size;   // limit expansion
+            ValuePointerType[] vptrs = arrayItemsType.ValuePointer;
+            foreach (var vp in vptrs)
+            {
+                if (EvalCondition(vp.Condition, variable, visualizer.ScopedNames))
+                {
+                    IVariableInformation ptrExpr = GetExpression("*(" + vp.Value + ")", variable, visualizer.ScopedNames);
+                    string typename = ptrExpr.TypeName;
+                    if (String.IsNullOrWhiteSpace(typename))
+                    {
+                        continue;
+                    }
+                    StringBuilder arrayBuilder = new StringBuilder();
+                    arrayBuilder.Append('(');
+                    arrayBuilder.Append(typename);
+                    arrayBuilder.Append('[');
+                    arrayBuilder.Append(size);
+                    arrayBuilder.Append("])*(");
+                    arrayBuilder.Append(vp.Value);
+                    arrayBuilder.Append(')');
+                    string arrayStr = arrayBuilder.ToString();
+                    IVariableInformation arrayExpr = GetExpression(arrayStr, variable, visualizer.ScopedNames);
+                    arrayExpr.EnsureChildren();
+                    if (arrayExpr.CountChildren != 0)
+                    {
+                        children.AddRange(arrayExpr.Children);
+                    }
+                    break;
+                }
+            }
+        }
+
+        private void ParseTreeItemsType(TreeItemsType treeItemsType, IVariableInformation variable, VisualizerInfo visualizer, List<IVariableInformation> children)
+        {
+            if (!EvalCondition(treeItemsType.Condition, variable, visualizer.ScopedNames))
+            {
+                return;
+            }
+            if (String.IsNullOrWhiteSpace(treeItemsType.Size) || String.IsNullOrWhiteSpace(treeItemsType.HeadPointer) || String.IsNullOrWhiteSpace(treeItemsType.LeftPointer) ||
+                String.IsNullOrWhiteSpace(treeItemsType.RightPointer))
+            {
+                return;
+            }
+            if (treeItemsType.ValueNode == null || String.IsNullOrWhiteSpace(treeItemsType.ValueNode.Value))
+            {
+                return;
+            }
+            string val = GetExpressionValue(treeItemsType.Size, variable, visualizer.ScopedNames);
+            uint size = MICore.Debugger.ParseUint(val, throwOnError: true);
+            size = size > MAX_EXPAND ? MAX_EXPAND : size;   // limit expansion
+            IVariableInformation headVal = GetExpression(treeItemsType.HeadPointer, variable, visualizer.ScopedNames);
+            ulong head = MICore.Debugger.ParseAddr(headVal.Value);
+            var content = new List<IVariableInformation>();
+            if (head != 0 && size != 0)
+            {
+                headVal.EnsureChildren();
+                Traverse goLeft = GetTraverse(treeItemsType.LeftPointer, headVal);
+                Traverse goRight = GetTraverse(treeItemsType.RightPointer, headVal);
+                Traverse getValue = null;
+                if (treeItemsType.ValueNode.Value == "this") // TODO: handle condition
+                {
+                    getValue = (v) => v;
+                }
+                else if (headVal.FindChildByName(treeItemsType.ValueNode.Value) != null)
+                {
+                    getValue = (v) => v.FindChildByName(treeItemsType.ValueNode.Value);
+                }
+                else if (GetExpression(treeItemsType.ValueNode.Value, headVal, visualizer.ScopedNames) != null)
+                {
+                    getValue = (v) => GetExpression(treeItemsType.ValueNode.Value, v, visualizer.ScopedNames);
+                }
+                if (goLeft == null || goRight == null || getValue == null)
+                {
+                    return;
+                }
+                TraverseTree(headVal, goLeft, goRight, getValue, children, size);
+            }
+        }
+
+        private void ParseLinkedListItemsType(LinkedListItemsType linkedListItemsType, IVariableInformation variable, VisualizerInfo visualizer, List<IVariableInformation> children)
+        {
+            // example:
+            //    <LinkedListItems>
+            //      <Size>m_nElements</Size>    -- optional, will go until NextPoint is 0 or == HeadPointer
+            //      <HeadPointer>m_pHead</HeadPointer>
+            //      <NextPointer>m_pNext</NextPointer>
+            //      <ValueNode>m_element</ValueNode>
+            //    </LinkedListItems>
+            if (String.IsNullOrWhiteSpace(linkedListItemsType.Condition))
+            {
+                if (!EvalCondition(linkedListItemsType.Condition, variable, visualizer.ScopedNames))
+                    return;
+            }
+            if (String.IsNullOrWhiteSpace(linkedListItemsType.HeadPointer) || String.IsNullOrWhiteSpace(linkedListItemsType.NextPointer))
+            {
+                return;
+            }
+            if (String.IsNullOrWhiteSpace(linkedListItemsType.ValueNode))
+            {
+                return;
+            }
+            uint size = MAX_EXPAND;
+            if (!String.IsNullOrWhiteSpace(linkedListItemsType.Size))
+            {
+                string val = GetExpressionValue(linkedListItemsType.Size, variable, visualizer.ScopedNames);
+                size = MICore.Debugger.ParseUint(val);
+                size = size > MAX_EXPAND ? MAX_EXPAND : size;   // limit expansion
+            }
+            IVariableInformation headVal = GetExpression(linkedListItemsType.HeadPointer, variable, visualizer.ScopedNames);
+            ulong head = MICore.Debugger.ParseAddr(headVal.Value);
+            var content = new List<IVariableInformation>();
+            if (head != 0 && size != 0)
+            {
+                headVal.EnsureChildren();
+                Traverse goNext = GetTraverse(linkedListItemsType.NextPointer, headVal);
+                Traverse getValue = null;
+                if (linkedListItemsType.ValueNode == "this")
+                {
+                    getValue = (v) => v;
+                }
+                else if (headVal.FindChildByName(linkedListItemsType.ValueNode) != null)
+                {
+                    getValue = (v) => v.FindChildByName(linkedListItemsType.ValueNode);
+                }
+                else
+                {
+                    var value = GetExpression(linkedListItemsType.ValueNode, headVal, visualizer.ScopedNames);
+                    if (value != null && !value.Error)
+                    {
+                        getValue = (v) => GetExpression(linkedListItemsType.ValueNode, v, visualizer.ScopedNames);
+                    }
+                }
+                if (goNext == null || getValue == null)
+                {
+                    return;
+                }
+                TraverseList(headVal, goNext, getValue, children, size, linkedListItemsType.NoValueHeadPointer);
+            }
+        }
+
+        private void ParseIndexListItemsType(IndexListItemsType indexListItemType, IVariableInformation variable, VisualizerInfo visualizer, List<IVariableInformation> children)
+        {
+            // example:
+            //     <IndexListItems>
+            //      <Size>_M_vector._M_index</Size>
+            //      <ValueNode>*(_M_vector._M_array[$i])</ValueNode>
+            //    </IndexListItems>
+            if (!EvalCondition(indexListItemType.Condition, variable, visualizer.ScopedNames))
+            {
+                return;
+            }
+            var sizes = indexListItemType.Size;
+            uint size = 0;
+            if (sizes == null)
+            {
+                return;
+            }
+            foreach (var s in sizes)
+            {
+                if (string.IsNullOrWhiteSpace(s.Value))
+                    continue;
+                if (EvalCondition(s.Condition, variable, visualizer.ScopedNames))
+                {
+                    string val = GetExpressionValue(s.Value, variable, visualizer.ScopedNames);
+                    size = MICore.Debugger.ParseUint(val);
+                    size = size > MAX_EXPAND ? MAX_EXPAND : size;   // limit expansion
+                    break;
+                }
+            }
+            var values = indexListItemType.ValueNode;
+            if (values == null)
+            {
+                return;
+            }
+            foreach (var v in values)
+            {
+                if (string.IsNullOrWhiteSpace(v.Value))
+                    continue;
+                if (EvalCondition(v.Condition, variable, visualizer.ScopedNames))
+                {
+                    string processedExpr = ReplaceNamesInExpression(v.Value, variable, visualizer.ScopedNames);
+                    Dictionary<string, string> indexDic = new Dictionary<string, string>();
+                    for (uint index = 0; index < size; ++index)
+                    {
+                        indexDic["$i"] = index.ToString(CultureInfo.InvariantCulture);
+                        string finalExpr = ReplaceNamesInExpression(processedExpr, null, indexDic);
+                        IVariableInformation expressionVariable = new VariableInformation(finalExpr, variable, _process.Engine, "[" + indexDic["$i"] + "]");
+                        expressionVariable.SyncEval();
+                        children.Add(expressionVariable);
+                    }
+                    break;
+                }
+            }
+        }
+
+        private void ParseExpandedItemType(ExpandedItemType expandedItemType, IVariableInformation variable, VisualizerInfo visualizer, List<IVariableInformation> children)
+        {
+            // example:
+            // <Type Name="std::auto_ptr&lt;*&gt;">
+            //   <DisplayString>auto_ptr {*_Myptr}</DisplayString>
+            //   <Expand>
+            //     <ExpandedItem>_Myptr</ExpandedItem>
+            //   </Expand>
+            // </Type>
+            if (expandedItemType.Condition != null)
+            {
+                if (!EvalCondition(expandedItemType.Condition, variable, visualizer.ScopedNames))
+                {
+                    return;
+                }
+            }
+            if (String.IsNullOrWhiteSpace(expandedItemType.Value))
+            {
+                return;
+            }
+            var expand = GetExpression(expandedItemType.Value, variable, visualizer.ScopedNames);
+            var eChildren = Expand(expand);
+            if (eChildren != null)
+            {
+                children.AddRange(eChildren);
+            }
         }
 
         private Traverse GetTraverse(string direction, IVariableInformation node)

--- a/test/CppTests/OpenDebug/CrossPlatCpp/DebuggerRunnerExtensions.cs
+++ b/test/CppTests/OpenDebug/CrossPlatCpp/DebuggerRunnerExtensions.cs
@@ -10,7 +10,7 @@ namespace DebuggerTesting.OpenDebug.CrossPlatCpp
     {
         public static void Launch(this IDebuggerRunner runner, IDebuggerSettings settings, bool stopAtEntry, string program, params string[] args)
         {
-            runner.RunCommand(new LaunchCommand(settings, program, false, args) { StopAtEntry = stopAtEntry });
+            runner.RunCommand(new LaunchCommand(settings, program, null, false, args) { StopAtEntry = stopAtEntry });
         }
 
         public static void Launch(this IDebuggerRunner runner, IDebuggerSettings settings, bool stopAtEntry, IDebuggee debuggee, params string[] args)

--- a/test/CppTests/OpenDebug/CrossPlatCpp/LaunchCommand.cs
+++ b/test/CppTests/OpenDebug/CrossPlatCpp/LaunchCommand.cs
@@ -32,6 +32,12 @@ namespace DebuggerTesting.OpenDebug.CrossPlatCpp
 
         [JsonProperty(DefaultValueHandling = DefaultValueHandling.Ignore)]
         public string MIMode;
+
+        [JsonProperty(DefaultValueHandling = DefaultValueHandling.Ignore)]
+        public string VisualizerFile;
+
+        [JsonProperty(DefaultValueHandling = DefaultValueHandling.Ignore)]
+        public bool ShowDisplayString;
     }
 
     #endregion
@@ -44,7 +50,7 @@ namespace DebuggerTesting.OpenDebug.CrossPlatCpp
         /// <param name="program">The full path to the program to launch</param>
         /// <param name="architecture">The architecture of the program</param>
         /// <param name="args">[OPTIONAL] Args to pass to the program</param>
-        public LaunchCommand(IDebuggerSettings settings, string program, bool isAttach = false, params string[] args)
+        public LaunchCommand(IDebuggerSettings settings, string program, string visualizerFile = null, bool isAttach = false, params string[] args)
         {
             this.Timeout = TimeSpan.FromSeconds(15);
 
@@ -68,6 +74,8 @@ namespace DebuggerTesting.OpenDebug.CrossPlatCpp
                 this.Args.miDebuggerPath = settings.DebuggerPath;
                 this.Args.targetArchitecture = settings.DebuggeeArchitecture.ToArchitectureString();
                 this.Args.MIMode = settings.MIMode;
+                this.Args.VisualizerFile = visualizerFile;
+                this.Args.ShowDisplayString = !string.IsNullOrEmpty(visualizerFile);
             }
         }
 

--- a/test/CppTests/Tests/DebuggeeMonikers.cs
+++ b/test/CppTests/Tests/DebuggeeMonikers.cs
@@ -55,5 +55,10 @@ namespace CppTests.Tests
         {
             public const int Default = 1;
         }
+
+        internal static class Natvis
+        {
+            public const int Default = 1;
+        }
     }
 }

--- a/test/CppTests/Tests/EnvironmentTests.cs
+++ b/test/CppTests/Tests/EnvironmentTests.cs
@@ -165,7 +165,7 @@ namespace CppTests.Tests
             using (IDebuggerRunner runner = CreateDebugAdapterRunner(settings))
             {
                 this.Comment("Configure launch");
-                LaunchCommand launch = new LaunchCommand(settings.DebuggerSettings, debuggee.OutputPath, false, "-fEnvironment") { StopAtEntry = false };
+                LaunchCommand launch = new LaunchCommand(settings.DebuggerSettings, debuggee.OutputPath, null, false, "-fEnvironment") { StopAtEntry = false };
                 if (variableValue != null)
                 {
                     launch.Args.environment = new EnvironmentEntry[] {

--- a/test/CppTests/Tests/NatvisTests.cs
+++ b/test/CppTests/Tests/NatvisTests.cs
@@ -1,0 +1,236 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using DebuggerTesting;
+using DebuggerTesting.Compilation;
+using DebuggerTesting.OpenDebug;
+using DebuggerTesting.OpenDebug.Commands;
+using DebuggerTesting.OpenDebug.CrossPlatCpp;
+using DebuggerTesting.OpenDebug.Events;
+using DebuggerTesting.OpenDebug.Extensions;
+using DebuggerTesting.Ordering;
+using DebuggerTesting.Settings;
+using DebuggerTesting.Utilities;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace CppTests.Tests
+{
+    [TestCaseOrderer(DependencyTestOrderer.TypeName, DependencyTestOrderer.AssemblyName)]
+    public class NatvisTests : TestBase
+    {
+        #region Constructor
+
+        public NatvisTests(ITestOutputHelper outputHelper) : base(outputHelper)
+        {
+        }
+
+        #endregion
+
+        #region Methods
+
+
+        private const string NatvisName = "natvis";
+        private const string NatvisSourceName = "main.cpp";
+        private const int ReturnSourceLine = 33;
+
+        [Theory]
+        [RequiresTestSettings]
+        public void CompileNatvisDebuggee(ITestSettings settings)
+        {
+            this.TestPurpose("Create and compile the 'natvis' debuggee");
+            this.WriteSettings(settings);
+
+            IDebuggee debuggee = Debuggee.Create(this, settings.CompilerSettings, NatvisName, DebuggeeMonikers.Natvis.Default);
+            debuggee.AddSourceFiles(NatvisSourceName);
+            debuggee.Compile();
+        }
+
+        [Theory]
+        [DependsOnTest(nameof(CompileNatvisDebuggee))]
+        [RequiresTestSettings]
+        [UnsupportedDebugger(SupportedDebugger.Lldb, SupportedArchitecture.x64 | SupportedArchitecture.x86)]
+        public void TestDisplayString(ITestSettings settings)
+        {
+            this.TestPurpose("This test checks if DisplayString are visualized.");
+            this.WriteSettings(settings);
+
+            IDebuggee debuggee = Debuggee.Open(this, settings.CompilerSettings, NatvisName, DebuggeeMonikers.Natvis.Default);
+
+            this.Comment("Run the debuggee, check argument count");
+            using (IDebuggerRunner runner = CreateDebugAdapterRunner(settings))
+            {
+                this.Comment("Configure launch");
+                string visFile = Path.Join(debuggee.SourceRoot, "visualizer_files", "Simple.natvis");
+
+                LaunchCommand launch = new LaunchCommand(settings.DebuggerSettings, debuggee.OutputPath, visFile, false);
+                runner.RunCommand(launch);
+
+                this.Comment("Set Breakpoint");
+                SourceBreakpoints writerBreakpoints = debuggee.Breakpoints(NatvisSourceName, ReturnSourceLine);
+                runner.SetBreakpoints(writerBreakpoints);
+
+                runner.Expects.StoppedEvent(StoppedReason.Breakpoint).AfterConfigurationDone();
+
+                using (IThreadInspector threadInspector = runner.GetThreadInspector())
+                {
+                    IFrameInspector currentFrame = threadInspector.Stack.First();
+
+                    this.Comment("Verifying 'DisplayString' natvis");
+                    Assert.Equal("Hello DisplayString", currentFrame.GetVariable("obj_1").Value);
+                }
+
+                runner.Expects.ExitedEvent(exitCode: 0).TerminatedEvent().AfterContinue();
+                runner.DisconnectAndVerify();
+            }
+        }
+
+        [Theory]
+        [DependsOnTest(nameof(CompileNatvisDebuggee))]
+        [RequiresTestSettings]
+        [UnsupportedDebugger(SupportedDebugger.Lldb, SupportedArchitecture.x64 | SupportedArchitecture.x86)]
+        public void TestArrayItems(ITestSettings settings)
+        {
+            this.TestPurpose("This test checks if ArrayItems are visualized.");
+            this.WriteSettings(settings);
+
+            IDebuggee debuggee = Debuggee.Open(this, settings.CompilerSettings, NatvisName, DebuggeeMonikers.Natvis.Default);
+
+            using (IDebuggerRunner runner = CreateDebugAdapterRunner(settings))
+            {
+                this.Comment("Configure launch");
+                string visFile = Path.Join(debuggee.SourceRoot, "visualizer_files", "Simple.natvis");
+
+                LaunchCommand launch = new LaunchCommand(settings.DebuggerSettings, debuggee.OutputPath, visFile, false);
+                runner.RunCommand(launch);
+
+                this.Comment("Set Breakpoint");
+                SourceBreakpoints writerBreakpoints = debuggee.Breakpoints(NatvisSourceName, ReturnSourceLine);
+                runner.SetBreakpoints(writerBreakpoints);
+
+                runner.Expects.StoppedEvent(StoppedReason.Breakpoint).AfterConfigurationDone();
+
+                using (IThreadInspector threadInspector = runner.GetThreadInspector())
+                {
+                    IFrameInspector currentFrame = threadInspector.Stack.First();
+
+                    this.Comment("Verifying ArrayItems natvis");
+                    var ll = currentFrame.GetVariable("vec");
+                    Assert.Equal("{ size=10 }", ll.Value);
+
+                    // Custom Item in natvis
+                    Assert.Equal("10", ll.GetVariable("Size").Value);
+
+                    // Index element for ArrayItems
+                    Assert.Equal("20", ll.GetVariable("[5]").Value);
+                    // TODO: Add test below when we can support the [More..] expansion to handle >50 elements
+                }
+
+                runner.Expects.ExitedEvent(exitCode: 0).TerminatedEvent().AfterContinue();
+                runner.DisconnectAndVerify();
+            }
+        }
+
+        [Theory]
+        [DependsOnTest(nameof(CompileNatvisDebuggee))]
+        [RequiresTestSettings]
+        [UnsupportedDebugger(SupportedDebugger.Lldb, SupportedArchitecture.x64 | SupportedArchitecture.x86)]
+        public void TestLinkedListItems(ITestSettings settings)
+        {
+            this.TestPurpose("This test checks if LinkedListItems are visualized.");
+            this.WriteSettings(settings);
+
+            IDebuggee debuggee = Debuggee.Open(this, settings.CompilerSettings, NatvisName, DebuggeeMonikers.Natvis.Default);
+
+            using (IDebuggerRunner runner = CreateDebugAdapterRunner(settings))
+            {
+                this.Comment("Configure launch");
+                string visFile = Path.Join(debuggee.SourceRoot, "visualizer_files", "Simple.natvis");
+
+                LaunchCommand launch = new LaunchCommand(settings.DebuggerSettings, debuggee.OutputPath, visFile, false);
+                runner.RunCommand(launch);
+
+                this.Comment("Set Breakpoint");
+                SourceBreakpoints writerBreakpoints = debuggee.Breakpoints(NatvisSourceName, ReturnSourceLine);
+                runner.SetBreakpoints(writerBreakpoints);
+
+                runner.Expects.StoppedEvent(StoppedReason.Breakpoint).AfterConfigurationDone();
+
+                using (IThreadInspector threadInspector = runner.GetThreadInspector())
+                {
+                    IFrameInspector currentFrame = threadInspector.Stack.First();
+
+                    this.Comment("Verifying LinkedListItems natvis");
+                    var ll = currentFrame.GetVariable("ll");
+                    Assert.Equal("{ size=100 }", ll.Value);
+
+                    // Custom Item in natvis
+                    Assert.Equal("100", ll.GetVariable("Count").Value);
+
+                    // Index element for LinkedListItems
+                    Assert.Equal("5", ll.GetVariable("[5]").Value);
+                    // TODO: Uncomment line below when we can support the [More..] expansion to handle >50 elements
+                    // Assert.Equal("75", ll.GetVariable("[More...]").GetVariable("[75]").Value);
+                }
+
+                runner.Expects.ExitedEvent(exitCode: 0).TerminatedEvent().AfterContinue();
+                runner.DisconnectAndVerify();
+            }
+        }
+
+        [Theory]
+        [DependsOnTest(nameof(CompileNatvisDebuggee))]
+        [RequiresTestSettings]
+        [UnsupportedDebugger(SupportedDebugger.Lldb, SupportedArchitecture.x64 | SupportedArchitecture.x86)]
+        public void TestTreeItems(ITestSettings settings)
+        {
+            this.TestPurpose("This test checks if TreeItems are visualized.");
+            this.WriteSettings(settings);
+
+            IDebuggee debuggee = Debuggee.Open(this, settings.CompilerSettings, NatvisName, DebuggeeMonikers.Natvis.Default);
+
+            using (IDebuggerRunner runner = CreateDebugAdapterRunner(settings))
+            {
+                this.Comment("Configure launch");
+                string visFile = Path.Join(debuggee.SourceRoot, "visualizer_files", "Simple.natvis");
+
+                LaunchCommand launch = new LaunchCommand(settings.DebuggerSettings, debuggee.OutputPath, visFile, false);
+                runner.RunCommand(launch);
+
+                this.Comment("Set Breakpoint");
+                SourceBreakpoints writerBreakpoints = debuggee.Breakpoints(NatvisSourceName, ReturnSourceLine);
+                runner.SetBreakpoints(writerBreakpoints);
+
+                runner.Expects.StoppedEvent(StoppedReason.Breakpoint).AfterConfigurationDone();
+
+                using (IThreadInspector threadInspector = runner.GetThreadInspector())
+                {
+                    IFrameInspector currentFrame = threadInspector.Stack.First();
+
+                    this.Comment("Verifying TreeItems natvis");
+                    var map = currentFrame.GetVariable("map");
+
+                    // Custom Item in natvis
+                    Assert.Equal("6", map.GetVariable("Count").Value);
+
+                    // Index element for TreeItems
+                    // Visualized map will show the BST in a flat ordered list.
+                    // Values are inserted as [0, -100, 15, -35, 4, -72]
+                    // Expected visualize list to be [-100, -72, -35, 0, 4, 15]
+                    Assert.Equal("-100", map.GetVariable("[0]").Value);
+                    Assert.Equal("0", map.GetVariable("[3]").Value);
+                    Assert.Equal("15", map.GetVariable("[5]").Value);
+                }
+
+                runner.Expects.ExitedEvent(exitCode: 0).TerminatedEvent().AfterContinue();
+                runner.DisconnectAndVerify();
+            }
+        }
+
+        #endregion
+    }
+}

--- a/test/CppTests/Tests/SourceMappingTests.cs
+++ b/test/CppTests/Tests/SourceMappingTests.cs
@@ -109,7 +109,7 @@ namespace CppTests.Tests
             using (IDebuggerRunner runner = CreateDebugAdapterRunner(settings))
             {
                 this.Comment("Configure");
-                LaunchCommand launch = new LaunchCommand(settings.DebuggerSettings, debuggee.OutputPath, false);
+                LaunchCommand launch = new LaunchCommand(settings.DebuggerSettings, debuggee.OutputPath, isAttach: false);
 
                 launch.Args.externalConsole = false;
 
@@ -195,7 +195,7 @@ namespace CppTests.Tests
             using (IDebuggerRunner runner = CreateDebugAdapterRunner(settings))
             {
                 this.Comment("Configure");
-                LaunchCommand launch = new LaunchCommand(settings.DebuggerSettings, debuggee.OutputPath, false, "-fCalling");
+                LaunchCommand launch = new LaunchCommand(settings.DebuggerSettings, debuggee.OutputPath, null, false, "-fCalling");
 
                 launch.Args.externalConsole = false;
 

--- a/test/CppTests/debuggees/natvis/src/BinarySearchTree.h
+++ b/test/CppTests/debuggees/natvis/src/BinarySearchTree.h
@@ -1,0 +1,50 @@
+#include <cstddef>
+
+class BinarySearchTree
+{
+private:
+  class Node {
+  public:
+    int data;
+    Node* left;
+    Node* right;
+
+    Node(int value) {
+      data = value;
+    }
+  };
+
+  Node *root = NULL;
+  int numElements;
+
+public:
+  BinarySearchTree()
+  {
+    numElements = 0;
+  }
+
+  void Insert(int value)
+  {
+    root = InsertNode(root, value);
+    numElements++;
+  }
+
+  Node* InsertNode(Node *root, int value)
+  {
+    if (root == NULL)
+    {
+      return new Node(value);
+    }
+    else
+    {
+      if (root->data > value)
+      {
+        root->left = InsertNode(root->left, value);
+      }
+      else
+      {
+        root->right = InsertNode(root->right, value);
+      }
+    }
+  }
+};

--- a/test/CppTests/debuggees/natvis/src/SimpleLinkedList.h
+++ b/test/CppTests/debuggees/natvis/src/SimpleLinkedList.h
@@ -1,0 +1,55 @@
+#include <cstddef>
+
+class SimpleLinkedList
+{
+private:
+  class Node {
+  public:
+    int data;
+    Node* next;
+
+    Node(int value) {
+      data = value;
+    }
+  };
+
+  Node *head = NULL;
+  Node *tail = NULL;
+  int numElements;
+
+public:
+  SimpleLinkedList()
+  {
+    numElements = 0;
+  }
+
+  void AddTail(int val) {
+    if (tail == NULL)
+    {
+      tail = new Node(val);
+      head = tail;
+    }
+    else 
+    {
+      Node* n = new Node(val);
+      tail->next = n;
+      tail = tail->next;
+    }
+    numElements++;
+  }
+
+  int Get(int idx)
+  {
+    Node* cur = head;
+    while (cur != NULL && idx >= 0)
+    {
+      if (idx == 0)
+      {
+        return cur->data;
+      }
+      idx--;
+      cur = cur->next;
+    }
+    return -1;
+  }
+};

--- a/test/CppTests/debuggees/natvis/src/SimpleVector.h
+++ b/test/CppTests/debuggees/natvis/src/SimpleVector.h
@@ -1,0 +1,23 @@
+#include <stdlib.h>
+
+class SimpleVector
+{
+public:
+  SimpleVector(int size)
+  {
+    _start = (int *)calloc(size, sizeof(int));
+    _size = size;
+  }
+
+  void Set(int idx, int value)
+  {
+    if (idx < 0 || idx >= _size)
+    {
+      return;
+    }
+    *(_start + idx) = value;
+  }
+
+  int* _start;
+  int  _size;
+};

--- a/test/CppTests/debuggees/natvis/src/main.cpp
+++ b/test/CppTests/debuggees/natvis/src/main.cpp
@@ -1,0 +1,34 @@
+#include "SimpleLinkedList.h"
+#include "BinarySearchTree.h"
+#include "SimpleVector.h"
+
+class SimpleDisplayObject
+{
+    public:
+        SimpleDisplayObject(){}
+};
+
+int main(int argc, char** argv)
+{
+    SimpleDisplayObject obj_1;
+
+    SimpleVector vec(10);
+    vec.Set(5, 20);
+
+    SimpleLinkedList ll;
+
+    for (int i = 0; i < 100; i++)
+    {
+        ll.AddTail(i);
+    }
+
+    BinarySearchTree map;
+    map.Insert(0);
+    map.Insert(-100);
+    map.Insert(15);
+    map.Insert(-35);
+    map.Insert(4);
+    map.Insert(-72);
+
+    return 0;
+}

--- a/test/CppTests/debuggees/natvis/src/visualizer_files/Simple.natvis
+++ b/test/CppTests/debuggees/natvis/src/visualizer_files/Simple.natvis
@@ -1,0 +1,45 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<AutoVisualizer xmlns="http://schemas.microsoft.com/vstudio/debugger/natvis/2010">
+  <Type Name="SimpleDisplayObject">
+   <DisplayString>Hello DisplayString</DisplayString>
+  </Type>
+
+  <Type Name="SimpleVector">
+   <DisplayString>{{ size={_size} }}</DisplayString>
+   <Expand>
+    <Item Name="Size">_size</Item>
+    <ArrayItems>
+      <Size>_size</Size>
+      <ValuePointer>_start</ValuePointer>
+    </ArrayItems>
+   </Expand>
+  </Type>
+
+  <Type Name="SimpleLinkedList">
+   <DisplayString>{{ size={numElements} }}</DisplayString>
+   <Expand>
+    <Item Name="Count">numElements</Item>
+    <LinkedListItems>
+      <Size>numElements</Size>
+      <HeadPointer>head</HeadPointer>
+      <NextPointer>next</NextPointer>
+      <ValueNode>data</ValueNode>
+    </LinkedListItems>
+   </Expand>
+  </Type>
+
+  <Type Name="BinarySearchTree">
+   <DisplayString>{{ size={numElements} }}</DisplayString>
+   <Expand>
+    <Item Name="Count">numElements</Item>
+    <TreeItems>
+      <Size>numElements</Size>
+      <HeadPointer>root</HeadPointer>
+      <LeftPointer>left</LeftPointer>
+      <RightPointer>right</RightPointer>
+      <ValueNode>data</ValueNode>
+    </TreeItems>
+   </Expand>
+  </Type>
+</AutoVisualizer>


### PR DESCRIPTION
This PR adds support for testing MIEngine Natvis.

- sending `visualizerFile` in the launch configuration for CppTests. 
- Added tests for:
  - DisplayView
  - ArrayItems
  - LinkedListItems
  - TreeItems