### PR TITLE
[#1336] Discard cached state after program starts stepping.

### DIFF
--- a/src/OpenDebugAD7/AD7DebugSession.cs
+++ b/src/OpenDebugAD7/AD7DebugSession.cs
@@ -811,7 +811,6 @@ namespace OpenDebugAD7
                 }
             }
 
-            BeforeContinue();
             ErrorBuilder builder = new ErrorBuilder(() => errorMessage);
             m_isStepping = true;
 
@@ -837,6 +836,9 @@ namespace OpenDebugAD7
                 m_isStopped = true;
                 throw;
             }
+            // The program should now be stepping, so it is safe to discard the
+            // cached program state.
+            BeforeContinue();
         }
 
         private enum ClientId


### PR DESCRIPTION
### Description

In `AD7DebugSession.StepInternal`, discard cached state _after_ program starts stepping, rather than before.

Previously the cached state was discarded before calling `Step`, but this meant that if `Step` failed then MIEngine was left with no cached state, causing a subsequent call to `GetDebugPropertyFromExpression` to fail with a fatal error.

Fixes #1336 (Evaluating a variable after a failed Step Out causes a fatal error, leaving debug session unusable).

### Note

`BeforeContinue` is also called by `HandleContinueRequestAsync`, `HandleIDebugEntryPointEvent2` and `HandleIDebugEntryPointEvent2`, so similar changes might make sense in some or all of those functions, but I didn't make those changes here because the Continue request doesn't have the same possibility of harmless failure as the Step Out request.