### PR TITLE
Address visualizing past 1000 ArrayItems

### DIFF
--- a/src/MIDebugEngine/Natvis.Impl/Natvis.cs
+++ b/src/MIDebugEngine/Natvis.Impl/Natvis.cs
@@ -605,7 +605,7 @@ namespace Microsoft.MIDebugEngine.Natvis
                             //   If requestedSize > 1000, the evaluation will only grab the first 1000 elements.
 
                             // We want to limit it to at most 50.
-                            uint requestedSize = totalSize - startIndex > MAX_EXPAND ? MAX_EXPAND : totalSize - startIndex;
+                            uint requestedSize = Math.Min(MAX_EXPAND, totalSize - startIndex);
 
                             StringBuilder arrayBuilder = new StringBuilder();
                             arrayBuilder.Append('(');

--- a/src/MIDebugEngine/Natvis.Impl/Natvis.cs
+++ b/src/MIDebugEngine/Natvis.Impl/Natvis.cs
@@ -577,9 +577,16 @@ namespace Microsoft.MIDebugEngine.Natvis
                     {
                         continue;
                     }
-                    uint size = 0;
+                    uint totalSize = 0;
                     string val = GetExpressionValue(item.Size, variable, visualizer.ScopedNames);
-                    size = MICore.Debugger.ParseUint(val, throwOnError: true);
+                    totalSize = MICore.Debugger.ParseUint(val, throwOnError: true);
+
+                    uint startIndex = 0;
+                    if (variable is PaginatedVisualizerWrapper pvwVariable)
+                    {
+                        startIndex = pvwVariable.StartIndex;
+                    }
+
                     ValuePointerType[] vptrs = item.ValuePointer;
                     foreach (var vp in vptrs)
                     {
@@ -591,34 +598,41 @@ namespace Microsoft.MIDebugEngine.Natvis
                             {
                                 continue;
                             }
+                            // Creates an expression: (T[50])*(<ValuePointer> + 50)
+                            // This evaluates for 50 elements of type T, starting at <ValuePointer> with an offet of 50 elements.
+                            // E.g. This will grab elements 50 - 99 from <ValuePointer>.
+                            // Note:
+                            //   If requestedSize > 1000, the evaluation will only grab the first 1000 elements.
+
+                            // We want to limit it to at most 50.
+                            uint requestedSize = totalSize - startIndex > MAX_EXPAND ? MAX_EXPAND : totalSize - startIndex;
+
                             StringBuilder arrayBuilder = new StringBuilder();
                             arrayBuilder.Append('(');
                             arrayBuilder.Append(typename);
                             arrayBuilder.Append('[');
-                            arrayBuilder.Append(size);
+                            arrayBuilder.Append(requestedSize);
                             arrayBuilder.Append("])*(");
                             arrayBuilder.Append(vp.Value);
+                            arrayBuilder.Append('+');
+                            arrayBuilder.Append(startIndex);
                             arrayBuilder.Append(')');
                             string arrayStr = arrayBuilder.ToString();
+
                             IVariableInformation arrayExpr = GetExpression(arrayStr, variable, visualizer.ScopedNames);
                             arrayExpr.EnsureChildren();
                             if (arrayExpr.CountChildren != 0)
                             {
-                                uint currentIndex = 0;
-                                if (variable is PaginatedVisualizerWrapper pvwVariable)
+                                uint offset = startIndex + requestedSize;
+
+                                for (uint index = 0; index < requestedSize; ++index)
                                 {
-                                    currentIndex = pvwVariable.StartIndex;
-                                }
-                                uint maxIndex = currentIndex + MAX_EXPAND > size ? size : currentIndex + MAX_EXPAND;
-                                for (uint index = currentIndex; index < maxIndex; ++index)
-                                {
-                                    children.Add(arrayExpr.Children[index]);
+                                    children.Add(new SimpleWrapper("[" + (startIndex + index).ToString(CultureInfo.InvariantCulture) + "]", _process.Engine, arrayExpr.Children[index]));
                                 }
 
-                                currentIndex += MAX_EXPAND;
-                                if (size > currentIndex)
+                                if (totalSize > offset)
                                 {
-                                    IVariableInformation moreVariable = new PaginatedVisualizerWrapper(ResourceStrings.MoreView, _process.Engine, variable, FindType(variable), isVisualizerView: true, currentIndex);
+                                    IVariableInformation moreVariable = new PaginatedVisualizerWrapper(ResourceStrings.MoreView, _process.Engine, variable, FindType(variable), isVisualizerView: true, offset);
                                     children.Add(moreVariable);
                                 }
                             }

--- a/test/CppTests/Tests/NatvisTests.cs
+++ b/test/CppTests/Tests/NatvisTests.cs
@@ -223,12 +223,28 @@ namespace CppTests.Tests
                     Assert.Equal("2000", ll.GetVariable("Size").Value);
 
                     var more = ll.GetVariable("[More...]");
-                    for (int i = 1; i < 20; i++)
+                    for (int i = 1; i < 40; i++)
                     {
                         string idx = (i * 50).ToString();
                         this.Comment($"Verifying ArrayItems [More...] for {idx}");
                         Assert.Equal(idx, more.GetVariable("[" + idx + "]").Value);
-                        more = more.GetVariable("[More...]");
+                        if (i == 39)
+                        {
+                            // For 1950 to 1999 there should not be a [More...] node.
+                            try
+                            {
+                                more = more.GetVariable("[More...]");
+                                Assert.True(false, "Unexpected [More...] node for the last page.");
+                            }
+                            catch (KeyNotFoundException)
+                            {
+                                // Success
+                            }
+                        }
+                        else
+                        {
+                            more = more.GetVariable("[More...]");
+                        }
                     }
                 }
 

--- a/test/CppTests/debuggees/natvis/src/main.cpp
+++ b/test/CppTests/debuggees/natvis/src/main.cpp
@@ -6,15 +6,19 @@
 
 class SimpleDisplayObject
 {
-    public:
-        SimpleDisplayObject(){}
+public:
+    SimpleDisplayObject() {}
 };
 
 int main(int argc, char** argv)
 {
     SimpleDisplayObject obj_1;
 
-    SimpleVector vec(52);
+    SimpleVector vec(2000);
+    for (int i = 0; i < 2000; i++)
+    {
+        vec.Set(i, i);
+    }
     vec.Set(5, 20);
 
     SimpleLinkedList ll;
@@ -33,12 +37,12 @@ int main(int argc, char** argv)
     map.Insert(-72);
 
     SimpleArray arr(52);
-    for (int i = 0 ; i < 52; i++)
+    for (int i = 0; i < 52; i++)
     {
         arr[i] = i * i;
     }
 
-    SimpleClass *simpleClass = nullptr;    
+    SimpleClass* simpleClass = nullptr;
     simpleClass = new SimpleClass();
 
     return 0;


### PR DESCRIPTION
We have a limit of 1000 child items that can be returned when we call `EnsureChildren`.
https://github.com/microsoft/MIEngine/blob/d5a05958d3cca45995b335645005d6917b515839/src/MICore/CommandFactories/MICommandFactory.cs#L353

Since we only ever need at most 50 at a time, this PR modified the request to be `(T[<At most 50>])*(<ValuePointer> +
StartOffset)` to handle child values past 1000.

Also added a test case to see if we can see past 1000 by testing with an
ArrayItem visualized type with 2000 elements.