### PR TITLE
Fix NPE with watching NatvisSection

### DIFF
--- a/src/DebugEngineHost/HostNatvisProject.cs
+++ b/src/DebugEngineHost/HostNatvisProject.cs
@@ -104,7 +104,7 @@ namespace Microsoft.DebugEngineHost
                             IDisposable disposable = rmw.CurrentMonitor;
 
                             // Watch NatvisDiagnostic section
-                            rmw = new RegisterMonitorWrapper(CreateAndStartNatvisDiagnosticMonitor(natvisDiagnosticSection, natvisLogger));
+                            rmw = new RegisterMonitorWrapper(CreateAndStartNatvisDiagnosticMonitor(checkForSection, natvisLogger));
 
                             disposable.Dispose();
                         }


### PR DESCRIPTION
This PR fixes the variable used for the RegistryMonitor on a fresh VS instance.

If the private registry does not have a NatvisDiagnostic section, it will watch for its creation then delete this watcher. However when creating the new watcher it would watch on a null section instead of the new natvis section.

This PR fixes that issue.