### PR TITLE
Update VSCodeDebugProtocol library

### DIFF
--- a/build/package_versions.settings.targets
+++ b/build/package_versions.settings.targets
@@ -3,7 +3,7 @@
         <Microsoft_VisualStudio_Debugger_Interop_Portable_Version>1.0.1</Microsoft_VisualStudio_Debugger_Interop_Portable_Version>
         <Microsoft_VisualStudio_Interop_Version>17.12.40391</Microsoft_VisualStudio_Interop_Version>
         <Newtonsoft_Json_Version>13.0.3</Newtonsoft_Json_Version>
-        <Microsoft_VisualStudio_Shared_VSCodeDebugProtocol_Version>17.2.60629.1</Microsoft_VisualStudio_Shared_VSCodeDebugProtocol_Version>
+        <Microsoft_VisualStudio_Shared_VSCodeDebugProtocol_Version>17.14.10225.1</Microsoft_VisualStudio_Shared_VSCodeDebugProtocol_Version>
 
         <!-- Test Packages -->
         <Microsoft_NET_Test_Sdk_Version>16.7.1</Microsoft_NET_Test_Sdk_Version>

--- a/src/MIDebugEngine.sln
+++ b/src/MIDebugEngine.sln
@@ -11,6 +11,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 	ProjectSection(SolutionItems) = preProject
 		..\.editorconfig = ..\.editorconfig
 		IDECodeAnalysis.ruleset = IDECodeAnalysis.ruleset
+		..\README.md = ..\README.md
 	EndProjectSection
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "MICoreUnitTests", "MICoreUnitTests\MICoreUnitTests.csproj", "{6D565BAE-4764-40C3-9C0F-204B6FFA0389}"


### PR DESCRIPTION
This PR updates the version of Microsoft.VisualStudio.Shared.VSCodeDebugProtocol to 17.14.10225.1. This completes the work for #1491.

I also noticed the solution doesn't reference README.md, so this adds a link.