### PR TITLE
Fixing File writing for EngineLogger (#1415)

### DIFF
--- a/src/DebugEngineHost/HostLogger.cs
+++ b/src/DebugEngineHost/HostLogger.cs
@@ -54,7 +54,9 @@ namespace Microsoft.DebugEngineHost
 
         public static void Reset()
         {
+            s_natvisLogChannel?.Close();
             s_natvisLogChannel = null;
+            s_engineLogChannel?.Close();
             s_engineLogChannel = null;
         }
     }

--- a/src/MIDebugEngine/MIDebugCommandDispatcher.cs
+++ b/src/MIDebugEngine/MIDebugCommandDispatcher.cs
@@ -4,6 +4,7 @@
 using MICore;
 using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
@@ -89,6 +90,23 @@ namespace Microsoft.MIDebugEngine
 
         public static void EnableLogging(bool output, string logFile)
         {
+            if (!string.IsNullOrEmpty(logFile))
+            {
+                string tempDirectory = Path.GetTempPath();
+                if (Path.IsPathRooted(logFile) || (!string.IsNullOrEmpty(tempDirectory) && Directory.Exists(tempDirectory)))
+                {
+                    string filePath = Path.Combine(tempDirectory, logFile);
+
+                    File.CreateText(filePath).Dispose(); // Test to see if we can create a text file in HostLogChannel. This will allow the error to be shown when enabling the setting.
+
+                    logFile = filePath;
+                }
+                else
+                {
+                    throw new ArgumentOutOfRangeException(nameof(logFile));
+                }
+            }
+
             Logger.CmdLogInfo.logFile = logFile;
             if (output)
                 Logger.CmdLogInfo.logToOutput = WriteLogToOutput;

--- a/src/MIDebugPackage/MIDebugPackagePackage.cs
+++ b/src/MIDebugPackage/MIDebugPackagePackage.cs
@@ -403,6 +403,16 @@ namespace Microsoft.MIDebugPackage
         private void EnableLogging(bool sendToOutputWindow, string logFile)
         {
             ThreadHelper.ThrowIfNotOnUIThread();
+
+            IVsDebugger debugger = (IVsDebugger)GetService(typeof(IVsDebugger));
+            DBGMODE[] mode = new DBGMODE[] { DBGMODE.DBGMODE_Design };
+            int hr = debugger.GetMode(mode);
+
+            if (hr == VSConstants.S_OK && mode[0] != DBGMODE.DBGMODE_Design)
+            {
+                throw new ArgumentException("Unable to update MIDebugLog while debugging.");
+            }
+
             try
             {
                 MIDebugCommandDispatcher.EnableLogging(sendToOutputWindow, logFile);

--- a/tools/Setup.csx
+++ b/tools/Setup.csx
@@ -218,7 +218,7 @@ class Setup {
         {
             listFilePath = Path.Join(scriptDirectoryPath, "VS.list");
             // Use <Configuration> folder.
-            binDirectoryPath = Path.Join(binDirectoryPath, Configuration.ToString());
+            binDirectoryPath = Path.Join(binDirectoryPath, "Lab." + Configuration.ToString());
         }
         else if (Client == Client.VSCode)
         {

--- a/tools/VS.list
+++ b/tools/VS.list
@@ -11,6 +11,8 @@ Microsoft.MICore.dll,bin,,\Common7\IDE\CommonExtensions\Microsoft\MDD\Debugger
 Microsoft.MICore.XmlSerializers.dll,bin,,\Common7\IDE\CommonExtensions\Microsoft\MDD\Debugger
 Microsoft.MIDebugEngine.dll,bin,,\Common7\IDE\CommonExtensions\Microsoft\MDD\Debugger
 Microsoft.MIDebugEngine.pkgdef,bin,,\Common7\IDE\CommonExtensions\Microsoft\MDD\Debugger
+Microsoft.MIDebugPackage.dll,bin,,\Common7\IDE\CommonExtensions\Microsoft\MDD\Debugger
+Microsoft.MIDebugPackage.pkgdef,bin,,\Common7\IDE\CommonExtensions\Microsoft\MDD\Debugger
 Microsoft.SSHDebugPS.dll,bin,,\Common7\IDE\CommonExtensions\Microsoft\MDD\Debugger
 Microsoft.SSHDebugPS.pkgdef,bin,,\Common7\IDE\CommonExtensions\Microsoft\MDD\Debugger
 OpenFolderSchema.json,bin,,\Common7\IDE\CommonExtensions\Microsoft\MDD\Debugger


### PR DESCRIPTION
* Fixing File writing for EngineLogger

With the Natvis Diagnostics Logger work, the file logger would fail since it would not close the file.

This PR also runs 'File.CreateText' in MIDebugCommandDispatcher so errors can be caught earlier and not set an invalid file path.