### PR TITLE
Newtonsoft.JSON update for DAR nuspec

### DIFF
--- a/test/DebugAdapterRunner/DebugAdapterRunner.nuspec
+++ b/test/DebugAdapterRunner/DebugAdapterRunner.nuspec
@@ -14,7 +14,7 @@
     <releaseNotes>https://go.microsoft.com/fwlink/?LinkID=746387</releaseNotes>
     <copyright>© Microsoft Corporation. All rights reserved.</copyright>
     <dependencies>
-      <dependency id="Newtonsoft.Json" version="12.0.2" />
+      <dependency id="Newtonsoft.Json" version="13.0.1" />
     </dependencies>
   </metadata>
   <files>


### PR DESCRIPTION
This PR fixes the Newtonsoft.Json dependency for DAR to be v13.0.1.