### PR TITLE
Escape newline characters in Debugger.cs commands

### DIFF
--- a/src/MICore/Debugger.cs
+++ b/src/MICore/Debugger.cs
@@ -784,6 +784,9 @@ namespace MICore
                     case '\\':
                         outStr.Append("\\\\");
                         break;
+                    case '\n':
+                        outStr.Append("\\n");
+                        break;
                     default:
                         outStr.Append(str[i]);
                         break;


### PR DESCRIPTION
Fixes microsoft/MIEngine#1364 - setting environment variables containing newlines will not be seen as separate commands