### PR TITLE
Adding UnitTests for Natvis Parsing (MIDebugEngineUnitTests)

### DIFF
--- a/.github/workflows/Build-And-Test.yml
+++ b/.github/workflows/Build-And-Test.yml
@@ -47,7 +47,7 @@ jobs:
       uses: darenm/Setup-VSTest@v1
 
     - name: Run VS Extension tests
-      run: vstest.console.exe ${{ github.workspace }}\bin\${{ matrix.configuration }}\MICoreUnitTests.dll ${{ github.workspace }}\bin\${{ matrix.configuration }}\JDbgUnitTests.dll ${{ github.workspace }}\bin\${{ matrix.configuration }}\SSHDebugTests.dll
+      run: vstest.console.exe ${{ github.workspace }}\bin\${{ matrix.configuration }}\MICoreUnitTests.dll ${{ github.workspace }}\bin\${{ matrix.configuration }}\JDbgUnitTests.dll ${{ github.workspace }}\bin\${{ matrix.configuration }}\SSHDebugTests.dll ${{ github.workspace }}\bin\${{ matrix.configuration }}\MIDebugEngineUnitTests.dll
 
   windows_vscode_build:
     runs-on: windows-latest

--- a/src/MICore/Logger.cs
+++ b/src/MICore/Logger.cs
@@ -18,6 +18,8 @@ namespace MICore
     public interface ILogger
     {
         void WriteLine(string line);
+
+        void WriteLine(string format, params object[] args);
     }
 
     /// <summary>

--- a/src/MICore/Logger.cs
+++ b/src/MICore/Logger.cs
@@ -15,10 +15,15 @@ using Microsoft.DebugEngineHost;
 
 namespace MICore
 {
+    public interface ILogger
+    {
+        void WriteLine(string line);
+    }
+
     /// <summary>
     /// Class which implements logging. The logging is control by a registry key. If enabled, logging goes to %TMP%\Microsoft.MIDebug.log
     /// </summary>
-    public class Logger
+    public class Logger : ILogger
     {
         private static bool s_isInitialized;
         private static bool s_isEnabled;

--- a/src/MIDebugEngine.sln
+++ b/src/MIDebugEngine.sln
@@ -102,6 +102,8 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "tools", "tools", "{20B91EF1
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "MakePIAPortableTool", "tools\MakePIAPortableTool\MakePIAPortableTool.csproj", "{CC5BDD33-7EB1-4FB9-BC67-806773018989}"
 EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "MIDebugEngineUnitTests", "MIDebugEngineUnitTests\MIDebugEngineUnitTests.csproj", "{7F98435A-526E-41DC-9F9A-BFD55CC991DE}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -278,6 +280,14 @@ Global
 		{CC5BDD33-7EB1-4FB9-BC67-806773018989}.Lab.Release|Any CPU.Build.0 = Lab.Release|Any CPU
 		{CC5BDD33-7EB1-4FB9-BC67-806773018989}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{CC5BDD33-7EB1-4FB9-BC67-806773018989}.Release|Any CPU.Build.0 = Release|Any CPU
+		{7F98435A-526E-41DC-9F9A-BFD55CC991DE}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{7F98435A-526E-41DC-9F9A-BFD55CC991DE}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{7F98435A-526E-41DC-9F9A-BFD55CC991DE}.Lab.Debug|Any CPU.ActiveCfg = Lab.Debug|Any CPU
+		{7F98435A-526E-41DC-9F9A-BFD55CC991DE}.Lab.Debug|Any CPU.Build.0 = Lab.Debug|Any CPU
+		{7F98435A-526E-41DC-9F9A-BFD55CC991DE}.Lab.Release|Any CPU.ActiveCfg = Lab.Release|Any CPU
+		{7F98435A-526E-41DC-9F9A-BFD55CC991DE}.Lab.Release|Any CPU.Build.0 = Lab.Release|Any CPU
+		{7F98435A-526E-41DC-9F9A-BFD55CC991DE}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{7F98435A-526E-41DC-9F9A-BFD55CC991DE}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/src/MIDebugEngine/Natvis.Impl/NatvisNames.cs
+++ b/src/MIDebugEngine/Natvis.Impl/NatvisNames.cs
@@ -38,10 +38,10 @@ namespace Microsoft.MIDebugEngine.Natvis
                     @"^(signed\s+char|unsigned\s+char|char16_t|char32_t|wchar_t|char|"
                     + @"signed\s+short\s+int|signed\s+short|unsigned\s+short\s+int|unsigned\s+short|short\s+int|short|"
                     + @"signed\s+int|unsigned\s+int|int|"
-                    + @"signed\s+long\s+int|unsigned\s+long\s+int|long\s+int|long|"
-                    + @"signed\s+long\s+long\s+int|long\s+long\s+int|unsigned\s+long\s+long\s+int|long\s+long"
+                    + @"signed\s+long\s+int|unsigned\s+long\s+int|"
+                    + @"signed\s+long\s+long\s+int|long\s+long\s+int|long\s+int|unsigned\s+long\s+long\s+int|long\s+long"
                     + @"float|double|"
-                    + @"long\s+double|bool|void)\b" // matches prefixes ending in '$' (e.g. void$Foo), these are checked for below
+                    + @"long\s+double|long|bool|void)\b" // matches prefixes ending in '$' (e.g. void$Foo), these are checked for below
                 );
         private static readonly TypeName s_any = new TypeName()
         {
@@ -138,7 +138,7 @@ namespace Microsoft.MIDebugEngine.Natvis
         /// </summary>
         /// <param name="fullyQualifiedName"></param>
         /// <returns></returns>
-        public static TypeName Parse(string fullyQualifiedName, Logger logger)
+        public static TypeName Parse(string fullyQualifiedName, ILogger logger)
         {
             if (String.IsNullOrEmpty(fullyQualifiedName))
                 return null;

--- a/src/MIDebugEngine/Natvis.Impl/NatvisNames.cs
+++ b/src/MIDebugEngine/Natvis.Impl/NatvisNames.cs
@@ -146,7 +146,7 @@ namespace Microsoft.MIDebugEngine.Natvis
             TypeName t = MatchTypeName(fullyQualifiedName.Trim(), out rest);
             if (!String.IsNullOrWhiteSpace(rest))
             {
-                logger.WriteLine("Natvis failed to parse typename: " + fullyQualifiedName);
+                logger.WriteLine("Natvis failed to parse typename: {0}", fullyQualifiedName);
                 return null;
             }
             return t;

--- a/src/MIDebugEngine/Properties/AssemblyInfo.cs
+++ b/src/MIDebugEngine/Properties/AssemblyInfo.cs
@@ -4,7 +4,6 @@
 using System.Reflection;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
-using System.Security.Cryptography;
 
 // General Information about an assembly is controlled through the following 
 // set of attributes. Change these attribute values to modify the information

--- a/src/MIDebugEngine/Properties/AssemblyInfo.cs
+++ b/src/MIDebugEngine/Properties/AssemblyInfo.cs
@@ -4,6 +4,7 @@
 using System.Reflection;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
+using System.Security.Cryptography;
 
 // General Information about an assembly is controlled through the following 
 // set of attributes. Change these attribute values to modify the information
@@ -20,3 +21,6 @@ using System.Runtime.InteropServices;
 
 // The following GUID is for the ID of the typelib if this project is exposed to COM
 [assembly: Guid("42127a66-b150-42db-8ca0-a4f059e60e6e")]
+
+// Allows MIDebugEngineUnitTests to access internal classes for testing.
+[assembly: InternalsVisibleTo("MIDebugEngineUnitTests, PublicKey=0024000004800000940000000602000000240000525341310004000001000100653b46738aa8d82f195b27b17982973efdbb5186bf3527246108bc1653b338a3a452eb99b7ca5a425008aefe385c7e463b5a99eed4c15a786b539480e7d3dd9fe404db485dd3bb9ba85aea38be088d7412337494f9a2d525a920a4c064acde81e4c4fe1e070f4900e7b2d6e0d4cd855c062cb3feb48011fffa98734f12e987f1")]

--- a/src/MIDebugEngineUnitTests/MIDebugEngineUnitTests.csproj
+++ b/src/MIDebugEngineUnitTests/MIDebugEngineUnitTests.csproj
@@ -1,0 +1,37 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <Import Project="..\..\build\miengine.settings.targets" />
+  <PropertyGroup>
+    <TargetFramework>net472</TargetFramework>
+    <IsPackable>false</IsPackable>
+
+    <AssemblyOriginatorKeyFile>..\..\Keys\ExternalKey.snk</AssemblyOriginatorKeyFile>
+    <SignAssembly>True</SignAssembly>
+    <OutputPath>$(MIDefaultOutputPath)</OutputPath>
+    <IsTestProject>true</IsTestProject>
+  </PropertyGroup>
+
+  <ItemGroup Label="NuGet Packages">
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="$(Microsoft_NET_Test_Sdk_Version)" />
+    <PackageReference Include="xunit" Version="$(xunit_Version)" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="$(xunit_runner_visualstudio_Version)">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+    <PackageReference Include="coverlet.collector" Version="$(coverlet_collector_Version)">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+  </ItemGroup>
+
+  <ItemGroup Label="Project References">
+    <ProjectReference Include="..\DebugEngineHost.Stub\DebugEngineHost.Stub.csproj">
+      <Project>{ea876a2d-ab0f-4204-97dd-dfb3b5568978}</Project>
+      <Name>DebugEngineHost.Stub</Name>
+      <Private>False</Private>
+    </ProjectReference>
+    <ProjectReference Include="..\MIDebugEngine\MIDebugEngine.csproj" />
+  </ItemGroup>
+
+  <Import Project="..\..\build\miengine.targets" />
+
+</Project>

--- a/src/MIDebugEngineUnitTests/NatvisNamesTest.cs
+++ b/src/MIDebugEngineUnitTests/NatvisNamesTest.cs
@@ -3,6 +3,7 @@ using Xunit;
 using Microsoft.MIDebugEngine.Natvis;
 using MICore;
 using Xunit.Abstractions;
+using System.Globalization;
 
 namespace MIDebugEngineUnitTests
 {
@@ -35,6 +36,11 @@ namespace MIDebugEngineUnitTests
         public void WriteLine(string line)
         {
             _output?.WriteLine(line);
+        }
+
+        public void WriteLine(string format, params object[] args)
+        {
+            _output?.WriteLine(string.Format(CultureInfo.InvariantCulture, format, args));
         }
     }
 

--- a/src/MIDebugEngineUnitTests/NatvisNamesTest.cs
+++ b/src/MIDebugEngineUnitTests/NatvisNamesTest.cs
@@ -1,0 +1,88 @@
+using Xunit;
+
+using Microsoft.MIDebugEngine.Natvis;
+using MICore;
+using Xunit.Abstractions;
+
+namespace MIDebugEngineUnitTests
+{
+    class TestLogger : ILogger
+    {
+        private static TestLogger s_instance;
+
+        public static TestLogger Instance
+        {
+            get
+            {
+                if (s_instance == null)
+                {
+                    s_instance = new TestLogger();
+                }
+
+                return s_instance;
+            }
+        }
+
+        private ITestOutputHelper _output;
+
+        private TestLogger() {}
+
+        internal void RegisterTestOutputHelper(ITestOutputHelper output)
+        {
+            _output = output;
+        }
+
+        public void WriteLine(string line)
+        {
+            _output?.WriteLine(line);
+        }
+    }
+
+    public class NatvisNamesTest
+    {
+        public NatvisNamesTest(ITestOutputHelper output)
+        {
+            TestLogger.Instance.RegisterTestOutputHelper(output);
+        }
+
+
+        [Fact]
+        public void TestPrimitiveParse()
+        {
+            Assert.NotNull(TypeName.Parse("bool", TestLogger.Instance));
+            Assert.NotNull(TypeName.Parse("char", TestLogger.Instance));
+            Assert.NotNull(TypeName.Parse("int", TestLogger.Instance));
+            Assert.NotNull(TypeName.Parse("float", TestLogger.Instance));
+            Assert.NotNull(TypeName.Parse("double", TestLogger.Instance));
+            Assert.NotNull(TypeName.Parse("void", TestLogger.Instance));
+            Assert.NotNull(TypeName.Parse("wchar_t", TestLogger.Instance));
+        }
+
+        [Fact]
+        public void TestModifiedPrimitiveParse()
+        {
+            Assert.NotNull(TypeName.Parse("unsigned char", TestLogger.Instance));
+            Assert.NotNull(TypeName.Parse("signed char", TestLogger.Instance));
+            Assert.NotNull(TypeName.Parse("signed int", TestLogger.Instance));
+            Assert.NotNull(TypeName.Parse("unsigned int", TestLogger.Instance));
+            Assert.NotNull(TypeName.Parse("short int", TestLogger.Instance));
+            Assert.NotNull(TypeName.Parse("signed short int", TestLogger.Instance));
+            Assert.NotNull(TypeName.Parse("unsigned short int", TestLogger.Instance));
+            Assert.NotNull(TypeName.Parse("long int", TestLogger.Instance));
+            Assert.NotNull(TypeName.Parse("signed long int", TestLogger.Instance));
+            Assert.NotNull(TypeName.Parse("unsigned long int", TestLogger.Instance));
+            Assert.NotNull(TypeName.Parse("long long int", TestLogger.Instance));
+            Assert.NotNull(TypeName.Parse("long double", TestLogger.Instance));
+        }
+
+        [Fact]
+        public void TestComplexParse()
+        {
+            Assert.NotNull(TypeName.Parse("std::vector<int>", TestLogger.Instance));
+            Assert.NotNull(TypeName.Parse("std::map<int, int>", TestLogger.Instance));
+            Assert.NotNull(TypeName.Parse("std::map<char, int>::iterator", TestLogger.Instance));
+            Assert.NotNull(TypeName.Parse("std::is_base_of<std::input_iterator_tag, tag>::value", TestLogger.Instance));
+            Assert.NotNull(TypeName.Parse("mpl::if_<T, std::true_type, std::false_type>", TestLogger.Instance));
+        }
+    }
+}


### PR DESCRIPTION
Adding UnitTests for `TypeNames.Parse(...)`

Required adding an IVT for MIDebugEngine and updating the build to run the tests.

Caught that both: `long long int` and `long double` did not succeeded in parsing and fixed it in NatvisName.cs regex.