### PR TITLE
Remove `isabase` from IntelGTRegisters check

### DIFF
--- a/src/MIDebugEngine/Engine.Impl/EngineUtils.cs
+++ b/src/MIDebugEngine/Engine.Impl/EngineUtils.cs
@@ -253,7 +253,7 @@ namespace Microsoft.MIDebugEngine
                 {
                     map._map = s_X86Registers;
                 }
-                else if (registerNames.Contains("isabase") && registerNames.Contains("ce")) // Intel GPU register set
+                else if (registerNames.Contains("ce")) // Intel GPU register set
                 {
                     map._map = s_IntelGTRegisters;
                 }


### PR DESCRIPTION
For compatibility with future IntelGT platforms, it is necessary to remove the check for the presence of the virtual register of `isabase`.
