### PR TITLE
Add configuration for handling of unknown breakpoints

### DIFF
--- a/src/MICore/JsonLaunchOptions.cs
+++ b/src/MICore/JsonLaunchOptions.cs
@@ -5,7 +5,9 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Globalization;
+using System.Runtime.Serialization;
 using Newtonsoft.Json;
+using Newtonsoft.Json.Converters;
 using Newtonsoft.Json.Linq;
 
 namespace MICore.Json.LaunchOptions
@@ -113,6 +115,12 @@ namespace MICore.Json.LaunchOptions
         /// </summary>
         [JsonProperty("hardwareBreakpoints", DefaultValueHandling = DefaultValueHandling.Ignore)]
         public HardwareBreakpointInfo HardwareBreakpointInfo { get; set; }
+
+        /// <summary>
+        /// Controls how breakpoints set externally (usually via raw GDB commands) are handled when hit. "throw" acts as if an exception was thrown by the application, "stop" only pauses the debug session, and "ignore" continues execution without pausing.
+        /// </summary>
+        [JsonProperty("unknownBreakpointHandling", DefaultValueHandling = DefaultValueHandling.Ignore)]
+        public UnknownBreakpointHandling? UnknownBreakpointHandling { get; set; }
     }
 
     public partial class AttachOptions : BaseOptions
@@ -263,6 +271,19 @@ namespace MICore.Json.LaunchOptions
         }
 
         #endregion
+    }
+
+    [JsonConverter(typeof(StringEnumConverter))]
+    public enum UnknownBreakpointHandling
+    {
+        [EnumMember(Value = "throw")]
+        Throw,
+
+        [EnumMember(Value = "stop")]
+        Stop,
+
+        [EnumMember(Value = "ignore")]
+        Ignore,
     }
 
     public partial class LaunchOptions : BaseOptions

--- a/src/MICore/JsonLaunchOptions.cs
+++ b/src/MICore/JsonLaunchOptions.cs
@@ -117,7 +117,7 @@ namespace MICore.Json.LaunchOptions
         public HardwareBreakpointInfo HardwareBreakpointInfo { get; set; }
 
         /// <summary>
-        /// Controls how breakpoints set externally (usually via raw GDB commands) are handled when hit. "throw" acts as if an exception was thrown by the application, "stop" only pauses the debug session, and "ignore" continues execution without pausing.
+        /// Controls how breakpoints set externally (usually via raw GDB commands) are handled when hit. "throw" acts as if an exception was thrown by the application and "stop" only pauses the debug session.
         /// </summary>
         [JsonProperty("unknownBreakpointHandling", DefaultValueHandling = DefaultValueHandling.Ignore)]
         public UnknownBreakpointHandling? UnknownBreakpointHandling { get; set; }
@@ -280,10 +280,7 @@ namespace MICore.Json.LaunchOptions
         Throw,
 
         [EnumMember(Value = "stop")]
-        Stop,
-
-        [EnumMember(Value = "ignore")]
-        Ignore,
+        Stop
     }
 
     public partial class LaunchOptions : BaseOptions

--- a/src/MICore/LaunchOptions.cs
+++ b/src/MICore/LaunchOptions.cs
@@ -20,6 +20,7 @@ using Microsoft.VisualStudio.Debugger.Interop;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 using System.Text;
+using MICore.Json.LaunchOptions;
 
 namespace MICore
 {
@@ -1202,6 +1203,18 @@ namespace MICore
             }
         }
 
+        private UnknownBreakpointHandling _unknownBreakpointHandling;
+
+        public UnknownBreakpointHandling UnknownBreakpointHandling
+        {
+            get { return _unknownBreakpointHandling; }
+            set
+            {
+                VerifyCanModifyProperty(nameof(UnknownBreakpointHandling));
+                _unknownBreakpointHandling = value;
+            }
+        }
+
         public string GetOptionsString()
         {
             try
@@ -1800,6 +1813,8 @@ namespace MICore
             {
                 throw new InvalidLaunchOptionsException(String.Format(CultureInfo.InvariantCulture, MICoreResources.Error_OptionNotSupported, nameof(options.HardwareBreakpointInfo.Require), nameof(MIMode.Lldb)));
             }
+
+            this.UnknownBreakpointHandling = options.UnknownBreakpointHandling ?? UnknownBreakpointHandling.Throw;
         }
 
         protected void InitializeCommonOptions(Xml.LaunchOptions.BaseLaunchOptions source)

--- a/src/MIDebugEngine/Engine.Impl/DebuggedProcess.cs
+++ b/src/MIDebugEngine/Engine.Impl/DebuggedProcess.cs
@@ -1234,13 +1234,23 @@ namespace Microsoft.MIDebugEngine
                     }
                     else
                     {
-                        // This is not one of our breakpoints, so stop with a message. Possibly it
-                        // was set by the user via "-exec break ...", so display the available
-                        // information.
-                        string desc = String.Format(CultureInfo.CurrentCulture,
-                                                    ResourceStrings.UnknownBreakpoint,
-                                                    bkptno, addr);
-                        _callback.OnException(thread, desc, "", 0);
+                        // This is not one of our breakpoints. Possibly it was set by the user
+                        // via "-exec break ...", so display the available information.
+                        switch (_launchOptions.UnknownBreakpointHandling)
+                        {
+                            case MICore.Json.LaunchOptions.UnknownBreakpointHandling.Throw:
+                                string desc = String.Format(CultureInfo.CurrentCulture,
+                                                            ResourceStrings.UnknownBreakpoint,
+                                                            bkptno, addr);
+                                _callback.OnException(thread, desc, "", 0);
+                                break;
+                            case MICore.Json.LaunchOptions.UnknownBreakpointHandling.Ignore:
+                                CmdContinueAsync();
+                                break;
+                            case MICore.Json.LaunchOptions.UnknownBreakpointHandling.Stop:
+                                _callback.OnBreakpoint(thread, new ReadOnlyCollection<object>(new AD7BoundBreakpoint[] { }));
+                                break;
+                        }
                     }
                 }
             }

--- a/src/MIDebugEngine/Engine.Impl/DebuggedProcess.cs
+++ b/src/MIDebugEngine/Engine.Impl/DebuggedProcess.cs
@@ -1244,9 +1244,6 @@ namespace Microsoft.MIDebugEngine
                                                             bkptno, addr);
                                 _callback.OnException(thread, desc, "", 0);
                                 break;
-                            case MICore.Json.LaunchOptions.UnknownBreakpointHandling.Ignore:
-                                CmdContinueAsync();
-                                break;
                             case MICore.Json.LaunchOptions.UnknownBreakpointHandling.Stop:
                                 _callback.OnBreakpoint(thread, new ReadOnlyCollection<object>(new AD7BoundBreakpoint[] { }));
                                 break;

--- a/src/MIDebugPackage/OpenFolderSchema.json
+++ b/src/MIDebugPackage/OpenFolderSchema.json
@@ -185,6 +185,15 @@
               },
               "hardwareBreakpoints": {
                 "$ref": "#/definitions/cpp_schema/definitions/hardwareBreakpointsOptions"
+              },
+              "unknownBreakpointHandling": {
+                "type": "string",
+                "enum": [
+                  "throw",
+                  "stop",
+                  "ignore"
+                ],
+                "description": "Controls how breakpoints set externally (usually via raw GDB commands) are handled when hit.\nAllowed values are \"throw\", which acts as if an exception was thrown by the application, \"stop\", which only pauses the debug session, and \"ignore\", which continues execution without pausing. The default value is \"throw\"."
               }
             },
             "definitions": {

--- a/src/MIDebugPackage/OpenFolderSchema.json
+++ b/src/MIDebugPackage/OpenFolderSchema.json
@@ -190,10 +190,9 @@
                 "type": "string",
                 "enum": [
                   "throw",
-                  "stop",
-                  "ignore"
+                  "stop"
                 ],
-                "description": "Controls how breakpoints set externally (usually via raw GDB commands) are handled when hit.\nAllowed values are \"throw\", which acts as if an exception was thrown by the application, \"stop\", which only pauses the debug session, and \"ignore\", which continues execution without pausing. The default value is \"throw\"."
+                "description": "Controls how breakpoints set externally (usually via raw GDB commands) are handled when hit.\nAllowed values are \"throw\", which acts as if an exception was thrown by the application, and \"stop\", which only pauses the debug session. The default value is \"throw\"."
               }
             },
             "definitions": {


### PR DESCRIPTION
Today, breakpoints set outside of a DAP or AD7 command are treated as application exceptions. This can be unexpected, particularly in cases where the breakpoint was also set in the launch configuration. For example, `postRemoteConnectCommands` might include `tbreak main`. This PR adds a new `unknownBreakpointHandling` configuration option to for these unknown breakpoints.

- `throw` current behavior
- `stop` pause the debug session but do not simulate an application exception
- `ignore` immedately continue