### PR TITLE
MIEngine: Fix multi-breakpoint gdb/mi information parsing

### DIFF
--- a/src/MIDebugEngine/Engine.Impl/BreakpointManager.cs
+++ b/src/MIDebugEngine/Engine.Impl/BreakpointManager.cs
@@ -58,20 +58,13 @@ namespace Microsoft.MIDebugEngine
             string bkptId = null;
             //
             // =breakpoint-modified,
-            //    bkpt ={number="2",type="breakpoint",disp="keep",enabled="y",addr="<MULTIPLE>",times="0",original-location="main.cpp:220"},
+            //    bkpt ={number="2",type="breakpoint",disp="keep",enabled="y",addr="<MULTIPLE>",times="0",original-location="main.cpp:220"},locations=[
             //          { number="2.1",enabled="y",addr="0x9c2149a9",func="Foo::bar<int>(int)",file="main.cpp",fullname="C:\\\\...\\\\main.cpp",line="220",thread-groups=["i1"]},
-            //          { number="2.2",enabled="y",addr="0x9c2149f2",func="Foo::bar<float>(float)",file="main.cpp",fullname="C:\\\\...\\\\main.cpp",line="220",thread-groups=["i1"]}
+            //          { number="2.2",enabled="y",addr="0x9c2149f2",func="Foo::bar<float>(float)",file="main.cpp",fullname="C:\\\\...\\\\main.cpp",line="220",thread-groups=["i1"]}]}
             // note: the ".x" part of the breakpoint number never appears in stopping events, that is, when executing at one of these addresses 
             //       the stopping event delivered contains bkptno="2"
-            if (bkpt is MICore.ValueListValue)
-            {
-                MICore.ValueListValue list = bkpt as MICore.ValueListValue;
-                bkptId = list.Content[0].FindString("number"); // 0 is the "<MULTIPLE>" entry
-            }
-            else
-            {
-                bkptId = bkpt.FindString("number");
-            }
+            bkptId = bkpt.FindString("number");
+
             AD7PendingBreakpoint pending = CodeBreakpoints.FirstOrDefault((p) => { return p.BreakpointId == bkptId; });
             if (pending == null)
             {

--- a/test/CppTests/Tests/BreakpointTests.cs
+++ b/test/CppTests/Tests/BreakpointTests.cs
@@ -125,7 +125,7 @@ namespace CppTests.Tests
                 runner.Launch(settings.DebuggerSettings, debuggee, "-fCalling");
 
                 this.Comment("Set initial function breakpoints");
-                FunctionBreakpoints functionBreakpoints = new FunctionBreakpoints("Arguments::CoreRun", "Calling::CoreRun", "a()");
+                FunctionBreakpoints functionBreakpoints = new FunctionBreakpoints("Arguments::CoreRun", "Calling::CoreRun", "a");
                 runner.SetFunctionBreakpoints(functionBreakpoints);
 
                 this.Comment("Launch and run until first initial breakpoint");
@@ -137,7 +137,7 @@ namespace CppTests.Tests
                               .AfterContinue();
 
                 this.Comment("Remove and replace third initial function breakpoint while in break mode");
-                functionBreakpoints.Remove("a()");
+                functionBreakpoints.Remove("a");
                 functionBreakpoints.Add("b()");
                 runner.SetFunctionBreakpoints(functionBreakpoints);
 

--- a/test/CppTests/debuggees/kitchensink/src/calling.cpp
+++ b/test/CppTests/debuggees/kitchensink/src/calling.cpp
@@ -53,3 +53,9 @@ void Calling::CoreRun()
     double ave = average(10, 1.0, 3.0, 4.5, 11.0, -30.0, 17.4, 2.1, -4.0, 0.0, 12.1);
     this->Log("Average ", ave);
 }
+
+int a(int count)
+{
+    b();
+    return count - 1;
+}


### PR DESCRIPTION
This PR fixes gdb/mi breakpoint information parsing for breakpoints that bind to multiple locations, which have a "\<MULTIPLE\>" in the addr field. According to https://sourceware.org/gdb/onlinedocs/gdb/GDB_002fMI-Breakpoint-Information.html#GDB_002fMI-Breakpoint-Information the locations field contains the list of locations for this breakpoint type. This list of locations is used then to create the bound breakpoints for the specific breakpoint.

Signed-off-by: Andria Pazarloglou <androniki.pazarloglou@intel.com>
