### PR TITLE
Get all startup msgs into log file

### DIFF
--- a/src/MIDebugEngine/AD7.Impl/AD7Engine.cs
+++ b/src/MIDebugEngine/AD7.Impl/AD7Engine.cs
@@ -189,7 +189,7 @@ namespace Microsoft.MIDebugEngine
         {
             Debug.Assert(_ad7ProgramId == Guid.Empty);
 
-            Logger.LoadMIDebugLogger();
+            Logger.EnsureInitialized();
 
             if (celtPrograms != 1)
             {
@@ -539,7 +539,7 @@ namespace Microsoft.MIDebugEngine
             Debug.Assert(_ad7ProgramId == Guid.Empty);
 
             // Check if the logger was enabled late.
-            Logger.LoadMIDebugLogger();
+            Logger.EnsureInitialized();
 
             process = null;
 


### PR DESCRIPTION
All message before the AD7EngineCreateEvent were being deleted from the engine log.