### PR TITLE
MIEngine: Convert TargetId to string

### DIFF
--- a/src/MIDebugEngine/AD7.Impl/AD7Thread.cs
+++ b/src/MIDebugEngine/AD7.Impl/AD7Thread.cs
@@ -209,7 +209,7 @@ namespace Microsoft.MIDebugEngine
         // Gets the system thread identifier.
         int IDebugThread2.GetThreadId(out uint threadId)
         {
-            threadId = _debuggedThread.TargetId;
+            threadId = (uint)_debuggedThread.Id;
             return Constants.S_OK;
         }
 
@@ -222,7 +222,7 @@ namespace Microsoft.MIDebugEngine
 
                 if ((dwFields & enum_THREADPROPERTY_FIELDS.TPF_ID) != 0)
                 {
-                    props.dwThreadId = _debuggedThread.TargetId;
+                    props.dwThreadId = (uint)_debuggedThread.Id;
                     props.dwFields |= enum_THREADPROPERTY_FIELDS.TPF_ID;
                 }
                 if ((dwFields & enum_THREADPROPERTY_FIELDS.TPF_SUSPENDCOUNT) != 0)


### PR DESCRIPTION
Convert TargetId field to string and remove all parsing logic. This way, the unique global ID is stored in Id and target specific target-id is stored in its string format. Stopped events fetch global ID for thread identification.

This fix should also address [issue 1448](https://github.com/microsoft/MIEngine/issues/1448).

Signed-off-by: intel-rganesh rakesh.ganesh@intel.com