### PR TITLE
Add support for applying post remote connect commands on attach

### DIFF
--- a/src/MICore/LaunchOptions.cs
+++ b/src/MICore/LaunchOptions.cs
@@ -1490,8 +1490,12 @@ namespace MICore
                 string optFile = Path.Combine(slnRoot, "Microsoft.MIEngine.Options.xml");
                 if (File.Exists(optFile))
                 {
-                    var reader = File.OpenText(optFile);
-                    string suppOptions = reader.ReadToEnd();
+                    string suppOptions = null;
+                    using (var reader = File.OpenText(optFile))
+                    {
+                        suppOptions = reader.ReadToEnd();
+                    }
+
                     if (!string.IsNullOrEmpty(suppOptions))
                     {
                         try
@@ -1554,6 +1558,11 @@ namespace MICore
             var newSetupCmds = LaunchCommand.CreateCollection(suppOptions.SetupCommands);
             setupCmds.AddRange(newSetupCmds);
             SetupCommands = new ReadOnlyCollection<LaunchCommand>(setupCmds);
+
+            var postRemoteConnectCmds = this.PostRemoteConnectCommands.ToList();
+            var newPostRemoteConnectCmds = LaunchCommand.CreateCollection(suppOptions.PostRemoteConnectCommands);
+            postRemoteConnectCmds.AddRange(newPostRemoteConnectCmds);
+            PostRemoteConnectCommands = new ReadOnlyCollection<LaunchCommand>(postRemoteConnectCmds);
 
             MergeMap(suppOptions.SourceMap);
             if (!string.IsNullOrWhiteSpace(suppOptions.AdditionalSOLibSearchPath))
@@ -1847,6 +1856,7 @@ namespace MICore
             this.WaitDynamicLibLoad = source.WaitDynamicLibLoad;
 
             this.SetupCommands = LaunchCommand.CreateCollection(source.SetupCommands);
+            this.PostRemoteConnectCommands = LaunchCommand.CreateCollection(source.PostRemoteConnectCommands);
 
             if (source.CustomLaunchSetupCommands != null)
             {

--- a/src/MICore/LaunchOptions.xsd
+++ b/src/MICore/LaunchOptions.xsd
@@ -413,6 +413,11 @@
           <xs:documentation>One or more GDB/LLDB commands to execute in order to setup the underlying debugger. These are not required.</xs:documentation>
         </xs:annotation>
       </xs:element>
+      <xs:element name="PostRemoteConnectCommands" minOccurs="0" maxOccurs="1" type="CommandList">
+        <xs:annotation>
+          <xs:documentation>One or more commands to execute after the connection has been made, in order to set up the remote connection. These are not required.</xs:documentation>
+        </xs:annotation>
+      </xs:element>
       <xs:element name="SourceMap" type="SourceMapList" minOccurs="0" maxOccurs="1">
       </xs:element>
       <xs:element name="ServerOptions" type="ServerOptions" minOccurs="0" maxOccurs="1">
@@ -480,6 +485,11 @@
       <xs:element name="SetupCommands" minOccurs="0" maxOccurs="1" type="CommandList">
         <xs:annotation>
           <xs:documentation>One or more GDB/LLDB commands to execute in order to setup the underlying debugger. These are not required.</xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="PostRemoteConnectCommands" minOccurs="0" maxOccurs="1" type="CommandList">
+        <xs:annotation>
+          <xs:documentation>One or more commands to execute after the connection has been made, in order to set up the remote connection. These are not required.</xs:documentation>
         </xs:annotation>
       </xs:element>
       <xs:element name="CustomLaunchSetupCommands" minOccurs="0" maxOccurs="1" type="CommandList">

--- a/src/MICore/LaunchOptions.xsd.types.designer.cs
+++ b/src/MICore/LaunchOptions.xsd.types.designer.cs
@@ -200,7 +200,11 @@ namespace MICore.Xml.LaunchOptions {
         /// <remarks/>
         [System.Xml.Serialization.XmlArrayItemAttribute(IsNullable=false)]
         public Command[] SetupCommands;
-        
+
+        /// <remarks/>
+        [System.Xml.Serialization.XmlArrayItemAttribute(IsNullable = false)]
+        public Command[] PostRemoteConnectCommands;
+
         /// <remarks/>
         [System.Xml.Serialization.XmlArrayItemAttribute(IsNullable=false)]
         public SourceMapEntry[] SourceMap;
@@ -354,7 +358,11 @@ namespace MICore.Xml.LaunchOptions {
         /// <remarks/>
         [System.Xml.Serialization.XmlArrayItemAttribute(IsNullable=false)]
         public Command[] SetupCommands;
-        
+
+        /// <remarks/>
+        [System.Xml.Serialization.XmlArrayItemAttribute(IsNullable = false)]
+        public Command[] PostRemoteConnectCommands;
+
         /// <remarks/>
         [System.Xml.Serialization.XmlArrayItemAttribute(IsNullable=false)]
         public Command[] CustomLaunchSetupCommands;


### PR DESCRIPTION
There was already support for the JSON implementation to execute post remote connect commands.
This extends the xml version used by Visual Studio to have the same capabilities