### PR TITLE
Cherry-pick Docker 'Platform' returns an object instead of a string in Docker Desktop v4.42.0 to rel/d17.14 and Security Updates

### DIFF
--- a/build/package_versions.settings.targets
+++ b/build/package_versions.settings.targets
@@ -1,7 +1,7 @@
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
     <PropertyGroup>
         <Microsoft_VisualStudio_Debugger_Interop_Portable_Version>1.0.1</Microsoft_VisualStudio_Debugger_Interop_Portable_Version>
-        <Microsoft_VisualStudio_Interop_Version>17.12.40391</Microsoft_VisualStudio_Interop_Version>
+        <Microsoft_VisualStudio_Interop_Version>17.13.40008</Microsoft_VisualStudio_Interop_Version>
         <Newtonsoft_Json_Version>13.0.3</Newtonsoft_Json_Version>
         <Microsoft_VisualStudio_Shared_VSCodeDebugProtocol_Version>17.14.10225.1</Microsoft_VisualStudio_Shared_VSCodeDebugProtocol_Version>
 
@@ -26,13 +26,13 @@
         <Microsoft_VisualStudio_Debugger_Interop_16_0_Version>17.5.33428.366</Microsoft_VisualStudio_Debugger_Interop_16_0_Version>
         <Microsoft_VisualStudio_Debugger_InteropA_Version>17.5.33428.366</Microsoft_VisualStudio_Debugger_InteropA_Version>
         <Microsoft_VisualStudio_Shell_15_0_Version>17.12.40392</Microsoft_VisualStudio_Shell_15_0_Version>
-        <Microsoft_VisualStudio_Shell_Framework_Version>17.12.40391</Microsoft_VisualStudio_Shell_Framework_Version>
-        <Microsoft_VisualStudio_Threading_Version>17.12.19</Microsoft_VisualStudio_Threading_Version>
-        <Microsoft_VisualStudio_Utilities_Version>17.12.40391</Microsoft_VisualStudio_Utilities_Version>
+        <Microsoft_VisualStudio_Shell_Framework_Version>17.13.40008</Microsoft_VisualStudio_Shell_Framework_Version>
+        <Microsoft_VisualStudio_Threading_Version>17.13.2</Microsoft_VisualStudio_Threading_Version>
+        <Microsoft_VisualStudio_Utilities_Version>17.13.40008</Microsoft_VisualStudio_Utilities_Version>
         <Microsoft_VisualStudio_Shell_Interop_15_0_DesignTime_Version>15.0.26932</Microsoft_VisualStudio_Shell_Interop_15_0_DesignTime_Version>
         <Microsoft_VisualStudio_Workspace_Version>15.0.392</Microsoft_VisualStudio_Workspace_Version>
         <Microsoft_VisualStudio_Workspace_VSIntegration_Version>15.0.392</Microsoft_VisualStudio_Workspace_VSIntegration_Version>
-        <Microsoft_VisualStudio_TextManager_Interop_Version>17.12.40391</Microsoft_VisualStudio_TextManager_Interop_Version>
+        <Microsoft_VisualStudio_TextManager_Interop_Version>17.13.40008</Microsoft_VisualStudio_TextManager_Interop_Version>
         <Microsoft_VSSDK_BuildTools_Version>17.3.2093</Microsoft_VSSDK_BuildTools_Version>
         <System_Runtime_Loader_Version>4.3.0</System_Runtime_Loader_Version>
 

--- a/src/SSHDebugPS/Docker/DockerContainerInstance.cs
+++ b/src/SSHDebugPS/Docker/DockerContainerInstance.cs
@@ -62,6 +62,7 @@ namespace Microsoft.SSHDebugPS.Docker
         [JsonProperty("CreatedAt")]
         public string Created { get; private set; }
 
+        [JsonIgnore]
         public string Platform { get; set; }
 
         #endregion

--- a/src/tools/MakePIAPortableTool/MakePIAPortableTool.cs
+++ b/src/tools/MakePIAPortableTool/MakePIAPortableTool.cs
@@ -40,6 +40,8 @@ namespace MakePIAPortable
             { "System.Collections.Generic.IEnumerable", System_Runtime },
             { "System.Reflection.DefaultMemberAttribute", System_Runtime },
             { "System.Reflection.AssemblyDelaySignAttribute", System_Runtime},
+            { "System.Reflection.AssemblyKeyFileAttribute", System_Runtime },
+            { "System.Reflection.AssemblySignatureKeyAttribute", System_Runtime },
             { "System.Runtime.CompilerServices.CompilationRelaxationsAttribute", System_Runtime },
             { "System.Runtime.CompilerServices.RuntimeCompatibilityAttribute", System_Runtime },
             { "System.Diagnostics.DebuggableAttribute", System_Runtime },


### PR DESCRIPTION
* Docker 'Platform' returns an object instead of a string in Docker Desktop v4.42.0 (#1505)
* Update MS.VS. Packages for CG Alert (https://github.com/microsoft/MIEngine/pull/1508)