### PR TITLE
Reverse sort sourceMap

### DIFF
--- a/src/MICore/LaunchOptions.cs
+++ b/src/MICore/LaunchOptions.cs
@@ -370,7 +370,7 @@ namespace MICore
 
         public static ReadOnlyCollection<SourceMapEntry> CreateCollection(Dictionary<string, object> source)
         {
-            IList<SourceMapEntry> sourceMaps = new List<SourceMapEntry>(source.Keys.Count);
+            var sourceMaps = new List<SourceMapEntry>(source.Keys.Count);
 
             foreach (var item in source)
             {
@@ -416,6 +416,7 @@ namespace MICore
                     throw new InvalidLaunchOptionsException(String.Format(CultureInfo.CurrentCulture, MICoreResources.Error_SourceFileMapInvalidEditorPath));
                 }
             }
+            sourceMaps.Sort((x, y) => string.CompareOrdinal(y.CompileTimePath, x.CompileTimePath));
             return new ReadOnlyCollection<SourceMapEntry>(sourceMaps);
         }
     }

--- a/src/MICore/LaunchOptions.cs
+++ b/src/MICore/LaunchOptions.cs
@@ -416,7 +416,11 @@ namespace MICore
                     throw new InvalidLaunchOptionsException(String.Format(CultureInfo.CurrentCulture, MICoreResources.Error_SourceFileMapInvalidEditorPath));
                 }
             }
+
+            // Ensure the map is sorted such that more specific directories are in front of less specific by sorting the map
+            // in descending order of the compile time path
             sourceMaps.Sort((x, y) => string.CompareOrdinal(y.CompileTimePath, x.CompileTimePath));
+            
             return new ReadOnlyCollection<SourceMapEntry>(sourceMaps);
         }
     }


### PR DESCRIPTION
Do reverse sort of the `sourceMap`.

In my `launch.json` configuration I have the following `sourceFileMap`:
```
            "sourceFileMap": {
                "/usr/src/debug/my-project/git-r0/build/src/../../git": "${workspaceFolder}",
                "/usr/src/debug": {
                    "editorPath": "${config:YOCTO_ARCH}",
                    "useForBreakpoints": false
                }
            },
```

The YOCTO_ARCH set in `settings.json` to:
```
    "terminal.integrated.env.linux": {
        "YOCTO_ARCH": "/home/mouse/linux-bsp/linux-devel-build/build/work/cortexa7t2hf-neon-vfpv4_linux-linux-gnueabi"
    },
```

The proposed change addresses an issue encountered while debugging a binary that's running on a remote system and built using Yocto. Currently, when debugging, the source files are being referenced from the Yocto build tree instead of the local workspace. This issue prevents setting breakpoints effectively in the local workspace source files.

To resolve this, the change involves modifying the way source mappings are processed. Specifically, it proposes sorting the mappings in reverse order, starting with the longer, more specific paths and moving towards the more general ones. By doing this, the debugger will first consider the project-specific paths defined in `sourceFileMap`. If it doesn't find a match there, it will then fall back to the more general paths. This reverse sorting ensures that the local workspace sources are prioritized over the Yocto build tree sources, allowing for effective breakpoint setting and debugging in the local workspace.