### PR TITLE
[Builds] Update MicroBuildInsertVsPayload to v5

### DIFF
--- a/eng/pipelines/VS-release.yml
+++ b/eng/pipelines/VS-release.yml
@@ -59,7 +59,7 @@ extends:
             Write-Host "##vso[task.setvariable variable=MDDPackageVersion;]$version"
           displayName: 'Set MDDPackage Version'
 
-        - task: ms-vseng.MicroBuildShipTasks.55100717-a81d-45ea-a363-b8fe3ec375ad.MicroBuildInsertVsPayload@4
+        - task: ms-vseng.MicroBuildShipTasks.55100717-a81d-45ea-a363-b8fe3ec375ad.MicroBuildInsertVsPayload@5
           displayName: 'Insert VS Payload'
           inputs:
             TargetBranch: $(TargetBranch)  


### PR DESCRIPTION
VS Eng has requested that we update from v4 to v5.

None of the parameters currently used have been renamed, nor are there any new ones we need to add. 