### PR TITLE
Dev/paulmay/kill on close

### DIFF
--- a/src/MICore/Transports/PipeTransport.cs
+++ b/src/MICore/Transports/PipeTransport.cs
@@ -209,7 +209,6 @@ namespace MICore
                         {
                             // kill only the process
                             _process.Kill();
-
                         }
                     }
                     catch

--- a/src/MICore/Transports/PipeTransport.cs
+++ b/src/MICore/Transports/PipeTransport.cs
@@ -197,11 +197,20 @@ namespace MICore
 
             if (_process != null)
             {
-                if (_killOnClose && !_process.HasExited)
+                if (!_process.HasExited)
                 {
                     try
                     {
-                        KillPipeProcessAndChildren(_process);
+                        if (_killOnClose)
+                        {
+                            KillPipeProcessAndChildren(_process);
+                        }
+                        else
+                        {
+                            // kill only the process
+                            _process.Kill();
+
+                        }
                     }
                     catch
                     {


### PR DESCRIPTION
Don't rely on closing the input pipe, WSL processes are often leaked when the transport process is not explicitly killed on close.