### PR TITLE
Fix missing s32 format specifier support

### DIFF
--- a/src/MIDebugEngine/Engine.Impl/Variables.cs
+++ b/src/MIDebugEngine/Engine.Impl/Variables.cs
@@ -425,6 +425,9 @@ namespace Microsoft.MIDebugEngine
                 case "su":
                 case "sub":
                     return "(const char16_t*)(" + exp.Substring(0, lastComma) + ")";
+                case "s32":
+                case "s32b":
+                    return "(const char32_t*)(" + exp.Substring(0, lastComma) + ")";
                 case "c":
                     return "(char)(" + exp.Substring(0, lastComma) + ")";
                 // just remove and ignore these


### PR DESCRIPTION
https://learn.microsoft.com/en-us/visualstudio/debugger/format-specifiers-in-cpp?view=vs-2022
the `s32` and `s32b` format specifiers for unicode 32-bit strings were not being parsed, I have added them. 
