### PR TITLE
DAR: Include OSX crash logs in exception

### DIFF
--- a/test/DebugAdapterRunner/DebugAdapterRunner.cs
+++ b/test/DebugAdapterRunner/DebugAdapterRunner.cs
@@ -49,6 +49,8 @@ namespace DebugAdapterRunner
         // The current thread id which is automatically updated when the tool receives a stopped event
         public int CurrentThreadId;
 
+        public DateTime StartTime { get; } = DateTime.Now;
+
         // Keep a trace of the debug adapter output if requested
         private StringBuilder _debugAdapterOutput = new StringBuilder();
 


### PR DESCRIPTION
This PR modifies DAR to try and find and include OSX crash log information if a test fails due to a debug adapter crashing.