### PR TITLE
Upgrading VSSDK: 17.0.1600 ->17.3.2093

### DIFF
--- a/build/package_versions.settings.targets
+++ b/build/package_versions.settings.targets
@@ -33,7 +33,7 @@
         <Microsoft_VisualStudio_Workspace_Version>15.0.392</Microsoft_VisualStudio_Workspace_Version>
         <Microsoft_VisualStudio_Workspace_VSIntegration_Version>15.0.392</Microsoft_VisualStudio_Workspace_VSIntegration_Version>
         <Microsoft_VisualStudio_TextManager_Interop_Version>17.0.0-previews-1-31410-258</Microsoft_VisualStudio_TextManager_Interop_Version>
-        <Microsoft_VSSDK_BuildTools_Version>17.0.1600</Microsoft_VSSDK_BuildTools_Version>
+        <Microsoft_VSSDK_BuildTools_Version>17.3.2093</Microsoft_VSSDK_BuildTools_Version>
         <System_Runtime_Loader_Version>4.3.0</System_Runtime_Loader_Version>
     </PropertyGroup>
 </Project>


### PR DESCRIPTION
Some builds are failing with 
>   C:\Users\runneradmin\.nuget\packages\microsoft.vssdk.buildtools\17.0.1600\tools\VSSDK\Microsoft.VsSDK.targets(792,3): error MSB4018: The "GetDeploymentPathFromVsixManifest" task failed unexpectedly. [D:\a\MIEngine\MIEngine\src\MIDebugPackage\MIDebugPackage.csproj]
C:\Users\runneradmin\.nuget\packages\microsoft.vssdk.buildtools\17.0.1600\tools\VSSDK\Microsoft.VsSDK.targets(792,3): error MSB4018: System.AggregateException: One or more errors occurred. ---> System.NullReferenceException: Object reference not set to an instance of an object. [D:\a\MIEngine\MIEngine\src\MIDebugPackage\MIDebugPackage.csproj]

Upgrading the VSSDK to a newer version. 