### PR TITLE
Override Newtonsoft.JSON for CG

### DIFF
--- a/src/DebugEngineHost/DebugEngineHost.csproj
+++ b/src/DebugEngineHost/DebugEngineHost.csproj
@@ -48,6 +48,19 @@
 
   <Import Project="..\..\build\Debugger.PIAs.NonPortable.Packages.settings.targets" />
 
+  
+  <!-- 
+    This ItemGroup is to override the packages that being depended on for the PackageReferences above. 
+    The issue is that Microsoft.VisualStudio.Shell.Framework v17.2.32505.113 -> 
+                      Microsoft.ServiceHub.[Client|Framework] ->
+                      StreamJsonRpc v2.7.70 ->
+                      Newtonsoft.Json v12.0.2
+    Delete this explicit override when we update 'Microsoft_VisualStudio_Shell_Framework_Version' away from v17.2.32505.113
+  -->
+  <ItemGroup Label="Component Governance Override"> 
+    <PackageReference Include="Newtonsoft.Json" Version="$(Newtonsoft_Json_Version)" />
+  </ItemGroup>
+
   <ItemGroup Label="NuGet Packages">
     <PackageReference Include="Microsoft.VisualStudio.Shell.15.0" Version="$(Microsoft_VisualStudio_Shell_15_0_Version)">
       <IncludeAssets>compile</IncludeAssets>

--- a/src/JDbgUnitTests/JDbgUnitTests.csproj
+++ b/src/JDbgUnitTests/JDbgUnitTests.csproj
@@ -21,6 +21,16 @@
     <IsTestProject>true</IsTestProject>
   </PropertyGroup>
 
+  <!-- 
+    This ItemGroup is to override the packages that being depended on for the PackageReferences above. 
+    The issue is that Microsoft.NET.Test.Sdk ->
+                      Newtonsoft.Json v12.0.2
+    Delete this explicit override when we update 'Microsoft_VisualStudio_Shell_Framework_Version' away from v17.2.32505.113
+  -->
+  <ItemGroup Label="Component Governance Override"> 
+    <PackageReference Include="Newtonsoft.Json" Version="$(Newtonsoft_Json_Version)" />
+  </ItemGroup>
+
   <ItemGroup Label="NuGet Packages">
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="$(Microsoft_NET_Test_Sdk_Version)" />
     <PackageReference Include="xunit" Version="$(xunit_Version)" />

--- a/src/MICoreUnitTests/MICoreUnitTests.csproj
+++ b/src/MICoreUnitTests/MICoreUnitTests.csproj
@@ -24,6 +24,17 @@
     <IsTestProject>true</IsTestProject>
   </PropertyGroup>
 
+  <!-- 
+    This ItemGroup is to override the packages that being depended on for the PackageReferences above. 
+    The issue is that Microsoft.NET.Test.Sdk ->
+                      Newtonsoft.Json v12.0.2
+    Delete this explicit override when we update 'Microsoft_VisualStudio_Shell_Framework_Version' away from v17.2.32505.113
+  -->
+  <ItemGroup Label="Component Governance Override"> 
+    <PackageReference Include="Newtonsoft.Json" Version="$(Newtonsoft_Json_Version)" />
+  </ItemGroup>
+
+
   <ItemGroup Label="NuGet Packages">
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="$(Microsoft_NET_Test_Sdk_Version)">
       <IncludeAssets>compile</IncludeAssets>

--- a/src/MIDebugEngineUnitTests/MIDebugEngineUnitTests.csproj
+++ b/src/MIDebugEngineUnitTests/MIDebugEngineUnitTests.csproj
@@ -10,6 +10,16 @@
     <IsTestProject>true</IsTestProject>
   </PropertyGroup>
 
+  <!-- 
+    This ItemGroup is to override the packages that being depended on for the PackageReferences above. 
+    The issue is that Microsoft.NET.Test.Sdk ->
+                      Newtonsoft.Json v12.0.2
+    Delete this explicit override when we update 'Microsoft_VisualStudio_Shell_Framework_Version' away from v17.2.32505.113
+  -->
+  <ItemGroup Label="Component Governance Override"> 
+    <PackageReference Include="Newtonsoft.Json" Version="$(Newtonsoft_Json_Version)" />
+  </ItemGroup>
+
   <ItemGroup Label="NuGet Packages">
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="$(Microsoft_NET_Test_Sdk_Version)" />
     <PackageReference Include="xunit" Version="$(xunit_Version)" />

--- a/src/OpenDebugAD7/OpenDebugAD7.csproj
+++ b/src/OpenDebugAD7/OpenDebugAD7.csproj
@@ -49,6 +49,16 @@
 
   <Import Project="..\..\build\Debugger.PIAs.Portable.Packages.settings.targets" />
 
+  <!-- 
+    This ItemGroup is to override the packages that being depended on for the PackageReferences above. 
+    The issue is that Microsoft.VisualStudio.Shared.VSCodeDebugProtocol ->
+                      Newtonsoft.Json v12.0.2
+    Delete this explicit override when we update 'Microsoft_VisualStudio_Shell_Framework_Version' away from v17.2.32505.113
+  -->
+  <ItemGroup Label="Component Governance Override"> 
+    <PackageReference Include="Newtonsoft.Json" Version="$(Newtonsoft_Json_Version)" />
+  </ItemGroup>
+
   <ItemGroup Label="NuGet Packages">
     <!-- TODO: Include in VSIX. (Optional since we don't F5 the DebugAdapterHost.Launch scenario.) -->
     <PackageReference Include="Microsoft.VisualStudio.Debugger.Interop.15.0" Version="$(Microsoft_VisualStudio_Debugger_Interop_15_0_Version)" />

--- a/src/SSHDebugPS/SSHDebugPS.csproj
+++ b/src/SSHDebugPS/SSHDebugPS.csproj
@@ -22,7 +22,6 @@
     <PackageReference Include="Microsoft.VisualStudio.Shell.15.0" Version="$(Microsoft_VisualStudio_Shell_15_0_Version)" />
     <PackageReference Include="Microsoft.VisualStudio.Shell.Framework" Version="$(Microsoft_VisualStudio_Shell_Framework_Version)" />
     <PackageReference Include="Microsoft.VisualStudio.Threading" Version="$(Microsoft_VisualStudio_Threading_Version)" />
-    <!-- NOTE: MIEngine's usage of Newtonsoft.Json's flows through public interfaces exposed by MICore (IPlatformAppLauncher). So this version needs to be within the binding redirect range used by devenv.exe (d17: 12.0.2) -->
     <PackageReference Include="Newtonsoft.Json" Version="$(Newtonsoft_Json_Version)">
       <IncludeAssets>compile</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>

--- a/src/SSHDebugTests/SSHDebugUnitTests.csproj
+++ b/src/SSHDebugTests/SSHDebugUnitTests.csproj
@@ -20,6 +20,16 @@
 
     <IsTestProject>true</IsTestProject>
   </PropertyGroup>
+
+  <!-- 
+    This ItemGroup is to override the packages that being depended on for the PackageReferences above. 
+    The issue is that Microsoft.NET.Test.Sdk ->
+                      Newtonsoft.Json v12.0.2
+    Delete this explicit override when we update 'Microsoft_VisualStudio_Shell_Framework_Version' away from v17.2.32505.113
+  -->
+  <ItemGroup Label="Component Governance Override"> 
+    <PackageReference Include="Newtonsoft.Json" Version="$(Newtonsoft_Json_Version)" />
+  </ItemGroup>
   
   <ItemGroup Label="NuGet Packages">
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="$(Microsoft_NET_Test_Sdk_Version)" />

--- a/test/CppTests/CppTests.csproj
+++ b/test/CppTests/CppTests.csproj
@@ -9,6 +9,16 @@
     <OutputPath>$(OutputPath)\CppTests</OutputPath>
   </PropertyGroup>
   
+  <!-- 
+    This ItemGroup is to override the packages that being depended on for the PackageReferences above. 
+    The issue is that Microsoft.NET.Test.Sdk ->
+                      Newtonsoft.Json v12.0.2
+    Delete this explicit override when we update 'Microsoft_VisualStudio_Shell_Framework_Version' away from v17.2.32505.113
+  -->
+  <ItemGroup Label="Component Governance Override"> 
+    <PackageReference Include="Newtonsoft.Json" Version="$(Newtonsoft_Json_Version)" />
+  </ItemGroup>
+
   <ItemGroup Label="Package References">
     <PackageReference Include="Microsoft.VisualStudioEng.MicroBuild.Core" Version="$(Microsoft_VisualStudioEng_MicroBuild_Core_Version)" GeneratePathProperty="true">
       <PrivateAssets>all</PrivateAssets>

--- a/test/DebuggerTesting/DebuggerTesting.csproj
+++ b/test/DebuggerTesting/DebuggerTesting.csproj
@@ -7,6 +7,16 @@
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 
+  <!-- 
+    This ItemGroup is to override the packages that being depended on for the PackageReferences above. 
+    The issue is that Microsoft.NET.Test.Sdk ->
+                      Newtonsoft.Json v12.0.2
+    Delete this explicit override when we update 'Microsoft_VisualStudio_Shell_Framework_Version' away from v17.2.32505.113
+  -->
+  <ItemGroup Label="Component Governance Override"> 
+    <PackageReference Include="Newtonsoft.Json" Version="$(Newtonsoft_Json_Version)" />
+  </ItemGroup>
+
   <ItemGroup Label="Package References">
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="$(Microsoft_NET_Test_Sdk_Version)" />
     <PackageReference Include="xunit" Version="$(xunit_Version)" />


### PR DESCRIPTION
This PR adds an explcit reference to Newtonsoft.Json for packages the
reference MS.NET.Test.SDK and MS.VS.Shell until they have properly
published packages using Newtonsoft.JSON v13.0.1