### PR TITLE
Fix SSH attach on a clean machine

### DIFF
--- a/src/SSHDebugPS/SSH/SSHConnection.cs
+++ b/src/SSHDebugPS/SSH/SSHConnection.cs
@@ -131,12 +131,15 @@ namespace Microsoft.SSHDebugPS.SSH
         /// <returns>Full path of the created directory.</returns>
         public override string MakeDirectory(string path)
         {
-            bool directoryExists = false;
-            liblinux.IO.IRemoteFileSystemInfo stat = null;
+            bool exists = false;
+            bool isDirectory = false;
+
             try
             {
-                stat = _remoteSystem.FileSystem.Stat(path);
-                directoryExists = stat.IsDirectory();
+                liblinux.IO.IRemoteFileSystemInfo stat = _remoteSystem.FileSystem.Stat(path);
+
+                exists = stat.Exists();
+                isDirectory = stat.IsDirectory();
             }
             catch
             {
@@ -144,11 +147,11 @@ namespace Microsoft.SSHDebugPS.SSH
                 // Unfortunately the exceptions that are thrown by liblinux are not public, so we can't specialize it.
             }
 
-            if (stat == null && !directoryExists)
+            if (!exists)
             {
                 return _remoteSystem.FileSystem.CreateDirectory(path).FullPath;
             }
-            else if (stat != null && directoryExists)
+            else if (exists && isDirectory)
             {
                 return _remoteSystem.FileSystem.GetDirectory(path).FullPath;
             }


### PR DESCRIPTION
Attaching to a C# process running on a brand-new Linux VM was failing with an error about being unable to create or access the `.vs-debugger` folder on the remote host.  After investigating, this is due to a behavior change in liblinux - previously, the call to `IRemoteFileSystem.Stat()` would fail if the file didn't exist, but it now returns a valid object that you can query to determine that the file doesn't exist.  I updated the logic accordingly.

Workaround: manually create the `.vs-debugger` folder on the remote host.  Once it exists, the remote debugger will deploy successfully.