### PR TITLE
Only use ps 'flags' for macOS

### DIFF
--- a/src/SSHDebugPS/AD7/AD7Process.cs
+++ b/src/SSHDebugPS/AD7/AD7Process.cs
@@ -25,7 +25,7 @@ namespace Microsoft.SSHDebugPS
         /// <summary>
         /// Flags are only used in ps command scenarios. It will be set to 0 for others.
         /// </summary>
-        private readonly uint _flags;
+        private readonly uint? _flags;
 
         /// <summary>
         /// Returns true if _commandLine appears to hold a real file name + args rather than just a description
@@ -297,7 +297,7 @@ namespace Microsoft.SSHDebugPS
         {
             // For Apple Silicon M1, it is possible that the process we are attaching to is being emulated as x86_64. 
             // The process is emulated if it has process flags has P_TRANSLATED (0x20000).
-            if (_port.IsOSX() && _systemArch == "arm64")
+            if (_port.IsOSX() && _systemArch == "arm64" && _flags.HasValue)
             {
                 if ((_flags & 0x20000) != 0)
                 {

--- a/src/SSHDebugPS/IConnection.cs
+++ b/src/SSHDebugPS/IConnection.cs
@@ -1,7 +1,9 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Threading;
 using Microsoft.DebugEngineHost;
 using Microsoft.SSHDebugPS.Utilities;
@@ -104,13 +106,13 @@ namespace Microsoft.SSHDebugPS
         /// <summary>
         /// Only used by the PSOutputParser
         /// </summary>
-        public uint Flags { get; private set; }
+        public uint? Flags { get; private set; }
         public string SystemArch { get; private set; }
         public string CommandLine { get; private set; }
         public string UserName { get; private set; }
         public bool IsSameUser { get; private set; }
 
-        public Process(uint id, string arch, uint flags, string userName, string commandLine, bool isSameUser)
+        public Process(uint id, string arch, uint? flags, string userName, string commandLine, bool isSameUser)
         {
             this.Id = id;
             this.Flags = flags;
@@ -121,15 +123,37 @@ namespace Microsoft.SSHDebugPS
         }
     }
 
+    internal static class OperatingSystemStringConverter
+    {
+        internal static PlatformID ConvertToPlatformID(this string value)
+        {
+            if (!string.IsNullOrEmpty(value))
+            {
+                value = value.ToLowerInvariant();
+                if (value.Contains("darwin"))
+                {
+                    return PlatformID.MacOSX;
+                } else if (value.Contains("linux"))
+                {
+                    return PlatformID.Unix;
+                }
+            }
+            Debug.Fail($"Expected a valid platform '{value}' of darwin or linux, but falling back to linux.");
+            return PlatformID.Unix;
+        }
+    }
+
     internal class SystemInformation
     {
         public string UserName { get; private set; }
         public string Architecture { get; private set; }
+        public PlatformID Platform { get; private set; }
 
-        public SystemInformation(string username, string architecture)
+        public SystemInformation(string username, string architecture, PlatformID platform)
         {
             this.UserName = username;
             this.Architecture = architecture;
+            Platform = platform;
         }
     }
 }

--- a/src/SSHDebugPS/IConnection.cs
+++ b/src/SSHDebugPS/IConnection.cs
@@ -125,7 +125,7 @@ namespace Microsoft.SSHDebugPS
 
     internal static class OperatingSystemStringConverter
     {
-        internal static PlatformID ConvertToPlatformID(this string value)
+        internal static PlatformID ConvertToPlatformID(string value)
         {
             if (!string.IsNullOrEmpty(value))
             {

--- a/src/SSHDebugPS/PipeConnection.cs
+++ b/src/SSHDebugPS/PipeConnection.cs
@@ -98,8 +98,8 @@ namespace Microsoft.SSHDebugPS
         /// <returns>SystemInformation containing username and architecture. If it was unable to obtain any of these, the value will be set to string.Empty.</returns>
         public SystemInformation GetSystemInformation()
         {
-            string commandOutput;
-            string errorMessage;
+            string commandOutput = string.Empty;
+            string errorMessage = string.Empty;
             int exitCode;
 
             string username = string.Empty;
@@ -108,13 +108,19 @@ namespace Microsoft.SSHDebugPS
                 username = commandOutput;
             }
 
+            string platform = string.Empty;
+            if (ExecuteCommand("uname", Timeout.Infinite, commandOutput: out commandOutput, errorMessage: out errorMessage, exitCode: out exitCode))
+            {
+                platform = commandOutput;
+            }
+
             string architecture = string.Empty;
             if (ExecuteCommand("uname -m", Timeout.Infinite, commandOutput: out commandOutput, errorMessage: out errorMessage, exitCode: out exitCode))
             {
                 architecture = commandOutput;
             }
 
-            return new SystemInformation(username, architecture);
+            return new SystemInformation(username, architecture, platform.ConvertToPlatformID());
         }
 
         public override List<Process> ListProcesses()
@@ -152,12 +158,15 @@ namespace Microsoft.SSHDebugPS
             errorMessage = string.Empty;
             string commandOutput;
             int exitCode;
-            if (!ExecuteCommand(PSOutputParser.PSCommandLine, Timeout.Infinite, out commandOutput, out errorMessage, out exitCode))
+
+            PSOutputParser psOutputParser = new PSOutputParser(systemInformation);
+
+            if (!ExecuteCommand(psOutputParser.PSCommandLine, Timeout.Infinite, out commandOutput, out errorMessage, out exitCode))
             {
                 // Clear output and errorMessage
                 commandOutput = string.Empty;
                 errorMessage = string.Empty;
-                if (!ExecuteCommand(PSOutputParser.AltPSCommandLine, Timeout.Infinite, out commandOutput, out errorMessage, out exitCode))
+                if (!ExecuteCommand(psOutputParser.AltPSCommandLine, Timeout.Infinite, out commandOutput, out errorMessage, out exitCode))
                 {
                     if (exitCode == 127)
                     {
@@ -174,7 +183,7 @@ namespace Microsoft.SSHDebugPS
                 }
             }
 
-            processes = PSOutputParser.Parse(commandOutput, systemInformation);
+            processes = psOutputParser.Parse(commandOutput);
             return true;
         }
 

--- a/src/SSHDebugPS/PipeConnection.cs
+++ b/src/SSHDebugPS/PipeConnection.cs
@@ -120,7 +120,7 @@ namespace Microsoft.SSHDebugPS
                 architecture = commandOutput;
             }
 
-            return new SystemInformation(username, architecture, platform.ConvertToPlatformID());
+            return new SystemInformation(username, architecture, OperatingSystemStringConverter.ConvertToPlatformID(platform));
         }
 
         public override List<Process> ListProcesses()

--- a/src/SSHDebugPS/SSH/SSHConnection.cs
+++ b/src/SSHDebugPS/SSH/SSHConnection.cs
@@ -52,6 +52,13 @@ namespace Microsoft.SSHDebugPS.SSH
                 username = usernameCommand.Output.TrimEnd('\n', '\r'); // trim line endings because 'id' command ends with a newline
             }
 
+            string operatingSystem = string.Empty;
+            var operatingSystemCommand = _remoteSystem.Shell.ExecuteCommand("uname", Timeout.InfiniteTimeSpan);
+            if (operatingSystemCommand.ExitCode == 0)
+            {
+                operatingSystem = operatingSystemCommand.Output.TrimEnd('\n', '\r'); // trim line endings because 'uname' command ends with a newline
+            }
+
             string architecture = string.Empty;
             var architectureCommand = _remoteSystem.Shell.ExecuteCommand("uname -m", Timeout.InfiniteTimeSpan);
             if (architectureCommand.ExitCode == 0)
@@ -59,15 +66,17 @@ namespace Microsoft.SSHDebugPS.SSH
                 architecture = architectureCommand.Output.TrimEnd('\n', '\r'); // trim line endings because 'uname -m' command ends with a newline
             }
 
-            SystemInformation systemInformation = new SystemInformation(username, architecture);
+            SystemInformation systemInformation = new SystemInformation(username, architecture, operatingSystem.ConvertToPlatformID());
 
-            var command = _remoteSystem.Shell.ExecuteCommand(PSOutputParser.PSCommandLine, Timeout.InfiniteTimeSpan);
+            PSOutputParser psOutputParser = new PSOutputParser(systemInformation);
+
+            var command = _remoteSystem.Shell.ExecuteCommand(psOutputParser.PSCommandLine, Timeout.InfiniteTimeSpan);
             if (command.ExitCode != 0)
             {
                 throw new CommandFailedException(StringResources.Error_PSFailed);
             }
 
-            return PSOutputParser.Parse(command.Output, systemInformation);
+            return psOutputParser.Parse(command.Output);
         }
 
         /// <inheritdoc/>

--- a/src/SSHDebugPS/SSH/SSHConnection.cs
+++ b/src/SSHDebugPS/SSH/SSHConnection.cs
@@ -66,7 +66,7 @@ namespace Microsoft.SSHDebugPS.SSH
                 architecture = architectureCommand.Output.TrimEnd('\n', '\r'); // trim line endings because 'uname -m' command ends with a newline
             }
 
-            SystemInformation systemInformation = new SystemInformation(username, architecture, operatingSystem.ConvertToPlatformID());
+            SystemInformation systemInformation = new SystemInformation(username, architecture, OperatingSystemStringConverter.ConvertToPlatformID(operatingSystem));
 
             PSOutputParser psOutputParser = new PSOutputParser(systemInformation);
 

--- a/src/SSHDebugTests/PSOutputParserTests.cs
+++ b/src/SSHDebugTests/PSOutputParserTests.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using System;
 using Microsoft.SSHDebugPS;
 using System.Collections.Generic;
 using Xunit;
@@ -10,21 +11,45 @@ namespace SSHDebugTests
     public class PSOutputParserTests
     {
         [Fact]
+        public void PSOutputParser_macOS()
+        {
+            const string username = "username";
+            const string architecture = "x86_64";
+            const string input =
+               "pppppppppp ffffffff rrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrr ARGS\n" +
+               "1          4004     root                             /sbin/launchd\n" +
+               "50         1004004  root                             /System/Library/Frameworks/CoreServices.framework/Versions/A/Frameworks/FSEvents.framework/Versions/A/Support/fseventsd\n" +
+               "70         1004004  root                             /System/Library/Frameworks/CoreServices.framework/Frameworks/Metadata.framework/Support/mds\n" +
+               "83         4004     _timed                           /usr/libexec/timed\n" +
+               "96         80004104 root                             /System/Library/CoreServices/loginwindow.app/Contents/MacOS/loginwindow console\n" +
+               "7835       4104     username                         ps axww -o pid=pppppppppp -o flags=ffffffff -o ruser=rrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrr -o args\n";
+
+            PSOutputParser psOutputParser = new PSOutputParser(new SystemInformation(username, architecture, PlatformID.MacOSX));
+            List<Process> r = psOutputParser.Parse(input);
+            Assert.Equal(5, r.Count);
+            // Testing flags here as PID USER ARGS are tested in the other tests.
+            Assert.Equal(r[0].Flags.Value, (uint)0x4004);
+            Assert.Equal(r[1].Flags.Value, (uint)0x1004004);
+            Assert.Equal(r[4].Flags.Value, (uint)0x80004104);
+        }
+
+        [Fact]
         public void PSOutputParser_Ubuntu14()
         {
             const string username = "greggm";
             const string architecture = "x86_64";
             // example output from ps on a real Ubuntu 14 machine (with many processes removed):
             const string input =
-                "pppppppppp ffffffff rrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrr COMMAND\n" +
-                "         1        0 root                             /sbin/init\n" +
-                "         2        0 root                             [kthreadd]\n" +
-                "       720        0 message+                         dbus-daemon --system --fork\n" +
-                "      2389        0 greggm                           -bash\n" +
-                "      2580        0 root                             /sbin/dhclient -d -sf /usr/lib/NetworkManager/nm-dhcp-client.action -pf /run/sendsigs.omit.d/network-manager.dhclient-eth0.pid -lf /var/lib/NetworkManager/dhclient-d08a482b-ff90-4007-9b13-6500eb94b673-eth0.lease -cf /var/lib/NetworkManager/dhclient-eth0.conf eth0\n" +
-                "      2913        0 greggm                           ps axww -o pid=pppppppppp -o flags=ffffffff -o ruser=rrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrr -o args\n";
+                "pppppppppp rrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrr COMMAND\n" +
+                "         1 root                             /sbin/init\n" +
+                "         2 root                             [kthreadd]\n" +
+                "       720 message+                         dbus-daemon --system --fork\n" +
+                "      2389 greggm                           -bash\n" +
+                "      2580 root                             /sbin/dhclient -d -sf /usr/lib/NetworkManager/nm-dhcp-client.action -pf /run/sendsigs.omit.d/network-manager.dhclient-eth0.pid -lf /var/lib/NetworkManager/dhclient-d08a482b-ff90-4007-9b13-6500eb94b673-eth0.lease -cf /var/lib/NetworkManager/dhclient-eth0.conf eth0\n" +
+                "      2913 greggm                           ps axww -o pid=pppppppppp -o ruser=rrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrr -o args\n";
 
-            List<Process> r = PSOutputParser.Parse(input, new SystemInformation(username, architecture));
+            PSOutputParser psOutputParser = new PSOutputParser(new SystemInformation(username, architecture, PlatformID.Unix));
+            List<Process> r = psOutputParser.Parse(input);
             Assert.Equal(5, r.Count);
 
             uint[] pids = { 1, 2, 720, 2389, 2580 };
@@ -47,10 +72,11 @@ namespace SSHDebugTests
             const string architecture = "x86_64";
             // made up output for what could happen if the fields were all just 1 character in size
             const string input =
-                "A B C D\n" +
-                "9 0 r /sbin/init";
+                "A B C\n" +
+                "9 r /sbin/init";
 
-            List<Process> r = PSOutputParser.Parse(input, new SystemInformation(username, architecture));
+            PSOutputParser psOutputParser = new PSOutputParser(new SystemInformation(username, architecture, PlatformID.Unix));
+            List<Process> r = psOutputParser.Parse(input);
             Assert.Single(r);
             Assert.Equal<uint>(9, r[0].Id);
             Assert.Equal("r", r[0].UserName);
@@ -64,12 +90,13 @@ namespace SSHDebugTests
             const string username = "";
             const string architecture = "";
             const string input =
-                "pppppppppp ffffffff rrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrr COMMAND\n" +
-                "         1        0 root                             /sbin/init\n" +
-                "       720        0                                  dbus-daemon --system --fork\n" +
-                "      2389        0 greggm                           -bash\n";
+                "pppppppppp rrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrr COMMAND\n" +
+                "         1 root                             /sbin/init\n" +
+                "       720                                  dbus-daemon --system --fork\n" +
+                "      2389 greggm                           -bash\n";
 
-            List<Process> r = PSOutputParser.Parse(input, new SystemInformation(username, architecture));
+            PSOutputParser psOutputParser = new PSOutputParser(new SystemInformation(username, architecture, PlatformID.Unix));
+            List<Process> r = psOutputParser.Parse(input);
             Assert.Equal(3, r.Count);
 
             uint[] pids = { 1, 720, 2389 };

--- a/tools/Setup.csx
+++ b/tools/Setup.csx
@@ -195,17 +195,10 @@ class Setup {
                 {
                     vscodeExtensionPath = Path.Join(Environment.GetEnvironmentVariable("HOME"), ".vscode/extensions");
                 }
-                IEnumerable<string> extensions = Directory.EnumerateDirectories(vscodeExtensionPath);
+                IEnumerable<string> extensions = Directory.EnumerateDirectories(vscodeExtensionPath).Where(extension => extension.Contains("ms-vscode.cpptools"));
                 if (extensions.Any())
                 {
-                    foreach (string extension in extensions)
-                    {
-                        if (extension.Contains("ms-vscode.cpptools"))
-                        {
-                            TargetPath = extension;
-                            break;
-                        }
-                    }
+                    TargetPath = extensions.First();
                 }
                 else 
                 {

--- a/tools/Setup.csx
+++ b/tools/Setup.csx
@@ -196,14 +196,20 @@ class Setup {
                     vscodeExtensionPath = Path.Join(Environment.GetEnvironmentVariable("HOME"), ".vscode/extensions");
                 }
                 IEnumerable<string> extensions = Directory.EnumerateDirectories(vscodeExtensionPath);
-
-                foreach (string extension in extensions)
+                if (extensions.Any())
                 {
-                    if (extension.Contains("ms-vscode.cpptools"))
+                    foreach (string extension in extensions)
                     {
-                        TargetPath = extension;
-                        break;
+                        if (extension.Contains("ms-vscode.cpptools"))
+                        {
+                            TargetPath = extension;
+                            break;
+                        }
                     }
+                }
+                else 
+                {
+                    throw new InvalidOperationException("Unable to find an installation of VS Code C++ Extension.");
                 }
             }
         }
@@ -217,7 +223,7 @@ class Setup {
 
         if (Client == Client.VS)
         {
-            listFilePath = Path.Join(scriptDirectoryPath, "VS.CodeSpaces.list");
+            listFilePath = Path.Join(scriptDirectoryPath, "VS.list");
             // Use <Configuration> folder.
             binDirectoryPath = Path.Join(binDirectoryPath, Configuration.ToString());
         }
@@ -225,13 +231,12 @@ class Setup {
         {
             listFilePath = Path.Join(scriptDirectoryPath, "VSCode.list");
             // Use Desktop.<Configuration> folder.
-            binDirectoryPath = Path.Join(binDirectoryPath, "Desktop." + Configuration.ToString());
+            binDirectoryPath = Path.Join(binDirectoryPath, Configuration.ToString());
         }
 
         if (!Directory.Exists(binDirectoryPath))
         {
-            string configurationToUse = Client == Client.VS ? Configuration.ToString() : "Desktop." + Configuration.ToString();
-            throw new InvalidOperationException(string.Format("'{0}' does not exist. Did you build {1}?", binDirectoryPath, configurationToUse));
+            throw new InvalidOperationException(string.Format("'{0}' does not exist. Did you build {1}?", binDirectoryPath, Configuration.ToString()));
         }
 
         IList<ListFileFormat> lffList = this.ParseListFiles(listFilePath);

--- a/tools/VS.CodeSpaces.list
+++ b/tools/VS.CodeSpaces.list
@@ -1,8 +1,0 @@
-# filename,source-root,source-dir,install-dir
-# Where 'source-root' is either 'src', or 'bin'
-Microsoft.MICore.dll,bin,,\Common7\IDE\CommonExtensions\Microsoft\MDD\Debugger
-Microsoft.MIDebugEngine.dll,bin,,\Common7\IDE\CommonExtensions\Microsoft\MDD\Debugger
-OpenDebugAD7.exe,bin,vscode,\Common7\IDE\CommonExtensions\Microsoft\MDD\Debugger\vscode
-Microsoft.DebugEngineHost.dll,bin,vscode,\Common7\IDE\CommonExtensions\Microsoft\MDD\Debugger\vscode
-Microsoft.VisualStudio.Shared.VSCodeDebugProtocol.dll,bin,vscode,\Common7\IDE\CommonExtensions\Microsoft\MDD\Debugger\vscode
-cppdbg.ad7Engine.json,src,OpenDebugAD7,\Common7\IDE\CommonExtensions\Microsoft\MDD\Debugger\vscode

--- a/tools/VS.list
+++ b/tools/VS.list
@@ -1,0 +1,16 @@
+# filename,source-root,source-dir,install-dir
+# Where 'source-root' is either 'src', or 'bin'
+Microsoft.Android.natvis,src,AndroidDebugLauncher,\Common7\IDE\CommonExtensions\Microsoft\MDD\Debugger
+Microsoft.AndroidDebugLauncher.dll,bin,,\Common7\IDE\CommonExtensions\Microsoft\MDD\Debugger
+Microsoft.AndroidDebugLauncher.pkgdef,bin,,\Common7\IDE\CommonExtensions\Microsoft\MDD\Debugger
+Microsoft.DebugEngineHost.dll,bin,,\Common7\IDE\CommonExtensions\Microsoft\MDD\Debugger
+Microsoft.IOSDebugLauncher.dll,bin,,\Common7\IDE\CommonExtensions\Microsoft\MDD\Debugger
+Microsoft.IOSDebugLauncher.pkgdef,bin,,\Common7\IDE\CommonExtensions\Microsoft\MDD\Debugger
+Microsoft.JDbg.dll,bin,,\Common7\IDE\CommonExtensions\Microsoft\MDD\Debugger
+Microsoft.MICore.dll,bin,,\Common7\IDE\CommonExtensions\Microsoft\MDD\Debugger
+Microsoft.MICore.XmlSerializers.dll,bin,,\Common7\IDE\CommonExtensions\Microsoft\MDD\Debugger
+Microsoft.MIDebugEngine.dll,bin,,\Common7\IDE\CommonExtensions\Microsoft\MDD\Debugger
+Microsoft.MIDebugEngine.pkgdef,bin,,\Common7\IDE\CommonExtensions\Microsoft\MDD\Debugger
+Microsoft.SSHDebugPS.dll,bin,,\Common7\IDE\CommonExtensions\Microsoft\MDD\Debugger
+Microsoft.SSHDebugPS.pkgdef,bin,,\Common7\IDE\CommonExtensions\Microsoft\MDD\Debugger
+OpenFolderSchema.json,bin,,\Common7\IDE\CommonExtensions\Microsoft\MDD\Debugger


### PR DESCRIPTION
This PR adds in an operating system check via uname to determine if we should run the PS command with the 'flags' flag. This feature was originally used to determine the architecture of a process for macOS M1 machines that can run as x64 or as arm64.

AD7Process only uses the flags field in macOS so this PR updates the command sent to only use it on macOS machines.

Other changes:
- Updated the setup.csx script to update VS with VS.list instead of VS.Codespaces.list
- Updated tests to use the new PSOutputParser
- Added a macOS test


Testing:
- [X] macOS SSH
- [X] WSL Ubuntu