### PR TITLE
Migrate Release Pipelines to 1ES

### DIFF
--- a/eng/pipelines/VS-release.yml
+++ b/eng/pipelines/VS-release.yml
@@ -2,11 +2,40 @@
 name: $(Date:yyyMMdd).$(Rev:r)
 variables:
   - group: TSDTUSR
-jobs:
-- template: ./jobs/VSEngSS-MicroBuild2022-1ES.job.yml
-  parameters:
-    DisplayName: 'VS_Release'
-    JobTemplate:
-    - template: ../templates/VS-release.template.yml
 
+resources:
+  repositories:
+  - repository: MicroBuildTemplate
+    type: git
+    name: 1ESPipelineTemplates/MicroBuildTemplate
+    ref: refs/tags/release
+
+extends:
+  template: azure-pipelines/MicroBuild.1ES.Official.yml@MicroBuildTemplate
+  parameters:
+    pool:
+      name: VSEngSS-MicroBuild2022-1ES
+      os: windows
+    sdl:
+      sourceAnalysisPool:
+        name: VSEngSS-MicroBuild2022-1ES
+        os: windows 
+    stages:
+    - stage: stage
+      displayName: VS_Release
+      jobs:
+      - job: Phase_1
+        displayName: VS_Release
+        timeoutInMinutes: 180
+        cancelTimeoutInMinutes: 1
+        templateContext:
+          mb:
+            signing:
+              enabled: true
+              signType: real
+              zipSources: false
+            localization:
+              enabled: true
+        steps:
+        - template: /eng/pipelines/templates/VS-release.template.yml@self
 ...

--- a/eng/pipelines/VSCode-release.yml
+++ b/eng/pipelines/VSCode-release.yml
@@ -2,31 +2,57 @@
 name: $(Date:yyyMMdd).$(Rev:r)
 variables:
   - group: TSDTUSR
-stages:
-- stage: Windows
-  dependsOn: []
-  jobs:
-  - template: ./jobs/VSEngSS-MicroBuild2022-1ES.job.yml
-    parameters:
-      DisplayName: 'VSCode_Release'
-      JobTemplate:
-      - template: ../templates/VSCode-release.template.yml
 
-- stage: OSX_CodeSign
-  dependsOn: [Windows]
-  jobs:
-  - template: ./jobs/MSHosted-OSX.job.yml
-    parameters:
-      DisplayName: 'OSX Sign/Harden'
-      JobTemplate:
-      - template: ../templates/VSCode-codesign-osx.template.yml
+resources:
+  repositories:
+  - repository: MicroBuildTemplate
+    type: git
+    name: 1ESPipelineTemplates/MicroBuildTemplate
+    ref: refs/tags/release
 
-- stage: OSX_ESRPSign
-  dependsOn: [OSX_CodeSign]
-  jobs:
-  - template: ./jobs/VSEngSS-MicroBuild2022-1ES.job.yml
-    parameters:
-      DisplayName: 'OSX Sign/Harden'
-      JobTemplate:
-      - template: ../templates/VSCode-esrp-sign-osx.template.yml
+extends:
+  template: azure-pipelines/MicroBuild.1ES.Official.yml@MicroBuildTemplate
+  parameters:
+    pool:
+      name: VSEngSS-MicroBuild2022-1ES
+      os: windows
+    sdl:
+      sourceAnalysisPool:
+        name: VSEngSS-MicroBuild2022-1ES
+        os: windows 
+    stages:
+    - stage: Windows
+      jobs:
+      - job: 
+        displayName: Windows
+        timeoutInMinutes: 180
+        cancelTimeoutInMinutes: 1
+        templateContext:
+          mb:
+            signing:
+              enabled: true
+              signType: real
+              zipSources: false
+            localization:
+              enabled: true
+        steps:
+        - template: /eng/pipelines/templates/VSCode-release.template.yml@self
+
+    - stage: OSX_CodeSign
+      dependsOn: [Windows]
+      jobs:
+      - template: /eng/pipelines/jobs/MSHosted-OSX.job.yml@self
+        parameters:
+          DisplayName: 'OSX Sign/Harden'
+          JobTemplate:
+          - template: ../templates/VSCode-codesign-osx.template.yml
+
+    - stage: OSX_ESRPSign
+      dependsOn: [OSX_CodeSign]
+      jobs:
+      - template: /eng/pipelines/jobs/VSEngSS-MicroBuild2022-1ES.job.yml@self
+        parameters:
+          DisplayName: 'OSX Sign/Harden'
+          JobTemplate:
+          - template: ../templates/VSCode-esrp-sign-osx.template.yml
 ...

--- a/eng/pipelines/jobs/MSHosted-OSX.job.yml
+++ b/eng/pipelines/jobs/MSHosted-OSX.job.yml
@@ -9,7 +9,9 @@ jobs:
 - job:
   displayName: ${{ parameters.DisplayName }}
   pool:
+    name: Azure Pipelines
     vmImage: 'macOS-latest'
+    os: macOS
   steps:
   - ${{ parameters.JobTemplate }}
 ...

--- a/eng/pipelines/steps/BuildSolution.yml
+++ b/eng/pipelines/steps/BuildSolution.yml
@@ -31,15 +31,17 @@ steps:
       "SIGN_TYPE": "$(SignType)" 
     } 
 
-- template: ../tasks/PublishPipelineArtifact.yml
+- template: ../tasks/1ES/PublishPipelineArtifact.yml
   parameters:
+    displayName: 'Publish binlogs'
+    targetPath: '$(Build.BinariesDirectory)/build_logs/'
     artifactName: '${{ parameters.Configuration }}_binlog'
-    path: '$(Build.BinariesDirectory)/build_logs/'
     condition: ne(variables['System.Debug'], '')
 
-- template: ../tasks/PublishPipelineArtifact.yml
+- template: ../tasks/1ES/PublishPipelineArtifact.yml
   parameters:
+    displayName: 'Publish debug binaries'
+    targetPath: '$(Build.SourcesDirectory)\bin\${{ parameters.Configuration }}'
     artifactName: '${{ parameters.Configuration }}_debug_bin'
-    path: '$(Build.SourcesDirectory)\bin\${{ parameters.Configuration }}'
     condition: ne(variables['System.Debug'], '')
 ...

--- a/eng/pipelines/steps/CollectAndPublishBinaries.yml
+++ b/eng/pipelines/steps/CollectAndPublishBinaries.yml
@@ -13,9 +13,9 @@ steps:
     CleanTargetFolder: true
     OverWrite: true
 
-- template: ../tasks/PublishPipelineArtifact.yml
+- template: ../tasks/1ES/PublishPipelineArtifact.yml
   parameters:
     displayName: 'Publish Binaries'
-    path: ${{ parameters.TargetFolder }}
-    artifactName: '${{ parameters.ArtifactName }}'
+    targetPath: ${{ parameters.TargetFolder }}
+    artifactName:  '${{ parameters.ArtifactName }}'
 ...

--- a/eng/pipelines/steps/CollectAndPublishBinaries.yml
+++ b/eng/pipelines/steps/CollectAndPublishBinaries.yml
@@ -17,5 +17,5 @@ steps:
   parameters:
     displayName: 'Publish Binaries'
     targetPath: ${{ parameters.TargetFolder }}
-    artifactName:  '${{ parameters.ArtifactName }}'
+    artifactName: '${{ parameters.ArtifactName }}'
 ...

--- a/eng/pipelines/steps/CopyAndPublishSymbols.yml
+++ b/eng/pipelines/steps/CopyAndPublishSymbols.yml
@@ -27,9 +27,9 @@ steps:
     SearchPattern: '**\*.pdb'
     SymbolServerType: TeamServices
 
-- template: ../tasks/PublishPipelineArtifact.yml
+- template: ../tasks/1ES/PublishPipelineArtifact.yml
   parameters:
     displayName: 'Publish Symbols'
-    path: '$(Build.ArtifactStagingDirectory)/symbols' 
+    targetPath: '$(Build.ArtifactStagingDirectory)/symbols' 
     artifactName: 'Symbols'
 ...

--- a/eng/pipelines/steps/PackAndPublishVSPackages.yml
+++ b/eng/pipelines/steps/PackAndPublishVSPackages.yml
@@ -12,10 +12,10 @@ steps:
     echo ##vso[task.setvariable variable=NugetPackageVersion;]%NugetPackageVersion%
   displayName: 'Get NuGet Version'
 
-- template: ../tasks/PublishPipelineArtifact.yml
+- template: ../tasks/1ES/PublishPipelineArtifact.yml
   parameters:
     displayName: 'Publish File Version'
-    path: '$(Build.SourcesDirectory)\obj\Lab.Release\NugetPackageVersion.txt' 
+    targetPath: '$(Build.SourcesDirectory)\obj\Lab.Release\NugetPackageVersion.txt'
     artifactName: 'PackageVersion'
 
 - template: ../tasks/NuGetCommand.yml
@@ -27,11 +27,13 @@ steps:
     buildProperties: 'version=$(NugetPackageVersion)'
     basePath: ${{ parameters.BasePath }}
 
-- template: ../tasks/NuGetCommand.yml
-  parameters:
-    displayName: 'NuGet push'
-    command: push
-    searchPatternPush: '$(Build.SourcesDirectory)\VS.Redist.Debugger.MDD.MIEngine.*.nupkg;$(Build.SourcesDirectory)\VS.Redist.Debugger.MDD.UnixPortSupplier.*.nupkg'
-    feedPublish: '97a41293-2972-4f48-8c0e-05493ae82010' # VS
-    condition: and(succeeded(), eq(variables['SignType'], 'real'))
+- task: 1ES.PublishNuget@1
+  displayName: Publish Nuget package
+  condition: and(succeeded(), eq(variables['SignType'], 'real'))
+  inputs:
+    useDotNetTask: false # The default is false to use the NuGetCommand task. Set to true to use the DotNetCoreCLI task to publish packages.
+    packagesToPush: '$(Build.SourcesDirectory)\VS.Redist.Debugger.MDD.MIEngine.*.nupkg;$(Build.SourcesDirectory)\VS.Redist.Debugger.MDD.UnixPortSupplier.*.nupkg'
+    packageParentPath: '$(Build.SourcesDirectory)'
+    publishVstsFeed: '97a41293-2972-4f48-8c0e-05493ae82010' # VS
+    nuGetFeedType: internal  # Change to external when publishing to external feed
 ...

--- a/eng/pipelines/steps/PackAndPublishVSPackages.yml
+++ b/eng/pipelines/steps/PackAndPublishVSPackages.yml
@@ -31,9 +31,8 @@ steps:
   displayName: Publish Nuget package
   condition: and(succeeded(), eq(variables['SignType'], 'real'))
   inputs:
-    useDotNetTask: false # The default is false to use the NuGetCommand task. Set to true to use the DotNetCoreCLI task to publish packages.
     packagesToPush: '$(Build.SourcesDirectory)\VS.Redist.Debugger.MDD.MIEngine.*.nupkg;$(Build.SourcesDirectory)\VS.Redist.Debugger.MDD.UnixPortSupplier.*.nupkg'
     packageParentPath: '$(Build.SourcesDirectory)'
     publishVstsFeed: '97a41293-2972-4f48-8c0e-05493ae82010' # VS
-    nuGetFeedType: internal  # Change to external when publishing to external feed
+    nuGetFeedType: internal
 ...

--- a/eng/pipelines/steps/PublishOpenDebugAD7.yml
+++ b/eng/pipelines/steps/PublishOpenDebugAD7.yml
@@ -39,11 +39,11 @@ steps:
       copy ${{ parameters.SignedBinariesFolder }}\Release\osxlaunchhelper.scpt $(Build.StagingDirectory)\${{ parameters.RuntimeID }}\debugAdapters\bin\.
     displayName: "Copy osxlaunchhelper.scpt"
 
-  - template: ../tasks/PublishPipelineArtifact.yml
+  - template: ../tasks/1ES/PublishPipelineArtifact.yml
     parameters:
       displayName: 'Publish Unsigned ${{ parameters.RuntimeID }}'
-      path: '$(Build.StagingDirectory)\${{ parameters.RuntimeID }}'
-      artifactName: 'unsigned_${{ parameters.RuntimeID }}_binaries'  
+      targetPath: '$(Build.StagingDirectory)\${{ parameters.RuntimeID }}'
+      artifactName: 'unsigned_${{ parameters.RuntimeID }}_binaries' 
 
 # Publishing for non-macOS
 - ${{ if not(startsWith(parameters.RuntimeID, 'osx-')) }}:
@@ -51,8 +51,8 @@ steps:
       Compress-Archive -Path $(Build.StagingDirectory)\${{ parameters.RuntimeID }}\debugAdapters -DestinationPath $(Build.StagingDirectory)\zips\${{ parameters.RuntimeID }}.zip
     displayName: "Create ${{ parameters.RuntimeID}}.zip"  
 
-  - template: ../tasks/PublishPipelineArtifact.yml
+  - template: ../tasks/1ES/PublishPipelineArtifact.yml
     parameters:
       displayName: 'Publish ${{ parameters.RuntimeID }}'
-      path: '$(Build.StagingDirectory)\zips\${{ parameters.RuntimeID }}.zip'
+      targetPath: '$(Build.StagingDirectory)\zips\${{ parameters.RuntimeID }}.zip'
       artifactName: '${{ parameters.RuntimeID }}_zip'

--- a/eng/pipelines/tasks/1ES/PublishPipelineArtifact.yml
+++ b/eng/pipelines/tasks/1ES/PublishPipelineArtifact.yml
@@ -10,6 +10,6 @@ steps:
   displayName: ${{ parameters.displayName }}
   inputs:
     targetPath: ${{ parameters.targetPath }}
-    artifactName:  '${{ parameters.artifactName }}'
+    artifactName: '${{ parameters.artifactName }}'
   condition: ${{ parameters.condition }}
 ...

--- a/eng/pipelines/tasks/1ES/PublishPipelineArtifact.yml
+++ b/eng/pipelines/tasks/1ES/PublishPipelineArtifact.yml
@@ -1,0 +1,15 @@
+---
+parameters:
+  displayName: 'Publish Pipeline Artifact'
+  targetPath: '$(Build.ArtifactStagingDirectory)'
+  artifactName: 'drop'
+  condition: 'succeeded()'
+
+steps:
+- task: 1ES.PublishPipelineArtifact@1
+  displayName: ${{ parameters.displayName }}
+  inputs:
+    targetPath: ${{ parameters.targetPath }}
+    artifactName:  '${{ parameters.artifactName }}'
+  condition: ${{ parameters.condition }}
+...

--- a/eng/pipelines/tasks/MicroBuildLocalizationPlugin.yml
+++ b/eng/pipelines/tasks/MicroBuildLocalizationPlugin.yml
@@ -1,5 +1,5 @@
 ---
 steps:
-- task: ms-vseng.MicroBuildTasks.a0262b21-fb8f-46f8-bb9a-60ed560d4a87.MicroBuildLocalizationPlugin@3
+- task: ms-vseng.MicroBuildTasks.a0262b21-fb8f-46f8-bb9a-60ed560d4a87.MicroBuildLocalizationPlugin@4
   displayName: 'Install Localization Plugin'
 ...

--- a/eng/pipelines/templates/VS-release.template.yml
+++ b/eng/pipelines/templates/VS-release.template.yml
@@ -6,10 +6,6 @@ steps:
 
 - template: ../tasks/NuGetToolInstaller.yml
 
-- template: ../tasks/MicroBuildSigningPlugin.yml
-
-- template: ../tasks/MicroBuildLocalizationPlugin.yml
-
 - template: ../steps/BuildSolution.yml
   parameters:
     Configuration: 'Lab.Release'

--- a/eng/pipelines/templates/VSCode-codesign-osx.template.yml
+++ b/eng/pipelines/templates/VSCode-codesign-osx.template.yml
@@ -22,9 +22,9 @@ steps:
       echo "#[command] zip -r $(Pipeline.Workspace)/${{ rid }}.zip ./debugAdapters"
       zip -r $(Pipeline.Workspace)/${{ rid }}.zip ./debugAdapters
 
-  - template: ../tasks/PublishPipelineArtifact.yml
+  - template: ../tasks/1ES/PublishPipelineArtifact.yml
     parameters:
       displayName: 'Publish Binaries'
-      path: '$(Pipeline.Workspace)/${{ rid }}.zip'
+      targetPath: '$(Pipeline.Workspace)/${{ rid }}.zip'
       artifactName: 'unsigned_${{ rid }}_zip'
 ...

--- a/eng/pipelines/templates/VSCode-esrp-sign-osx.template.yml
+++ b/eng/pipelines/templates/VSCode-esrp-sign-osx.template.yml
@@ -18,9 +18,9 @@ steps:
       SigningTarget: '$(Pipeline.Workspace)\Artifacts\${{ rid }}.zip'
       SigningCert: 8023
 
-  - template: ../tasks/PublishPipelineArtifact.yml
+  - template: ../tasks/1ES/PublishPipelineArtifact.yml
     parameters:
       displayName: 'Publish Binaries'
-      path: '$(Pipeline.Workspace)\Artifacts\${{ rid }}.zip'
+      targetPath: '$(Pipeline.Workspace)\Artifacts\${{ rid }}.zip'
       artifactName: '${{ rid }}_zip'
 ...

--- a/eng/pipelines/templates/VSCode-release.template.yml
+++ b/eng/pipelines/templates/VSCode-release.template.yml
@@ -8,8 +8,6 @@ steps:
 
 - template: ../tasks/NuGetToolInstaller.yml
 
-- template: ../tasks/MicroBuildSigningPlugin.yml
-
 - template: ../tasks/UseDotNet.yml
 
 - template: ../steps/BuildSolution.yml


### PR DESCRIPTION
This PR migrates the VS and VS Code Release Pipelines to use the 1ES template.

This extends the existing Microbuild Template and converts the PublishArtifact and NugetPush to the 1ES tasks.