### PR TITLE
Add support for comma format specifier for lldb

### DIFF
--- a/src/MIDebugEngine/Engine.Impl/Variables.cs
+++ b/src/MIDebugEngine/Engine.Impl/Variables.cs
@@ -341,11 +341,12 @@ namespace Microsoft.MIDebugEngine
         /// This callback is used when we need to call into the engine for additional information for
         /// the format specifier.
         ///
-        /// <param name="int">threadId</param>
-        /// <param name="uint">frameLevel</param>
+        /// <param name="threadId">The threadId to use when calling the engine.</param>
+        /// <param name="frameLevel">The frameLevel to use when calling the engine.</param>
         /// <returns>The expression to send to the engine</returns>
         /// </summary>
-        private Func<int, uint, Task<string>> _deferedFormatExpression;
+        private delegate Task<string> DeferedFormatExpression(int threadId, uint frameLevel);
+        private DeferedFormatExpression _deferedFormatExpression;
         private IVariableInformation _parent;
         private string _format;
         private string _strippedName;  // "Name" stripped of format specifiers
@@ -452,7 +453,7 @@ namespace Microsoft.MIDebugEngine
                 {
                     _deferedFormatExpression = async (int threadId, uint frameLevel) =>
                     {
-                        string derefType = await GetDereferencedTypeString(expr, threadId, frameLevel);
+                        string derefType = await GetDereferencedTypeStringAsync(expr, threadId, frameLevel);
 
                         if (!string.IsNullOrEmpty(derefType))
                         {
@@ -474,7 +475,7 @@ namespace Microsoft.MIDebugEngine
             return exp;
         }
 
-        private async Task<string> GetDereferencedTypeString(string expr, int threadId, uint frameLevel)
+        private async Task<string> GetDereferencedTypeStringAsync(string expr, int threadId, uint frameLevel)
         {
             // TODO: Should we error if the current type is not a pointer type?
 

--- a/test/CppTests/Tests/NatvisTests.cs
+++ b/test/CppTests/Tests/NatvisTests.cs
@@ -402,9 +402,7 @@ namespace CppTests.Tests
         [Theory]
         [DependsOnTest(nameof(CompileNatvisDebuggee))]
         [RequiresTestSettings]
-        // Disable on macOS
-        [UnsupportedDebugger(SupportedDebugger.Lldb, SupportedArchitecture.x64 | SupportedArchitecture.x86)]
-        public void TestArrayPointer(ITestSettings settings)
+        public void TestCommaFormatSpecifier(ITestSettings settings)
         {
             this.TestPurpose("This test checks if the comma format specifier is visualized.");
             this.WriteSettings(settings);
@@ -431,6 +429,43 @@ namespace CppTests.Tests
                     this.Comment("Verifying comma format specifier");
                     int[] expected = { 0, 1, 4, 9 };
                     currentFrame.AssertEvaluateAsIntArray("arr._array,4", EvaluateContext.Watch, expected);
+                }
+
+                runner.Expects.ExitedEvent(exitCode: 0).TerminatedEvent().AfterContinue();
+                runner.DisconnectAndVerify();
+            }
+        }
+
+        [Theory]
+        [DependsOnTest(nameof(CompileNatvisDebuggee))]
+        [RequiresTestSettings]
+        public void TestCommaFormatWithSquareBrackets(ITestSettings settings)
+        {
+            this.TestPurpose("This test checks if the comma format specifier with square brackets is visualized.");
+            this.WriteSettings(settings);
+
+            IDebuggee debuggee = Debuggee.Open(this, settings.CompilerSettings, NatvisName, DebuggeeMonikers.Natvis.Default);
+
+            this.Comment("Run the debuggee, check argument count");
+            using (IDebuggerRunner runner = CreateDebugAdapterRunner(settings))
+            {
+                this.Comment("Configure launch");
+                LaunchCommand launch = new LaunchCommand(settings.DebuggerSettings, debuggee.OutputPath);
+                runner.RunCommand(launch);
+
+                this.Comment("Set Breakpoint");
+                SourceBreakpoints writerBreakpoints = debuggee.Breakpoints(NatvisSourceName, ReturnSourceLine);
+                runner.SetBreakpoints(writerBreakpoints);
+
+                runner.Expects.StoppedEvent(StoppedReason.Breakpoint).AfterConfigurationDone();
+
+                using (IThreadInspector threadInspector = runner.GetThreadInspector())
+                {
+                    IFrameInspector currentFrame = threadInspector.Stack.First();
+
+                    this.Comment("Verifying comma format specifier");
+                    int[] expected = { 0, 1, 4, 9 };
+                    currentFrame.AssertEvaluateAsIntArray("arr._array,[4]", EvaluateContext.Watch, expected);
                 }
 
                 runner.Expects.ExitedEvent(exitCode: 0).TerminatedEvent().AfterContinue();


### PR DESCRIPTION
This PR enables the comma format specifier for lldb scenarios.

Also fixes the issue that `,[#]` was not being handled correctly.
Adds a test for the `,[#]` and updates the test name.