### PR TITLE
Fix var-set-format MI result processing for LLDB

### DIFF
--- a/src/MIDebugEngine/Engine.Impl/Variables.cs
+++ b/src/MIDebugEngine/Engine.Impl/Variables.cs
@@ -714,7 +714,12 @@ namespace Microsoft.MIDebugEngine
             Results results = await _engine.DebuggedProcess.MICommandFactory.VarSetFormat(_internalName, _format, ResultClass.None);
             if (results.ResultClass == ResultClass.done)
             {
-                Value = results.FindString("value");
+                // Sample output for LLDB:    ^done,changelist=[{name="var1",value="123",in_scope="true",type_changed="false",type_changed="0"}]
+                // Sample output for GDB:     ^done,format="natural",value="123"
+                if (_engine.DebuggedProcess.LaunchOptions.DebuggerMIMode == MIMode.Lldb)
+                    Value = results.Find<ValueListValue>("changelist").Content[0].FindString("value");
+                else
+                    Value = results.FindString("value");
             }
             else if (results.ResultClass == ResultClass.error)
             {


### PR DESCRIPTION
Unlike GDB, LLDB-MI has a different result format for var-set-format. It wraps the new value in an array which only ever has one element. I'm not sure why that is the case, but it stops custom formats in Natvis from working.

### Min repro:

```c++
struct Wrapper
{
	int mFoo;
};

int main(int argc, char* argv[])
{
	Wrapper w;
	w.mFoo = 123456789;

	__builtin_debugtrap();
}
```

Natvis:
```xml
<Type Name="Wrapper">
	<DisplayString>{mFoo,x}</DisplayString>
</Type>
```

### Before

<img width="429" height="85" alt="4bq6n4LaLm" src="https://github.com/user-attachments/assets/96f30256-1f8b-4428-9f64-402db98ab49e" />

### After

<img width="242" height="44" alt="fEtO3lj0fQ" src="https://github.com/user-attachments/assets/539b59d0-9850-4ead-8771-8d3afe35ac0c" />
