### PR TITLE
DAR: Set Encoding to UTF-8

### DIFF
--- a/test/DebugAdapterRunner/DebugAdapterRunner.cs
+++ b/test/DebugAdapterRunner/DebugAdapterRunner.cs
@@ -56,6 +56,8 @@ namespace DebugAdapterRunner
 
         private IDictionary<string, CallbackRequestHandler> _callbackHandlers = new Dictionary<string, CallbackRequestHandler>();
 
+        private static readonly Encoding s_utf8NoBOM = new UTF8Encoding(encoderShouldEmitUTF8Identifier: false);
+
         // Current list of responses received from the debug adapter
         public List<string> Responses { get; private set; }
 
@@ -155,7 +157,9 @@ namespace DebugAdapterRunner
             startInfo.CreateNoWindow = true;
             startInfo.RedirectStandardInput = true;
             startInfo.RedirectStandardOutput = true;
-            startInfo.RedirectStandardError = true;                
+            startInfo.RedirectStandardError = true;
+            startInfo.StandardOutputEncoding = s_utf8NoBOM;
+            startInfo.StandardInputEncoding = s_utf8NoBOM;
 
             if (redirectVSAssert)
             {


### PR DESCRIPTION
DAR failed to set the encoding to UTF-8, leading to corrupt messages if we tried to marshal non-ascii strings.