### PR TITLE
Address .NET 8 SDK Build issues

### DIFF
--- a/src/SSHDebugPS/SSHDebugPS.csproj
+++ b/src/SSHDebugPS/SSHDebugPS.csproj
@@ -13,7 +13,7 @@
     <TargetFramework>net472</TargetFramework>
     <UseWPF>true</UseWPF>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-    <IncludePackageReferencesDuringMarkupCompilation>false</IncludePackageReferencesDuringMarkupCompilation>
+    <IncludePackageReferencesDuringMarkupCompilation>true</IncludePackageReferencesDuringMarkupCompilation>
   </PropertyGroup>
 
   <Import Project="..\..\build\Debugger.PIAs.NonPortable.Packages.settings.targets" />


### PR DESCRIPTION
This PR addresses issues building MIEngine with .NET 8 SDK.

See https://github.com/dotnet/sdk/issues/34438