### PR TITLE
Fix Remote AsyncBreak

### DIFF
--- a/src/MICore/CommandFactories/MICommandFactory.cs
+++ b/src/MICore/CommandFactories/MICommandFactory.cs
@@ -675,7 +675,6 @@ namespace MICore
                 {
                     return MICore.AsyncBreakSignal.SIGINT;
                 }
-                return MICore.AsyncBreakSignal.Unknown;
             }
 
             return MICore.AsyncBreakSignal.None;

--- a/src/MICore/CommandFactories/MICommandFactory.cs
+++ b/src/MICore/CommandFactories/MICommandFactory.cs
@@ -660,7 +660,7 @@ namespace MICore
             {
                 if (results.TryFindString("signal-name") == "SIGTRAP" || 
                     // If we are remote, we use -exec-interrupt to async-break. GDB will send a SIGINT and we will need to handle the async break
-                    (_debugger.IsRemoteGdbTarget() && results.TryFindString("signal-name") == "SIGINT"))
+                    (_debugger.IsRemoteGdbTarget() && (_debugger.IsRequestingInternalAsyncBreak || _debugger.IsRequestingRealAsyncBreak) && results.TryFindString("signal-name") == "SIGINT"))
                 {
                     isAsyncBreak = true;
                 }

--- a/src/MICore/CommandFactories/MICommandFactory.cs
+++ b/src/MICore/CommandFactories/MICommandFactory.cs
@@ -667,11 +667,12 @@ namespace MICore
         {
             if (results.TryFindString("reason") == "signal-received")
             {
-                if (results.TryFindString("signal-name") == "SIGTRAP")
+                string signalName = results.TryFindString("signal-name");
+                if (signalName == "SIGTRAP")
                 {
                     return MICore.AsyncBreakSignal.SIGTRAP;
                 }
-                else if (results.TryFindString("signal-name") == "SIGINT")
+                else if (signalName == "SIGINT")
                 {
                     return MICore.AsyncBreakSignal.SIGINT;
                 }

--- a/src/MICore/CommandFactories/MICommandFactory.cs
+++ b/src/MICore/CommandFactories/MICommandFactory.cs
@@ -658,7 +658,9 @@ namespace MICore
 
             if (results.TryFindString("reason") == "signal-received")
             {
-                if (results.TryFindString("signal-name") == "SIGTRAP")
+                if (results.TryFindString("signal-name") == "SIGTRAP" || 
+                    // If we are remote, we use -exec-interrupt to async-break. GDB will send a SIGINT and we will need to handle the async break
+                    (_debugger.IsRemoteGdbTarget() && results.TryFindString("signal-name") == "SIGINT"))
                 {
                     isAsyncBreak = true;
                 }

--- a/src/MICore/CommandFactories/MICommandFactory.cs
+++ b/src/MICore/CommandFactories/MICommandFactory.cs
@@ -35,6 +35,17 @@ namespace MICore
         BreakThrown = 0x2
     }
 
+    /// <summary>
+    /// The signals that are using for async-break.
+    /// None will be used for no signal or signals that are not listed in the enum
+    /// </summary>
+    public enum AsyncBreakSignal
+    {
+        None = 0,
+        SIGTRAP = 2,
+        SIGINT = 5
+    }
+
     public abstract class MICommandFactory
     {
         protected Debugger _debugger;
@@ -652,21 +663,22 @@ namespace MICore
             get { return false; }
         }
 
-        public virtual bool IsAsyncBreakSignal(Results results)
+        public virtual AsyncBreakSignal GetAsyncBreakSignal(Results results)
         {
-            bool isAsyncBreak = false;
-
             if (results.TryFindString("reason") == "signal-received")
             {
-                if (results.TryFindString("signal-name") == "SIGTRAP" || 
-                    // If we are remote, we use -exec-interrupt to async-break. GDB will send a SIGINT and we will need to handle the async break
-                    (_debugger.IsRemoteGdbTarget() && (_debugger.IsRequestingInternalAsyncBreak || _debugger.IsRequestingRealAsyncBreak) && results.TryFindString("signal-name") == "SIGINT"))
+                if (results.TryFindString("signal-name") == "SIGTRAP")
                 {
-                    isAsyncBreak = true;
+                    return MICore.AsyncBreakSignal.SIGTRAP;
                 }
+                else if (results.TryFindString("signal-name") == "SIGINT")
+                {
+                    return MICore.AsyncBreakSignal.SIGINT;
+                }
+                return MICore.AsyncBreakSignal.Unknown;
             }
 
-            return isAsyncBreak;
+            return MICore.AsyncBreakSignal.None;
         }
 
         public Results IsModuleLoad(string cmd)

--- a/src/MICore/Debugger.cs
+++ b/src/MICore/Debugger.cs
@@ -591,7 +591,7 @@ namespace MICore
                 _launchOptions is LocalLaunchOptions && !IsLocalLaunchUsingServer());
         }
 
-        private bool IsRemoteGdbTarget()
+        internal bool IsRemoteGdbTarget()
         {
             return MICommandFactory.Mode == MIMode.Gdb &&
                (_launchOptions is PipeLaunchOptions || _launchOptions is UnixShellPortLaunchOptions ||

--- a/src/MIDebugEngine/Engine.Impl/DebuggedProcess.cs
+++ b/src/MIDebugEngine/Engine.Impl/DebuggedProcess.cs
@@ -1332,14 +1332,18 @@ namespace Microsoft.MIDebugEngine
             else if (reason == "signal-received")
             {
                 string name = results.Results.TryFindString("signal-name");
+                AsyncBreakSignal signal = MICommandFactory.GetAsyncBreakSignal(results.Results);
+                bool isAsyncBreak = signal == AsyncBreakSignal.SIGTRAP || (IsUsingExecInterrupt && signal == AsyncBreakSignal.SIGINT);
                 if ((name == "SIG32") || (name == "SIG33"))
                 {
                     // we are going to ignore these (Sigma) signals for now
                     CmdContinueAsyncConditional(breakRequest);
                 }
-                else if (MICommandFactory.IsAsyncBreakSignal(results.Results))
+                else if (isAsyncBreak)
                 {
                     _callback.OnAsyncBreakComplete(thread);
+                    // Reset flag for real async break
+                    IsUsingExecInterrupt = false;
                 }
                 else
                 {


### PR DESCRIPTION
https://github.com/microsoft/MIEngine/commit/5f6213cf60fdd271cd7bf6b03b4225a914a10da5 accidently broke async-break for gdb remote scenarios as we send "-exec-interrupt" for async-break instead of sending a 'kill SIGTRAP'.

This PR modifies the `IsAsyncBreakSignal` to return a newly created enum `AsyncBreakSignal`, and renames it to `GetAsyncBreakSignal`. `GetAsyncBreakSignal` will now return if it saw a `SIGINT`, `SIGTRAP`, or `None` if its an unknown signal related to async break or no signal was retrieved at all.

This will be used along with a new flag called `IsUsingExecInterrupt`, which will be set before `-exec-interrupt` is sent to the debugger.

`IsUsingExecInterrupt` will be reset when the engine resolves the `async-break` from the user (see DebuggedProcess.cs changes) or when we are resolving an internal async break (See Debugger.cs DoInternalBreakActions).

Resolves: #1382