### PR TITLE
MIEngine: Set MajorVersion from the correct place

### DIFF
--- a/src/MICore/Debugger.cs
+++ b/src/MICore/Debugger.cs
@@ -494,6 +494,8 @@ namespace MICore
             {
                 _consoleDebuggerInitializeCompletionSource = null;
 
+                // We no longer care about keeping these, so empty them out
+                _initializationLog = null;
                 _initialErrors = null;
             }
         }


### PR DESCRIPTION
We were previously setting the MajorGdbVersion when the process exited and this was too late.
We need to set this OnStateChanged so we can use this to opt for the latest gdb MI commands.
Additionally include Intel GNU gdb example when fetching the GDB version.

Signed-off-by: intel-rganesh rakesh.ganesh@intel.com