### PR TITLE
Align use of sendInvalidate request arguments

### DIFF
--- a/src/OpenDebugAD7/AD7DebugSession.cs
+++ b/src/OpenDebugAD7/AD7DebugSession.cs
@@ -137,22 +137,25 @@ namespace OpenDebugAD7
         private void HandleSendInvalidateRequestAsync(IRequestResponder<SendInvalidateArguments> responder)
         {
             InvalidatedEvent invalidated = new InvalidatedEvent();
-            
-            // Setting the area and adding it to the result
-            invalidated.Areas.Add(responder.Arguments.Areas);
+            // Set the Arguments only if passed
+            if (null != responder.Arguments) {
+                // Setting the Areas if passed
+                if (null != responder.Arguments.Areas || responder.Arguments.Areas.Length != 0) {
+                    invalidated.Areas = responder.Arguments.Areas.ToList();
+                }
 
-            // Setting the StackFrameId if passed (and the 'threadId' is ignored).
-            if (null != responder.Arguments.StackFrameId)
-            {
-                invalidated.StackFrameId = responder.Arguments.StackFrameId;
+                // Setting the StackFrameId if passed (and the 'threadId' is ignored).
+                if (null != responder.Arguments.StackFrameId)
+                {
+                    invalidated.StackFrameId = responder.Arguments.StackFrameId;
+                }
+
+                // Setting the ThreadId if passed
+                else if (null != responder.Arguments.ThreadId)
+                {
+                    invalidated.ThreadId = responder.Arguments.ThreadId;
+                }
             }
-
-            // Setting the ThreadId if passed
-            else if (null != responder.Arguments.ThreadId)
-            {
-                invalidated.ThreadId = responder.Arguments.ThreadId;
-            }
-
 
             Protocol.SendEvent(invalidated);
 
@@ -3913,7 +3916,7 @@ namespace OpenDebugAD7
     internal class SendInvalidateArguments : DebugRequestArguments
     {
 
-        public InvalidatedAreas Areas { get; set; }
+        public InvalidatedAreas[]? Areas { get; set; }
         public int? ThreadId { get; set; }
         public int? StackFrameId { get; set; }
 

--- a/src/OpenDebugAD7/AD7DebugSession.cs
+++ b/src/OpenDebugAD7/AD7DebugSession.cs
@@ -3916,7 +3916,7 @@ namespace OpenDebugAD7
     internal class SendInvalidateArguments : DebugRequestArguments
     {
 
-        public InvalidatedAreas[]? Areas { get; set; }
+        public List<InvalidatedAreas> Areas { get; set; }
         public int? ThreadId { get; set; }
         public int? StackFrameId { get; set; }
 

--- a/src/OpenDebugAD7/AD7DebugSession.cs
+++ b/src/OpenDebugAD7/AD7DebugSession.cs
@@ -140,7 +140,7 @@ namespace OpenDebugAD7
             // Set the Arguments only if passed
             if (null != responder.Arguments) {
                 // Setting the Areas if passed
-                if (null != responder.Arguments.Areas || responder.Arguments.Areas.Length != 0) {
+                if (null != responder.Arguments.Areas) {
                     invalidated.Areas = responder.Arguments.Areas.ToList();
                 }
 

--- a/src/OpenDebugAD7/AD7DebugSession.cs
+++ b/src/OpenDebugAD7/AD7DebugSession.cs
@@ -141,7 +141,7 @@ namespace OpenDebugAD7
             if (null != responder.Arguments) {
                 // Setting the Areas if passed
                 if (null != responder.Arguments.Areas) {
-                    invalidated.Areas = responder.Arguments.Areas.ToList();
+                    invalidated.Areas = responder.Arguments.Areas;
                 }
 
                 // Setting the StackFrameId if passed (and the 'threadId' is ignored).


### PR DESCRIPTION
Using the `sendInvalidate` request I realised that I was forced to provide a single `Area` as an argument. This PR aligns the behaviour of `sendInvalidate` request with the `invalidate` event.

Thanks to @sbobko for his original contribution, I only hope this patch doesn't contradict the original intent of the behaviour of `sendInvalidate`