### PR TITLE
[#1349] Always use `--simple-values` in newer versions of GDB.

### DIFF
--- a/src/MICore/CommandFactories/MICommandFactory.cs
+++ b/src/MICore/CommandFactories/MICommandFactory.cs
@@ -711,6 +711,24 @@ namespace MICore
         {
             return false;
         }
+
+        /// <summary>
+        /// Get the set of features supported by the underlying debugger.
+        /// </summary>
+        public virtual Task<HashSet<string>> GetFeatures()
+        {
+            return Task.FromResult(new HashSet<string>());
+        }
+
+        /// <summary>
+        /// True if the underlying debugger excludes the printing of references to
+        /// compound types when PrintValue.SimpleValues is used as an argument to
+        /// StackListLocals(), StackListArguments() and StackListVariables().
+        /// </summary>
+        public virtual Task<bool> SupportsSimpleValuesExcludesRefTypes()
+        {
+            return Task.FromResult(false);
+        }
         #endregion
     }
 }

--- a/src/MICore/CommandFactories/gdb.cs
+++ b/src/MICore/CommandFactories/gdb.cs
@@ -198,6 +198,18 @@ namespace MICore
             }
         }
 
+        public override async Task<HashSet<string>> GetFeatures()
+        {
+            Results results = await _debugger.CmdAsync("-list-features", ResultClass.done);
+            return new HashSet<string>(results.Find<ValueListValue>("features").AsStrings);
+        }
+
+        public override async Task<bool> SupportsSimpleValuesExcludesRefTypes()
+        {
+            HashSet<string> features = await GetFeatures();
+            return features.Contains("simple-values-ref-types");
+        }
+
         public override async Task Terminate()
         {
             // Although the mi documentation states that the correct command to terminate is -exec-abort

--- a/src/MIDebugEngine/Engine.Impl/DebuggedProcess.cs
+++ b/src/MIDebugEngine/Engine.Impl/DebuggedProcess.cs
@@ -52,6 +52,7 @@ namespace Microsoft.MIDebugEngine
         private IProcessSequence _childProcessHandler;
         private bool _deleteEntryPointBreakpoint;
         private string _entryPointBreakpoint = string.Empty;
+        private bool _simpleValuesExcludesRefTypes = false;
 
         public DebuggedProcess(bool bLaunched, LaunchOptions launchOptions, ISampleEngineCallback callback, WorkerThread worker, BreakpointManager bpman, AD7Engine engine, HostConfigurationStore configStore, HostWaitLoop waitLoop = null) : base(launchOptions, engine.Logger)
         {
@@ -550,6 +551,8 @@ namespace Microsoft.MIDebugEngine
 
             try
             {
+                _simpleValuesExcludesRefTypes = await this.MICommandFactory.SupportsSimpleValuesExcludesRefTypes();
+
                 await this.MICommandFactory.EnableTargetAsyncOption();
 
                 await this.CheckCygwin(_launchOptions as LocalLaunchOptions);
@@ -1985,8 +1988,14 @@ namespace Microsoft.MIDebugEngine
         //NOTE: eval is not called
         public async Task<List<ArgumentList>> GetParameterInfoOnly(AD7Thread thread, bool values, bool types, uint low, uint high)
         {
-            // If values are requested, request simple values, otherwise we'll use -var-create to get the type of argument it is.
-            var frames = await MICommandFactory.StackListArguments(values ? PrintValue.SimpleValues : PrintValue.NoValues, thread.Id, low, high);
+            // If SimpleValues excludes printing values for references to compound types,
+            // use SimpleValues (even if values are not requested) as it gets types too.
+            // Otherwise, if values are requested, use SimpleValues, but if not, the
+            // potential performance penalty of fetching values for references to compound
+            // types is too high, so use NoValues and follow up with -var-create to get
+            // the types.
+            PrintValue printValue = (_simpleValuesExcludesRefTypes || values) ? PrintValue.SimpleValues : PrintValue.NoValues;
+            var frames = await MICommandFactory.StackListArguments(printValue, thread.Id, low, high);
             List<ArgumentList> parameters = new List<ArgumentList>();
 
             foreach (var f in frames)


### PR DESCRIPTION
## Summary

In newer versions of GDB, the `--simple-values` option to the `-stack-list-arguments`, `-stack-list-locals` and
`-stack-list-variables` commands no longer prints the value for references to compound types. This improves the performance of these commands when the stack has references to large data structures.

When these versions of GDB are available, take advantage by using `--simple-values` in `DebuggedProcess.GetParameterInfoOnly` to fetch names and types in a single `-stack-list-arguments` command. This is faster than the old approach of using `--no-values` followed with `-var-create` and `-var-delete` for each parameter to get the type.

The new method `MICommandFactory.SupportsSimpleValuesExcludesRefTypes` determines if the debugger supports the improved behaviour of the `--simple-values` option, by executing the `-list-features` command and checking for the `"simple-values-ref-types"` feature in the output. We cache the result on the `DebuggedProcess` object as the set of supported features does not change during the lifetime of the debug session.

Fixes #1349 (Unnecessary `-var-create` and `-var-delete` commands during a stack trace can cause noticeable pause each time the debuggee stops)

### Details

The behaviour of GDB was changed in [commit 51f8dafba8](https://sourceware.org/git/gitweb.cgi?p=binutils-gdb.git;h=51f8dafba8175a8d59716f220a46de4e626e5073) and this change will be included in the next release of GDB. I understand that Microsoft developers are not allowed to look at GDB's source code (see [comment from Gregg Miskelly here](https://github.com/microsoft/MIEngine/issues/1349#issuecomment-1239671665)), so I have summarized the effect of the change above. Let me know if there is anything else you'd like to know about this change.

I repeated the reproduction procedure from #1349, took a copy of the commands issued by a single Step Over operation with ten frames on the stack and attached them here: [stack-list-arguments-after.gz](https://github.com/microsoft/MIEngine/files/11429955/stack-list-arguments-after.gz). The table below shows the counts of GDB/MI commands issued for the Step Over operation by the MIEngine from `main` against GDB 13.1 and the MIEngine from this branch against the updated GDB.

| Command | Counts (main) | Counts (this branch) |
| ------- | ----- | ----- |
| `-stack-list-arguments` | 2 | 2 |
| `-stack-list-frames` | 1 | 1 |
| `-stack-list-variables` | 1 | 1 |
| `-stack-select-frame` | 20 | 0 |
| `-var-create` | 210 | 10 |
| `-var-delete` | 210 | 10 |