### PR TITLE
Fix CodeAnalysis Pipeline from 1ES Pipeline Upgrade

### DIFF
--- a/eng/pipelines/steps/BuildSolution.yml
+++ b/eng/pipelines/steps/BuildSolution.yml
@@ -4,6 +4,7 @@ parameters:
   Solution: '$(Build.SourcesDirectory)\src\MIDebugEngine.sln'
   Configuration: 'Release'
   BuildArguments: ''
+  OneESPT: false
 
 steps:
 - template: ../tasks/NuGetCommand.yml
@@ -37,6 +38,7 @@ steps:
     targetPath: '$(Build.BinariesDirectory)/build_logs/'
     artifactName: '${{ parameters.Configuration }}_binlog'
     condition: ne(variables['System.Debug'], '')
+    OneESPT: ${{ parameters.OneESPT }}
 
 - template: ../tasks/1ES/PublishPipelineArtifact.yml
   parameters:
@@ -44,4 +46,5 @@ steps:
     targetPath: '$(Build.SourcesDirectory)\bin\${{ parameters.Configuration }}'
     artifactName: '${{ parameters.Configuration }}_debug_bin'
     condition: ne(variables['System.Debug'], '')
+    OneESPT: ${{ parameters.OneESPT }}
 ...

--- a/eng/pipelines/steps/CollectAndPublishBinaries.yml
+++ b/eng/pipelines/steps/CollectAndPublishBinaries.yml
@@ -3,6 +3,7 @@
 parameters:
   TargetFolder: '$(Build.SourcesDirectory)\drop'
   ArtifactName: 'drop'
+  OneESPT: false
 
 steps:
 - template: ../tasks/CopyFiles.yml
@@ -18,4 +19,5 @@ steps:
     displayName: 'Publish Binaries'
     targetPath: ${{ parameters.TargetFolder }}
     artifactName: '${{ parameters.ArtifactName }}'
+    OneESPT: ${{ parameters.OneESPT }}
 ...

--- a/eng/pipelines/steps/CopyAndPublishSymbols.yml
+++ b/eng/pipelines/steps/CopyAndPublishSymbols.yml
@@ -1,5 +1,8 @@
 # Collects build symbols and publishes them as 'Symbols'
 ---
+parameters:
+  OneESPT: false
+
 steps:
 - template: ../tasks/CopyFiles.yml
   parameters:
@@ -32,4 +35,5 @@ steps:
     displayName: 'Publish Symbols'
     targetPath: '$(Build.ArtifactStagingDirectory)/symbols' 
     artifactName: 'Symbols'
+    OneESPT: ${{ parameters.OneESPT }}
 ...

--- a/eng/pipelines/steps/PackAndPublishVSPackages.yml
+++ b/eng/pipelines/steps/PackAndPublishVSPackages.yml
@@ -17,6 +17,7 @@ steps:
     displayName: 'Publish File Version'
     targetPath: '$(Build.SourcesDirectory)\obj\Lab.Release\NugetPackageVersion.txt'
     artifactName: 'PackageVersion'
+    OneESPT: true
 
 - template: ../tasks/NuGetCommand.yml
   parameters:

--- a/eng/pipelines/steps/PublishOpenDebugAD7.yml
+++ b/eng/pipelines/steps/PublishOpenDebugAD7.yml
@@ -44,6 +44,7 @@ steps:
       displayName: 'Publish Unsigned ${{ parameters.RuntimeID }}'
       targetPath: '$(Build.StagingDirectory)\${{ parameters.RuntimeID }}'
       artifactName: 'unsigned_${{ parameters.RuntimeID }}_binaries' 
+      OneESPT: true
 
 # Publishing for non-macOS
 - ${{ if not(startsWith(parameters.RuntimeID, 'osx-')) }}:
@@ -56,3 +57,4 @@ steps:
       displayName: 'Publish ${{ parameters.RuntimeID }}'
       targetPath: '$(Build.StagingDirectory)\zips\${{ parameters.RuntimeID }}.zip'
       artifactName: '${{ parameters.RuntimeID }}_zip'
+      OneESPT: true

--- a/eng/pipelines/tasks/1ES/PublishPipelineArtifact.yml
+++ b/eng/pipelines/tasks/1ES/PublishPipelineArtifact.yml
@@ -4,12 +4,21 @@ parameters:
   targetPath: '$(Build.ArtifactStagingDirectory)'
   artifactName: 'drop'
   condition: 'succeeded()'
+  OneESPT: false # Indicates that this is running under the 1ES Pipeline Template
 
 steps:
-- task: 1ES.PublishPipelineArtifact@1
-  displayName: ${{ parameters.displayName }}
-  inputs:
-    targetPath: ${{ parameters.targetPath }}
-    artifactName: '${{ parameters.artifactName }}'
-  condition: ${{ parameters.condition }}
+- ${{ if eq(parameters['OneESPT'], true) }}:
+  - task: 1ES.PublishPipelineArtifact@1
+    displayName: ${{ parameters.displayName }}
+    inputs:
+      targetPath: ${{ parameters.targetPath }}
+      artifactName: '${{ parameters.artifactName }}'
+    condition: ${{ parameters.condition }}
+- ${{ else }}:
+  - template: ../PublishPipelineArtifact.yml
+    parameters:
+      path: '${{ parameters.targetPath }}'
+      artifactName: '${{ parameters.artifactName }}'
+      displayName: ${{ parameters.displayName }}
+      condition: ${{ parameters.condition }}
 ...

--- a/eng/pipelines/templates/Build.template.yml
+++ b/eng/pipelines/templates/Build.template.yml
@@ -18,6 +18,7 @@ steps:
 - template: ../steps/BuildSolution.yml
   parameters:
     Configuration: ${{ parameters.Configuration }}
+    OneESPT: false
 
 - template: ../tasks/CSharp.yml
 
@@ -26,6 +27,7 @@ steps:
   parameters:
     TargetFolder: '$(Build.StagingDirectory)\drop'
     ArtifactName: '${{ parameters.Configuration }}'
+    OneESPT: false
 
 - template: ../tasks/MicroBuildCleanup.yml
 ...

--- a/eng/pipelines/templates/VS-release.template.yml
+++ b/eng/pipelines/templates/VS-release.template.yml
@@ -9,17 +9,21 @@ steps:
 - template: ../steps/BuildSolution.yml
   parameters:
     Configuration: 'Lab.Release'
+    OneESPT: true
 
 - template: ../steps/CollectAndPublishBinaries.yml
   parameters:
     TargetFolder: '$(Build.StagingDirectory)\drop'
     ArtifactName: 'drop'
+    OneESPT: true
 
 - template: ../tasks/SignVerify.yml
   parameters:
     TargetFolders: '$(Build.StagingDirectory)\drop'
 
 - template: ../steps/CopyAndPublishSymbols.yml
+  parameters:
+    OneESPT: true
 
 - template: ../steps/PackAndPublishVSPackages.yml
   parameters:

--- a/eng/pipelines/templates/VSCode-codesign-osx.template.yml
+++ b/eng/pipelines/templates/VSCode-codesign-osx.template.yml
@@ -27,4 +27,5 @@ steps:
       displayName: 'Publish Binaries'
       targetPath: '$(Pipeline.Workspace)/${{ rid }}.zip'
       artifactName: 'unsigned_${{ rid }}_zip'
+      OneESPT: true
 ...

--- a/eng/pipelines/templates/VSCode-esrp-sign-osx.template.yml
+++ b/eng/pipelines/templates/VSCode-esrp-sign-osx.template.yml
@@ -23,4 +23,5 @@ steps:
       displayName: 'Publish Binaries'
       targetPath: '$(Pipeline.Workspace)\Artifacts\${{ rid }}.zip'
       artifactName: '${{ rid }}_zip'
+      OneESPT: true
 ...

--- a/eng/pipelines/templates/VSCode-release.template.yml
+++ b/eng/pipelines/templates/VSCode-release.template.yml
@@ -13,11 +13,13 @@ steps:
 - template: ../steps/BuildSolution.yml
   parameters:
     Configuration: 'Lab.Release'
+    OneESPT: true
 
 - template: ../steps/CollectAndPublishBinaries.yml
   parameters:
     TargetFolder: '$(Build.StagingDirectory)\bin'
     ArtifactName: 'bin'
+    OneESPT: true
 
 - template: ../tasks/SignVerify.yml
   parameters:
@@ -25,6 +27,8 @@ steps:
     ExcludeFolders: '.git MicroBuild'
 
 - template: ../steps/CopyAndPublishSymbols.yml
+  parameters:
+    OneESPT: true
 
 - script: |
     mkdir $(Build.StagingDirectory)\zips\


### PR DESCRIPTION
Add OneESPT flags to toggle between different publish

This PR fixes the changes from the 1ES Pipeline Update that caused the CI to not find the 1ES tasks as they are running on regular machines. The chages add a new parameter `OneESPT` which to indicate if a particular pipeline step is running under 1ES machines. 