### PR TITLE
[#1349] Update the default stack trace format to include values.

### DIFF
--- a/src/OpenDebugAD7/AD7DebugSession.cs
+++ b/src/OpenDebugAD7/AD7DebugSession.cs
@@ -1703,10 +1703,11 @@ namespace OpenDebugAD7
                 }
                 else
                 {
-                    // No formatting flags provided in the request - use the default format, which includes the module name and argument names / types
+                    // No formatting flags provided in the request - use the default format, which includes the module name and argument names / types / values
                     flags |= enum_FRAMEINFO_FLAGS.FIF_FUNCNAME_MODULE |
                                 enum_FRAMEINFO_FLAGS.FIF_FUNCNAME_ARGS |
                                 enum_FRAMEINFO_FLAGS.FIF_FUNCNAME_ARGS_TYPES |
+                                enum_FRAMEINFO_FLAGS.FIF_FUNCNAME_ARGS_VALUES |
                                 enum_FRAMEINFO_FLAGS.FIF_FUNCNAME_ARGS_NAMES;
                 }
 


### PR DESCRIPTION
### Summary

This reduces the number of round-trips to the debugger, because when values are requested, the `-stack-list-arguments` command also returns the type of each argument immediately, avoiding the need for subsequent `-var-create` and `-var-delete` commands to get these types.

Fixes #1349 (Unnecessary -var-create and -var-delete commands during a stack trace can cause noticeable pause each time the debuggee stops)

### Details

I repeated the reproduction procedure from #1349, took a copy of the commands issued by a single Step Over operation with ten frames on the stack and attached them here: [stack-list-arguments-after.gz](https://github.com/microsoft/MIEngine/files/9498177/stack-list-arguments-after.gz). Here's a comparison of the before and after counts of commands:

| Command | Counts (main) | Counts (this branch) |
| ------- | ----- | ----- |
| `-stack-list-arguments` | 2 | 1 |
| `-stack-list-frames` | 1 | 1 |
| `-stack-list-variables` | 1 | 1 |
| `-stack-select-frame` | 20 | 0 |
| `-var-create` | 210 | 10 |
| `-var-delete` | 210 | 10 |

### Notes

A side-effect of this change is that we get values in the CALL STACK window in Visual Studio Code (see screenshots below). I think this is an improvement, but since it is a big UX change you need to take it into consideration.

| main | this branch |
| ---- | ----------- |
|![Screenshot from 2022-09-06 16-02-07](https://user-images.githubusercontent.com/922721/188670016-73a6e4f7-0295-4f5e-81a7-546c2243fe0c.png)|![Screenshot from 2022-09-06 16-03-40](https://user-images.githubusercontent.com/922721/188670048-ddeff34a-3aa6-4db4-aa69-be3c3b8b2732.png)|

If this is not acceptable, let me know, and I can implement solution 2 from #1349 instead.
