### PR TITLE
Add IndexListItems Natvis test and enable on macOS

### DIFF
--- a/test/CppTests/Tests/NatvisTests.cs
+++ b/test/CppTests/Tests/NatvisTests.cs
@@ -121,7 +121,10 @@ namespace CppTests.Tests
                     Assert.Equal("{ size=15 }", arr.Value);
 
                     // Index element for IndexListItems
-                    Assert.Equal("100", arr.GetVariable("[10]").Value);
+                    // Natvis retrieves items in reverse order.
+                    Assert.Equal("196", arr.GetVariable("[0]").Value);
+                    Assert.Equal("16", arr.GetVariable("[10]").Value);
+                    Assert.Equal("0", arr.GetVariable("[14]").Value);
                     // TODO: Add test below when we can support the [More..] expansion to handle >50 elements
                 }
 

--- a/test/CppTests/debuggees/natvis/src/SimpleArray.h
+++ b/test/CppTests/debuggees/natvis/src/SimpleArray.h
@@ -1,0 +1,21 @@
+#include <stdlib.h>
+
+class SimpleArray
+{
+public:
+  SimpleArray(int size)
+  {
+    _array = (int *)calloc(size, sizeof(int));
+    _size = size;
+  }
+
+  int operator [] (int i) const {
+    return _array[i];
+  }
+  int& operator [] (int i) {
+    return _array[i];
+  }
+
+  int* _array;
+  int  _size;
+};

--- a/test/CppTests/debuggees/natvis/src/main.cpp
+++ b/test/CppTests/debuggees/natvis/src/main.cpp
@@ -1,6 +1,7 @@
 #include "SimpleLinkedList.h"
 #include "BinarySearchTree.h"
 #include "SimpleVector.h"
+#include "SimpleArray.h"
 
 class SimpleDisplayObject
 {
@@ -29,6 +30,12 @@ int main(int argc, char** argv)
     map.Insert(-35);
     map.Insert(4);
     map.Insert(-72);
+
+    SimpleArray arr(15);
+    for (int i = 0 ; i < 15; i++)
+    {
+        arr[i] = i * i;
+    }
 
     return 0;
 }

--- a/test/CppTests/debuggees/natvis/src/visualizer_files/Simple.natvis
+++ b/test/CppTests/debuggees/natvis/src/visualizer_files/Simple.natvis
@@ -21,7 +21,7 @@
   <Expand>
     <IndexListItems>
       <Size>_size</Size>
-      <ValueNode>_array[$i]</ValueNode>
+      <ValueNode>_array[_size - 1 - $i]</ValueNode>
     </IndexListItems>
   </Expand>
   </Type>

--- a/test/CppTests/debuggees/natvis/src/visualizer_files/Simple.natvis
+++ b/test/CppTests/debuggees/natvis/src/visualizer_files/Simple.natvis
@@ -16,6 +16,16 @@
    </Expand>
   </Type>
 
+  <Type Name="SimpleArray">
+  <DisplayString>{{ size={_size} }}</DisplayString>
+  <Expand>
+    <IndexListItems>
+      <Size>_size</Size>
+      <ValueNode>_array[$i]</ValueNode>
+    </IndexListItems>
+  </Expand>
+  </Type>
+
   <Type Name="SimpleLinkedList">
    <DisplayString>{{ size={numElements} }}</DisplayString>
    <Expand>


### PR DESCRIPTION
This PR adds a test for IndexListItems and enables all but TestArrayItems for macOS