### PR TITLE
mark logger not initialized on close

### DIFF
--- a/src/MICore/Logger.cs
+++ b/src/MICore/Logger.cs
@@ -97,6 +97,7 @@ namespace MICore
             {
                 HostLogger.Reset();
                 s_isEnabled = false;
+                s_isInitialized = false;
             }
         }
 


### PR DESCRIPTION
Logging only gets marked as enabled once; after closing the log the first time it will never get opened again. This fixes the problem by marking the logger uninitialized when reset.