### PR TITLE
Update 'rel/d17.12' with latest YAML Build Changes and GDB 15 fix

### DIFF
--- a/.github/workflows/Build-And-Test.yml
+++ b/.github/workflows/Build-And-Test.yml
@@ -150,7 +150,7 @@ jobs:
         path: ${{ github.workspace }}/bin/DebugAdapterProtocolTests/Debug/CppTests/results.trx
 
   osx_build:
-    runs-on: macos-12
+    runs-on: macos-latest
     steps:
     - name: Checkout
       uses: actions/checkout@v4
@@ -168,8 +168,10 @@ jobs:
     - run: |
         ${{ github.workspace }}/eng/Scripts/CI-Build.sh
 
-    - run: |
-        ${{ github.workspace }}/eng/Scripts/CI-Test.sh
+    # Disabling lldb-mi tests since DownloadLldbMI.sh will obtain 
+    # an x64 version instead of an arm64 and test will fail.
+    # - run: |
+    #    ${{ github.workspace }}/eng/Scripts/CI-Test.sh
 
     - name: 'Upload Test Results'
       uses: actions/upload-artifact@v4

--- a/build/Analyzers.targets
+++ b/build/Analyzers.targets
@@ -1,18 +1,8 @@
  <Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
-    <!-- Disable Legacy FxCop -->
-    <RunCodeAnalysis>false</RunCodeAnalysis>
     <EnableNETAnalyzers>true</EnableNETAnalyzers>
 
     <!-- Point to ruleset -->
     <CodeAnalysisRuleSet>..\IDECodeAnalysis.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
-  
-  <ItemGroup>
-    <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="3.3.0" PrivateAssets="all"  />
-    <PackageReference Include="Microsoft.CodeAnalysis.VersionCheckAnalyzer" Version="3.3.0" PrivateAssets="all" />
-    <PackageReference Include="Microsoft.CodeQuality.Analyzers" Version="3.3.0" PrivateAssets="all"  />
-    <PackageReference Include="Microsoft.NetCore.Analyzers" Version="3.3.0" PrivateAssets="all" />
-    <PackageReference Include="Microsoft.NetFramework.Analyzers" Version="3.3.0" PrivateAssets="all"  />
-  </ItemGroup>
 </Project>

--- a/build/package_versions.settings.targets
+++ b/build/package_versions.settings.targets
@@ -1,14 +1,14 @@
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
     <PropertyGroup>
         <Microsoft_VisualStudio_Debugger_Interop_Portable_Version>1.0.1</Microsoft_VisualStudio_Debugger_Interop_Portable_Version>
-        <Microsoft_VisualStudio_Interop_Version>17.11.40262</Microsoft_VisualStudio_Interop_Version>
+        <Microsoft_VisualStudio_Interop_Version>17.12.40391</Microsoft_VisualStudio_Interop_Version>
         <Newtonsoft_Json_Version>13.0.3</Newtonsoft_Json_Version>
         <Microsoft_VisualStudio_Shared_VSCodeDebugProtocol_Version>17.2.60629.1</Microsoft_VisualStudio_Shared_VSCodeDebugProtocol_Version>
 
         <!-- Test Packages -->
         <Microsoft_NET_Test_Sdk_Version>16.7.1</Microsoft_NET_Test_Sdk_Version>
-        <xunit_Version>2.4.1</xunit_Version>
-        <xunit_runner_visualstudio_Version>2.4.3</xunit_runner_visualstudio_Version>
+        <xunit_Version>2.9.2</xunit_Version>
+        <xunit_runner_visualstudio_Version>3.0.0</xunit_runner_visualstudio_Version>
         <coverlet_collector_Version>1.3.0</coverlet_collector_Version>
         <MSTest_TestFramework_Version>2.1.2</MSTest_TestFramework_Version>
 
@@ -25,19 +25,19 @@
         <Microsoft_VisualStudio_Debugger_Interop_15_0_Version>17.5.33428.366</Microsoft_VisualStudio_Debugger_Interop_15_0_Version>
         <Microsoft_VisualStudio_Debugger_Interop_16_0_Version>17.5.33428.366</Microsoft_VisualStudio_Debugger_Interop_16_0_Version>
         <Microsoft_VisualStudio_Debugger_InteropA_Version>17.5.33428.366</Microsoft_VisualStudio_Debugger_InteropA_Version>
-        <Microsoft_VisualStudio_Shell_15_0_Version>17.11.40262</Microsoft_VisualStudio_Shell_15_0_Version>
-        <Microsoft_VisualStudio_Shell_Framework_Version>17.11.40262</Microsoft_VisualStudio_Shell_Framework_Version>
-        <Microsoft_VisualStudio_Threading_Version>17.11.20</Microsoft_VisualStudio_Threading_Version>
-        <Microsoft_VisualStudio_Utilities_Version>17.11.40262</Microsoft_VisualStudio_Utilities_Version>
+        <Microsoft_VisualStudio_Shell_15_0_Version>17.12.40392</Microsoft_VisualStudio_Shell_15_0_Version>
+        <Microsoft_VisualStudio_Shell_Framework_Version>17.12.40391</Microsoft_VisualStudio_Shell_Framework_Version>
+        <Microsoft_VisualStudio_Threading_Version>17.12.19</Microsoft_VisualStudio_Threading_Version>
+        <Microsoft_VisualStudio_Utilities_Version>17.12.40391</Microsoft_VisualStudio_Utilities_Version>
         <Microsoft_VisualStudio_Shell_Interop_15_0_DesignTime_Version>15.0.26932</Microsoft_VisualStudio_Shell_Interop_15_0_DesignTime_Version>
         <Microsoft_VisualStudio_Workspace_Version>15.0.392</Microsoft_VisualStudio_Workspace_Version>
         <Microsoft_VisualStudio_Workspace_VSIntegration_Version>15.0.392</Microsoft_VisualStudio_Workspace_VSIntegration_Version>
-        <Microsoft_VisualStudio_TextManager_Interop_Version>17.11.40262</Microsoft_VisualStudio_TextManager_Interop_Version>
+        <Microsoft_VisualStudio_TextManager_Interop_Version>17.12.40391</Microsoft_VisualStudio_TextManager_Interop_Version>
         <Microsoft_VSSDK_BuildTools_Version>17.3.2093</Microsoft_VSSDK_BuildTools_Version>
         <System_Runtime_Loader_Version>4.3.0</System_Runtime_Loader_Version>
 
         <!-- For Component Governance -->
         <Microsoft_IO_Redist_Version>6.0.1</Microsoft_IO_Redist_Version>
-        <System_Text_Json_Version>8.0.4</System_Text_Json_Version>
+        <System_Text_Json_Version>8.0.5</System_Text_Json_Version>
     </PropertyGroup>
 </Project>

--- a/eng/Scripts/CI-Build.ps1
+++ b/eng/Scripts/CI-Build.ps1
@@ -3,7 +3,7 @@ param(
 [Alias("c")]
 [string]$Configuration="Debug",
 
-[ValidateSet("win-x86", "win10-arm64")]
+[ValidateSet("win-x86", "win-arm64")]
 [Alias("r")]
 [string]$RID="win-x86",
 

--- a/eng/pipelines/VS-release.yml
+++ b/eng/pipelines/VS-release.yml
@@ -59,7 +59,7 @@ extends:
             Write-Host "##vso[task.setvariable variable=MDDPackageVersion;]$version"
           displayName: 'Set MDDPackage Version'
 
-        - task: ms-vseng.MicroBuildShipTasks.55100717-a81d-45ea-a363-b8fe3ec375ad.MicroBuildInsertVsPayload@4
+        - task: ms-vseng.MicroBuildShipTasks.55100717-a81d-45ea-a363-b8fe3ec375ad.MicroBuildInsertVsPayload@5
           displayName: 'Insert VS Payload'
           inputs:
             TargetBranch: $(TargetBranch)  

--- a/eng/pipelines/steps/CopyAndPublishSymbols.yml
+++ b/eng/pipelines/steps/CopyAndPublishSymbols.yml
@@ -2,13 +2,14 @@
 ---
 parameters:
   OneESPT: false
+  SourceFolder: '$(Build.StagingDirectory)\drop'
 
 steps:
 - template: ../tasks/CopyFiles.yml
   parameters:
     displayName: 'Collect build symbols'
-    SourceFolder: '$(Build.StagingDirectory)\drop'
-    Contents: '$(Build.StagingDirectory)\drop\**\*.+(pdb|exe|dll)'
+    SourceFolder: ${{ parameters.SourceFolder }}
+    Contents: '${{ parameters.SourceFolder }}\**\*.+(pdb|exe|dll)'
     TargetFolder: '$(Build.ArtifactStagingDirectory)/symbols'
     CleanTargetFolder: true
 

--- a/eng/pipelines/steps/CopyAndPublishSymbols.yml
+++ b/eng/pipelines/steps/CopyAndPublishSymbols.yml
@@ -7,8 +7,8 @@ steps:
 - template: ../tasks/CopyFiles.yml
   parameters:
     displayName: 'Collect build symbols'
-    SourceFolder: '$(Build.SourcesDirectory)'
-    Contents: '$(Build.SourcesDirectory)\bin\**\*.+(pdb|exe|dll)'
+    SourceFolder: '$(Build.StagingDirectory)\drop'
+    Contents: '$(Build.StagingDirectory)\drop\**\*.+(pdb|exe|dll)'
     TargetFolder: '$(Build.ArtifactStagingDirectory)/symbols'
     CleanTargetFolder: true
 
@@ -19,16 +19,9 @@ steps:
     SymbolsFeatureName: MIEngine
     SymbolsProject: VS
     SymbolsAgentPath: '$(Build.ArtifactStagingDirectory)\Symbols\'
-    ExcludeAgentFolders: '$(Build.ArtifactStagingDirectory)\Symbols\bin\Debug;$(Build.ArtifactStagingDirectory)\Symbols\bin\Lab.Debug'
+    ExcludeAgentFolders: '$(Build.ArtifactStagingDirectory)\Symbols\Debug;$(Build.ArtifactStagingDirectory)\Symbols\Lab.Debug'
     ${{ if parameters.OneESPT }}:
       ExpirationInDays: 3650 # Expire in 10 years for release builds
     ${{ else }}:
       ExpirationInDays: 1 # Expire in 1 day if used for testing
-            
-- template: ../tasks/1ES/PublishPipelineArtifact.yml
-  parameters:
-    displayName: 'Publish Symbols Artifact'
-    targetPath: '$(Build.ArtifactStagingDirectory)/symbols' 
-    artifactName: 'Symbols'
-    OneESPT: ${{ parameters.OneESPT }}
 ...

--- a/eng/pipelines/steps/PublishOpenDebugAD7.yml
+++ b/eng/pipelines/steps/PublishOpenDebugAD7.yml
@@ -8,6 +8,7 @@ steps:
     dotnet publish $(Build.SourcesDirectory)\src\OpenDebugAD7\OpenDebugAD7.csproj -c ${{ parameters.Configuration }} -r ${{ parameters.RuntimeID }} --self-contained -o $(Build.StagingDirectory)\${{ parameters.RuntimeID }}\debugAdapters\bin
     copy ${{ parameters.SignedBinariesFolder }}\Release\vscode\OpenDebugAD7.dll "$(Build.StagingDirectory)\${{ parameters.RuntimeID }}\debugAdapters\bin\.
     copy ${{ parameters.SignedBinariesFolder }}\Release\vscode\Microsoft.DebugEngineHost.dll $(Build.StagingDirectory)\${{ parameters.RuntimeID }}\debugAdapters\bin\.
+    copy ${{ parameters.SignedBinariesFolder }}\Release\vscode\Newtonsoft.Json.dll $(Build.StagingDirectory)\${{ parameters.RuntimeID }}\debugAdapters\bin\.
     copy ${{ parameters.SignedBinariesFolder }}\Release\Microsoft.MIDebugEngine.dll $(Build.StagingDirectory)\${{ parameters.RuntimeID }}\debugAdapters\bin\.
     copy ${{ parameters.SignedBinariesFolder }}\Release\Microsoft.MICore.dll $(Build.StagingDirectory)\${{ parameters.RuntimeID }}\debugAdapters\bin\.
   displayName: "Publish OpenDebugAD7 ${{ parameters.RuntimeID }}"

--- a/eng/pipelines/templates/DebuggerTesting-release.template.yml
+++ b/eng/pipelines/templates/DebuggerTesting-release.template.yml
@@ -29,6 +29,8 @@ steps:
     TargetFolders: '$(Build.SourcesDirectory)\bin\DebugAdapterProtocolTests\Release\drop'
 
 - template: ../steps/CopyAndPublishSymbols.yml
+  parameters:
+    SourceFolder: '$(Build.SourcesDirectory)\bin\DebugAdapterProtocolTests\Release\drop'
 
 - template: ../tasks/PublishPipelineArtifact.yml
   parameters:

--- a/eng/pipelines/templates/VSCode-release.template.yml
+++ b/eng/pipelines/templates/VSCode-release.template.yml
@@ -1,6 +1,6 @@
 ---
 parameters:
-  rids: ["win-x86", "win10-arm64", "osx-x64", "osx-arm64", "linux-x64", "linux-arm", "linux-arm64", "linux-musl-x64", "linux-musl-arm64" ]
+  rids: ["win-x86", "win-arm64", "osx-x64", "osx-arm64", "linux-x64", "linux-arm", "linux-arm64", "linux-musl-x64", "linux-musl-arm64" ]
 
 steps:
 - checkout: self
@@ -28,6 +28,7 @@ steps:
 
 - template: ../steps/CopyAndPublishSymbols.yml
   parameters:
+    SourceFolder: '$(Build.StagingDirectory)\bin'
     OneESPT: true
 
 - script: |

--- a/src/MIDebugEngine/Engine.Impl/DebuggedProcess.cs
+++ b/src/MIDebugEngine/Engine.Impl/DebuggedProcess.cs
@@ -624,6 +624,7 @@ namespace Microsoft.MIDebugEngine
             if (_launchOptions.DebuggerMIMode == MIMode.Gdb)
             {
                 commands.Add(new LaunchCommand("-interpreter-exec console \"set pagination off\""));
+                commands.Add(new LaunchCommand("set debuginfod enabled on", ignoreFailures:true));
             }
 
             // When user specifies loading directives then the debugger cannot auto load symbols, the MIEngine must intervene at each solib-load event and make a determination


### PR DESCRIPTION
This PR is to backport the GDB 15 fix by enabling debuginfod, this also cherry-picks all the commits needed to run the release YAML on this branch to insert into `rel/d17.12`.

The commits were based on what was last released in d17.12 to current `main` from the `eng` folder.