### PR TITLE
Fix anonymous union parsing in Natvis for LLDB

### DIFF
--- a/src/MIDebugEngine/Engine.Impl/Variables.cs
+++ b/src/MIDebugEngine/Engine.Impl/Variables.cs
@@ -289,8 +289,9 @@ namespace Microsoft.MIDebugEngine
             {
                 VariableNodeType = NodeType.ArrayElement;
             }
-            else if (Name == "<anonymous union>")
+            else if (Name == "<anonymous union>" || TypeName.EndsWith("(anonymous union)", StringComparison.InvariantCulture))
             {
+                // GDB provides anonymous unions in the expression; LLDB includes them in the type name and leaves the expression empty
                 VariableNodeType = NodeType.AnonymousUnion;
             }
             else if (Name.Length > 1 && Name[0] == '*')


### PR DESCRIPTION
Consider the following example code:

```c++
int main(int argc, char *argv[])
{
	struct Foo
	{
		union
		{
			int a;
			float b;
		};
	};

	Foo f;
	f.b = 1.0f;

	__builtin_debugtrap();
}
```

When breaking at the debug trap, the following MI sequence is exchanged when using LLDB-MI (reformatted for readability):
```
1022-var-create - - "f" --thread 1 --frame 0
1022^done,name="var2",numchild="1",value="{...}",type="Foo",thread-id="1",has_more="0"

1025-var-list-children --all-values "var2" 0 1000
1025^done,numchild="1",children=[
    child={name="var2.$0",exp="",numchild="2",type="Foo::(anonymous union)",thread-id="1",value="{...}",has_more="0"}
],has_more="0"

1027-var-list-children --all-values "var2.$0" 0 1000
1027^done,numchild="2",children=[
    child={name="var2.$0.a",exp="a",numchild="0",type="int",thread-id="1",value="1065353216",has_more="0"},
    child={name="var2.$0.b",exp="b",numchild="0",type="float",thread-id="1",value="1",has_more="0"}
],has_more="0"
```

The anonymous union in `Foo` is listed by LLDB-MI as an unnamed child (no expression) and with type name `Foo::(anonymous union)`. The current check for anonymous unions only accounts for the syntax flavor that GDB uses, and so when using LLDB, anonymous unions incorrectly get flagged as `NodeType.Field` by MIEngine. This in turn affects `FullName()` which will return an incorrect expression if the members of the union are also compounds.

This change ensures that the LLDB flavor of anonymous unions get flagged properly.