### PR TITLE
Fix Rank > 1 Display Strings for Natvis

### DIFF
--- a/src/MIDebugEngine/Natvis.Impl/Natvis.cs
+++ b/src/MIDebugEngine/Natvis.Impl/Natvis.cs
@@ -676,12 +676,8 @@ namespace Microsoft.MIDebugEngine.Natvis
 
                                 for (uint index = 0; index < requestedSize; ++index)
                                 {
-                                    string displayName = (startIndex + index).ToString(CultureInfo.InvariantCulture);
-                                    if (rank > 1)
-                                    {
-                                        displayName = GetDisplayNameFromArrayIndex(index, rank, dimensions, isForward);
-                                    }
-
+                                    uint currentOffsetIndex = startIndex + index;
+                                    string displayName = rank > 1 ? GetDisplayNameFromArrayIndex(currentOffsetIndex, rank, dimensions, isForward) : currentOffsetIndex.ToString(CultureInfo.InvariantCulture);
                                     children.Add(new SimpleWrapper("[" + displayName + "]", _process.Engine, arrayExpr.Children[index]));
                                 }
 

--- a/test/CppTests/Tests/NatvisTests.cs
+++ b/test/CppTests/Tests/NatvisTests.cs
@@ -181,7 +181,8 @@ namespace CppTests.Tests
 
                     // Multi-dimensional array
                     var matrix = currentFrame.GetVariable("matrix");
-                    Assert.Equal("3", matrix.GetVariable("[1,1]").Value);
+                    Assert.Equal("1", matrix.GetVariable("[0,1]").Value);
+                    Assert.Equal("51", matrix.GetVariable("[More...]").GetVariable("[0,51]").Value);
                 }
 
                 runner.Expects.ExitedEvent(exitCode: 0).TerminatedEvent().AfterContinue();

--- a/test/CppTests/debuggees/natvis/src/SimpleMatrix.h
+++ b/test/CppTests/debuggees/natvis/src/SimpleMatrix.h
@@ -1,27 +1,20 @@
 class SimpleMatrix
 {
 public:
-    int m_size1;
-    int m_size2;
-    bool m_fUseSize1;
+    int m_rows;
+    int m_cols;
     int* m_pData;
 
-    SimpleMatrix(int size1, int size2, bool fUseSize1)
+    SimpleMatrix(int row, int col, bool fUseSize1)
     {
-        m_size1 = size1;
-        m_size2 = size2;
-        m_fUseSize1 = fUseSize1;
+        m_rows = row;
+        m_cols = col;
 
-        m_pData = new int[GetSize()];
+        m_pData = new int[row * col];
 
-        for (int i = 0; i < GetSize(); i++)
+        for (int i = 0; i < row * col; i++)
         {
             m_pData[i] = i;
         }
-    }
-
-    int GetSize()
-    {
-        return m_fUseSize1 ? m_size1 : m_size2;
     }
 };

--- a/test/CppTests/debuggees/natvis/src/SimpleMatrix.h
+++ b/test/CppTests/debuggees/natvis/src/SimpleMatrix.h
@@ -5,7 +5,7 @@ public:
     int m_cols;
     int* m_pData;
 
-    SimpleMatrix(int row, int col, bool fUseSize1)
+    SimpleMatrix(int row, int col)
     {
         m_rows = row;
         m_cols = col;

--- a/test/CppTests/debuggees/natvis/src/main.cpp
+++ b/test/CppTests/debuggees/natvis/src/main.cpp
@@ -46,7 +46,7 @@ int main(int argc, char** argv)
     SimpleClass* simpleClass = nullptr;
     simpleClass = new SimpleClass();
 
-    SimpleMatrix matrix(2, 256, false);
+    SimpleMatrix matrix(2, 256);
 
     return 0;
 }

--- a/test/CppTests/debuggees/natvis/src/main.cpp
+++ b/test/CppTests/debuggees/natvis/src/main.cpp
@@ -46,7 +46,7 @@ int main(int argc, char** argv)
     SimpleClass* simpleClass = nullptr;
     simpleClass = new SimpleClass();
 
-    SimpleMatrix matrix(5, 8, false);
+    SimpleMatrix matrix(2, 256, false);
 
     return 0;
 }

--- a/test/CppTests/debuggees/natvis/src/visualizer_files/Simple.natvis
+++ b/test/CppTests/debuggees/natvis/src/visualizer_files/Simple.natvis
@@ -64,7 +64,7 @@
       <ArrayItems>
         <Direction>Forward</Direction>
         <Rank>2</Rank>
-        <Size>($i == 1) ? 2 : m_size2/2</Size>
+        <Size>($i == 0) ? m_rows : m_cols</Size>
         <ValuePointer>m_pData</ValuePointer>
       </ArrayItems>
     </Expand>

--- a/test/CppTests/debuggees/natvis/src/visualizer_files/Simple2.natvis
+++ b/test/CppTests/debuggees/natvis/src/visualizer_files/Simple2.natvis
@@ -27,16 +27,4 @@
     </TreeItems>
    </Expand>
   </Type>
-
-  <Type Name="SimpleMatrix">
-    <DisplayString>SimpleMatrix</DisplayString>
-    <Expand>
-      <ArrayItems>
-        <Direction>Forward</Direction>
-        <Rank>2</Rank>
-        <Size>($i == 1) ? 2 : m_size2/2</Size>
-        <ValuePointer>m_pData</ValuePointer>
-      </ArrayItems>
-    </Expand>
-  </Type>
 </AutoVisualizer>


### PR DESCRIPTION
This PR fixes the display string for ArrayItems with Rank > 1 when the "[More...]" is expanded.
Before "[More...]" will expand starting at [0,0] instead of [0,50] for the first expansion since the offsets are at 50.

This change updated the call to GetDisplayNameFromArrayIndex from just `index` which would always start at 0, to `startIndex + index` to include the offet.
Added a test to cover this case and refactored the Matrix Natvis syntax to use rol/col instead of random behavior. 

Fixes: #1403