### PR TITLE
Enable NatvisDiagnostics for VS Debug Option

### DIFF
--- a/src/DebugEngineHost.Common/HostLogChannel.cs
+++ b/src/DebugEngineHost.Common/HostLogChannel.cs
@@ -37,6 +37,8 @@ namespace Microsoft.DebugEngineHost
     // This must match the interface in DebugEngineHost.ref.cs
     public interface ILogChannel
     {
+        void SetLogLevel(LogLevel level);
+
         void WriteLine(LogLevel level, string message);
 
         void WriteLine(LogLevel level, string format, params object[] values);

--- a/src/DebugEngineHost.Stub/DebugEngineHost.ref.cs
+++ b/src/DebugEngineHost.Stub/DebugEngineHost.ref.cs
@@ -218,6 +218,12 @@ namespace Microsoft.DebugEngineHost
     public interface ILogChannel
     {
         /// <summary>
+        /// Changes the log level of the channel
+        /// </summary>
+        /// <param name="newLevel">The new log level to use.</param>
+        void SetLogLevel(LogLevel newLevel);
+
+        /// <summary>
         /// Writes the given message with a newline to the log channel.
         /// </summary>
         /// <param name="level">The level of the log</param>
@@ -248,14 +254,22 @@ namespace Microsoft.DebugEngineHost
     /// </summary>
     public static class HostLogger
     {
-        // EnableNatvisLogger is only used in OpenDebugAD7
-
         /// <summary>
         /// Enables engine logging if not already enabled.
         /// </summary>
         /// <param name="callback">The callback to use to send the engine log.</param>
         /// <param name="level">The level of the log to filter the channel on.</param>
         public static void EnableHostLogging(Action<string> callback, LogLevel level = LogLevel.Verbose)
+        {
+            throw new NotImplementedException();
+        }
+
+        /// <summary>
+        /// Enables natvis logging if not already enabled.
+        /// </summary>
+        /// <param name="callback">The callback to use to send the natvis log.</param>
+        /// <param name="level">The level of the log to filter the channel on.</param>
+        public static void EnableNatvisDiagnostics(Action<string> callback, LogLevel level = LogLevel.Verbose)
         {
             throw new NotImplementedException();
         }
@@ -268,7 +282,6 @@ namespace Microsoft.DebugEngineHost
         {
             throw new NotImplementedException();
         }
-
 
         /// <summary>
         /// Gets the engine log channel created by 'EnableHostLogging'
@@ -435,6 +448,14 @@ namespace Microsoft.DebugEngineHost
         /// <param name="loader">Natvis loader method to invoke</param>
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Naming", "CA1704:IdentifiersShouldBeSpelledCorrectly", MessageId = "Natvis")]
         public static void FindNatvis(NatvisLoader loader)
+        {
+            throw new NotImplementedException();
+        }
+
+        /// <summary>
+        /// Enable's tracking the VS 'Natvis Diagnostic Messages (C++ only)' setting.
+        /// </summary>
+        public static IDisposable WatchNatvisOptionSetting(HostConfigurationStore configStore)
         {
             throw new NotImplementedException();
         }

--- a/src/DebugEngineHost.VSCode/HostLogger.cs
+++ b/src/DebugEngineHost.VSCode/HostLogger.cs
@@ -12,7 +12,7 @@ namespace Microsoft.DebugEngineHost
 
         private static string s_engineLogFile;
 
-        public static void EnableNatvisLogger(Action<string> callback, LogLevel level = LogLevel.Verbose)
+        public static void EnableNatvisDiagnostics(Action<string> callback, LogLevel level = LogLevel.Verbose)
         {
             if (s_natvisLogChannel == null)
             {

--- a/src/DebugEngineHost.VSCode/HostNatvisProject.cs
+++ b/src/DebugEngineHost.VSCode/HostNatvisProject.cs
@@ -14,6 +14,12 @@ namespace Microsoft.DebugEngineHost
             // In-solution natvis is not supported for VS Code now, so do nothing.
         }
 
+        public static IDisposable WatchNatvisOptionSetting(HostConfigurationStore configStore)
+        {
+            // VS Code does not have a registry setting for Natvis Diagnostics
+            return null;
+        }
+
         public static string FindSolutionRoot()
         {
             // This was added in MIEngine to support breakpoint sourcefile mapping. 

--- a/src/DebugEngineHost/HostConfigurationSection.cs
+++ b/src/DebugEngineHost/HostConfigurationSection.cs
@@ -42,5 +42,7 @@ namespace Microsoft.DebugEngineHost
         {
             return _key.GetValueNames();
         }
+
+        public IntPtr YOLOHandle => _key.Handle.DangerousGetHandle();
     }
 }

--- a/src/DebugEngineHost/HostLogger.cs
+++ b/src/DebugEngineHost/HostLogger.cs
@@ -24,6 +24,19 @@ namespace Microsoft.DebugEngineHost
             }
         }
 
+        public static void EnableNatvisDiagnostics(Action<string> callback, LogLevel level = LogLevel.Verbose)
+        {
+            if (s_natvisLogChannel== null)
+            {
+                s_natvisLogChannel = new HostLogChannel(callback, null, level);
+            }
+        }
+
+        public static void DisableNatvisDiagnostics()
+        {
+            s_natvisLogChannel = null;
+        }
+
         public static void SetEngineLogFile(string logFile)
         {
             s_engineLogFile = logFile;

--- a/src/DebugEngineHost/HostNatvisProject.cs
+++ b/src/DebugEngineHost/HostNatvisProject.cs
@@ -18,9 +18,26 @@ using Microsoft.VisualStudio.Threading;
 using Microsoft.VisualStudio.Workspace;
 using Microsoft.VisualStudio.Workspace.Indexing;
 using Microsoft.VisualStudio.Workspace.VSIntegration.Contracts;
+using Microsoft.Win32;
 
 namespace Microsoft.DebugEngineHost
 {
+    internal class RegisterMonitorWrapper : IDisposable
+    {
+        public RegistryMonitor CurrentMonitor { get; set; }
+
+        internal RegisterMonitorWrapper(RegistryMonitor currentMonitor)
+        {
+            CurrentMonitor = currentMonitor;
+        }
+
+        public void Dispose()
+        {
+            CurrentMonitor.Dispose();
+            CurrentMonitor = null;
+        }
+    }
+
     /// <summary>
     /// Provides interactions with the host's source workspace to locate and load any natvis files
     /// in the project.
@@ -47,6 +64,111 @@ namespace Microsoft.DebugEngineHost
             {
             }
             paths.ForEach((s) => loader(s));
+        }
+
+        public static IDisposable WatchNatvisOptionSetting(HostConfigurationStore configStore)
+        {
+            RegisterMonitorWrapper rmw = null;
+
+            HostConfigurationSection natvisDiagnosticSection = configStore.GetNatvisDiagnosticSection();
+            if (natvisDiagnosticSection != null)
+            {
+                // DiagnosticSection exists, set current log level and watch for changes.
+                SetNatvisLogLevel(natvisDiagnosticSection);
+
+                rmw = new RegisterMonitorWrapper(CreateAndStartNatvisDiagnosticMonitor(natvisDiagnosticSection));
+            }
+            else
+            {
+                // NatvisDiagnostic section has not been created, we need to watch for the creation.
+                HostConfigurationSection debuggerSection = configStore.GetCurrentUserDebuggerSection();
+
+                if (debuggerSection != null)
+                {
+                    // We only care about the debugger subkey's keys since we are waiting for the NatvisDiagnostics
+                    // section to be created.
+                    RegistryMonitor rm = new RegistryMonitor(debuggerSection, false);
+
+                    rmw = new RegisterMonitorWrapper(rm);
+
+                    rm.RegChanged += (sender, e) =>
+                    {
+                        HostConfigurationSection checkForSection = configStore.GetNatvisDiagnosticSection();
+
+                        if (checkForSection != null)
+                        {
+                            // NatvisDiagnostic section found. Update the logger
+                            SetNatvisLogLevel(checkForSection);
+
+                            // Remove debugger section tracking 
+                            IDisposable disposable = rmw.CurrentMonitor;
+
+                            // Watch NatvisDiagnostic section
+                            rmw = new RegisterMonitorWrapper(CreateAndStartNatvisDiagnosticMonitor(natvisDiagnosticSection));
+
+                            disposable.Dispose();
+                        }
+                    };
+
+                    rm.Start();
+                }
+            }
+
+
+            return rmw;
+        }
+
+        private static RegistryMonitor CreateAndStartNatvisDiagnosticMonitor(HostConfigurationSection natvisDiagnosticSection)
+        {
+            RegistryMonitor rm = new RegistryMonitor(natvisDiagnosticSection, true);
+
+            rm.RegChanged += (sender, e) =>
+            {
+                SetNatvisLogLevel(natvisDiagnosticSection);
+            };
+
+            rm.Start();
+
+            return rm;
+        }
+
+        private static void SetNatvisLogLevel(HostConfigurationSection natvisDiagnosticSection)
+        {
+            string level = natvisDiagnosticSection.GetValue("Level") as string;
+            if (level != null)
+            {
+                level = level.ToLower(CultureInfo.InvariantCulture);
+            }
+            LogLevel logLevel;
+            switch (level)
+            {
+                case "off":
+                    logLevel = LogLevel.None;
+                    break;
+                case "error":
+                    logLevel = LogLevel.Error;
+                    break;
+                case "warning":
+                    logLevel = LogLevel.Warning;
+                    break;
+                case "verbose":
+                default: // Unknown, default to verbose
+                    logLevel = LogLevel.Verbose;
+                    break;
+            }
+
+            if (logLevel == LogLevel.None)
+            {
+                HostLogger.DisableNatvisDiagnostics();
+            }
+            else
+            {
+                HostLogger.EnableNatvisDiagnostics((message) => {
+                    string formattedMessage = string.Format(CultureInfo.InvariantCulture, "Natvis: {0}", message);
+                    HostOutputWindow.WriteLaunchError(formattedMessage);
+                }, logLevel);
+                HostLogger.GetNatvisLogChannel().SetLogLevel(logLevel);
+            }
         }
 
         public static string FindSolutionRoot()

--- a/src/DebugEngineHost/HostOutputWindow.cs
+++ b/src/DebugEngineHost/HostOutputWindow.cs
@@ -2,13 +2,139 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
-
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Threading;
 using Microsoft.VisualStudio;
 using Microsoft.VisualStudio.Shell;
 using Microsoft.VisualStudio.Shell.Interop;
 
 namespace Microsoft.DebugEngineHost
 {
+    internal static class VsOutputWindowWrapper
+    {
+        private static Lazy<IVsOutputWindow> outputWindowLazy = new Lazy<IVsOutputWindow>(() =>
+        {
+            IVsOutputWindow outputWindow = null;
+            try
+            {
+                ThreadHelper.ThrowIfNotOnUIThread();
+                outputWindow = Package.GetGlobalService(typeof(SVsOutputWindow)) as IVsOutputWindow;
+            }
+            catch (Exception)
+            {
+                Debug.Fail("Could not get OutputWindow service.");
+            }
+            return outputWindow;
+        }, LazyThreadSafetyMode.PublicationOnly);
+
+        private static Lazy<IVsUIShell> shellLazy = new Lazy<IVsUIShell>(() =>
+        {
+            IVsUIShell shell = null;
+            try
+            {
+                ThreadHelper.ThrowIfNotOnUIThread();
+                shell = Package.GetGlobalService(typeof(SVsUIShell)) as IVsUIShell;
+            }
+            catch (Exception)
+            {
+                Debug.Fail("Could not get VSShell service.");
+            }
+            return shell;
+            // Use "PublicationOnly", because the implementation of GetService does its own locking
+        }, LazyThreadSafetyMode.PublicationOnly);
+
+        private class PaneInfo
+        {
+            public PaneInfo(Guid paneId)
+            {
+                this.paneId = paneId;
+                this.Shown = false;
+            }
+
+            internal Guid paneId;
+            internal bool Shown { get; set; }
+        }
+
+        private const string DefaultOutputPane = "Debug";
+
+        private static Dictionary<string, PaneInfo> panes = new Dictionary<string, PaneInfo>()
+        {
+            // The 'Debug' pane exists by default
+            { DefaultOutputPane, new PaneInfo(VSConstants.GUID_OutWindowDebugPane) }
+        };
+
+        /// <summary>
+        /// Writes text directly to the VS Output window.
+        /// </summary>
+        public static void Write(string message, string pane = DefaultOutputPane)
+        {
+            ThreadHelper.JoinableTaskFactory.RunAsync(async delegate
+            {
+                await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
+                try
+                {
+                    // Get the Output window
+                    IVsOutputWindow outputWindow = outputWindowLazy.Value;
+                    if (outputWindow == null)
+                    {
+                        return;
+                    }
+
+                    // Get the pane guid
+                    PaneInfo paneInfo;
+                    if (!panes.TryGetValue(pane, out paneInfo))
+                    {
+                        // Pane didn't exist, create it
+                        paneInfo = new PaneInfo(Guid.NewGuid());
+                        panes.Add(pane, paneInfo);
+                    }
+
+                    // Get the pane
+                    IVsOutputWindowPane outputPane;
+                    if (outputWindow.GetPane(ref paneInfo.paneId, out outputPane) != VSConstants.S_OK)
+                    {
+                        // Failed to get the pane - might need to create it first
+                        outputWindow.CreatePane(ref paneInfo.paneId, pane, fInitVisible: 1, fClearWithSolution: 1);
+                        outputWindow.GetPane(ref paneInfo.paneId, out outputPane);
+                    }
+
+                    // The first time we output text to a pane, ensure it's visible
+                    if (!paneInfo.Shown)
+                    {
+                        paneInfo.Shown = true;
+
+                        // Switch to the pane of the Output window
+                        outputPane.Activate();
+
+                        // Show the output window
+                        IVsUIShell shell = shellLazy.Value;
+                        if (shell != null)
+                        {
+                            object inputVariant = null;
+                            shell.PostExecCommand(VSConstants.GUID_VSStandardCommandSet97, (uint)VSConstants.VSStd97CmdID.OutputWindow, 0, ref inputVariant);
+                        }
+                    }
+
+                    // Output the text
+                    outputPane.OutputString(message);
+                }
+                catch (Exception)
+                {
+                    Debug.Fail("Failed to write to output pane.");
+                }
+            }).FileAndForget("VS/Diagnostics/Debugger/DebugEngineHost/VsOutputWindowWrapper/Write");
+        }
+
+        /// <summary>
+        /// Writes text directly to the VS Output window, appending a newline.
+        /// </summary>
+        public static void WriteLine(string message, string pane = DefaultOutputPane)
+        {
+            Write(string.Concat(message, Environment.NewLine), pane);
+        }
+    }
+
     /// <summary>
     /// Provides direct access to the underlying output window without going through debug events
     /// </summary>
@@ -19,32 +145,7 @@ namespace Microsoft.DebugEngineHost
         {
             internal static void SetText(string outputMessage)
             {
-                int hr;
-
-                var outputWindow = (IVsOutputWindow)Package.GetGlobalService(typeof(SVsOutputWindow));
-                if (outputWindow == null)
-                    return;
-
-                IVsOutputWindowPane pane;
-                Guid guidDebugOutputPane = VSConstants.GUID_OutWindowDebugPane;
-                hr = outputWindow.GetPane(ref guidDebugOutputPane, out pane);
-                if (hr < 0)
-                    return;
-
-                pane.Clear();
-                pane.Activate();
-
-                hr = pane.OutputString(outputMessage);
-                if (hr < 0)
-                    return;
-
-                var shell = (IVsUIShell)Package.GetGlobalService(typeof(SVsUIShell));
-                if (shell == null)
-                    return;
-
-                Guid commandSet = VSConstants.GUID_VSStandardCommandSet97;
-                object inputVariant = null;
-                shell.PostExecCommand(commandSet, (uint)VSConstants.VSStd97CmdID.OutputWindow, 0, ref inputVariant);
+                VsOutputWindowWrapper.WriteLine(outputMessage);
             }
         }
 

--- a/src/DebugEngineHost/RegistryMonitor.cs
+++ b/src/DebugEngineHost/RegistryMonitor.cs
@@ -1,0 +1,148 @@
+﻿// // Copyright (c) Microsoft. All rights reserved.
+// // Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Microsoft.Win32;
+using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Diagnostics.CodeAnalysis;
+using System.Linq;
+using System.Runtime.InteropServices;
+using System.Runtime.Remoting.Messaging;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using static System.Collections.Specialized.BitVector32;
+
+namespace Microsoft.DebugEngineHost
+{
+    internal class RegistryMonitor : IDisposable
+    {
+        #region Native Methods
+
+        /// <summary>
+        /// Filter for notifications reported by <see cref="RegistryMonitor"/>.
+        /// </summary>
+        [Flags]
+        public enum RegChangeNotifyFilter
+        {
+            /// <summary>Notify the caller if a subkey is added or deleted.</summary>
+            Key = 1,
+            /// <summary>Notify the caller of changes to the attributes of the key,
+            /// such as the security descriptor information.</summary>
+            Attribute = 2,
+            /// <summary>Notify the caller of changes to a value of the key. This can
+            /// include adding or deleting a value, or changing an existing value.</summary>
+            Value = 4,
+            /// <summary>Notify the caller of changes to the security descriptor
+            /// of the key.</summary>
+            Security = 8,
+        }
+
+        [DllImport("advapi32.dll", SetLastError = true)]
+        private static extern int RegOpenKeyEx(IntPtr hKey, string subKey, uint options, int samDesired,
+                                               out IntPtr phkResult);
+
+        [DllImport("advapi32.dll", SetLastError = true)]
+        private static extern int RegNotifyChangeKeyValue(IntPtr hKey, bool bWatchSubtree,
+                                                          RegChangeNotifyFilter dwNotifyFilter, IntPtr hEvent,
+                                                          bool fAsynchronous);
+
+        [DllImport("advapi32.dll", SetLastError = true)]
+        private static extern int RegCloseKey(IntPtr hKey);
+
+        private const int KEY_QUERY_VALUE = 0x0001;
+        private const int KEY_NOTIFY = 0x0010;
+        private const int STANDARD_RIGHTS_READ = 0x00020000;
+
+        private static readonly IntPtr HKEY_LOCAL_MACHINE = new IntPtr(unchecked((int)0x80000002));
+
+        #endregion
+
+        private HostConfigurationSection _section;
+        private readonly bool _watchSubtree;
+
+        // Set when registry value is changed
+        private AutoResetEvent m_changeEvent;
+
+        // Set when monitoring is stopped
+        private AutoResetEvent m_stoppedEvent;
+
+        /// <summary>
+        /// Occurs when the specified registry key has changed.
+        /// </summary>
+        public event EventHandler RegChanged;
+
+        public RegistryMonitor(HostConfigurationSection section, bool watchSubtree)
+        {
+            _section = section;
+            _watchSubtree = watchSubtree;
+        }
+
+        public void Start()
+        {
+            Thread registryMonitor = new Thread(Monitor);
+            registryMonitor.IsBackground = true;
+            registryMonitor.Name = "RegistryMonitor";
+            registryMonitor.Start();
+        }
+
+        public void Stop()
+        {
+            if (m_stoppedEvent != null)
+            {
+                m_stoppedEvent.Set();
+            }
+        }
+
+        // The handle is owned by change event instance which lives while we use the handle.
+        [SuppressMessage("Microsoft.Reliability", "CA2001:AvoidCallingProblematicMethods", MessageId = "System.Runtime.InteropServices.SafeHandle.DangerousGetHandle")]
+        private void Monitor()
+        {
+            bool stopped = false;
+
+            m_stoppedEvent = new AutoResetEvent(false);
+            m_changeEvent = new AutoResetEvent(false);
+
+            IntPtr handle = m_changeEvent.SafeWaitHandle.DangerousGetHandle();
+
+            int errorCode = RegNotifyChangeKeyValue(_section.YOLOHandle, _watchSubtree, RegChangeNotifyFilter.Key | RegChangeNotifyFilter.Attribute | RegChangeNotifyFilter.Value | RegChangeNotifyFilter.Security, handle, true);
+            if (errorCode != 0) // 0 is ERROR_SUCCESS
+            {
+                throw new Win32Exception(errorCode);
+            }
+            try
+            {
+                while (!stopped)
+                {
+                    int waitResult = WaitHandle.WaitAny(new WaitHandle[] { m_stoppedEvent, m_changeEvent });
+
+                    if (waitResult == 0)
+                    {
+                        stopped = true;
+                    }
+                    else
+                    {
+                        errorCode = RegNotifyChangeKeyValue(_section.YOLOHandle, _watchSubtree, RegChangeNotifyFilter.Key | RegChangeNotifyFilter.Attribute | RegChangeNotifyFilter.Value | RegChangeNotifyFilter.Security, handle, true);
+                        if (errorCode != 0) // 0 is ERROR_SUCCESS
+                        {
+                            throw new Win32Exception(errorCode);
+                        }
+                        RegChanged.Invoke(this, null);
+                    }
+                }
+            }
+            finally
+            {
+                _section.Dispose();
+                m_stoppedEvent?.Dispose();
+                m_changeEvent?.Dispose();
+            }
+        }
+
+        public void Dispose()
+        {
+            m_stoppedEvent.Set();
+        }
+    }
+}

--- a/src/MICore/Logger.cs
+++ b/src/MICore/Logger.cs
@@ -74,6 +74,11 @@ namespace MICore
             return res;
         }
 
+        public static void EnableNatvisDiagnostics(LogLevel level)
+        {
+            HostLogger.EnableNatvisDiagnostics(HostOutputWindow.WriteLaunchError, level);
+        }
+
         public static void LoadMIDebugLogger()
         {
             if (CmdLogInfo.enabled)

--- a/src/MIDebugEngine/Engine.Impl/DebuggedProcess.cs
+++ b/src/MIDebugEngine/Engine.Impl/DebuggedProcess.cs
@@ -65,7 +65,7 @@ namespace Microsoft.MIDebugEngine
             _deleteEntryPointBreakpoint = false;
             MICommandFactory = MICommandFactory.GetInstance(launchOptions.DebuggerMIMode, this);
             _waitDialog = (MICommandFactory.SupportsStopOnDynamicLibLoad() && launchOptions.WaitDynamicLibLoad) ? new HostWaitDialog(ResourceStrings.LoadingSymbolMessage, ResourceStrings.LoadingSymbolCaption) : null;
-            Natvis = new Natvis.Natvis(this, launchOptions.ShowDisplayString);
+            Natvis = new Natvis.Natvis(this, launchOptions.ShowDisplayString, configStore);
 
             // we do NOT have real Win32 process IDs, so we use a guid
             AD_PROCESS_ID pid = new AD_PROCESS_ID();
@@ -1032,6 +1032,8 @@ namespace Microsoft.MIDebugEngine
             {
                 _waitDialog.Dispose();
             }
+
+            Natvis?.Dispose();
 
             Logger.Flush();
         }

--- a/src/MIDebugEngine/Natvis.Impl/Natvis.cs
+++ b/src/MIDebugEngine/Natvis.Impl/Natvis.cs
@@ -157,7 +157,7 @@ namespace Microsoft.MIDebugEngine.Natvis
         }
     };
 
-    public class Natvis
+    public class Natvis : IDisposable
     {
         private class AliasInfo
         {
@@ -227,6 +227,7 @@ namespace Microsoft.MIDebugEngine.Natvis
         private static Regex s_expression = new Regex(@"^\{[^\}]*\}");
         private List<FileInfo> _typeVisualizers;
         private DebuggedProcess _process;
+        private HostConfigurationStore _configStore;
         private Dictionary<string, VisualizerInfo> _vizCache;
         private uint _depth;
         public HostWaitDialog WaitDialog { get; private set; }
@@ -237,6 +238,8 @@ namespace Microsoft.MIDebugEngine.Natvis
         private const int MAX_FORMAT_DEPTH = 10;
         private const int MAX_ALIAS_CHAIN = 10;
 
+        private IDisposable _natvisSettingWatcher;
+
         public enum DisplayStringsState
         {
             On,
@@ -245,7 +248,7 @@ namespace Microsoft.MIDebugEngine.Natvis
         }
         public DisplayStringsState ShowDisplayStrings { get; set; }
 
-        internal Natvis(DebuggedProcess process, bool showDisplayString)
+        internal Natvis(DebuggedProcess process, bool showDisplayString, HostConfigurationStore configStore)
         {
             _typeVisualizers = new List<FileInfo>();
             _process = process;
@@ -254,12 +257,14 @@ namespace Microsoft.MIDebugEngine.Natvis
             ShowDisplayStrings = showDisplayString ? DisplayStringsState.On : DisplayStringsState.ForVisualizedItems;  // don't compute display strings unless explicitly requested
             _depth = 0;
             Cache = new VisualizationCache();
+            _configStore = configStore;
         }
 
         public void Initialize(string fileName)
         {
             try
             {
+                _natvisSettingWatcher = HostNatvisProject.WatchNatvisOptionSetting(_configStore);
                 HostNatvisProject.FindNatvis((s) => LoadFile(s));
             }
             catch (FileNotFoundException)
@@ -1365,5 +1370,10 @@ namespace Microsoft.MIDebugEngine.Natvis
             return displayName.ToString();
         }
 
+        public void Dispose()
+        {
+            _natvisSettingWatcher?.Dispose();
+            _natvisSettingWatcher = null;
+        }
     }
 }

--- a/src/MIDebugEngineUnitTests/NatvisNamesTest.cs
+++ b/src/MIDebugEngineUnitTests/NatvisNamesTest.cs
@@ -47,6 +47,9 @@ namespace MIDebugEngineUnitTests
 
         // Unused as ITestOutputHelper does not have a Close implementation
         public void Close() { }
+
+        // Unused as ITestOutputHelper does not have LogLevels
+        public void SetLogLevel(LogLevel level) { }
     }
 
     public class NatvisNamesTest

--- a/src/OpenDebugAD7/AD7DebugSession.cs
+++ b/src/OpenDebugAD7/AD7DebugSession.cs
@@ -270,7 +270,7 @@ namespace OpenDebugAD7
                         if (natvisDiagnosticsBool)
                         {
                             m_logger.SetLoggingConfiguration(LoggingCategory.NatvisDiagnostics, true);
-                            HostLogger.EnableNatvisLogger((message) => m_logger.WriteLine(LoggingCategory.NatvisDiagnostics, message), LogLevel.Verbose);
+                            HostLogger.EnableNatvisDiagnostics((message) => m_logger.WriteLine(LoggingCategory.NatvisDiagnostics, message), LogLevel.Verbose);
                         }
                     }
                     else if (natvisDiagnostics.Type == JTokenType.String)
@@ -279,7 +279,7 @@ namespace OpenDebugAD7
                         if (Enum.TryParse(natvisDiagnosticsString, ignoreCase: true, out LogLevel level))
                         {
                             m_logger.SetLoggingConfiguration(LoggingCategory.NatvisDiagnostics, true);
-                            HostLogger.EnableNatvisLogger((message) => m_logger.WriteLine(LoggingCategory.NatvisDiagnostics, string.Concat("[Natvis] ", message)), level);
+                            HostLogger.EnableNatvisDiagnostics((message) => m_logger.WriteLine(LoggingCategory.NatvisDiagnostics, string.Concat("[Natvis] ", message)), level);
                         }
                     }
                     else

--- a/src/OpenDebugAD7/OpenDebug/Program.cs
+++ b/src/OpenDebugAD7/OpenDebug/Program.cs
@@ -53,9 +53,9 @@ namespace OpenDebug
                         Console.WriteLine("--engineLogging[=filePath]: Enable logging from the debug engine. If not");
                         Console.WriteLine("    specified, the log will go to the console.");
                         Console.WriteLine("--engineLogLevel=<LogLevel>: Set's the log level for engine logging.");
-                        Console.WriteLine("    If not specified, default log level is LogLevel.Trace");
+                        Console.WriteLine("    If not specified, default log level is LogLevel.Verbose");
                         Console.WriteLine("--natvisDiagnostics[=logLevel]: Enable logging for natvis. If not");
-                        Console.WriteLine("    specified, the log will go to the console. Default logging level is LogLevel.Trace.");
+                        Console.WriteLine("    specified, the log will go to the console. Default logging level is LogLevel.Verbose.");
                         Console.WriteLine("--server[=port_num] : Start the debug adapter listening for requests on the");
                         Console.WriteLine("    specified TCP/IP port instead of stdin/out. If port is not specified");
                         Console.WriteLine("    TCP {0} will be used.", DEFAULT_PORT);
@@ -75,7 +75,7 @@ namespace OpenDebug
                         break;
                     case "--natvisDiagnostics":
                         loggingCategories.Add(LoggingCategory.NatvisDiagnostics);
-                        HostLogger.EnableNatvisLogger((msg) =>
+                        HostLogger.EnableNatvisDiagnostics((msg) =>
                         {
                             Console.Error.WriteLine(msg);
                         }, LogLevel.Verbose);
@@ -105,7 +105,7 @@ namespace OpenDebug
                             if (!Enum.TryParse(a.Substring("--natvisDiagnostics=".Length), out LogLevel natvisLogLevel))
                             {
                                 loggingCategories.Add(LoggingCategory.NatvisDiagnostics);
-                                HostLogger.EnableNatvisLogger((msg) =>
+                                HostLogger.EnableNatvisDiagnostics((msg) =>
                                 {
                                     Console.Error.WriteLine(msg);
                                 }, natvisLogLevel);


### PR DESCRIPTION
This PR enables Natvis Diagnostics for VS.
If the NatvisDiagnostics in the VS Debug Options is enabled, it will output to the debug pane.