### PR TITLE
Fix VS Code Builds

### DIFF
--- a/eng/Scripts/CI-Build.ps1
+++ b/eng/Scripts/CI-Build.ps1
@@ -3,7 +3,7 @@ param(
 [Alias("c")]
 [string]$Configuration="Debug",
 
-[ValidateSet("win-x86", "win10-arm64")]
+[ValidateSet("win-x86", "win-arm64")]
 [Alias("r")]
 [string]$RID="win-x86",
 

--- a/eng/pipelines/steps/CopyAndPublishSymbols.yml
+++ b/eng/pipelines/steps/CopyAndPublishSymbols.yml
@@ -2,13 +2,14 @@
 ---
 parameters:
   OneESPT: false
+  SourceFolder: '$(Build.StagingDirectory)\drop'
 
 steps:
 - template: ../tasks/CopyFiles.yml
   parameters:
     displayName: 'Collect build symbols'
-    SourceFolder: '$(Build.StagingDirectory)\drop'
-    Contents: '$(Build.StagingDirectory)\drop\**\*.+(pdb|exe|dll)'
+    SourceFolder: ${{ parameters.SourceFolder }}
+    Contents: '${{ parameters.SourceFolder }}\**\*.+(pdb|exe|dll)'
     TargetFolder: '$(Build.ArtifactStagingDirectory)/symbols'
     CleanTargetFolder: true
 

--- a/eng/pipelines/templates/VSCode-release.template.yml
+++ b/eng/pipelines/templates/VSCode-release.template.yml
@@ -1,6 +1,6 @@
 ---
 parameters:
-  rids: ["win-x86", "win10-arm64", "osx-x64", "osx-arm64", "linux-x64", "linux-arm", "linux-arm64", "linux-musl-x64", "linux-musl-arm64" ]
+  rids: ["win-x86", "win-arm64", "osx-x64", "osx-arm64", "linux-x64", "linux-arm", "linux-arm64", "linux-musl-x64", "linux-musl-arm64" ]
 
 steps:
 - checkout: self
@@ -28,6 +28,7 @@ steps:
 
 - template: ../steps/CopyAndPublishSymbols.yml
   parameters:
+    SourceFolder: '$(Build.StagingDirectory)\bin'
     OneESPT: true
 
 - script: |


### PR DESCRIPTION
The MIEngine_VSCode_Release pipeline was failing. This addresses it.

Fix was authored by Andrew Wang.