### PR TITLE
MIEngine: Array evaluation and address check

### DIFF
--- a/src/MIDebugEngine/AD7.Impl/AD7Disassembly.cs
+++ b/src/MIDebugEngine/AD7.Impl/AD7Disassembly.cs
@@ -34,8 +34,14 @@ namespace Microsoft.MIDebugEngine
         public int GetCodeLocationId(IDebugCodeContext2 pCodeContext, out ulong puCodeLocationId)
         {
             AD7MemoryAddress addr = pCodeContext as AD7MemoryAddress;
-            puCodeLocationId = addr.Address;
-            return Constants.S_OK;
+            if (addr != null)
+            {
+                puCodeLocationId = addr.Address;
+                return Constants.S_OK;
+            }
+
+            puCodeLocationId = 0;
+            return Constants.S_FALSE;
         }
 
         public int GetCurrentLocation(out ulong puCodeLocationId)

--- a/src/MIDebugEngine/AD7.Impl/AD7Disassembly.cs
+++ b/src/MIDebugEngine/AD7.Impl/AD7Disassembly.cs
@@ -41,7 +41,7 @@ namespace Microsoft.MIDebugEngine
             }
 
             puCodeLocationId = 0;
-            return Constants.S_FALSE;
+            return Constants.E_FAIL;
         }
 
         public int GetCurrentLocation(out ulong puCodeLocationId)

--- a/src/MIDebugEngine/AD7.Impl/AD7Property.cs
+++ b/src/MIDebugEngine/AD7.Impl/AD7Property.cs
@@ -242,8 +242,7 @@ namespace Microsoft.MIDebugEngine
                 {
                     return AD7_HRESULT.S_GETMEMORYCONTEXT_NO_MEMORY_CONTEXT;
                 }
-                AD7Property propArray = new AD7Property(_engine, viArray);
-                v = propArray._variableInformation.Value;
+                v = viArray.Value;
                 v.Trim();
                 if (v.Length == 0)
                 {

--- a/src/MIDebugEngine/AD7.Impl/AD7Property.cs
+++ b/src/MIDebugEngine/AD7.Impl/AD7Property.cs
@@ -229,11 +229,38 @@ namespace Microsoft.MIDebugEngine
             {
                 return AD7_HRESULT.S_GETMEMORYCONTEXT_NO_MEMORY_CONTEXT;
             }
-            v = v.Trim();
+
+            if ((v[0] == '[') && (v[v.Length-1] == ']'))
+            {
+                // this is an array evaluation result from GDB, which does not contain an address
+                // VS on the other hand supports direct array evaluations without address operator
+                // therefore we need to re-evaluate with an address operator
+                //
+                VariableInformation viArray = new VariableInformation("&(" + _variableInformation.FullName() + ")", (VariableInformation)_variableInformation);
+                viArray.SyncEval();
+                if (viArray.Error)
+                {
+                    return AD7_HRESULT.S_GETMEMORYCONTEXT_NO_MEMORY_CONTEXT;
+                }
+                AD7Property propArray = new AD7Property(_engine, viArray);
+                v = propArray._variableInformation.Value;
+                v.Trim();
+                if (v.Length == 0)
+                {
+                    return AD7_HRESULT.S_GETMEMORYCONTEXT_NO_MEMORY_CONTEXT;
+                }
+            }
+
             if (v[0] == '{')
             {
+                var index = v.IndexOf('}');
+                if (index == -1)
+                {
+                    // syntax error!
+                    return AD7_HRESULT.S_GETMEMORYCONTEXT_NO_MEMORY_CONTEXT;
+                }
                 // strip type name and trailing spaces
-                v = v.Substring(v.IndexOf('}') + 1);
+                v = v.Substring(index+1);
                 v = v.Trim();
             }
             int i = v.IndexOf(' ');


### PR DESCRIPTION
Issue description & fix:

Issue 1
When the address is not an AD7Memory address, we get a null reference exception while assigning puCodeLocationId.
![image](https://github.com/microsoft/MIEngine/assets/86831308/3c80274b-af16-4330-8c68-20f2b6db5acd)

Fix
The fix is to add a null reference check for this condition.

Issue 2 
We would like to evaluate array addresses in Memory View. This was not possible without evaluating without an address operator.
![image](https://github.com/microsoft/MIEngine/assets/86831308/81a6873f-2bcd-4e8a-b73e-2f7a89eb23aa)

Fix
For variable information value that looks like [], re-evaluate with address operator.
![image](https://github.com/microsoft/MIEngine/assets/86831308/5f89fbf1-342c-46d9-bfe5-a40b4fd22a61)
![image](https://github.com/microsoft/MIEngine/assets/86831308/fd17c2bf-acef-4ec3-a13e-081f4770d472)

With this change we can evaluate an array address.
![image](https://github.com/microsoft/MIEngine/assets/86831308/a632c9a8-dc34-462d-97c1-0ff0c565b7c9)

Signed-off-by: intel-rganesh [rakesh.ganesh@intel.com](mailto:rakesh.ganesh@intel.com)