### PR TITLE
Update Actions and Fix Build Warnings

### DIFF
--- a/.github/workflows/Build-And-Test.yml
+++ b/.github/workflows/Build-And-Test.yml
@@ -22,20 +22,20 @@ jobs:
 
     steps:
     - name: Checkout
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
       with:
         fetch-depth: 0
 
     - name: Install .NET Core
-      uses: actions/setup-dotnet@v1
+      uses: actions/setup-dotnet@v3
       with:
         dotnet-version: 6.0.x
 
     - name: Setup MSBuild.exe
-      uses: microsoft/setup-msbuild@v1.0.2
+      uses: microsoft/setup-msbuild@v1.1
 
     - name: Setup NuGet.exe for use with actions
-      uses: NuGet/setup-nuget@v1.0.5
+      uses: NuGet/setup-nuget@v1
 
     - name: Build MIDebugEngine
       run: |
@@ -44,7 +44,7 @@ jobs:
         Configuration: ${{ matrix.configuration }}
 
     - name: Setup VSTest.console.exe
-      uses: darenm/Setup-VSTest@v1
+      uses: darenm/Setup-VSTest@v1.2
 
     - name: Run VS Extension tests
       run: vstest.console.exe ${{ github.workspace }}\bin\${{ matrix.configuration }}\MICoreUnitTests.dll ${{ github.workspace }}\bin\${{ matrix.configuration }}\JDbgUnitTests.dll ${{ github.workspace }}\bin\${{ matrix.configuration }}\SSHDebugTests.dll ${{ github.workspace }}\bin\${{ matrix.configuration }}\MIDebugEngineUnitTests.dll
@@ -54,20 +54,20 @@ jobs:
 
     steps:
     - name: Checkout
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
       with:
         fetch-depth: 0
 
     - name: Install .NET Core
-      uses: actions/setup-dotnet@v1
+      uses: actions/setup-dotnet@v3
       with:
         dotnet-version: 6.0.x
 
     - name: Setup MSBuild.exe
-      uses: microsoft/setup-msbuild@v1.0.2
+      uses: microsoft/setup-msbuild@v1.1
 
     - name: Setup NuGet.exe for use with actions
-      uses: NuGet/setup-nuget@v1.0.5
+      uses: NuGet/setup-nuget@v1
 
     - name: Build MIDebugEngine
       run: |
@@ -102,7 +102,7 @@ jobs:
         dotnet test $CppTestsPath --logger "trx;LogFileName=$ResultsPath"
 
     - name: 'Upload Test Results'
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3
       if: ${{ always() }}
       with:
         name: win_msys2_x64_results
@@ -112,12 +112,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
       with:
         fetch-depth: 0
 
     - name: Install .NET Core
-      uses: actions/setup-dotnet@v1
+      uses: actions/setup-dotnet@v3
       with:
         dotnet-version: 6.0.x
 
@@ -143,7 +143,7 @@ jobs:
         ${{ github.workspace }}/eng/Scripts/CI-Test.sh
 
     - name: 'Upload Test Results'
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3
       if: ${{ always() }}
       with:
         name: linux_x64_results
@@ -153,12 +153,12 @@ jobs:
     runs-on: macos-latest
     steps:
     - name: Checkout
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
       with:
         fetch-depth: 0
 
     - name: Install .NET Core
-      uses: actions/setup-dotnet@v1
+      uses: actions/setup-dotnet@v3
       with:
         dotnet-version: 6.0.x
 
@@ -172,7 +172,7 @@ jobs:
         ${{ github.workspace }}/eng/Scripts/CI-Test.sh
 
     - name: 'Upload Test Results'
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3
       if: ${{ always() }}
       with:
         name: osx_x64_results

--- a/src/MICore/JsonLaunchOptions.cs
+++ b/src/MICore/JsonLaunchOptions.cs
@@ -54,7 +54,7 @@ namespace MICore.Json.LaunchOptions
         /// <summary>
         /// Indicates the console debugger that the MIDebugEngine will connect to. Allowed values are "gdb" "lldb".
         /// </summary>
-        [JsonProperty("MIMode", DefaultValueHandling = DefaultValueHandling.Ignore)]
+        [JsonProperty(nameof(MIMode), DefaultValueHandling = DefaultValueHandling.Ignore)]
         public string MIMode { get; set; }
 
         /// <summary>

--- a/src/SSHDebugPS/Docker/DockerContainerInstance.cs
+++ b/src/SSHDebugPS/Docker/DockerContainerInstance.cs
@@ -47,16 +47,16 @@ namespace Microsoft.SSHDebugPS.Docker
         [JsonProperty("Names")]
         public override string Name { get; set; }
 
-        [JsonProperty("Image")]
+        [JsonProperty(nameof(Image))]
         public string Image { get; private set; }
 
-        [JsonProperty("Ports")]
+        [JsonProperty(nameof(Ports))]
         public string Ports { get; set; }
 
-        [JsonProperty("Command")]
+        [JsonProperty(nameof(Command))]
         public string Command { get; private set; }
 
-        [JsonProperty("Status")]
+        [JsonProperty(nameof(Status))]
         public string Status { get; private set; }
 
         [JsonProperty("CreatedAt")]


### PR DESCRIPTION
This PR update the GitHub action tasks that are warning due to node-12 being outdated and cleaing up some C# warnings.
The tasks are:
- checkout v3
- setup-dotnet v3
- setup-msbuild v1.1
- Setup-VSTest v1.2
- upload-artifact v3

Also addrssed hardcoded strings that were the same name as the variable name that appeared as warnings.