### PR TITLE
Only print evaluate requests in REPL context

### DIFF
--- a/src/MIDebugEngine/Engine.Impl/Variables.cs
+++ b/src/MIDebugEngine/Engine.Impl/Variables.cs
@@ -524,13 +524,8 @@ namespace Microsoft.MIDebugEngine
                     string consoleResults = null;
 
                     consoleResults = await MIDebugCommandDispatcher.ExecuteCommand(consoleCommand, _debuggedProcess, ignoreFailures: true);
-                    Value = String.Empty;
+                    Value = consoleResults;
                     this.TypeName = null;
-
-                    if (!String.IsNullOrEmpty(consoleResults))
-                    {
-                        _debuggedProcess.WriteOutput(consoleResults);
-                    }
                 }
                 else
                 {


### PR DESCRIPTION
This PR fixes the EvaluateRequest with an `-exec` command and assign the return protocol with the correct `Value`.

This causes the DebugConsole in VS Code to show the output as a REPL output instead of an engine output.

Old: 
![ret-exec-val-old](https://user-images.githubusercontent.com/3953714/184026949-85b2abaf-51be-4b3c-8874-28b8c87b507a.gif)

New:
![ret-exec-val](https://user-images.githubusercontent.com/3953714/184026955-ba816e9d-15f0-4780-9905-78d5c54dd03a.gif)

Fixes: https://github.com/microsoft/MIEngine/issues/1236