### PR TITLE
Merge 'main' into 'release/mdd'

### DIFF
--- a/src/SSHDebugPS/Docker/DockerContainerInstance.cs
+++ b/src/SSHDebugPS/Docker/DockerContainerInstance.cs
@@ -62,6 +62,7 @@ namespace Microsoft.SSHDebugPS.Docker
         [JsonProperty("CreatedAt")]
         public string Created { get; private set; }
 
+        [JsonIgnore]
         public string Platform { get; set; }
 
         #endregion


### PR DESCRIPTION
Changelog:
* Docker 'Platform' returns an object instead of a string in Docker Desktop v4.42.0