### PR TITLE
Move UnixPortSupplierInterop NuGet Sign

### DIFF
--- a/MIEngine.UnixPortSupplier.nuspec
+++ b/MIEngine.UnixPortSupplier.nuspec
@@ -12,7 +12,7 @@
     <tags></tags>
   </metadata>
   <files>
-    <file src="ReferenceAssemblies\Microsoft.VisualStudio.Debugger.Interop.UnixPortSupplier.DesignTime.xml" target="ref\dotnet" />
-    <file src="ReferenceAssemblies\Microsoft.VisualStudio.Debugger.Interop.UnixPortSupplier.DesignTime.dll" target="ref\dotnet" />
+    <file src="Microsoft.VisualStudio.Debugger.Interop.UnixPortSupplier.DesignTime.xml" target="ref\dotnet" />
+    <file src="Microsoft.VisualStudio.Debugger.Interop.UnixPortSupplier.DesignTime.dll" target="ref\dotnet" />
   </files>
 </package>

--- a/eng/pipelines/steps/PublishVSPackages.yml
+++ b/eng/pipelines/steps/PublishVSPackages.yml
@@ -7,6 +7,18 @@ parameters:
   BasePath: $(Build.StagingDirectory)
 
 steps:
+- script: |
+    for /f "delims=" %%f in ($(Build.SourcesDirectory)\obj\Lab.Release\NugetPackageVersion.txt) do set NugetPackageVersion=%%f
+    echo ##vso[task.setvariable variable=NugetPackageVersion;]%NugetPackageVersion%
+  displayName: 'Get NuGet Version'
+
+- template: ../tasks/1ES/PublishPipelineArtifact.yml
+  parameters:
+    displayName: 'Publish File Version'
+    targetPath: '$(Build.SourcesDirectory)\obj\Lab.Release\NugetPackageVersion.txt'
+    artifactName: 'PackageVersion'
+    OneESPT: true
+    
 - task: 1ES.PublishNuget@1
   displayName: Publish Nuget package
   condition: and(succeeded(), eq(variables['SignType'], 'real'))

--- a/src/Microsoft.VisualStudio.Debugger.Interop.UnixPortSupplier/Microsoft.VisualStudio.Debugger.Interop.UnixPortSupplier.DesignTime.csproj
+++ b/src/Microsoft.VisualStudio.Debugger.Interop.UnixPortSupplier/Microsoft.VisualStudio.Debugger.Interop.UnixPortSupplier.DesignTime.csproj
@@ -35,6 +35,11 @@
   <ItemGroup>
     <DropSignedFile Include="$(OutDir)\$(AssemblyName).dll" />
   </ItemGroup>
+
+  <ItemGroup>
+    <PackageNuspec Include="$(MIEngineRoot)\MIEngine.UnixPortSupplier.nuspec" />
+    <NugetPackages Include="VS.Redist.Debugger.MDD.UnixPortSupplier" />
+  </ItemGroup>
   
   <Import Project="..\..\build\miengine.targets" />
   <Import Project="..\..\build\DropFiles.targets" />

--- a/src/SSHDebugPS/SSHDebugPS.csproj
+++ b/src/SSHDebugPS/SSHDebugPS.csproj
@@ -91,11 +91,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageNuspec Include="$(MIEngineRoot)\MIEngine.UnixPortSupplier.nuspec" />
-    <NugetPackages Include="VS.Redist.Debugger.MDD.UnixPortSupplier" />
-  </ItemGroup>
-
-  <ItemGroup>
     <Compile Update="StringResources.Designer.cs">
       <DesignTime>True</DesignTime>
       <AutoGen>True</AutoGen>


### PR DESCRIPTION
Properly create VS.Redist.Debugger.MDD.UnixPortSupplier.*.nupkg

SSHDebugPS was the wrong project to create this package. Moved it to The UnixPortSupplier project.