### PR TITLE
Parse 'Name' from gdb thread-info response

### DIFF
--- a/src/MICore/CommandFactories/gdb.cs
+++ b/src/MICore/CommandFactories/gdb.cs
@@ -176,6 +176,30 @@ namespace MICore
             {
                 _currentThreadId = results.FindInt("current-thread-id");
             }
+
+            var tlist = results.Find<ValueListValue>("threads");
+            foreach (var tVal in tlist.Content)
+            {
+                if (tVal.Contains("details"))
+                {
+                    string details = tVal.FindString("details");
+                    var keyValuePairs = details.Split(',')
+                        .Select(part => part.Split(new[] { ':' }, 2))
+                        .Where(part => part.Length == 2)
+                        .ToDictionary(
+                            part => part[0].Trim(),
+                            part => part[1].Trim()
+                        );
+
+                    if (keyValuePairs.TryGetValue("Name", out string name))
+                    {
+                        if (tVal is TupleValue tupleValue)
+                        {
+                            tupleValue.Content.Add(new NamedResultValue("name", new ConstValue(name)));
+                        }
+                    }
+                }
+            }
             return results;
         }
 


### PR DESCRIPTION
GDB thread-info packet combines the 'Name' and 'State' fields into a type of dictionary response. Even though the internal thread-info and wire protocol include separate and distinct fields, they get combined for some reason.

This code parses the fields back out, and makes it so the thread names are displayed properly in vscode.

## Before
![Screenshot at 2024-11-05 23-12-51](https://github.com/user-attachments/assets/f70f9a16-e176-4b08-aeeb-c8f46369c831)

## After
![Screenshot at 2024-11-05 23-13-41](https://github.com/user-attachments/assets/14ab239a-63ec-435a-b8fb-7397cde17fbb)
