### PR TITLE
Migrate ADO Release to 1ES ADO Pipeline

### DIFF
--- a/eng/pipelines/VS-release.yml
+++ b/eng/pipelines/VS-release.yml
@@ -1,7 +1,9 @@
 ---
 name: $(Date:yyyMMdd).$(Rev:r)
+
 variables:
-  - group: TSDTUSR
+- name: TeamName
+  value: MDDDebugger
 
 resources:
   repositories:
@@ -21,7 +23,7 @@ extends:
         name: VSEngSS-MicroBuild2022-1ES
         os: windows 
     stages:
-    - stage: stage
+    - stage: BuildVSReleasePackage
       displayName: VS_Release
       jobs:
       - job: Phase_1
@@ -38,4 +40,34 @@ extends:
               enabled: true
         steps:
         - template: /eng/pipelines/templates/VS-release.template.yml@self
+
+    - stage: VS_Insertion
+      dependsOn: [BuildVSReleasePackage]
+      jobs:
+      - job:
+        displayName: Insert package into VS
+        templateContext:
+          inputs:
+          - input: pipelineArtifact
+            artifactName: PackageVersion
+            targetPath: $(Build.ArtifactStagingDirectory)\PackageVersion
+        steps:
+        - checkout: none
+
+        - powershell: |
+            $version= [IO.File]::ReadAllText("$(Build.ArtifactStagingDirectory)\PackageVersion\NugetPackageVersion.txt")
+            Write-Host "##vso[task.setvariable variable=MDDPackageVersion;]$version"
+          displayName: 'Set MDDPackage Version'
+
+        - task: ms-vseng.MicroBuildShipTasks.55100717-a81d-45ea-a363-b8fe3ec375ad.MicroBuildInsertVsPayload@4
+          displayName: 'Insert VS Payload'
+          inputs:
+            TargetBranch: $(TargetBranch)  
+            TeamName: 'VS Debugger Platform'
+            TeamEmail: $(TEAMEMAIL)
+            DefaultConfigValues: 'VS.Redist.Debugger.MDD.MIEngine=$(MDDPackageVersion)'
+            RevisionTextFiles: 'src/SetupPackages/VC/IDE/MDD/core/revision.txt,src/SetupPackages/VC/IDE/MDD/res/revision.txt'
+            InsertionPayloadName: 'MIEngine $(MDDPackageVersion)'
+            InsertionDescription: 'Updating MIEngine to $(MDDPackageVersion). See $(Release.Artifacts.MIEngine_MDD.BuildURI)'
+            InsertionReviewers: $(InsertionReviewers)
 ...

--- a/eng/pipelines/VSCode-release.yml
+++ b/eng/pipelines/VSCode-release.yml
@@ -1,7 +1,9 @@
 ---
 name: $(Date:yyyMMdd).$(Rev:r)
+
 variables:
-  - group: TSDTUSR
+- name: TeamName
+  value: MDDDebugger
 
 resources:
   repositories:

--- a/eng/pipelines/steps/CopyAndPublishSymbols.yml
+++ b/eng/pipelines/steps/CopyAndPublishSymbols.yml
@@ -12,27 +12,22 @@ steps:
     TargetFolder: '$(Build.ArtifactStagingDirectory)/symbols'
     CleanTargetFolder: true
 
-- task: PowerShell@2
-  displayName: 'Set Variables for PublishSymbols'
+    
+- task: ms-vseng.MicroBuildShipTasks.0ffdda1d-8c7b-40da-b8b1-061660eaeea3.MicroBuildArchiveSymbols@5
+  displayName: 'Archive MIEngine_MDD on Symweb'
   inputs:
-    targetType: 'inline'
-    script: |
-      Write-Host "##vso[task.setvariable variable=ArtifactServices.Symbol.AccountName]microsoft"
-      Write-Host "##vso[task.setvariable variable=ArtifactServices.Symbol.PAT;issecret=true;]${env:ARTIFACTSERVICES_SYMBOL_PAT}"
-      Write-Host "##vso[task.setvariable variable=ArtifactServices.Symbol.UseAAD]false"
-  env:
-    ARTIFACTSERVICES_SYMBOL_PAT: $(all-org-SymbolsReadWrite)
-
-- template: ../tasks/PublishSymbols.yml
-  parameters:
-    IndexSources: false
-    SymbolsFolder: '$(Build.ArtifactStagingDirectory)/symbols'
-    SearchPattern: '**\*.pdb'
-    SymbolServerType: TeamServices
-
+    SymbolsFeatureName: MIEngine
+    SymbolsProject: VS
+    SymbolsAgentPath: '$(Build.ArtifactStagingDirectory)\Symbols\'
+    ExcludeAgentFolders: '$(Build.ArtifactStagingDirectory)\Symbols\bin\Debug;$(Build.ArtifactStagingDirectory)\Symbols\bin\Lab.Debug'
+    ${{ if parameters.OneESPT }}:
+      ExpirationInDays: 3650 # Expire in 10 years for release builds
+    ${{ else }}:
+      ExpirationInDays: 1 # Expire in 1 day if used for testing
+            
 - template: ../tasks/1ES/PublishPipelineArtifact.yml
   parameters:
-    displayName: 'Publish Symbols'
+    displayName: 'Publish Symbols Artifact'
     targetPath: '$(Build.ArtifactStagingDirectory)/symbols' 
     artifactName: 'Symbols'
     OneESPT: ${{ parameters.OneESPT }}


### PR DESCRIPTION
This PR address the issue that ADO Release is not using a governed template. This PR adds the release stage as part of the official build 