### PR TITLE
Add "sendInvalidate" request

### DIFF
--- a/src/OpenDebugAD7/AD7DebugSession.cs
+++ b/src/OpenDebugAD7/AD7DebugSession.cs
@@ -128,8 +128,54 @@ namespace OpenDebugAD7
             m_dataBreakpoints = new Dictionary<string, IDebugPendingBreakpoint2>();
             m_exceptionBreakpoints = new List<string>();
             m_variableManager = new VariableManager();
+
+            //Register sendInvalidate request
+            Protocol.RegisterRequestType<SendInvalidateRequest, SendInvalidateArguments, SendInvalidateResponse>(r => this.HandleSendInvalidateRequestAsync(r));
+    
         }
 
+        private void HandleSendInvalidateRequestAsync(IRequestResponder<SendInvalidateArguments> responder)
+        {
+            InvalidatedEvent invalidated = new InvalidatedEvent();
+            SendInvalidateResponse response = new SendInvalidateResponse();
+            
+            // Setting the area and adding it to the result
+            switch (responder.Arguments.Areas.ToString())
+            {
+                case "Threads":
+                    invalidated.Areas.Add(InvalidatedAreas.Threads);
+                    break;
+                case "Stacks":
+                    invalidated.Areas.Add(InvalidatedAreas.Stacks);
+                    break;
+                case "Variables":
+                    invalidated.Areas.Add(InvalidatedAreas.Variables);
+                    break;
+                case "Unknown":
+                    invalidated.Areas.Add(InvalidatedAreas.Unknown);
+                    break;
+                default:
+                    invalidated.Areas.Add(InvalidatedAreas.All);
+                    break;
+            }
+
+            // Setting the StackFrameId if passed (and the 'threadId' is ignored).
+            if (null != responder.Arguments.StackFrameId)
+            {
+                invalidated.StackFrameId = responder.Arguments.StackFrameId;
+            }
+
+            // Setting the ThreadId if passed
+            else if (null != responder.Arguments.ThreadId)
+            {
+                invalidated.ThreadId = responder.Arguments.ThreadId;
+            }
+
+
+            Protocol.SendEvent(invalidated);
+            response.body.result = JsonConvert.SerializeObject(responder);
+            responder.SetResponse(response);
+        }
         #endregion
 
         #region Utility
@@ -3873,5 +3919,32 @@ namespace OpenDebugAD7
                 throw new NotImplementedException();
             }
         }
+    }
+
+    internal class SendInvalidateRequest : DebugRequestWithResponse<SendInvalidateArguments, SendInvalidateResponse>
+    {
+ 
+        public SendInvalidateRequest(): base("sendInvalidate")
+        {
+        }
+    }
+
+    internal class SendInvalidateResponse : ResponseBody
+    {
+        public sealed class Body
+        {
+            public string result;
+        }
+
+        public Body body = new Body();
+    }
+
+    internal class SendInvalidateArguments : DebugRequestArguments
+    {
+
+        public string Areas { get; set; }
+        public int? ThreadId { get; set; }
+        public int? StackFrameId { get; set; }
+
     }
 }

--- a/src/OpenDebugAD7/AD7DebugSession.cs
+++ b/src/OpenDebugAD7/AD7DebugSession.cs
@@ -130,34 +130,16 @@ namespace OpenDebugAD7
             m_variableManager = new VariableManager();
 
             //Register sendInvalidate request
-            Protocol.RegisterRequestType<SendInvalidateRequest, SendInvalidateArguments, SendInvalidateResponse>(r => this.HandleSendInvalidateRequestAsync(r));
+            Protocol.RegisterRequestType<SendInvalidateRequest, SendInvalidateArguments>(r => this.HandleSendInvalidateRequestAsync(r));
     
         }
 
         private void HandleSendInvalidateRequestAsync(IRequestResponder<SendInvalidateArguments> responder)
         {
             InvalidatedEvent invalidated = new InvalidatedEvent();
-            SendInvalidateResponse response = new SendInvalidateResponse();
             
             // Setting the area and adding it to the result
-            switch (responder.Arguments.Areas.ToString())
-            {
-                case "Threads":
-                    invalidated.Areas.Add(InvalidatedAreas.Threads);
-                    break;
-                case "Stacks":
-                    invalidated.Areas.Add(InvalidatedAreas.Stacks);
-                    break;
-                case "Variables":
-                    invalidated.Areas.Add(InvalidatedAreas.Variables);
-                    break;
-                case "Unknown":
-                    invalidated.Areas.Add(InvalidatedAreas.Unknown);
-                    break;
-                default:
-                    invalidated.Areas.Add(InvalidatedAreas.All);
-                    break;
-            }
+            invalidated.Areas.Add(responder.Arguments.Areas);
 
             // Setting the StackFrameId if passed (and the 'threadId' is ignored).
             if (null != responder.Arguments.StackFrameId)
@@ -173,8 +155,7 @@ namespace OpenDebugAD7
 
 
             Protocol.SendEvent(invalidated);
-            response.body.result = JsonConvert.SerializeObject(responder);
-            responder.SetResponse(response);
+
         }
         #endregion
 
@@ -3921,7 +3902,7 @@ namespace OpenDebugAD7
         }
     }
 
-    internal class SendInvalidateRequest : DebugRequestWithResponse<SendInvalidateArguments, SendInvalidateResponse>
+    internal class SendInvalidateRequest : DebugRequest<SendInvalidateArguments>
     {
  
         public SendInvalidateRequest(): base("sendInvalidate")
@@ -3929,20 +3910,10 @@ namespace OpenDebugAD7
         }
     }
 
-    internal class SendInvalidateResponse : ResponseBody
-    {
-        public sealed class Body
-        {
-            public string result;
-        }
-
-        public Body body = new Body();
-    }
-
     internal class SendInvalidateArguments : DebugRequestArguments
     {
 
-        public string Areas { get; set; }
+        public InvalidatedAreas Areas { get; set; }
         public int? ThreadId { get; set; }
         public int? StackFrameId { get; set; }
 


### PR DESCRIPTION
This PR adds support for OpenDebugAD7 to handle `sendInvalidate` requests which will respond if it successfully fired an InvalidatedEvent to the UI.

Here is the schema:
```json
"SendInvalidateRequest": {
    "allOf": [
        {
            "$ref": "#/definitions/Request"
        },
        {
            "type": "object",
            "properties": {
               "areas": {
                  "type": "array",
                  "description": "Set of logical areas that got invalidated. This property has a hint characteristic: a client can only be expected to make a 'best effort' in honoring the areas but there are no guarantees. If this property is missing, empty, or if values are not understood, the client should assume a single value `all`.",
                  "items": {
                     "$ref": "#/definitions/InvalidatedAreas"
                  }
               },
                "threadId": {
                    "type": "int",
                },
                "stackFrameId": {
                    "type": "int",
                },
            },
            "required": [
                "areas"
            ]
        }
    ]
},
```