### PR TITLE
Fix DebuggerTesting-release build

### DIFF
--- a/eng/pipelines/templates/DebuggerTesting-release.template.yml
+++ b/eng/pipelines/templates/DebuggerTesting-release.template.yml
@@ -29,6 +29,8 @@ steps:
     TargetFolders: '$(Build.SourcesDirectory)\bin\DebugAdapterProtocolTests\Release\drop'
 
 - template: ../steps/CopyAndPublishSymbols.yml
+  parameters:
+    SourceFolder: '$(Build.SourcesDirectory)\bin\DebugAdapterProtocolTests\Release\drop'
 
 - template: ../tasks/PublishPipelineArtifact.yml
   parameters:


### PR DESCRIPTION
The DebuggerTesting-release build was failing. This fixes it.