### PR TITLE
MIEngine: New methods and framework update

### DIFF
--- a/src/MIDebugEngine/Engine.Impl/DebuggedThread.cs
+++ b/src/MIDebugEngine/Engine.Impl/DebuggedThread.cs
@@ -150,6 +150,9 @@ namespace Microsoft.MIDebugEngine
 
         internal async Task<ThreadContext> GetThreadContext(DebuggedThread thread)
         {
+            if (thread == null)
+                return null;
+
             lock (_threadList)
             {
                 if (_topContext.ContainsKey(thread.Id))

--- a/src/MIDebugEngine/MIDebugCommandDispatcher.cs
+++ b/src/MIDebugEngine/MIDebugCommandDispatcher.cs
@@ -41,7 +41,7 @@ namespace Microsoft.MIDebugEngine
             return GetLastProcess().ProcessState;
         }
 
-        public static async Task<Results> SetSelectedThread(int threadId)
+        public static async Task<Results> ViewSelectedThreadInfo(int threadId)
         {
             GetLastProcess().MICommandFactory.DefineCurrentThread(threadId);
             return await Task.FromResult<Results>(new Results(ResultClass.done));
@@ -60,7 +60,7 @@ namespace Microsoft.MIDebugEngine
             }
             else
             {
-                return null;
+                throw new ArgumentOutOfRangeException(nameof(command));
             }
         }
 

--- a/src/MIDebugEngine/MIDebugCommandDispatcher.cs
+++ b/src/MIDebugEngine/MIDebugCommandDispatcher.cs
@@ -41,12 +41,6 @@ namespace Microsoft.MIDebugEngine
             return GetLastProcess().ProcessState;
         }
 
-        public static async Task<Results> ViewSelectedThreadInfo(int threadId)
-        {
-            GetLastProcess().MICommandFactory.DefineCurrentThread(threadId);
-            return await Task.FromResult<Results>(new Results(ResultClass.done));
-        }
-
         public static async Task<Results> ExecuteMICommandWithResultsObject(string command)
         {
             if (string.IsNullOrWhiteSpace(command))

--- a/src/MIDebugEngine/MIDebugCommandDispatcher.cs
+++ b/src/MIDebugEngine/MIDebugCommandDispatcher.cs
@@ -15,6 +15,39 @@ namespace Microsoft.MIDebugEngine
     {
         private readonly static List<DebuggedProcess> s_processes = new List<DebuggedProcess>();
 
+        public static async Task<Results> ExecuteMICommandWithResultsObject(string command)
+        {
+            DebuggedProcess lastProcess;
+            lock (s_processes)
+            {
+                if (s_processes.Count == 0)
+                {
+                    throw new InvalidOperationException(MICoreResources.Error_NoMIDebuggerProcess);
+                }
+
+                lastProcess = s_processes[s_processes.Count - 1];
+            }
+
+            if (string.IsNullOrWhiteSpace(command))
+                throw new ArgumentNullException(nameof(command));
+
+            if (lastProcess == null)
+            {
+                throw new InvalidOperationException(MICoreResources.Error_NoMIDebuggerProcess);
+            }
+
+            command = command.Trim();
+
+            if (command[0] == '-')
+            {
+                return await lastProcess.CmdAsync(command, ResultClass.None);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
         public static Task<string> ExecuteCommand(string command)
         {
             DebuggedProcess lastProcess;

--- a/src/MIDebugPackage/source.extension.vsixmanifest
+++ b/src/MIDebugPackage/source.extension.vsixmanifest
@@ -5,7 +5,7 @@
     <DisplayName>Microsoft MI-based Debugger</DisplayName>
     <Description xml:space="preserve">Provides support for connecting Visual Studio to MI compatible debuggers</Description>
   </Metadata>
-  <Installation InstalledByMsi="false">
+  <Installation InstalledByMsi="false" AllUsers="true">
     <InstallationTarget Id="Microsoft.VisualStudio.Pro" Version="[15.0, 17.0)" />
     <InstallationTarget Id="Microsoft.VisualStudio.Community" Version="[15.0, 17.0)" />
   </Installation>

--- a/src/WindowsDebugLauncher/WindowsDebugLauncher.csproj
+++ b/src/WindowsDebugLauncher/WindowsDebugLauncher.csproj
@@ -13,7 +13,7 @@
     <StartAction>Program</StartAction>
     <OutputPath>$(MIDefaultOutputPath)\vscode</OutputPath>
     <DropSubDir>vscode</DropSubDir>
-    <TargetFramework>net462</TargetFramework>
+    <TargetFramework>net472</TargetFramework>
     <OutputType>Exe</OutputType>
     <Externalconsole>true</Externalconsole>
   </PropertyGroup>


### PR DESCRIPTION
This PR covers the following commits:

- Add null condition check in DebuggedThread.GetThreadContext​
- Add a method to get the process state of the last process​ and another method that sets the selected thread
- Updating .net target framework to net472 for WindowsDebugLauncher​
- Correct VSIX file so that plugin integration is performed for ALL users​
- Option to execute MI Commands using CmdAsync alone without result-class

Signed-off-by: intel-rganesh [rakesh.ganesh@intel.com](mailto:rakesh.ganesh@intel.com)




