### PR TITLE
[#1370] Change the type of breakpoint ids from `ulong` to `long`

### DIFF
--- a/src/MICore/CommandFactories/MICommandFactory.cs
+++ b/src/MICore/CommandFactories/MICommandFactory.cs
@@ -557,7 +557,7 @@ namespace MICore
         /// exceptions in the category. Note that this clear all previous exception breakpoints set in this category.</param>
         /// <param name="exceptionBreakpointState">Indicates when the exception breakpoint should fire</param>
         /// <returns>Task containing the exception breakpoint id's for the various set exceptions</returns>
-        public virtual Task<IEnumerable<ulong>> SetExceptionBreakpoints(Guid exceptionCategory, /*OPTIONAL*/ IEnumerable<string> exceptionNames, ExceptionBreakpointStates exceptionBreakpointState)
+        public virtual Task<IEnumerable<long>> SetExceptionBreakpoints(Guid exceptionCategory, /*OPTIONAL*/ IEnumerable<string> exceptionNames, ExceptionBreakpointStates exceptionBreakpointState)
         {
             // NOTES:
             // GDB /MI has no support for exceptions. Though they do have it through the non-MI through a 'catch' command. Example:
@@ -573,7 +573,7 @@ namespace MICore
             throw new NotImplementedException();
         }
 
-        public virtual Task RemoveExceptionBreakpoint(Guid exceptionCategory, IEnumerable<ulong> exceptionBreakpoints)
+        public virtual Task RemoveExceptionBreakpoint(Guid exceptionCategory, IEnumerable<long> exceptionBreakpoints)
         {
             throw new NotImplementedException();
         }

--- a/src/MICore/CommandFactories/gdb.cs
+++ b/src/MICore/CommandFactories/gdb.cs
@@ -310,11 +310,11 @@ namespace MICore
             return new Guid[] { new Guid(CppExceptionCategoryString) };
         }
 
-        public override async Task<IEnumerable<ulong>> SetExceptionBreakpoints(Guid exceptionCategory, IEnumerable<string> exceptionNames, ExceptionBreakpointStates exceptionBreakpointStates)
+        public override async Task<IEnumerable<long>> SetExceptionBreakpoints(Guid exceptionCategory, IEnumerable<string> exceptionNames, ExceptionBreakpointStates exceptionBreakpointStates)
         {
             string command;
             Results result;
-            List<ulong> breakpointNumbers = new List<ulong>();
+            List<long> breakpointNumbers = new List<long>();
 
             if (exceptionNames == null) // set breakpoint for all exceptions in exceptionCategory
             {
@@ -353,9 +353,9 @@ namespace MICore
             return breakpointNumbers;
         }
 
-        public override async Task RemoveExceptionBreakpoint(Guid exceptionCategory, IEnumerable<ulong> exceptionBreakpoints)
+        public override async Task RemoveExceptionBreakpoint(Guid exceptionCategory, IEnumerable<long> exceptionBreakpoints)
         {
-            foreach (ulong breakpointNumber in exceptionBreakpoints)
+            foreach (long breakpointNumber in exceptionBreakpoints)
             {
                 await BreakDelete(breakpointNumber.ToString(CultureInfo.InvariantCulture));
             }


### PR DESCRIPTION
GDB represents a breakpoint number as an `int`. See the definition of `struct breakpoint` in [breakpoint.h, which includes](https://sourceware.org/git/?p=binutils-gdb.git;a=blob;f=gdb/breakpoint.h;h=360fa760577396ada7bd529890abc1819302eca0;hb=refs/heads/master#l739):

    /* Number assigned to distinguish breakpoints.  */
    int number = 0;

GDB uses negative breakpoint numbers to represent "internal" breakpoints. See the "[Setting Breakpoints](https://sourceware.org/gdb/onlinedocs/gdb/Set-Breaks.html)" documentation which says:

> GDB itself sometimes sets breakpoints in your program for special purposes, such as proper handling of `longjmp` (in C programs). These internal breakpoints are assigned negative numbers, starting with -1; `info breakpoints` does not display them. You can see these breakpoints with the GDB maintenance command `maint info breakpoints`

Internal breakpoints can also be [created in Python](https://sourceware.org/gdb/onlinedocs/gdb/Breakpoints-In-Python.html), for example:

    python gdb.Breakpoint("function_name", internal=True)

When an internal breakpoint is hit, MIEngine must not crash, so this commit changes the representation of breakpoint numbers from unsigned to signed integers. This avoids a `System.OverflowException` from the call to `Convert.ToUint32` in `TryGetExceptionBreakpoint`. Fixes #1370.

With this fix, the reproducer from #1370 now behaves as shown below, with the debuggee stopping at the internal breakpoint:

![Screenshot from 2022-11-07 14-41-29](https://user-images.githubusercontent.com/922721/200337845-3f9d7360-c1f3-4510-9018-aa0e7f46cc9d.png)
