### PR TITLE
MIEngine: Disable individual info threads call for each thread created

### DIFF
--- a/src/MIDebugEngine/Engine.Impl/DebuggedProcess.cs
+++ b/src/MIDebugEngine/Engine.Impl/DebuggedProcess.cs
@@ -408,12 +408,12 @@ namespace Microsoft.MIDebugEngine
                 _callback.OnError(message);
             };
 
-            ThreadCreatedEvent += async delegate (object o, EventArgs args)
+            ThreadCreatedEvent += delegate (object o, EventArgs args)
             {
                 try
                 {
                     ResultEventArgs result = (ResultEventArgs)args;
-                    await ThreadCache.ThreadCreatedEvent(result.Results.FindInt("id"), result.Results.TryFindString("group-id"));
+                    ThreadCache.ThreadCreatedEvent(result.Results.FindInt("id"), result.Results.TryFindString("group-id"));
                     _childProcessHandler?.ThreadCreatedEvent(result.Results);
                 }
                 catch (Exception e) when (ExceptionHelper.BeforeCatch(e, Logger, reportOnlyCorrupting: true))


### PR DESCRIPTION
Changes to disable info thread for each created thread to expedite GPU
debugging. GPUs are likely to have 1000s of threads and calling thread
info for each thread created is very time consuming. 
We call SetThreadInfoFromResultValue from CollectThreadInfo when we
get thread context.

Signed-off-by: intel-rganesh rakesh.ganesh@intel.com