### PR TITLE
MIEngine: Introduce --thread and --frame options

### DIFF
--- a/src/MICore/CommandFactories/MICommandFactory.cs
+++ b/src/MICore/CommandFactories/MICommandFactory.cs
@@ -54,6 +54,8 @@ namespace MICore
 
         public abstract string Name { get; }
 
+        internal int MajorVersion { get; set; }
+
         public static MICommandFactory GetInstance(MIMode mode, Debugger debugger)
         {
             MICommandFactory commandFactory;
@@ -119,16 +121,18 @@ namespace MICore
 
         public async Task<Results> StackInfoDepth(int threadId, int maxDepth = 1000, ResultClass resultClass = ResultClass.done)
         {
-            string command = string.Format(CultureInfo.InvariantCulture, @"-stack-info-depth {0}", maxDepth);
-            Results results = await ThreadCmdAsync(command, resultClass, threadId);
+            string command = "-stack-info-depth";
+            string args = string.Format(CultureInfo.InvariantCulture, $@"{maxDepth}");
+            Results results = await ThreadCmdAsync(command, args, resultClass, threadId);
 
             return results;
         }
 
         public async Task<TupleValue[]> StackListFrames(int threadId, uint lowFrameLevel, uint highFrameLevel = 1000)
         {
-            string command = string.Format(CultureInfo.InvariantCulture, @"-stack-list-frames {0} {1}", lowFrameLevel, highFrameLevel);
-            Results results = await ThreadCmdAsync(command, ResultClass.done, threadId);
+            string command = "-stack-list-frames";
+            string args = string.Format(CultureInfo.InvariantCulture, $@"{lowFrameLevel} {highFrameLevel}");
+            Results results = await ThreadCmdAsync(command, args, ResultClass.done, threadId);
 
             ListValue list = results.Find<ListValue>("stack");
             if (list is ResultListValue)
@@ -164,9 +168,10 @@ namespace MICore
         /// <returns></returns>
         public async Task<ResultValue> StackListLocals(PrintValue printValues, int threadId, uint frameLevel)
         {
-            string cmd = string.Format(CultureInfo.InvariantCulture, @"-stack-list-locals {0}", (int)printValues);
+            string cmd = "-stack-list-locals";
+            string args = string.Format(CultureInfo.InvariantCulture, $@"{(int)printValues}");
 
-            Results localsResults = await ThreadFrameCmdAsync(cmd, ResultClass.done, threadId, frameLevel);
+            Results localsResults = await ThreadFrameCmdAsync(cmd, args, ResultClass.done, threadId, frameLevel);
             return localsResults.Find("locals");
         }
 
@@ -180,8 +185,9 @@ namespace MICore
         /// <returns>This returns an array of results of frames, which contains a level and an args array. </returns>
         public virtual async Task<TupleValue[]> StackListArguments(PrintValue printValues, int threadId, uint lowFrameLevel, uint hiFrameLevel)
         {
-            string cmd = string.Format(CultureInfo.InvariantCulture, @"-stack-list-arguments {0} {1} {2}", (int)printValues, lowFrameLevel, hiFrameLevel);
-            Results argumentsResults = await ThreadCmdAsync(cmd, ResultClass.done, threadId);
+            string command = "-stack-list-arguments";
+            string args = string.Format(CultureInfo.InvariantCulture, $@"{(int)printValues} {lowFrameLevel} {hiFrameLevel}");
+            Results argumentsResults = await ThreadCmdAsync(command, args, ResultClass.done, threadId);
 
             return argumentsResults.Find<ListValue>("stack-args").IsEmpty()
                 ? new TupleValue[0]
@@ -213,9 +219,9 @@ namespace MICore
         /// <returns>Returns an array of results for variables</returns>
         public async Task<ValueListValue> StackListVariables(PrintValue printValues, int threadId, uint frameLevel)
         {
-            string cmd = string.Format(CultureInfo.InvariantCulture, @"-stack-list-variables {0}", (int)printValues);
-
-            Results variablesResults = await ThreadFrameCmdAsync(cmd, ResultClass.done, threadId, frameLevel);
+            string cmd = "-stack-list-variables";
+            string args = string.Format(CultureInfo.InvariantCulture, $@"{(int)printValues}");
+            Results variablesResults = await ThreadFrameCmdAsync(cmd, args, ResultClass.done, threadId, frameLevel);
             return variablesResults.Find<ValueListValue>("variables");
         }
 
@@ -226,31 +232,36 @@ namespace MICore
         public async Task ExecStep(int threadId, ResultClass resultClass = ResultClass.running)
         {
             string command = "-exec-step";
-            await ThreadFrameCmdAsync(command, resultClass, threadId, 0);
+            string args = string.Empty;
+            await ThreadFrameCmdAsync(command, args, resultClass, threadId, 0);
         }
 
         public async Task ExecNext(int threadId, ResultClass resultClass = ResultClass.running)
         {
             string command = "-exec-next";
-            await ThreadFrameCmdAsync(command, resultClass, threadId, 0);
+            string args = string.Empty;
+            await ThreadFrameCmdAsync(command, args, resultClass, threadId, 0);
         }
 
         public async Task ExecFinish(int threadId, ResultClass resultClass = ResultClass.running)
         {
             string command = "-exec-finish";
-            await ThreadFrameCmdAsync(command, resultClass, threadId, 0);
+            string args = string.Empty;
+            await ThreadFrameCmdAsync(command, args, resultClass, threadId, 0);
         }
 
         public async Task ExecStepInstruction(int threadId, ResultClass resultClass = ResultClass.running)
         {
             string command = "-exec-step-instruction";
-            await ThreadFrameCmdAsync(command, resultClass, threadId, 0);
+            string args = string.Empty;
+            await ThreadFrameCmdAsync(command, args, resultClass, threadId, 0);
         }
 
         public async Task ExecNextInstruction(int threadId, ResultClass resultClass = ResultClass.running)
         {
             string command = "-exec-next-instruction";
-            await ThreadFrameCmdAsync(command, resultClass, threadId, 0);
+            string args = string.Empty;
+            await ThreadFrameCmdAsync(command, args, resultClass, threadId, 0);
         }
 
         /// <summary>
@@ -296,15 +307,17 @@ namespace MICore
 
         public async Task<TupleValue[]> DataListRegisterValues(int threadId)
         {
-            string command = "-data-list-register-values x";
-            Results results = await ThreadCmdAsync(command, ResultClass.done, threadId);
+            string command = "-data-list-register-values";
+            string args = "x";
+            Results results = await ThreadCmdAsync(command, args, ResultClass.done, threadId);
             return results.Find<ValueListValue>("register-values").AsArray<TupleValue>();
         }
 
         public async Task<string> DataEvaluateExpression(string expr, int threadId, uint frame)
         {
-            string command = "-data-evaluate-expression \"" + expr + "\"";
-            Results results = await ThreadFrameCmdAsync(command, ResultClass.None, threadId, frame);
+            string command = "-data-evaluate-expression";
+            string args = $"\"{expr}\"";
+            Results results = await ThreadFrameCmdAsync(command, args, ResultClass.None, threadId, frame);
             return results.FindString("value");
         }
 
@@ -344,8 +357,9 @@ namespace MICore
         public virtual async Task<Results> VarCreate(string expression, int threadId, uint frameLevel, enum_EVALFLAGS dwFlags, ResultClass resultClass = ResultClass.done)
         {
             string quoteEscapedExpression = EscapeQuotes(HandleInvalidChars(expression));
-            string command = string.Format(CultureInfo.InvariantCulture, "-var-create - * \"{0}\"", quoteEscapedExpression);
-            Results results = await ThreadFrameCmdAsync(command, resultClass, threadId, frameLevel);
+            string command = "-var-create";
+            string args = string.Format(CultureInfo.InvariantCulture, $" - * \"{quoteEscapedExpression}\"");
+            Results results = await ThreadFrameCmdAsync(command, args, resultClass, threadId, frameLevel);
 
             return results;
         }
@@ -646,8 +660,8 @@ namespace MICore
 
         #region Other
 
-        abstract protected Task<Results> ThreadFrameCmdAsync(string command, ResultClass expectedResultClass, int threadId, uint frameLevel);
-        abstract protected Task<Results> ThreadCmdAsync(string command, ResultClass expectedResultClass, int threadId);
+        abstract protected Task<Results> ThreadFrameCmdAsync(string command, string args, ResultClass expectedResultClass, int threadId, uint frameLevel);
+        abstract protected Task<Results> ThreadCmdAsync(string command, string args, ResultClass expectedResultClass, int threadId);
 
         abstract public string GetSetEnvironmentVariableCommand(string name, string value);
 

--- a/src/MICore/CommandFactories/gdb.cs
+++ b/src/MICore/CommandFactories/gdb.cs
@@ -48,7 +48,7 @@ namespace MICore
             return false;
         }
 
-        protected override async Task<Results> ThreadFrameCmdAsync(string command, ResultClass expectedResultClass, int threadId, uint frameLevel)
+        protected override async Task<Results> ThreadFrameCmdAsync(string command, string args, ResultClass expectedResultClass, int threadId, uint frameLevel)
         {
             // first aquire an exclusive lock. This is used as we don't want to fight with other commands that also require the current
             // thread to be set to a particular value
@@ -56,8 +56,20 @@ namespace MICore
 
             try
             {
-                await ThreadSelect(threadId, lockToken);
-                await StackSelectFrame(frameLevel, lockToken);
+
+                string threadFrameCommand;
+                // With source code of gdb 7.0.0, the --thread and --frame options were introduced and -thread-select and
+                // -stack-select-frame were deprecated
+                if (MajorVersion < 7)
+                {
+                    await ThreadSelect(threadId, lockToken);
+                    await StackSelectFrame(frameLevel, lockToken);
+                    threadFrameCommand = string.Format(CultureInfo.InvariantCulture, $@"{command} {args}");
+                }
+                else
+                {
+                    threadFrameCommand = string.Format(CultureInfo.InvariantCulture, $@"{command} --thread {threadId} --frame {frameLevel} {args}");
+                }
 
                 // Before we execute the provided command, we need to switch to a shared lock. This is because the provided
                 // command may be an expression evaluation command which could be long running, and we don't want to hold the
@@ -65,7 +77,7 @@ namespace MICore
                 lockToken.ConvertToSharedLock();
                 lockToken = null;
 
-                return await _debugger.CmdAsync(command, expectedResultClass);
+                return await _debugger.CmdAsync(threadFrameCommand, expectedResultClass);
             }
             finally
             {
@@ -82,7 +94,7 @@ namespace MICore
             }
         }
 
-        protected override async Task<Results> ThreadCmdAsync(string command, ResultClass expectedResultClass, int threadId)
+        protected override async Task<Results> ThreadCmdAsync(string command, string args, ResultClass expectedResultClass, int threadId)
         {
             // first aquire an exclusive lock. This is used as we don't want to fight with other commands that also require the current
             // thread to be set to a particular value
@@ -90,7 +102,18 @@ namespace MICore
 
             try
             {
-                await ThreadSelect(threadId, lockToken);
+                string threadCommand;
+                // With source code of gdb 7.0.0, the --thread option was introduced and -thread-select
+                // was deprecated
+                if (MajorVersion < 7)
+                {
+                    await ThreadSelect(threadId, lockToken);
+                    threadCommand = string.Format(CultureInfo.InvariantCulture, $@"{command} {args}");
+                }
+                else
+                {
+                    threadCommand = string.Format(CultureInfo.InvariantCulture, $@"{command} --thread {threadId} {args}"); ;
+                }
 
                 // Before we execute the provided command, we need to switch to a shared lock. This is because the provided
                 // command may be an expression evaluation command which could be long running, and we don't want to hold the
@@ -98,7 +121,7 @@ namespace MICore
                 lockToken.ConvertToSharedLock();
                 lockToken = null;
 
-                return await _debugger.CmdAsync(command, expectedResultClass);
+                return await _debugger.CmdAsync(threadCommand, expectedResultClass);
             }
             finally
             {
@@ -301,12 +324,13 @@ namespace MICore
 
         public override async Task<string[]> AutoComplete(string command, int threadId, uint frameLevel)
         {
-            command = "-complete \"" + command + "\"";
+            string cmd = "-complete";
+            string args = $"\"{command}\"";
             Results res;
             if (threadId == -1)
-                res = await _debugger.CmdAsync(command, ResultClass.done);
+                res = await _debugger.CmdAsync($"{cmd} {args}", ResultClass.done);
             else
-                res = await ThreadFrameCmdAsync(command, ResultClass.done, threadId, frameLevel);
+                res = await ThreadFrameCmdAsync(cmd, args, ResultClass.done, threadId, frameLevel);
 
             var matchlist = res.Find<ValueListValue>("matches");
 

--- a/src/MICore/CommandFactories/lldb.cs
+++ b/src/MICore/CommandFactories/lldb.cs
@@ -76,9 +76,10 @@ namespace MICore
 
         public override async Task<Results> VarCreate(string expression, int threadId, uint frameLevel, enum_EVALFLAGS dwFlags, ResultClass resultClass = ResultClass.done)
         {
+            string command = "-var-create";
             string quoteEscapedExpression = EscapeQuotes(expression);
-            string command = string.Format(CultureInfo.InvariantCulture, "-var-create - - \"{0}\"", quoteEscapedExpression);  // use '-' to indicate that "--frame" should be used to determine the frame number
-            Results results = await ThreadFrameCmdAsync(command, resultClass, threadId, frameLevel);
+            string args = string.Format(CultureInfo.InvariantCulture, $"- - \"{quoteEscapedExpression}\"");  // use '-' to indicate that "--frame" should be used to determine the frame number
+            Results results = await ThreadFrameCmdAsync(command, args, resultClass, threadId, frameLevel);
 
             return results;
         }
@@ -94,16 +95,16 @@ namespace MICore
             return results;
         }
 
-        protected override async Task<Results> ThreadFrameCmdAsync(string command, ResultClass exepctedResultClass, int threadId, uint frameLevel)
+        protected override async Task<Results> ThreadFrameCmdAsync(string command, string args, ResultClass exepctedResultClass, int threadId, uint frameLevel)
         {
-            string threadFrameCommand = string.Format(CultureInfo.InvariantCulture, @"{0} --thread {1} --frame {2}", command, threadId, frameLevel);
+            string threadFrameCommand = string.Format(CultureInfo.InvariantCulture, $@"{command} {args} --thread {threadId} --frame {frameLevel}");
 
             return await _debugger.CmdAsync(threadFrameCommand, exepctedResultClass);
         }
 
-        protected override async Task<Results> ThreadCmdAsync(string command, ResultClass expectedResultClass, int threadId)
+        protected override async Task<Results> ThreadCmdAsync(string command, string args, ResultClass expectedResultClass, int threadId)
         {
-            string threadCommand = string.Format(CultureInfo.InvariantCulture, @"{0} --thread {1}", command, threadId);
+            string threadCommand = string.Format(CultureInfo.InvariantCulture, $@"{command} {args} --thread {threadId}");
 
             return await _debugger.CmdAsync(threadCommand, expectedResultClass);
         }

--- a/src/MICore/Debugger.cs
+++ b/src/MICore/Debugger.cs
@@ -980,6 +980,13 @@ namespace MICore
                             MIDebuggerInitializeFailedException exception;
                             string version = GdbVersionFromLog();
 
+                            int majorVersion = -1;
+                            if (!string.IsNullOrWhiteSpace(version))
+                            {
+                                int.TryParse(version.Split('.').FirstOrDefault(), out majorVersion);
+                            }
+                            MICommandFactory.MajorVersion = majorVersion;
+
                             // We can't use IsMinGW or IsCygwin because we never connected to the debugger
                             bool isMinGWOrCygwin = _launchOptions is LocalLaunchOptions &&
                                     PlatformUtilities.IsWindows() &&


### PR DESCRIPTION
Remove -thread-select and -stack-select-frame and introduce --thread and --frame options instead.

It is general recommendation to not use -thread-select and -stack-select-frame and use --thread and --frame instead. More info can be found here:
https://sourceware.org/gdb/onlinedocs/gdb/Context-management.html

And here are the deprecation notes:
-thread-select
-thread-select: https://sourceware.org/gdb/onlinedocs/gdb/GDB_002fMI-Thread-Commands.html#GDB_002fMI-Thread-Commands

-stack-select-frame
-stack-select-frame: https://sourceware.org/gdb/onlinedocs/gdb/GDB_002fMI-Stack-Manipulation.html#GDB_002fMI-Stack-Manipulation

Signed-off-by: intel-rganesh rakesh.ganesh@intel.com