### PR TITLE
Don't try to parse JSON strings as date

### DIFF
--- a/src/MICore/LaunchOptions.cs
+++ b/src/MICore/LaunchOptions.cs
@@ -1268,6 +1268,10 @@ namespace MICore
                 try
                 {
                     JObject parsedOptions = JsonConvert.DeserializeObject<JObject>(options, new JsonSerializerSettings { DateParseHandling = DateParseHandling.None });
+                    if (parsedOptions is null)
+                    {
+                        throw new InvalidLaunchOptionsException(MICoreResources.Error_UnknownLaunchOptions);
+                    }
 
                     // if the customLauncher element is present then try using the custom launcher implementation from the config store
                     if (parsedOptions["customLauncher"] != null && !string.IsNullOrWhiteSpace(parsedOptions["customLauncher"].Value<string>()))

--- a/src/MICore/LaunchOptions.cs
+++ b/src/MICore/LaunchOptions.cs
@@ -1267,7 +1267,7 @@ namespace MICore
             {
                 try
                 {
-                    JObject parsedOptions = JObject.Parse(options);
+                    JObject parsedOptions = JsonConvert.DeserializeObject<JObject>(options, new JsonSerializerSettings { DateParseHandling = DateParseHandling.None });
 
                     // if the customLauncher element is present then try using the custom launcher implementation from the config store
                     if (parsedOptions["customLauncher"] != null && !string.IsNullOrWhiteSpace(parsedOptions["customLauncher"].Value<string>()))


### PR DESCRIPTION
When parsing launch options from JSON, the JSON parser's default behavior is – for whatever reason – to parse slightly datetime-ish looking strings as date objects. This PR explicitly forbids this behavior when parsing launch options.

Partially fixes https://github.com/microsoft/MIEngine/issues/1491, https://github.com/microsoft/vscode-cpptools/issues/13241 and https://github.com/microsoft/vscode/issues/238514.