### PR TITLE
Build improvements

### DIFF
--- a/src/MICore/GenerateXmlSerializersAssembly.targets
+++ b/src/MICore/GenerateXmlSerializersAssembly.targets
@@ -80,32 +80,37 @@
         If TEST_LAB_BUILD is set, we are public signing. 
         sgen.exe does not have -publicsign and does not work if a keyfile is passed in. 
       -->
-      <SerializationSigningCompilerOptions Condition="'$(TEST_LAB_BUILD)'==''">/keyfile:$(AssemblyOriginatorKeyFile)</SerializationSigningCompilerOptions>
-
+      <SerializationSigningKeyFile Condition="'$(TEST_LAB_BUILD)'==''">$(AssemblyOriginatorKeyFile)</SerializationSigningKeyFile>
+      <SerializationSigningCompilerOptions Condition="'$(TEST_LAB_BUILD)'==''">/keyfile:$(SerializationSigningKeyFile)</SerializationSigningCompilerOptions>
+      
       <!--
         Add $(MIEngineRoot)src\MICore\SGEN_SHA2_SIGNATUREKEY to enable SHA2 signing for sgen.exe.
       -->
-      <SerializationSigningCompilerOptions Condition="'$(DelaySign)'=='true'">$(SerializationSigningCompilerOptions) /delaysign $(MIEngineRoot)src\MICore\SGEN_SHA2_SIGNATUREKEY</SerializationSigningCompilerOptions>
-
-      <CompilerPath>$(CscToolPath)$(CscToolExe)</CompilerPath>
-      <CompilerPath Condition="'$(CompilerPath)' == '' and Exists('$(MSBuildBinPath)\csc.exe')">$(MSBuildBinPath)\csc.exe</CompilerPath>
-      <CompilerPath Condition="'$(CompilerPath)' == '' and Exists('$(MSBuildBinPath)\roslyn\csc.exe')">$(MSBuildBinPath)\roslyn\csc.exe</CompilerPath>
-
-      <!-- Fix for VS 2019 -->
-      <CompilerPath Condition="'$(CompilerPath)' == '' and Exists('$(RoslynTargetsPath)\csc.exe')">$(RoslynTargetsPath)\csc.exe</CompilerPath>
+      <SgenSha2SignatureKeyFile Condition="'$(DelaySign)'=='true'">SGEN_SHA2_SIGNATUREKEY</SgenSha2SignatureKeyFile>
+      <SerializationSigningCompilerOptions Condition="'$(DelaySign)'=='true'">$(SerializationSigningCompilerOptions) /delaysign $(MIEngineRoot)src\MICore\$(SgenSha2SignatureKeyFile)</SerializationSigningCompilerOptions>
 
       <RefPath>$(MSBuildFrameworkToolsPath)</RefPath>
     </PropertyGroup>
 
     <Error Condition="'$(SDK40ToolsPath)'==''" Text="SDK40ToolsPath msbuild property is undefined." />
     <Error Condition="!Exists('$(SDK40ToolsPath)sgen.exe')" Text="sgen.exe does not exist in the SDK40ToolsPath ($(SDK40ToolsPath)xsd.exe)." />
-    <Error Condition="'$(CompilerPath)' == '' or !Exists('$(CompilerPath)')" Text="Unable to locate csc.exe - path '$(CompilerPath)' is not valid!" />
 
     <RemoveDir Condition="Exists('$(IntermediateOutputPath)sgen')" Directories="$(IntermediateOutputPath)sgen" />
     <MakeDir Directories="$(IntermediateOutputPath)sgen" />
     
     <!-- Compile the types file into an assembly that we can use as input to sgen. We don't want to pass our real assembly as we have some things that sgen doesn't like. -->
-    <Exec Command="&quot;$(CompilerPath)&quot; $(XsdCodeFile) $(GeneratedAssemblyInfoFile) /out:$(IntermediateOutputPath)sgen/$(AssemblyName).dll /target:library /noconfig $(SerializationSigningCompilerOptions) /r:$(RefPath)/System.dll /r:$(RefPath)/System.Xml.dll" />
+    <Csc
+        Sources="$(XsdCodeFile);$(GeneratedAssemblyInfoFile);$(SgenSha2SignatureKeyFile)"
+        OutputAssembly="$(IntermediateOutputPath)sgen/$(AssemblyName).dll"
+        TargetType="Library"
+        NoConfig="true"
+        NoLogo="$(NoLogo)"
+        DelaySign="$(DelaySign)"
+        KeyFile="$(SerializationSigningKeyFile)"
+        DebugType="none"
+        LangVersion="$(LangVersion)"
+        References="$(RefPath)/mscorlib.dll;$(RefPath)/System.dll;$(RefPath)/System.Xml.dll"
+        />
 
     <!-- Now generate the serialization assembly -->
     <Exec Command="&quot;$(SDK40ToolsPath)sgen.exe&quot; $(IntermediateOutputPath)sgen/$(AssemblyName).dll /force /compiler:&quot;$(SerializationSigningCompilerOptions)&quot; /keep" />

--- a/src/MakePIAPortable/MakePIAPortable.csproj
+++ b/src/MakePIAPortable/MakePIAPortable.csproj
@@ -65,9 +65,17 @@
     
     <MakePIAPortableExe>$(MIDefaultOutputPath)tools\MakePIAPortableTool.dll</MakePIAPortableExe>
     <ILToolsExist Condition="Exists($(ILDAsmFileLocation)) AND Exists($(ILAsmFileLocation))">true</ILToolsExist>
+    <PackageVersionTargetsFile>..\..\build\package_versions.settings.targets</PackageVersionTargetsFile>
   </PropertyGroup>
-  
-  <Target Name="GeneratePortablePIA" Inputs="@(MakePIAPortableFiles)" Outputs="@(MakePIAPortableFiles->'$(PIAOutput)%(Filename)')" BeforeTargets="SignFiles" AfterTargets="Build">
+
+  <ItemGroup>
+    <!--Ensure that VS doesn't skip incremental build if package_versions.settings.targets is changed, or the target failed on the last run.
+    For more information: https://github.com/dotnet/project-system/blob/main/docs/up-to-date-check.md#customization
+    -->
+    <UpToDateCheckInput Include="$(PackageVersionTargetsFile)" />
+    <UpToDateCheckOutput Include="@(MakePIAPortableFiles->'$(PIAOutput)%(Filename)%(Extension)')" />
+  </ItemGroup>
+  <Target Name="GeneratePortablePIA" Inputs="$(PackageVersionTargetsFile);@(MakePIAPortableFiles)" Outputs="@(MakePIAPortableFiles->'$(PIAOutput)%(Filename)%(Extension)')" BeforeTargets="SignFiles" AfterTargets="Build">
     <Message Importance="High" Text="ILDAsmFileLocation: $(ILDAsmFileLocation)" />
     <Message Importance="High" Text="ILAsmFileLocation: $(ILAsmFileLocation)" />
     <Error Condition="'$(ILToolsExist)' != 'true'" Text="Unable to retrieve IL tools needed for MakePIAPortable" />


### PR DESCRIPTION
## Changes

This PR contains two fixes to make MIEngine's build work better on my machine:
1. The incremental build rules were incorrect for MakePIAPortable, so it could run when it didn't need to, and it might not run when it was necessary.
2. On one of my machines, the sgen code didn't work anymore as it couldn't find csc.exe. This switches to using the `Csc` task instead.

## Testing

- Verified MakePIAPortable doesn't run the `GeneratePortablePIA` target after touching dummy.cs
- Verified MakePIAPortable runs the `GeneratePortablePIA` target after touching package_versions.settings.targets
- Verified no IL differences in Microsoft.MICore.XmlSerializers.dll between the version currently shipping in VS and a locally compiled Lab.Release version
- Verified no IL differences in Microsoft.MICore.XmlSerializers.dll between current main build and build with these changes