### PR TITLE
Migrate MIEngine to .NET 8

### DIFF
--- a/.github/workflows/Build-And-Test.yml
+++ b/.github/workflows/Build-And-Test.yml
@@ -29,7 +29,7 @@ jobs:
     - name: Install .NET Core
       uses: actions/setup-dotnet@v3
       with:
-        dotnet-version: 6.0.x
+        dotnet-version: 8.0.x
 
     - name: Setup MSBuild.exe
       uses: microsoft/setup-msbuild@v1.1
@@ -61,7 +61,7 @@ jobs:
     - name: Install .NET Core
       uses: actions/setup-dotnet@v3
       with:
-        dotnet-version: 6.0.x
+        dotnet-version: 8.0.x
 
     - name: Setup MSBuild.exe
       uses: microsoft/setup-msbuild@v1.1
@@ -119,7 +119,7 @@ jobs:
     - name: Install .NET Core
       uses: actions/setup-dotnet@v3
       with:
-        dotnet-version: 6.0.x
+        dotnet-version: 8.0.x
 
     - name: Build
       run: dotnet build ${{ github.workspace }}/src/MIDebugEngine-Unix.sln
@@ -160,7 +160,7 @@ jobs:
     - name: Install .NET Core
       uses: actions/setup-dotnet@v3
       with:
-        dotnet-version: 6.0.x
+        dotnet-version: 8.0.x
 
     - name: Build
       run: dotnet build ${{ github.workspace }}/src/MIDebugEngine-Unix.sln

--- a/eng/pipelines/tasks/UseDotNet.yml
+++ b/eng/pipelines/tasks/UseDotNet.yml
@@ -3,4 +3,4 @@ steps:
   displayName: 'Use .NET Core sdk'
   inputs:
     packageType: sdk
-    version: 6.x
+    version: 8.x

--- a/src/OpenDebugAD7/OpenDebugAD7.csproj
+++ b/src/OpenDebugAD7/OpenDebugAD7.csproj
@@ -14,7 +14,7 @@
     <OutputPath>$(MIDefaultOutputPath)\vscode</OutputPath>
     <OutputType>Exe</OutputType>
     <DropSubDir>vscode</DropSubDir>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
 
     <!--
       For non-Windows platforms, .NET Core depends on libicu for data about locales and international settings.

--- a/src/tools/MakePIAPortableTool/MakePIAPortableTool.csproj
+++ b/src/tools/MakePIAPortableTool/MakePIAPortableTool.csproj
@@ -4,7 +4,7 @@
   
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
 
     <OutputPath>$(MIDefaultOutputPath)tools</OutputPath>
     <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>

--- a/test/CppTests/CppTests.csproj
+++ b/test/CppTests/CppTests.csproj
@@ -2,7 +2,7 @@
   <Import Project="..\..\build\debuggertesting.settings.targets" />
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
 
     <IsPackable>false</IsPackable>
 

--- a/test/CppTests/CppTests.nuspec
+++ b/test/CppTests/CppTests.nuspec
@@ -14,10 +14,10 @@
     <copyright>© Microsoft Corporation. All rights reserved.</copyright>
   </metadata>
   <files>
-    <file src="$binRoot$CppTests.dll" target="lib\net6.0" />
-    <file src="$binRoot$CppTests.pdb" target="lib\net6.0" />
-    <file src="$binRoot$DebuggerTesting.dll" target="lib\net6.0" />
-    <file src="$binRoot$DebuggerTesting.pdb" target="lib\net6.0" />
+    <file src="$binRoot$CppTests.dll" target="lib\net8.0" />
+    <file src="$binRoot$CppTests.pdb" target="lib\net8.0" />
+    <file src="$binRoot$DebuggerTesting.dll" target="lib\net8.0" />
+    <file src="$binRoot$DebuggerTesting.pdb" target="lib\net8.0" />
     <file src="$binRoot$contentFiles\**\*" target="contentFiles" />
   </files>
 </package>

--- a/test/DebugAdapterRunner/DebugAdapterRunner.nuspec
+++ b/test/DebugAdapterRunner/DebugAdapterRunner.nuspec
@@ -18,7 +18,7 @@
     </dependencies>
   </metadata>
   <files>
-    <file src="$binRoot$dar.dll" target="lib\net6.0" />
-    <file src="$binRoot$dar.pdb" target="lib\net6.0" />
+    <file src="$binRoot$dar.dll" target="lib\net8.0" />
+    <file src="$binRoot$dar.pdb" target="lib\net8.0" />
   </files>
 </package>

--- a/test/DebuggerTesting/DebuggerTesting.csproj
+++ b/test/DebuggerTesting/DebuggerTesting.csproj
@@ -2,7 +2,7 @@
   <Import Project="..\..\build\debuggertesting.settings.targets" />
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
 
     <IsPackable>false</IsPackable>
   </PropertyGroup>


### PR DESCRIPTION
This PR upgrades OpenDebugAD7, MakePIAPortable, and CppTests/DAR from .NET 6 to .NET 8. 

.NET 6 will be ending on Nov 2024, so this PR moves to the latest LTS, .NET 8.

See https://learn.microsoft.com/en-us/lifecycle/products/microsoft-net-and-net-core