### PR TITLE
Add support for HitCount and HitCondition

### DIFF
--- a/src/MICore/CommandFactories/MICommandFactory.cs
+++ b/src/MICore/CommandFactories/MICommandFactory.cs
@@ -567,6 +567,15 @@ namespace MICore
             await _debugger.CmdAsync(command, ResultClass.done);
         }
 
+        /// <summary>
+        /// Sends -break-after to set an ignore count on a breakpoint.
+        /// </summary>
+        public virtual async Task<Results> BreakAfter(string bkptno, uint count)
+        {
+            string command = string.Format(CultureInfo.InvariantCulture, "-break-after {0} {1}", bkptno, count);
+            return await _debugger.CmdAsync(command, ResultClass.done);
+        }
+
         public virtual IEnumerable<Guid> GetSupportedExceptionCategories()
         {
             return new Guid[0];

--- a/src/MIDebugEngine/AD7.Impl/AD7BoundBreakpoint.cs
+++ b/src/MIDebugEngine/AD7.Impl/AD7BoundBreakpoint.cs
@@ -5,6 +5,7 @@ using Microsoft.DebugEngineHost;
 using Microsoft.VisualStudio.Debugger.Interop;
 using System;
 using System.Diagnostics;
+using System.Threading.Tasks;
 
 namespace Microsoft.MIDebugEngine
 {
@@ -162,15 +163,18 @@ namespace Microsoft.MIDebugEngine
         int IDebugBoundBreakpoint2.SetHitCount(uint dwHitCount)
         {
             _bp.SetHitCount(dwHitCount);
+            _pendingBreakpoint?.RecomputeBreakAfter(dwHitCount);
+
             return Constants.S_OK;
         }
 
         /// <summary>
-        /// Syncs the hit count from GDB's "times" field in =breakpoint-modified events.
+        /// Syncs the hit count from GDB's "times" field using a delta
+        /// to preserve any user-initiated hit count reset.
         /// </summary>
         internal void SetHitCount(uint hitCount)
         {
-            _bp.SetHitCount(hitCount);
+            _bp.SetGdbHitCount(hitCount);
         }
 
         // This is used to specify the breakpoint hit count condition.
@@ -182,6 +186,8 @@ namespace Microsoft.MIDebugEngine
         }
 
         #endregion
+
+        internal uint HitCount => _bp.HitCount;
 
         internal void IncrementHitCount()
         {
@@ -208,6 +214,33 @@ namespace Microsoft.MIDebugEngine
                     return _passCountValue != 0 && (hitCount % _passCountValue) == 0;
                 default:
                     return true;
+            }
+        }
+
+        /// <summary>
+        /// Re-sends -break-after to GDB after a pass count breakpoint fires.
+        /// MOD: skips passCount-1 hits. EQUAL: clears the ignore count.
+        /// </summary>
+        internal async Task RearmBreakAfterAsync()
+        {
+            uint ignoreCount;
+            switch (_passCountStyle)
+            {
+                case enum_BP_PASSCOUNT_STYLE.BP_PASSCOUNT_MOD:
+                    if (_passCountValue == 0) return;
+                    ignoreCount = _passCountValue - 1;
+                    break;
+                case enum_BP_PASSCOUNT_STYLE.BP_PASSCOUNT_EQUAL:
+                    ignoreCount = 0;
+                    break;
+                default:
+                    return;
+            }
+
+            PendingBreakpoint bp = _pendingBreakpoint?.PendingBreakpoint;
+            if (bp != null && _engine?.DebuggedProcess != null)
+            {
+                await bp.SetBreakAfterAsync(ignoreCount, _engine.DebuggedProcess);
             }
         }
 

--- a/src/MIDebugEngine/AD7.Impl/AD7BoundBreakpoint.cs
+++ b/src/MIDebugEngine/AD7.Impl/AD7BoundBreakpoint.cs
@@ -19,6 +19,8 @@ namespace Microsoft.MIDebugEngine
         private BoundBreakpoint _bp;
 
         private bool _deleted;
+        private enum_BP_PASSCOUNT_STYLE _passCountStyle;
+        private uint _passCountValue;
 
         internal bool Enabled
         {
@@ -143,8 +145,7 @@ namespace Microsoft.MIDebugEngine
             return Constants.S_OK;
         }
 
-        // The sample engine does not support hit counts on breakpoints. A real-world debugger will want to keep track 
-        // of how many times a particular bound breakpoint has been hit and return it here.
+        // Returns the number of times this breakpoint has been hit.
         int IDebugBoundBreakpoint2.GetHitCount(out uint pdwHitCount)
         {
             pdwHitCount = _bp.HitCount;
@@ -156,28 +157,50 @@ namespace Microsoft.MIDebugEngine
             return ((IDebugPendingBreakpoint2)_pendingBreakpoint).SetCondition(bpCondition);  // setting on the pending break will set the condition
         }
 
-        // The sample engine does not support hit counts on breakpoints. A real-world debugger will want to keep track 
-        // of how many times a particular bound breakpoint has been hit. The debugger calls SetHitCount when the user 
-        // resets a breakpoint's hit count.
+        // Called by the debugger when the user resets a breakpoint's hit count.
         int IDebugBoundBreakpoint2.SetHitCount(uint dwHitCount)
         {
-            throw new NotImplementedException();
+            _bp.SetHitCount(dwHitCount);
+            return Constants.S_OK;
         }
 
-        // The sample engine does not support pass counts on breakpoints.
         // This is used to specify the breakpoint hit count condition.
         int IDebugBoundBreakpoint2.SetPassCount(BP_PASSCOUNT bpPassCount)
         {
-            if (bpPassCount.stylePassCount != enum_BP_PASSCOUNT_STYLE.BP_PASSCOUNT_NONE)
-            {
-                Delete();
-                _engine.Callback.OnBreakpointUnbound(this, enum_BP_UNBOUND_REASON.BPUR_BREAKPOINT_ERROR);
-                return Constants.E_FAIL;
-            }
+            _passCountStyle = bpPassCount.stylePassCount;
+            _passCountValue = bpPassCount.dwPassCount;
             return Constants.S_OK;
         }
 
         #endregion
+
+        internal void IncrementHitCount()
+        {
+            _bp.IncrementHitCount();
+        }
+
+        /// <summary>
+        /// Evaluates whether the debugger should break at this breakpoint based on the
+        /// current hit count and the configured pass count condition.
+        /// Must be called after IncrementHitCount.
+        /// </summary>
+        internal bool ShouldBreak()
+        {
+            uint hitCount = _bp.HitCount;
+            switch (_passCountStyle)
+            {
+                case enum_BP_PASSCOUNT_STYLE.BP_PASSCOUNT_NONE:
+                    return true;
+                case enum_BP_PASSCOUNT_STYLE.BP_PASSCOUNT_EQUAL:
+                    return hitCount == _passCountValue;
+                case enum_BP_PASSCOUNT_STYLE.BP_PASSCOUNT_EQUAL_OR_GREATER:
+                    return hitCount >= _passCountValue;
+                case enum_BP_PASSCOUNT_STYLE.BP_PASSCOUNT_MOD:
+                    return _passCountValue != 0 && (hitCount % _passCountValue) == 0;
+                default:
+                    return true;
+            }
+        }
 
         internal void UpdateAddr(ulong addr)
         {

--- a/src/MIDebugEngine/AD7.Impl/AD7BoundBreakpoint.cs
+++ b/src/MIDebugEngine/AD7.Impl/AD7BoundBreakpoint.cs
@@ -39,6 +39,7 @@ namespace Microsoft.MIDebugEngine
         internal string Number { get { return _bp.Number; } }
         internal AD7PendingBreakpoint PendingBreakpoint { get { return _pendingBreakpoint; } }
         internal bool IsDataBreakpoint { get { return PendingBreakpoint.IsDataBreakpoint; } }
+        internal bool HasPassCount { get { return _passCountStyle != enum_BP_PASSCOUNT_STYLE.BP_PASSCOUNT_NONE; } }
 
         public AD7BoundBreakpoint(AD7Engine engine, AD7PendingBreakpoint pendingBreakpoint, AD7BreakpointResolution breakpointResolution, BoundBreakpoint bp)
         {
@@ -162,6 +163,14 @@ namespace Microsoft.MIDebugEngine
         {
             _bp.SetHitCount(dwHitCount);
             return Constants.S_OK;
+        }
+
+        /// <summary>
+        /// Syncs the hit count from GDB's "times" field in =breakpoint-modified events.
+        /// </summary>
+        internal void SetHitCount(uint hitCount)
+        {
+            _bp.SetHitCount(hitCount);
         }
 
         // This is used to specify the breakpoint hit count condition.

--- a/src/MIDebugEngine/AD7.Impl/AD7PendingBreakpoint.cs
+++ b/src/MIDebugEngine/AD7.Impl/AD7PendingBreakpoint.cs
@@ -388,6 +388,30 @@ namespace Microsoft.MIDebugEngine
                         }
                     }
                 }
+
+                // Set ignore count via -break-after if a pass count is configured
+                if (_bp != null && (_bpRequestInfo.dwFields & enum_BPREQI_FIELDS.BPREQI_PASSCOUNT) != 0
+                    && _bpRequestInfo.bpPassCount.stylePassCount != enum_BP_PASSCOUNT_STYLE.BP_PASSCOUNT_NONE)
+                {
+                    uint ignoreCount = ComputeIgnoreCount(_bpRequestInfo.bpPassCount.stylePassCount, _bpRequestInfo.bpPassCount.dwPassCount);
+                    await _bp.SetBreakAfterAsync(ignoreCount, _engine.DebuggedProcess);
+                }
+            }
+        }
+
+        /// <summary>
+        /// Computes the ignore count for -break-after. All styles skip the first N-1 hits.
+        /// </summary>
+        private static uint ComputeIgnoreCount(enum_BP_PASSCOUNT_STYLE style, uint passCount)
+        {
+            switch (style)
+            {
+                case enum_BP_PASSCOUNT_STYLE.BP_PASSCOUNT_EQUAL:
+                case enum_BP_PASSCOUNT_STYLE.BP_PASSCOUNT_EQUAL_OR_GREATER:
+                case enum_BP_PASSCOUNT_STYLE.BP_PASSCOUNT_MOD:
+                    return passCount > 0 ? passCount - 1 : 0;
+                default:
+                    return 0;
             }
         }
 

--- a/src/MIDebugEngine/AD7.Impl/AD7PendingBreakpoint.cs
+++ b/src/MIDebugEngine/AD7.Impl/AD7PendingBreakpoint.cs
@@ -115,11 +115,6 @@ namespace Microsoft.MIDebugEngine
                     return false;
                 }
             }
-            if ((_bpRequestInfo.dwFields & enum_BPREQI_FIELDS.BPREQI_PASSCOUNT) != 0)
-            {
-                this.SetError(new AD7ErrorBreakpoint(this, ResourceStrings.UnsupportedPassCountBreakpoint, enum_BP_ERROR_TYPE.BPET_GENERAL_ERROR));
-                return false;
-            }
 
             return true;
         }
@@ -406,6 +401,11 @@ namespace Microsoft.MIDebugEngine
                 }
                 AD7BreakpointResolution breakpointResolution = new AD7BreakpointResolution(_engine, IsDataBreakpoint, bp.Addr, bp.FunctionName, bp.DocumentContext(_engine));
                 AD7BoundBreakpoint boundBreakpoint = new AD7BoundBreakpoint(_engine, this, breakpointResolution, bp);
+                // Apply pass count (hit count condition) from the original request to the bound breakpoint
+                if ((_bpRequestInfo.dwFields & enum_BPREQI_FIELDS.BPREQI_PASSCOUNT) != 0)
+                {
+                    ((IDebugBoundBreakpoint2)boundBreakpoint).SetPassCount(_bpRequestInfo.bpPassCount);
+                }
                 //check can bind one last time. If the pending breakpoint was deleted before now, we need to clean up gdb side
                 if (CanBind())
                 {
@@ -645,13 +645,17 @@ namespace Microsoft.MIDebugEngine
             return Constants.S_OK;
         }
 
-        // The sample engine does not support pass counts on breakpoints.
         int IDebugPendingBreakpoint2.SetPassCount(BP_PASSCOUNT bpPassCount)
         {
-            if (bpPassCount.stylePassCount != enum_BP_PASSCOUNT_STYLE.BP_PASSCOUNT_NONE)
+            _bpRequestInfo.bpPassCount = bpPassCount;
+            _bpRequestInfo.dwFields |= enum_BPREQI_FIELDS.BPREQI_PASSCOUNT;
+
+            lock (_boundBreakpoints)
             {
-                this.SetError(new AD7ErrorBreakpoint(this, ResourceStrings.UnsupportedPassCountBreakpoint, enum_BP_ERROR_TYPE.BPET_GENERAL_ERROR), true);
-                return Constants.E_FAIL;
+                foreach (AD7BoundBreakpoint bp in _boundBreakpoints)
+                {
+                    ((IDebugBoundBreakpoint2)bp).SetPassCount(bpPassCount);
+                }
             }
             return Constants.S_OK;
         }

--- a/src/MIDebugEngine/AD7.Impl/AD7PendingBreakpoint.cs
+++ b/src/MIDebugEngine/AD7.Impl/AD7PendingBreakpoint.cs
@@ -697,23 +697,27 @@ namespace Microsoft.MIDebugEngine
                 }
             }
 
-            // Re-send -break-after to GDB with the updated ignore count, accounting
-            // for the current hit count so the breakpoint fires at the right time.
-            if (bp != null && bpPassCount.stylePassCount != enum_BP_PASSCOUNT_STYLE.BP_PASSCOUNT_NONE)
+            // When the pass count is cleared (NONE), send ignore count 0 to clear
+            // any stale GDB ignore count from the previous condition.
+            if (bp != null)
             {
-                uint currentHits = 0;
-                lock (_boundBreakpoints)
+                uint ignoreCount = 0;
+                if (bpPassCount.stylePassCount != enum_BP_PASSCOUNT_STYLE.BP_PASSCOUNT_NONE)
                 {
-                    foreach (AD7BoundBreakpoint boundBp in _boundBreakpoints)
+                    uint currentHits = 0;
+                    lock (_boundBreakpoints)
                     {
-                        uint hc;
-                        if (((IDebugBoundBreakpoint2)boundBp).GetHitCount(out hc) == Constants.S_OK && hc > currentHits)
+                        foreach (AD7BoundBreakpoint boundBp in _boundBreakpoints)
                         {
-                            currentHits = hc;
+                            uint hc;
+                            if (((IDebugBoundBreakpoint2)boundBp).GetHitCount(out hc) == Constants.S_OK && hc > currentHits)
+                            {
+                                currentHits = hc;
+                            }
                         }
                     }
+                    ignoreCount = ComputeIgnoreCount(bpPassCount.stylePassCount, bpPassCount.dwPassCount, currentHits);
                 }
-                uint ignoreCount = ComputeIgnoreCount(bpPassCount.stylePassCount, bpPassCount.dwPassCount, currentHits);
                 _engine.DebuggedProcess.WorkerThread.RunOperation(() =>
                 {
                     _engine.DebuggedProcess.AddInternalBreakAction(
@@ -722,6 +726,28 @@ namespace Microsoft.MIDebugEngine
                 });
             }
             return Constants.S_OK;
+        }
+
+        /// <summary>
+        /// Re-sends -break-after to GDB after a hit count reset.
+        /// </summary>
+        internal void RecomputeBreakAfter(uint currentHits)
+        {
+            if (_bp == null
+                || (_bpRequestInfo.dwFields & enum_BPREQI_FIELDS.BPREQI_PASSCOUNT) == 0
+                || _bpRequestInfo.bpPassCount.stylePassCount == enum_BP_PASSCOUNT_STYLE.BP_PASSCOUNT_NONE)
+            {
+                return;
+            }
+
+            PendingBreakpoint bp = _bp;
+            uint ignoreCount = ComputeIgnoreCount(_bpRequestInfo.bpPassCount.stylePassCount, _bpRequestInfo.bpPassCount.dwPassCount, currentHits);
+            _engine.DebuggedProcess.WorkerThread.RunOperation(() =>
+            {
+                _engine.DebuggedProcess.AddInternalBreakAction(
+                    () => bp.SetBreakAfterAsync(ignoreCount, _engine.DebuggedProcess)
+                );
+            });
         }
 
         // Toggles the virtualized state of this pending breakpoint. When a pending breakpoint is virtualized, 

--- a/src/MIDebugEngine/AD7.Impl/AD7PendingBreakpoint.cs
+++ b/src/MIDebugEngine/AD7.Impl/AD7PendingBreakpoint.cs
@@ -393,23 +393,33 @@ namespace Microsoft.MIDebugEngine
                 if (_bp != null && (_bpRequestInfo.dwFields & enum_BPREQI_FIELDS.BPREQI_PASSCOUNT) != 0
                     && _bpRequestInfo.bpPassCount.stylePassCount != enum_BP_PASSCOUNT_STYLE.BP_PASSCOUNT_NONE)
                 {
-                    uint ignoreCount = ComputeIgnoreCount(_bpRequestInfo.bpPassCount.stylePassCount, _bpRequestInfo.bpPassCount.dwPassCount);
+                    uint ignoreCount = ComputeIgnoreCount(_bpRequestInfo.bpPassCount.stylePassCount, _bpRequestInfo.bpPassCount.dwPassCount, 0);
                     await _bp.SetBreakAfterAsync(ignoreCount, _engine.DebuggedProcess);
                 }
             }
         }
 
         /// <summary>
-        /// Computes the ignore count for -break-after. All styles skip the first N-1 hits.
+        /// Computes the ignore count for -break-after, accounting for hits already
+        /// counted from a prior breakpoint (<paramref name="currentHits"/>).
         /// </summary>
-        private static uint ComputeIgnoreCount(enum_BP_PASSCOUNT_STYLE style, uint passCount)
+        private static uint ComputeIgnoreCount(enum_BP_PASSCOUNT_STYLE style, uint passCount, uint currentHits)
         {
+            if (passCount == 0)
+            {
+                return 0;
+            }
+
             switch (style)
             {
                 case enum_BP_PASSCOUNT_STYLE.BP_PASSCOUNT_EQUAL:
                 case enum_BP_PASSCOUNT_STYLE.BP_PASSCOUNT_EQUAL_OR_GREATER:
+                    // Need to stop at hit N. Already counted currentHits, so skip (N - 1 - currentHits) more.
+                    return passCount - 1 > currentHits ? passCount - 1 - currentHits : 0;
                 case enum_BP_PASSCOUNT_STYLE.BP_PASSCOUNT_MOD:
-                    return passCount > 0 ? passCount - 1 : 0;
+                    // Next stop is at the next multiple of passCount after currentHits.
+                    uint remainder = currentHits % passCount;
+                    return remainder == 0 ? passCount - 1 : passCount - 1 - remainder;
                 default:
                     return 0;
             }
@@ -674,12 +684,42 @@ namespace Microsoft.MIDebugEngine
             _bpRequestInfo.bpPassCount = bpPassCount;
             _bpRequestInfo.dwFields |= enum_BPREQI_FIELDS.BPREQI_PASSCOUNT;
 
+            PendingBreakpoint bp = null;
             lock (_boundBreakpoints)
             {
-                foreach (AD7BoundBreakpoint bp in _boundBreakpoints)
+                foreach (AD7BoundBreakpoint boundBp in _boundBreakpoints)
                 {
-                    ((IDebugBoundBreakpoint2)bp).SetPassCount(bpPassCount);
+                    ((IDebugBoundBreakpoint2)boundBp).SetPassCount(bpPassCount);
                 }
+                if (_bp != null)
+                {
+                    bp = _bp;
+                }
+            }
+
+            // Re-send -break-after to GDB with the updated ignore count, accounting
+            // for the current hit count so the breakpoint fires at the right time.
+            if (bp != null && bpPassCount.stylePassCount != enum_BP_PASSCOUNT_STYLE.BP_PASSCOUNT_NONE)
+            {
+                uint currentHits = 0;
+                lock (_boundBreakpoints)
+                {
+                    foreach (AD7BoundBreakpoint boundBp in _boundBreakpoints)
+                    {
+                        uint hc;
+                        if (((IDebugBoundBreakpoint2)boundBp).GetHitCount(out hc) == Constants.S_OK && hc > currentHits)
+                        {
+                            currentHits = hc;
+                        }
+                    }
+                }
+                uint ignoreCount = ComputeIgnoreCount(bpPassCount.stylePassCount, bpPassCount.dwPassCount, currentHits);
+                _engine.DebuggedProcess.WorkerThread.RunOperation(() =>
+                {
+                    _engine.DebuggedProcess.AddInternalBreakAction(
+                        () => bp.SetBreakAfterAsync(ignoreCount, _engine.DebuggedProcess)
+                    );
+                });
             }
             return Constants.S_OK;
         }

--- a/src/MIDebugEngine/Engine.Impl/BreakpointManager.cs
+++ b/src/MIDebugEngine/Engine.Impl/BreakpointManager.cs
@@ -71,6 +71,20 @@ namespace Microsoft.MIDebugEngine
                 return;
             }
 
+            // Sync GDB's hit count ("times") for pass count breakpoints.
+            // e.g. =breakpoint-modified,bkpt={number="1",...,times="5",ignore="2",...}
+            string timesStr = bkpt.TryFindString("times");
+            if (!string.IsNullOrEmpty(timesStr) && uint.TryParse(timesStr, out uint times))
+            {
+                foreach (AD7BoundBreakpoint boundBp in pending.EnumBoundBreakpoints())
+                {
+                    if (boundBp.HasPassCount)
+                    {
+                        boundBp.SetHitCount(times);
+                    }
+                }
+            }
+
             string warning = bkpt.TryFindString("warning");
             if (!string.IsNullOrEmpty(warning))
             {
@@ -212,7 +226,11 @@ namespace Microsoft.MIDebugEngine
                     continue;
                 }
 
-                currBoundBp.IncrementHitCount();
+                // Pass count breakpoints get their hit count from =breakpoint-modified.
+                if (!currBoundBp.HasPassCount)
+                {
+                    currBoundBp.IncrementHitCount();
+                }
                 if (currBoundBp.ShouldBreak())
                 {
                     hitBoundBreakpoints.Add(currBoundBp);

--- a/src/MIDebugEngine/Engine.Impl/BreakpointManager.cs
+++ b/src/MIDebugEngine/Engine.Impl/BreakpointManager.cs
@@ -84,9 +84,10 @@ namespace Microsoft.MIDebugEngine
                         boundBp.SetHitCount(times);
 
                         // Re-arm GDB's ignore count so it skips to the next target hit.
-                        // Guard on hit count change to avoid looping: -break-after
-                        // itself triggers =breakpoint-modified.
-                        if (boundBp.HitCount != previousHitCount)
+                        // HitCount guard: -break-after itself triggers =breakpoint-modified.
+                        // ShouldBreak guard: GDB also emits =breakpoint-modified on ignored
+                        //   hits, and re-arming then would shift the next stop.
+                        if (boundBp.HitCount != previousHitCount && boundBp.ShouldBreak())
                         {
                             await boundBp.RearmBreakAfterAsync();
                         }

--- a/src/MIDebugEngine/Engine.Impl/BreakpointManager.cs
+++ b/src/MIDebugEngine/Engine.Impl/BreakpointManager.cs
@@ -80,7 +80,16 @@ namespace Microsoft.MIDebugEngine
                 {
                     if (boundBp.HasPassCount)
                     {
+                        uint previousHitCount = boundBp.HitCount;
                         boundBp.SetHitCount(times);
+
+                        // Re-arm GDB's ignore count so it skips to the next target hit.
+                        // Guard on hit count change to avoid looping: -break-after
+                        // itself triggers =breakpoint-modified.
+                        if (boundBp.HitCount != previousHitCount)
+                        {
+                            await boundBp.RearmBreakAfterAsync();
+                        }
                     }
                 }
             }

--- a/src/MIDebugEngine/Engine.Impl/BreakpointManager.cs
+++ b/src/MIDebugEngine/Engine.Impl/BreakpointManager.cs
@@ -212,7 +212,11 @@ namespace Microsoft.MIDebugEngine
                     continue;
                 }
 
-                hitBoundBreakpoints.Add(currBoundBp);
+                currBoundBp.IncrementHitCount();
+                if (currBoundBp.ShouldBreak())
+                {
+                    hitBoundBreakpoints.Add(currBoundBp);
+                }
             }
 
             fContinue = (hitBoundBreakpoints.Count == 0 && hitBps.Length != 0);

--- a/src/MIDebugEngine/Engine.Impl/Breakpoints.cs
+++ b/src/MIDebugEngine/Engine.Impl/Breakpoints.cs
@@ -353,6 +353,18 @@ namespace Microsoft.MIDebugEngine
                 await process.MICommandFactory.BreakCondition(Number, expr);
             }
         }
+
+        /// <summary>
+        /// Sends -break-after to set an ignore count on this breakpoint.
+        /// </summary>
+        internal async Task<Results> SetBreakAfterAsync(uint count, DebuggedProcess process)
+        {
+            if (process.ProcessState != MICore.ProcessState.Exited)
+            {
+                return await process.MICommandFactory.BreakAfter(Number, count);
+            }
+            return null;
+        }
     }
 
     internal class BoundBreakpoint

--- a/src/MIDebugEngine/Engine.Impl/Breakpoints.cs
+++ b/src/MIDebugEngine/Engine.Impl/Breakpoints.cs
@@ -375,6 +375,8 @@ namespace Microsoft.MIDebugEngine
         /*OPTIONAL*/
         public string FunctionName { get; private set; }
         internal uint HitCount { get; private set; }
+        private uint _rawGdbHitCount;
+        private readonly object _hitCountLock = new object();
         internal bool Enabled { get; set; }
         internal bool IsDataBreakpoint { get { return _parent.AD7breakpoint.IsDataBreakpoint; } }
         private MITextPosition _textPosition;
@@ -450,12 +452,34 @@ namespace Microsoft.MIDebugEngine
 
         internal void IncrementHitCount()
         {
-            HitCount++;
+            lock (_hitCountLock)
+            {
+                HitCount++;
+            }
         }
 
         internal void SetHitCount(uint count)
         {
-            HitCount = count;
+            lock (_hitCountLock)
+            {
+                HitCount = count;
+            }
+        }
+
+        /// <summary>
+        /// Applies the delta from GDB's "times" field, preserving user-initiated resets.
+        /// </summary>
+        internal void SetGdbHitCount(uint gdbTimes)
+        {
+            lock (_hitCountLock)
+            {
+                if (gdbTimes >= _rawGdbHitCount)
+                {
+                    uint delta = gdbTimes - _rawGdbHitCount;
+                    HitCount += delta;
+                }
+                _rawGdbHitCount = gdbTimes;
+            }
         }
     }
 }

--- a/src/MIDebugEngine/Engine.Impl/Breakpoints.cs
+++ b/src/MIDebugEngine/Engine.Impl/Breakpoints.cs
@@ -398,6 +398,7 @@ namespace Microsoft.MIDebugEngine
         internal BoundBreakpoint(PendingBreakpoint parent, ulong addr, uint size, string bkptno)
         {
             Addr = addr;
+            HitCount = 0;
             Enabled = true;
             this.Number = bkptno;
             _parent = parent;
@@ -433,6 +434,16 @@ namespace Microsoft.MIDebugEngine
                 }
                 _textPosition = new MITextPosition(_textPosition.FileName, value);
             }
+        }
+
+        internal void IncrementHitCount()
+        {
+            HitCount++;
+        }
+
+        internal void SetHitCount(uint count)
+        {
+            HitCount = count;
         }
     }
 }

--- a/src/OpenDebugAD7/AD7DebugSession.cs
+++ b/src/OpenDebugAD7/AD7DebugSession.cs
@@ -2448,10 +2448,36 @@ namespace OpenDebugAD7
                                 // Check to see if hit condition changed
                                 else if (!StringComparer.Ordinal.Equals(ad7BPRequest.HitCondition, bp.HitCondition))
                                 {
-                                    // Hit condition has been modified. Delete breakpoint so it will be recreated with the updated hit condition.
-                                    var toRemove = dict[bp.Line];
-                                    toRemove.Delete();
-                                    dict.Remove(bp.Line);
+                                    // Hit condition has been modified. Update the existing breakpoint's
+                                    // pass count in-place (matching VS behavior) so the hit count is
+                                    // preserved and the engine re-sends -break-after to GDB.
+                                    ad7BPRequest.UpdateHitCondition(bp.HitCondition);
+                                    if (ad7BPRequest.TryParseHitCondition(out var style, out var passCount))
+                                    {
+                                        var bpPassCount = new BP_PASSCOUNT
+                                        {
+                                            stylePassCount = style,
+                                            dwPassCount = passCount
+                                        };
+                                        dict[bp.Line].SetPassCount(bpPassCount);
+                                        resBreakpoints.Add(new Breakpoint()
+                                        {
+                                            Id = (int)ad7BPRequest.Id,
+                                            Verified = true,
+                                            Line = bp.Line
+                                        });
+                                    }
+                                    else
+                                    {
+                                        resBreakpoints.Add(new Breakpoint()
+                                        {
+                                            Id = (int)ad7BPRequest.Id,
+                                            Verified = false,
+                                            Line = bp.Line,
+                                            Message = AD7Resources.Error_UnableToParseHitCondition
+                                        });
+                                    }
+                                    continue;
                                 }
                                 // Check to see if tracepoint changed
                                 else if (!StringComparer.Ordinal.Equals(ad7BPRequest.LogMessage, bp.LogMessage))

--- a/src/OpenDebugAD7/AD7DebugSession.cs
+++ b/src/OpenDebugAD7/AD7DebugSession.cs
@@ -1095,7 +1095,8 @@ namespace OpenDebugAD7
                 SupportsDisassembleRequest = m_engine is IDebugMemoryBytesDAP,
                 SupportsValueFormattingOptions = true,
                 SupportsSteppingGranularity = true,
-                SupportsInstructionBreakpoints = m_engine is IDebugMemoryBytesDAP
+                SupportsInstructionBreakpoints = m_engine is IDebugMemoryBytesDAP,
+                SupportsHitConditionalBreakpoints = true
             };
 
             responder.SetResponse(initializeResponse);
@@ -2444,6 +2445,14 @@ namespace OpenDebugAD7
                                     toRemove.Delete();
                                     dict.Remove(bp.Line);
                                 }
+                                // Check to see if hit condition changed
+                                else if (!StringComparer.Ordinal.Equals(ad7BPRequest.HitCondition, bp.HitCondition))
+                                {
+                                    // Hit condition has been modified. Delete breakpoint so it will be recreated with the updated hit condition.
+                                    var toRemove = dict[bp.Line];
+                                    toRemove.Delete();
+                                    dict.Remove(bp.Line);
+                                }
                                 // Check to see if tracepoint changed
                                 else if (!StringComparer.Ordinal.Equals(ad7BPRequest.LogMessage, bp.LogMessage))
                                 {
@@ -2478,16 +2487,27 @@ namespace OpenDebugAD7
                         if (!dict.ContainsKey(bp.Line))
                         {
                             IDebugPendingBreakpoint2 pendingBp;
-                            AD7BreakPointRequest pBPRequest = new AD7BreakPointRequest(m_sessionConfig, convertedPath, m_pathConverter.ConvertClientLineToDebugger(bp.Line), bp.Condition);
+                            AD7BreakPointRequest pBPRequest = new AD7BreakPointRequest(m_sessionConfig, convertedPath, m_pathConverter.ConvertClientLineToDebugger(bp.Line), bp.Condition, bp.HitCondition);
 
                             try
                             {
-                                bool verified = true;
+                                List<string> errorMessages = new List<string>();
                                 if (!string.IsNullOrEmpty(bp.LogMessage))
                                 {
                                     // Make sure tracepoint is valid.
-                                    verified = pBPRequest.SetLogMessage(bp.LogMessage);
+                                    if (!pBPRequest.SetLogMessage(bp.LogMessage))
+                                    {
+                                        errorMessages.Add(AD7Resources.Error_UnableToParseLogMessage);
+                                    }
                                 }
+
+                                if (!pBPRequest.IsHitConditionValid)
+                                {
+                                    errorMessages.Add(AD7Resources.Error_UnableToParseHitCondition);
+                                }
+
+                                bool verified = errorMessages.Count == 0;
+                                string errorMessage = verified ? null : string.Join(" ", errorMessages);
 
                                 if (verified)
                                 {
@@ -2510,7 +2530,7 @@ namespace OpenDebugAD7
                                         Id = (int)pBPRequest.Id,
                                         Verified = verified,
                                         Line = bp.Line,
-                                        Message = string.Format(CultureInfo.CurrentCulture, AD7Resources.Error_UnableToParseLogMessage)
+                                        Message = errorMessage
                                     });
                                 }
                             }

--- a/src/OpenDebugAD7/AD7Impl/AD7BreakPointRequest.cs
+++ b/src/OpenDebugAD7/AD7Impl/AD7BreakPointRequest.cs
@@ -198,10 +198,6 @@ namespace OpenDebugAD7.AD7Impl
         #region Hit Conditions
 
         /// <summary>
-        /// Attempts to parse the hit condition string into a pass count style and value.
-        /// Returns true if HitCondition is null/empty (no condition) or if it is a valid hit condition.
-        /// </summary>
-        /// <summary>
         /// Updates the hit condition string so that subsequent <see cref="TryParseHitCondition"/>
         /// calls return the new pass count, and future comparisons see the updated value.
         /// </summary>
@@ -210,6 +206,10 @@ namespace OpenDebugAD7.AD7Impl
             HitCondition = hitCondition;
         }
 
+        /// <summary>
+        /// Attempts to parse the hit condition string into a pass count style and value.
+        /// Returns true if HitCondition is null/empty (no condition) or if it is a valid hit condition.
+        /// </summary>
         internal bool TryParseHitCondition(out enum_BP_PASSCOUNT_STYLE style, out uint passCount)
         {
             style = enum_BP_PASSCOUNT_STYLE.BP_PASSCOUNT_NONE;

--- a/src/OpenDebugAD7/AD7Impl/AD7BreakPointRequest.cs
+++ b/src/OpenDebugAD7/AD7Impl/AD7BreakPointRequest.cs
@@ -201,6 +201,15 @@ namespace OpenDebugAD7.AD7Impl
         /// Attempts to parse the hit condition string into a pass count style and value.
         /// Returns true if HitCondition is null/empty (no condition) or if it is a valid hit condition.
         /// </summary>
+        /// <summary>
+        /// Updates the hit condition string so that subsequent <see cref="TryParseHitCondition"/>
+        /// calls return the new pass count, and future comparisons see the updated value.
+        /// </summary>
+        internal void UpdateHitCondition(string hitCondition)
+        {
+            HitCondition = hitCondition;
+        }
+
         internal bool TryParseHitCondition(out enum_BP_PASSCOUNT_STYLE style, out uint passCount)
         {
             style = enum_BP_PASSCOUNT_STYLE.BP_PASSCOUNT_NONE;

--- a/src/OpenDebugAD7/AD7Impl/AD7BreakPointRequest.cs
+++ b/src/OpenDebugAD7/AD7Impl/AD7BreakPointRequest.cs
@@ -19,6 +19,8 @@ namespace OpenDebugAD7.AD7Impl
 
         public string Condition { get; private set; }
 
+        public string HitCondition { get; private set; }
+
         public AD7DocumentPosition DocumentPosition { get; private set; }
 
         public AD7FunctionPosition FunctionPosition { get; private set; }
@@ -39,10 +41,11 @@ namespace OpenDebugAD7.AD7Impl
         // Bind result from IDebugBreakpointErrorEvent2 or IDebugBreakpointBoundEvent2
         public Breakpoint BindResult { get; set; }
 
-        public AD7BreakPointRequest(SessionConfiguration config, string path, int line, string condition)
+        public AD7BreakPointRequest(SessionConfiguration config, string path, int line, string condition, string hitCondition)
         {
             DocumentPosition = new AD7DocumentPosition(config, path, line);
             Condition = condition;
+            HitCondition = hitCondition;
         }
 
         public AD7BreakPointRequest(string functionName)
@@ -119,9 +122,13 @@ namespace OpenDebugAD7.AD7Impl
                 pBPRequestInfo[0].bpCondition.bstrCondition = Condition;
                 pBPRequestInfo[0].bpCondition.styleCondition = enum_BP_COND_STYLE.BP_COND_WHEN_TRUE;
             }
-            if ((dwFields & enum_BPREQI_FIELDS.BPREQI_PASSCOUNT) != 0)
+            if ((dwFields & enum_BPREQI_FIELDS.BPREQI_PASSCOUNT) != 0
+                && !string.IsNullOrWhiteSpace(HitCondition)
+                && TryParseHitCondition(out enum_BP_PASSCOUNT_STYLE style, out uint passCount))
             {
-                // not supported
+                pBPRequestInfo[0].dwFields |= enum_BPREQI_FIELDS.BPREQI_PASSCOUNT;
+                pBPRequestInfo[0].bpPassCount.stylePassCount = style;
+                pBPRequestInfo[0].bpPassCount.dwPassCount = passCount;
             }
             return 0;
         }
@@ -185,6 +192,51 @@ namespace OpenDebugAD7.AD7Impl
         public bool HasTracepoint => !string.IsNullOrEmpty(m_logMessage) && m_Tracepoint != null;
 
         public Tracepoint Tracepoint => m_Tracepoint;
+
+        #endregion
+
+        #region Hit Conditions
+
+        /// <summary>
+        /// Attempts to parse the hit condition string into a pass count style and value.
+        /// Returns true if HitCondition is null/empty (no condition) or if it is a valid hit condition.
+        /// </summary>
+        internal bool TryParseHitCondition(out enum_BP_PASSCOUNT_STYLE style, out uint passCount)
+        {
+            style = enum_BP_PASSCOUNT_STYLE.BP_PASSCOUNT_NONE;
+            passCount = 0;
+
+            if (string.IsNullOrWhiteSpace(HitCondition))
+            {
+                return true;
+            }
+
+            string hc = HitCondition.Trim();
+            string numberPart = hc;
+
+            if (hc.StartsWith(">="))
+            {
+                style = enum_BP_PASSCOUNT_STYLE.BP_PASSCOUNT_EQUAL_OR_GREATER;
+                numberPart = hc.Substring(2).Trim();
+            }
+            else if (hc.StartsWith("%"))
+            {
+                style = enum_BP_PASSCOUNT_STYLE.BP_PASSCOUNT_MOD;
+                numberPart = hc.Substring(1).Trim();
+            }
+            else
+            {
+                style = enum_BP_PASSCOUNT_STYLE.BP_PASSCOUNT_EQUAL;
+            }
+
+            return uint.TryParse(numberPart, out passCount);
+        }
+
+        /// <summary>
+        /// Validates that the hit condition string can be parsed into a pass count.
+        /// Returns true if HitCondition is null/empty (no condition) or if it is a valid hit condition.
+        /// </summary>
+        internal bool IsHitConditionValid => TryParseHitCondition(out _, out _);
 
         #endregion
     }

--- a/src/OpenDebugAD7/AD7Resources.Designer.cs
+++ b/src/OpenDebugAD7/AD7Resources.Designer.cs
@@ -479,6 +479,15 @@ namespace OpenDebugAD7 {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Unable to parse &apos;hitCondition&apos;. Expected a number, optionally prefixed with &gt;= or %..
+        /// </summary>
+        internal static string Error_UnableToParseHitCondition {
+            get {
+                return ResourceManager.GetString("Error_UnableToParseHitCondition", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Error setting breakpoint. {0}.
         /// </summary>
         internal static string Error_UnableToSetBreakpoint {

--- a/src/OpenDebugAD7/AD7Resources.resx
+++ b/src/OpenDebugAD7/AD7Resources.resx
@@ -198,6 +198,9 @@
   <data name="Error_UnableToParseLogMessage" xml:space="preserve">
     <value>Unable to parse 'logMessage'.</value>
   </data>
+  <data name="Error_UnableToParseHitCondition" xml:space="preserve">
+    <value>Unable to parse 'hitCondition'. Expected a number, optionally prefixed with &gt;= or %.</value>
+  </data>
   <data name="Msg_E_CRASHDUMP_UNSUPPORTED" xml:space="preserve">
     <value>This operation is not supported when debugging dump files.</value>
   </data>

--- a/test/CppTests/Tests/BreakpointTests.cs
+++ b/test/CppTests/Tests/BreakpointTests.cs
@@ -695,6 +695,590 @@ namespace CppTests.Tests
         [Theory]
         [DependsOnTest(nameof(CompileKitchenSinkForBreakpointTests))]
         [RequiresTestSettings]
+        public void HitConditionBreakpointEqualFirst(ITestSettings settings)
+        {
+            this.TestPurpose("Tests that hitCondition '1' breaks on the very first hit");
+            this.WriteSettings(settings);
+
+            IDebuggee debuggee = SinkHelper.Open(this, settings.CompilerSettings, DebuggeeMonikers.KitchenSink.Breakpoint);
+
+            using (IDebuggerRunner runner = CreateDebugAdapterRunner(settings))
+            {
+                this.Comment("Configure launch");
+                runner.Launch(settings.DebuggerSettings, debuggee, "-fCalling");
+
+                this.Comment("Set a breakpoint with hit condition = 1 (first hit)");
+                SourceBreakpoints callingBreakpoints = new SourceBreakpoints(debuggee, SinkHelper.Calling);
+                callingBreakpoints.Add(17, hitCondition: "1");
+                runner.SetBreakpoints(callingBreakpoints);
+
+                this.Comment("Run to breakpoint - should stop on the very first hit");
+                runner.Expects.HitBreakpointEvent(SinkHelper.Calling, 17)
+                              .AfterConfigurationDone();
+
+                this.Comment("Verify i == 0 (first iteration)");
+                using (IThreadInspector inspector = runner.GetThreadInspector())
+                {
+                    IFrameInspector mainFrame = inspector.Stack.First();
+                    mainFrame.AssertVariables("i", "0");
+                }
+
+                this.Comment("Run to completion - equal condition already satisfied, should not stop again");
+                runner.Expects.ExitedEvent()
+                              .TerminatedEvent()
+                              .AfterContinue();
+
+                runner.DisconnectAndVerify();
+            }
+        }
+
+        [Theory]
+        [DependsOnTest(nameof(CompileKitchenSinkForBreakpointTests))]
+        [RequiresTestSettings]
+        public void HitConditionBreakpointEqualLast(ITestSettings settings)
+        {
+            this.TestPurpose("Tests that hitCondition equal to the loop bound stops on the last iteration");
+            this.WriteSettings(settings);
+
+            IDebuggee debuggee = SinkHelper.Open(this, settings.CompilerSettings, DebuggeeMonikers.KitchenSink.Breakpoint);
+
+            using (IDebuggerRunner runner = CreateDebugAdapterRunner(settings))
+            {
+                this.Comment("Configure launch");
+                runner.Launch(settings.DebuggerSettings, debuggee, "-fCalling");
+
+                this.Comment("Set a breakpoint with hit condition = 10 (last hit in a 10-iteration loop)");
+                SourceBreakpoints callingBreakpoints = new SourceBreakpoints(debuggee, SinkHelper.Calling);
+                callingBreakpoints.Add(17, hitCondition: "10");
+                runner.SetBreakpoints(callingBreakpoints);
+
+                this.Comment("Run to breakpoint - should stop on the 10th and final hit");
+                runner.Expects.HitBreakpointEvent(SinkHelper.Calling, 17)
+                              .AfterConfigurationDone();
+
+                this.Comment("Verify i == 9 (last iteration, 0-indexed)");
+                using (IThreadInspector inspector = runner.GetThreadInspector())
+                {
+                    IFrameInspector mainFrame = inspector.Stack.First();
+                    mainFrame.AssertVariables("i", "9");
+                }
+
+                this.Comment("Run to completion");
+                runner.Expects.ExitedEvent()
+                              .TerminatedEvent()
+                              .AfterContinue();
+
+                runner.DisconnectAndVerify();
+            }
+        }
+
+        [Theory]
+        [DependsOnTest(nameof(CompileKitchenSinkForBreakpointTests))]
+        [RequiresTestSettings]
+        public void HitConditionBreakpointEqualExceedsIterations(ITestSettings settings)
+        {
+            this.TestPurpose("Tests that hitCondition exceeding total iterations never stops");
+            this.WriteSettings(settings);
+
+            IDebuggee debuggee = SinkHelper.Open(this, settings.CompilerSettings, DebuggeeMonikers.KitchenSink.Breakpoint);
+
+            using (IDebuggerRunner runner = CreateDebugAdapterRunner(settings))
+            {
+                this.Comment("Configure launch");
+                runner.Launch(settings.DebuggerSettings, debuggee, "-fCalling");
+
+                this.Comment("Set a breakpoint with hit condition = 99 inside a loop that only iterates 10 times");
+                SourceBreakpoints callingBreakpoints = new SourceBreakpoints(debuggee, SinkHelper.Calling);
+                callingBreakpoints.Add(17, hitCondition: "99");
+                runner.SetBreakpoints(callingBreakpoints);
+
+                this.Comment("Run to completion - breakpoint should never fire");
+                runner.Expects.ExitedEvent()
+                              .TerminatedEvent()
+                              .AfterConfigurationDone();
+
+                runner.DisconnectAndVerify();
+            }
+        }
+
+        [Theory]
+        [DependsOnTest(nameof(CompileKitchenSinkForBreakpointTests))]
+        [RequiresTestSettings]
+        public void HitConditionBreakpointGreaterOrEqualOne(ITestSettings settings)
+        {
+            this.TestPurpose("Tests that hitCondition '>=1' stops on every single hit (same as no condition)");
+            this.WriteSettings(settings);
+
+            IDebuggee debuggee = SinkHelper.Open(this, settings.CompilerSettings, DebuggeeMonikers.KitchenSink.Breakpoint);
+
+            using (IDebuggerRunner runner = CreateDebugAdapterRunner(settings))
+            {
+                this.Comment("Configure launch");
+                runner.Launch(settings.DebuggerSettings, debuggee, "-fCalling");
+
+                this.Comment("Set a breakpoint with hit condition >= 1 (should stop on every hit)");
+                SourceBreakpoints callingBreakpoints = new SourceBreakpoints(debuggee, SinkHelper.Calling);
+                callingBreakpoints.Add(17, hitCondition: ">=1");
+                runner.SetBreakpoints(callingBreakpoints);
+
+                this.Comment("Run to breakpoint - should stop on first hit");
+                runner.Expects.HitBreakpointEvent(SinkHelper.Calling, 17)
+                              .AfterConfigurationDone();
+
+                using (IThreadInspector inspector = runner.GetThreadInspector())
+                {
+                    IFrameInspector mainFrame = inspector.Stack.First();
+                    mainFrame.AssertVariables("i", "0");
+                }
+
+                this.Comment("Continue - should stop on second hit");
+                runner.Expects.HitBreakpointEvent(SinkHelper.Calling, 17)
+                              .AfterContinue();
+
+                using (IThreadInspector inspector = runner.GetThreadInspector())
+                {
+                    IFrameInspector mainFrame = inspector.Stack.First();
+                    mainFrame.AssertVariables("i", "1");
+                }
+
+                this.Comment("Continue - should stop on third hit");
+                runner.Expects.HitBreakpointEvent(SinkHelper.Calling, 17)
+                              .AfterContinue();
+
+                using (IThreadInspector inspector = runner.GetThreadInspector())
+                {
+                    IFrameInspector mainFrame = inspector.Stack.First();
+                    mainFrame.AssertVariables("i", "2");
+                }
+
+                // Remove the breakpoint so we can run to completion without stopping 7 more times
+                this.Comment("Remove the breakpoint and run to completion");
+                callingBreakpoints.Remove(17);
+                runner.SetBreakpoints(callingBreakpoints);
+
+                runner.Expects.ExitedEvent()
+                              .TerminatedEvent()
+                              .AfterContinue();
+
+                runner.DisconnectAndVerify();
+            }
+        }
+
+        [Theory]
+        [DependsOnTest(nameof(CompileKitchenSinkForBreakpointTests))]
+        [RequiresTestSettings]
+        public void HitConditionBreakpointModuloOne(ITestSettings settings)
+        {
+            this.TestPurpose("Tests that hitCondition '%%1' stops on every hit (degenerate modulo)");
+            this.WriteSettings(settings);
+
+            IDebuggee debuggee = SinkHelper.Open(this, settings.CompilerSettings, DebuggeeMonikers.KitchenSink.Breakpoint);
+
+            using (IDebuggerRunner runner = CreateDebugAdapterRunner(settings))
+            {
+                this.Comment("Configure launch");
+                runner.Launch(settings.DebuggerSettings, debuggee, "-fCalling");
+
+                this.Comment("Set a breakpoint with hit condition %1 (every hit is a multiple of 1)");
+                SourceBreakpoints callingBreakpoints = new SourceBreakpoints(debuggee, SinkHelper.Calling);
+                callingBreakpoints.Add(17, hitCondition: "%1");
+                runner.SetBreakpoints(callingBreakpoints);
+
+                this.Comment("Run to breakpoint - should stop on first hit");
+                runner.Expects.HitBreakpointEvent(SinkHelper.Calling, 17)
+                              .AfterConfigurationDone();
+
+                using (IThreadInspector inspector = runner.GetThreadInspector())
+                {
+                    IFrameInspector mainFrame = inspector.Stack.First();
+                    mainFrame.AssertVariables("i", "0");
+                }
+
+                this.Comment("Continue - should stop on second hit");
+                runner.Expects.HitBreakpointEvent(SinkHelper.Calling, 17)
+                              .AfterContinue();
+
+                using (IThreadInspector inspector = runner.GetThreadInspector())
+                {
+                    IFrameInspector mainFrame = inspector.Stack.First();
+                    mainFrame.AssertVariables("i", "1");
+                }
+
+                // Remove the breakpoint so we can run to completion
+                this.Comment("Remove the breakpoint and run to completion");
+                callingBreakpoints.Remove(17);
+                runner.SetBreakpoints(callingBreakpoints);
+
+                runner.Expects.ExitedEvent()
+                              .TerminatedEvent()
+                              .AfterContinue();
+
+                runner.DisconnectAndVerify();
+            }
+        }
+
+        [Theory]
+        [DependsOnTest(nameof(CompileKitchenSinkForBreakpointTests))]
+        [RequiresTestSettings]
+        public void HitConditionBreakpointModuloNoMultiple(ITestSettings settings)
+        {
+            this.TestPurpose("Tests that a modulo hit condition whose value exceeds total iterations only fires once at the Nth hit");
+            this.WriteSettings(settings);
+
+            IDebuggee debuggee = SinkHelper.Open(this, settings.CompilerSettings, DebuggeeMonikers.KitchenSink.Breakpoint);
+
+            using (IDebuggerRunner runner = CreateDebugAdapterRunner(settings))
+            {
+                this.Comment("Configure launch");
+                runner.Launch(settings.DebuggerSettings, debuggee, "-fCalling");
+
+                this.Comment("Set a breakpoint with hit condition %7 inside a loop that iterates 10 times");
+                SourceBreakpoints callingBreakpoints = new SourceBreakpoints(debuggee, SinkHelper.Calling);
+                callingBreakpoints.Add(17, hitCondition: "%7");
+                runner.SetBreakpoints(callingBreakpoints);
+
+                this.Comment("Run to breakpoint - should stop on 7th hit");
+                runner.Expects.HitBreakpointEvent(SinkHelper.Calling, 17)
+                              .AfterConfigurationDone();
+
+                this.Comment("Verify i == 6 (0-indexed, 7th iteration)");
+                using (IThreadInspector inspector = runner.GetThreadInspector())
+                {
+                    IFrameInspector mainFrame = inspector.Stack.First();
+                    mainFrame.AssertVariables("i", "6");
+                }
+
+                this.Comment("Run to completion - 14th hit would be next multiple but loop only has 10 iterations");
+                runner.Expects.ExitedEvent()
+                              .TerminatedEvent()
+                              .AfterContinue();
+
+                runner.DisconnectAndVerify();
+            }
+        }
+
+        [Theory]
+        [DependsOnTest(nameof(CompileKitchenSinkForBreakpointTests))]
+        [RequiresTestSettings]
+        public void HitConditionBreakpointModifyMidRun(ITestSettings settings)
+        {
+            this.TestPurpose("Tests changing a hitCondition while stopped at the breakpoint");
+            this.WriteSettings(settings);
+
+            IDebuggee debuggee = SinkHelper.Open(this, settings.CompilerSettings, DebuggeeMonikers.KitchenSink.Breakpoint);
+
+            using (IDebuggerRunner runner = CreateDebugAdapterRunner(settings))
+            {
+                this.Comment("Configure launch");
+                runner.Launch(settings.DebuggerSettings, debuggee, "-fCalling");
+
+                this.Comment("Set a breakpoint with hit condition = 3");
+                SourceBreakpoints callingBreakpoints = new SourceBreakpoints(debuggee, SinkHelper.Calling);
+                callingBreakpoints.Add(17, hitCondition: "3");
+                runner.SetBreakpoints(callingBreakpoints);
+
+                this.Comment("Run to breakpoint - should stop on 3rd hit");
+                runner.Expects.HitBreakpointEvent(SinkHelper.Calling, 17)
+                              .AfterConfigurationDone();
+
+                this.Comment("Verify i == 2 (3rd iteration)");
+                using (IThreadInspector inspector = runner.GetThreadInspector())
+                {
+                    IFrameInspector mainFrame = inspector.Stack.First();
+                    mainFrame.AssertVariables("i", "2");
+                }
+
+                // Change from EQUAL to GREATER_OR_EQUAL. The engine carries over the
+                // 3 hits already counted, so >=8 should fire on the 8th overall hit.
+                this.Comment("Change hit condition to >=8 while stopped");
+                callingBreakpoints.Remove(17);
+                callingBreakpoints.Add(17, hitCondition: ">=8");
+                runner.SetBreakpoints(callingBreakpoints);
+
+                this.Comment("Continue - should stop on 8th overall hit (i == 7)");
+                runner.Expects.HitBreakpointEvent(SinkHelper.Calling, 17)
+                              .AfterContinue();
+
+                this.Comment("Verify i == 7 (8th iteration)");
+                using (IThreadInspector inspector = runner.GetThreadInspector())
+                {
+                    IFrameInspector mainFrame = inspector.Stack.First();
+                    mainFrame.AssertVariables("i", "7");
+                }
+
+                this.Comment("Continue - should stop on 9th hit");
+                runner.Expects.HitBreakpointEvent(SinkHelper.Calling, 17)
+                              .AfterContinue();
+
+                using (IThreadInspector inspector = runner.GetThreadInspector())
+                {
+                    IFrameInspector mainFrame = inspector.Stack.First();
+                    mainFrame.AssertVariables("i", "8");
+                }
+
+                this.Comment("Continue - should stop on 10th hit");
+                runner.Expects.HitBreakpointEvent(SinkHelper.Calling, 17)
+                              .AfterContinue();
+
+                using (IThreadInspector inspector = runner.GetThreadInspector())
+                {
+                    IFrameInspector mainFrame = inspector.Stack.First();
+                    mainFrame.AssertVariables("i", "9");
+                }
+
+                this.Comment("Run to completion");
+                runner.Expects.ExitedEvent()
+                              .TerminatedEvent()
+                              .AfterContinue();
+
+                runner.DisconnectAndVerify();
+            }
+        }
+
+        [Theory]
+        [DependsOnTest(nameof(CompileKitchenSinkForBreakpointTests))]
+        [RequiresTestSettings]
+        public void HitConditionBreakpointModifyGteToEqual(ITestSettings settings)
+        {
+            this.TestPurpose("Tests changing hitCondition from >=N to exact N (GTE -> EQUAL) mid-run");
+            this.WriteSettings(settings);
+
+            IDebuggee debuggee = SinkHelper.Open(this, settings.CompilerSettings, DebuggeeMonikers.KitchenSink.Breakpoint);
+
+            using (IDebuggerRunner runner = CreateDebugAdapterRunner(settings))
+            {
+                this.Comment("Configure launch");
+                runner.Launch(settings.DebuggerSettings, debuggee, "-fCalling");
+
+                this.Comment("Set a breakpoint with hit condition >=2");
+                SourceBreakpoints callingBreakpoints = new SourceBreakpoints(debuggee, SinkHelper.Calling);
+                callingBreakpoints.Add(17, hitCondition: ">=2");
+                runner.SetBreakpoints(callingBreakpoints);
+
+                this.Comment("Run to breakpoint - should stop on 2nd hit");
+                runner.Expects.HitBreakpointEvent(SinkHelper.Calling, 17)
+                              .AfterConfigurationDone();
+
+                this.Comment("Verify i == 1 (2nd iteration)");
+                using (IThreadInspector inspector = runner.GetThreadInspector())
+                {
+                    IFrameInspector mainFrame = inspector.Stack.First();
+                    mainFrame.AssertVariables("i", "1");
+                }
+
+                // Change from GTE to EQUAL. Hit count is 2. We want to stop at exactly hit 5.
+                this.Comment("Change hit condition to 5 (exact) while stopped at hit 2");
+                callingBreakpoints.Remove(17);
+                callingBreakpoints.Add(17, hitCondition: "5");
+                runner.SetBreakpoints(callingBreakpoints);
+
+                this.Comment("Continue - should stop on 5th overall hit (i == 4)");
+                runner.Expects.HitBreakpointEvent(SinkHelper.Calling, 17)
+                              .AfterContinue();
+
+                this.Comment("Verify i == 4 (5th iteration)");
+                using (IThreadInspector inspector = runner.GetThreadInspector())
+                {
+                    IFrameInspector mainFrame = inspector.Stack.First();
+                    mainFrame.AssertVariables("i", "4");
+                }
+
+                // Now change from EQUAL to a target that the hit count has already passed.
+                // Changing to "3" while at hit 5 means the target is already passed — program should run to completion.
+                this.Comment("Change hit condition to 3 (already passed) while stopped at hit 5");
+                callingBreakpoints.Remove(17);
+                callingBreakpoints.Add(17, hitCondition: "3");
+                runner.SetBreakpoints(callingBreakpoints);
+
+                this.Comment("Run to completion - hit 3 already passed, EQUAL never fires again");
+                runner.Expects.ExitedEvent()
+                              .TerminatedEvent()
+                              .AfterContinue();
+
+                runner.DisconnectAndVerify();
+            }
+        }
+
+        [Theory]
+        [DependsOnTest(nameof(CompileKitchenSinkForBreakpointTests))]
+        [RequiresTestSettings]
+        public void HitConditionBreakpointRemoveAndReAdd(ITestSettings settings)
+        {
+            this.TestPurpose("Tests removing a hit condition breakpoint and re-adding it with a different condition");
+            this.WriteSettings(settings);
+
+            IDebuggee debuggee = SinkHelper.Open(this, settings.CompilerSettings, DebuggeeMonikers.KitchenSink.Breakpoint);
+
+            using (IDebuggerRunner runner = CreateDebugAdapterRunner(settings))
+            {
+                this.Comment("Configure launch");
+                runner.Launch(settings.DebuggerSettings, debuggee, "-fCalling");
+
+                this.Comment("Set a breakpoint with hit condition = 2");
+                SourceBreakpoints callingBreakpoints = new SourceBreakpoints(debuggee, SinkHelper.Calling);
+                callingBreakpoints.Add(17, hitCondition: "2");
+                runner.SetBreakpoints(callingBreakpoints);
+
+                this.Comment("Run to breakpoint - should stop on 2nd hit");
+                runner.Expects.HitBreakpointEvent(SinkHelper.Calling, 17)
+                              .AfterConfigurationDone();
+
+                this.Comment("Verify i == 1 (2nd iteration)");
+                using (IThreadInspector inspector = runner.GetThreadInspector())
+                {
+                    IFrameInspector mainFrame = inspector.Stack.First();
+                    mainFrame.AssertVariables("i", "1");
+                }
+
+                this.Comment("Remove the breakpoint entirely");
+                callingBreakpoints.Remove(17);
+                runner.SetBreakpoints(callingBreakpoints);
+
+                this.Comment("Re-add with modulo condition %4 - hit count resets for new breakpoint");
+                callingBreakpoints.Add(17, hitCondition: "%4");
+                runner.SetBreakpoints(callingBreakpoints);
+
+                this.Comment("Continue - breakpoint was removed and re-added, hit count restarted from 0");
+                // After removal and re-add, the next hits are 3rd through 10th loop iterations.
+                // With a fresh %4 condition, it should stop when the new hit count reaches 4.
+                // The 3rd loop iteration is the 1st new hit, so 4th new hit = 6th loop iteration (i==5).
+                runner.Expects.HitBreakpointEvent(SinkHelper.Calling, 17)
+                              .AfterContinue();
+
+                this.Comment("Verify the breakpoint stopped at the expected iteration");
+                using (IThreadInspector inspector = runner.GetThreadInspector())
+                {
+                    IFrameInspector mainFrame = inspector.Stack.First();
+                    mainFrame.AssertVariables("i", "5");
+                }
+
+                this.Comment("Continue - next %4 would be the 8th new hit = 10th loop iteration (i==9)");
+                runner.Expects.HitBreakpointEvent(SinkHelper.Calling, 17)
+                              .AfterContinue();
+
+                using (IThreadInspector inspector = runner.GetThreadInspector())
+                {
+                    IFrameInspector mainFrame = inspector.Stack.First();
+                    mainFrame.AssertVariables("i", "9");
+                }
+
+                this.Comment("Run to completion");
+                runner.Expects.ExitedEvent()
+                              .TerminatedEvent()
+                              .AfterContinue();
+
+                runner.DisconnectAndVerify();
+            }
+        }
+
+        [Theory]
+        [DependsOnTest(nameof(CompileKitchenSinkForBreakpointTests))]
+        [RequiresTestSettings]
+        public void HitConditionBreakpointWithCondition(ITestSettings settings)
+        {
+            this.TestPurpose("Tests combining a boolean condition with a hitCondition on the same breakpoint");
+            this.WriteSettings(settings);
+
+            IDebuggee debuggee = SinkHelper.Open(this, settings.CompilerSettings, DebuggeeMonikers.KitchenSink.Breakpoint);
+
+            using (IDebuggerRunner runner = CreateDebugAdapterRunner(settings))
+            {
+                this.Comment("Configure launch");
+                runner.Launch(settings.DebuggerSettings, debuggee, "-fCalling");
+
+                this.Comment("Set a breakpoint with condition 'i >= 4' and hitCondition '3'");
+                // The loop runs i = 0..9. The condition 'i >= 4' is true for i = 4,5,6,7,8,9.
+                // Among those qualifying hits, the hitCondition '3' means break on the 3rd qualifying hit.
+                // 1st qualifying hit: i=4, 2nd: i=5, 3rd: i=6 -> should stop at i=6.
+                SourceBreakpoints callingBreakpoints = new SourceBreakpoints(debuggee, SinkHelper.Calling);
+                callingBreakpoints.Add(17, condition: "i >= 4", hitCondition: "3");
+                runner.SetBreakpoints(callingBreakpoints);
+
+                this.Comment("Run to breakpoint");
+                runner.Expects.HitBreakpointEvent(SinkHelper.Calling, 17)
+                              .AfterConfigurationDone();
+
+                this.Comment("Verify the breakpoint stopped at the 3rd hit where i >= 4 (i == 6)");
+                using (IThreadInspector inspector = runner.GetThreadInspector())
+                {
+                    IFrameInspector mainFrame = inspector.Stack.First();
+                    mainFrame.AssertVariables("i", "6");
+                }
+
+                this.Comment("Run to completion - equal condition already satisfied");
+                runner.Expects.ExitedEvent()
+                              .TerminatedEvent()
+                              .AfterContinue();
+
+                runner.DisconnectAndVerify();
+            }
+        }
+
+        [Theory]
+        [DependsOnTest(nameof(CompileKitchenSinkForBreakpointTests))]
+        [RequiresTestSettings]
+        public void HitConditionBreakpointGreaterOrEqualWithCondition(ITestSettings settings)
+        {
+            this.TestPurpose("Tests combining a boolean condition with a >= hitCondition");
+            this.WriteSettings(settings);
+
+            IDebuggee debuggee = SinkHelper.Open(this, settings.CompilerSettings, DebuggeeMonikers.KitchenSink.Breakpoint);
+
+            using (IDebuggerRunner runner = CreateDebugAdapterRunner(settings))
+            {
+                this.Comment("Configure launch");
+                runner.Launch(settings.DebuggerSettings, debuggee, "-fCalling");
+
+                this.Comment("Set a breakpoint with condition 'i % 2 == 0' and hitCondition '>=3'");
+                // The loop runs i = 0..9. The condition 'i % 2 == 0' is true for i = 0,2,4,6,8.
+                // Among those qualifying hits: 1st: i=0, 2nd: i=2, 3rd: i=4, 4th: i=6, 5th: i=8
+                // The hitCondition '>=3' means break from the 3rd qualifying hit onward.
+                SourceBreakpoints callingBreakpoints = new SourceBreakpoints(debuggee, SinkHelper.Calling);
+                callingBreakpoints.Add(17, condition: "i % 2 == 0", hitCondition: ">=3");
+                runner.SetBreakpoints(callingBreakpoints);
+
+                this.Comment("Run to breakpoint - should stop on 3rd qualifying hit (i == 4)");
+                runner.Expects.HitBreakpointEvent(SinkHelper.Calling, 17)
+                              .AfterConfigurationDone();
+
+                using (IThreadInspector inspector = runner.GetThreadInspector())
+                {
+                    IFrameInspector mainFrame = inspector.Stack.First();
+                    mainFrame.AssertVariables("i", "4");
+                }
+
+                this.Comment("Continue - should stop on 4th qualifying hit (i == 6)");
+                runner.Expects.HitBreakpointEvent(SinkHelper.Calling, 17)
+                              .AfterContinue();
+
+                using (IThreadInspector inspector = runner.GetThreadInspector())
+                {
+                    IFrameInspector mainFrame = inspector.Stack.First();
+                    mainFrame.AssertVariables("i", "6");
+                }
+
+                this.Comment("Continue - should stop on 5th qualifying hit (i == 8)");
+                runner.Expects.HitBreakpointEvent(SinkHelper.Calling, 17)
+                              .AfterContinue();
+
+                using (IThreadInspector inspector = runner.GetThreadInspector())
+                {
+                    IFrameInspector mainFrame = inspector.Stack.First();
+                    mainFrame.AssertVariables("i", "8");
+                }
+
+                this.Comment("Run to completion");
+                runner.Expects.ExitedEvent()
+                              .TerminatedEvent()
+                              .AfterContinue();
+
+                runner.DisconnectAndVerify();
+            }
+        }
+
+        [Theory]
+        [DependsOnTest(nameof(CompileKitchenSinkForBreakpointTests))]
+        [RequiresTestSettings]
         [UnsupportedDebugger(SupportedDebugger.VsDbg, SupportedArchitecture.x86 | SupportedArchitecture.x64)]
         public void InvalidHitConditionBreakpoint(ITestSettings settings)
         {

--- a/test/CppTests/Tests/BreakpointTests.cs
+++ b/test/CppTests/Tests/BreakpointTests.cs
@@ -960,6 +960,85 @@ namespace CppTests.Tests
         [Theory]
         [DependsOnTest(nameof(CompileKitchenSinkForBreakpointTests))]
         [RequiresTestSettings]
+        public void HitConditionBreakpointModuloRearms(ITestSettings settings)
+        {
+            this.TestPurpose("Tests that a modulo breakpoint fires on every Nth hit across many cycles, verifying that GDB's ignore count is re-armed after each stop");
+            this.WriteSettings(settings);
+
+            IDebuggee debuggee = SinkHelper.Open(this, settings.CompilerSettings, DebuggeeMonikers.KitchenSink.Breakpoint);
+
+            using (IDebuggerRunner runner = CreateDebugAdapterRunner(settings))
+            {
+                this.Comment("Configure launch");
+                runner.Launch(settings.DebuggerSettings, debuggee, "-fCalling");
+
+                this.Comment("Set a breakpoint with hit condition %2 inside a loop that iterates 10 times");
+                SourceBreakpoints callingBreakpoints = new SourceBreakpoints(debuggee, SinkHelper.Calling);
+                callingBreakpoints.Add(17, hitCondition: "%2");
+                runner.SetBreakpoints(callingBreakpoints);
+
+                this.Comment("Run to breakpoint - should stop on 2nd hit (i == 1)");
+                runner.Expects.HitBreakpointEvent(SinkHelper.Calling, 17)
+                              .AfterConfigurationDone();
+
+                using (IThreadInspector inspector = runner.GetThreadInspector())
+                {
+                    IFrameInspector mainFrame = inspector.Stack.First();
+                    mainFrame.AssertVariables("i", "1");
+                }
+
+                this.Comment("Continue - should stop on 4th hit (i == 3)");
+                runner.Expects.HitBreakpointEvent(SinkHelper.Calling, 17)
+                              .AfterContinue();
+
+                using (IThreadInspector inspector = runner.GetThreadInspector())
+                {
+                    IFrameInspector mainFrame = inspector.Stack.First();
+                    mainFrame.AssertVariables("i", "3");
+                }
+
+                this.Comment("Continue - should stop on 6th hit (i == 5)");
+                runner.Expects.HitBreakpointEvent(SinkHelper.Calling, 17)
+                              .AfterContinue();
+
+                using (IThreadInspector inspector = runner.GetThreadInspector())
+                {
+                    IFrameInspector mainFrame = inspector.Stack.First();
+                    mainFrame.AssertVariables("i", "5");
+                }
+
+                this.Comment("Continue - should stop on 8th hit (i == 7)");
+                runner.Expects.HitBreakpointEvent(SinkHelper.Calling, 17)
+                              .AfterContinue();
+
+                using (IThreadInspector inspector = runner.GetThreadInspector())
+                {
+                    IFrameInspector mainFrame = inspector.Stack.First();
+                    mainFrame.AssertVariables("i", "7");
+                }
+
+                this.Comment("Continue - should stop on 10th hit (i == 9)");
+                runner.Expects.HitBreakpointEvent(SinkHelper.Calling, 17)
+                              .AfterContinue();
+
+                using (IThreadInspector inspector = runner.GetThreadInspector())
+                {
+                    IFrameInspector mainFrame = inspector.Stack.First();
+                    mainFrame.AssertVariables("i", "9");
+                }
+
+                this.Comment("Run to completion - loop is exhausted");
+                runner.Expects.ExitedEvent()
+                              .TerminatedEvent()
+                              .AfterContinue();
+
+                runner.DisconnectAndVerify();
+            }
+        }
+
+        [Theory]
+        [DependsOnTest(nameof(CompileKitchenSinkForBreakpointTests))]
+        [RequiresTestSettings]
         public void HitConditionBreakpointModifyMidRun(ITestSettings settings)
         {
             this.TestPurpose("Tests changing a hitCondition while stopped at the breakpoint");
@@ -1025,6 +1104,65 @@ namespace CppTests.Tests
                     IFrameInspector mainFrame = inspector.Stack.First();
                     mainFrame.AssertVariables("i", "9");
                 }
+
+                this.Comment("Run to completion");
+                runner.Expects.ExitedEvent()
+                              .TerminatedEvent()
+                              .AfterContinue();
+
+                runner.DisconnectAndVerify();
+            }
+        }
+
+        [Theory]
+        [DependsOnTest(nameof(CompileKitchenSinkForBreakpointTests))]
+        [RequiresTestSettings]
+        public void HitConditionBreakpointClearMidRun(ITestSettings settings)
+        {
+            this.TestPurpose("Tests that clearing a hit condition mid-run resets GDB's ignore count so the breakpoint fires on the next hit");
+            this.WriteSettings(settings);
+
+            IDebuggee debuggee = SinkHelper.Open(this, settings.CompilerSettings, DebuggeeMonikers.KitchenSink.Breakpoint);
+
+            using (IDebuggerRunner runner = CreateDebugAdapterRunner(settings))
+            {
+                this.Comment("Configure launch");
+                runner.Launch(settings.DebuggerSettings, debuggee, "-fCalling");
+
+                this.Comment("Set a breakpoint with hit condition %5 inside a loop that iterates 10 times");
+                SourceBreakpoints callingBreakpoints = new SourceBreakpoints(debuggee, SinkHelper.Calling);
+                callingBreakpoints.Add(17, hitCondition: "%5");
+                runner.SetBreakpoints(callingBreakpoints);
+
+                this.Comment("Run to breakpoint - should stop on 5th hit (i == 4)");
+                runner.Expects.HitBreakpointEvent(SinkHelper.Calling, 17)
+                              .AfterConfigurationDone();
+
+                using (IThreadInspector inspector = runner.GetThreadInspector())
+                {
+                    IFrameInspector mainFrame = inspector.Stack.First();
+                    mainFrame.AssertVariables("i", "4");
+                }
+
+                this.Comment("Clear the hit condition while stopped — remove and re-add without hitCondition");
+                callingBreakpoints.Remove(17);
+                callingBreakpoints.Add(17);
+                runner.SetBreakpoints(callingBreakpoints);
+
+                this.Comment("Continue - with no hit condition, should stop on the very next hit (i == 5)");
+                runner.Expects.HitBreakpointEvent(SinkHelper.Calling, 17)
+                              .AfterContinue();
+
+                this.Comment("Verify the breakpoint fired immediately, not at the next modulo multiple");
+                using (IThreadInspector inspector = runner.GetThreadInspector())
+                {
+                    IFrameInspector mainFrame = inspector.Stack.First();
+                    mainFrame.AssertVariables("i", "5");
+                }
+
+                this.Comment("Remove the breakpoint and run to completion");
+                callingBreakpoints.Remove(17);
+                runner.SetBreakpoints(callingBreakpoints);
 
                 this.Comment("Run to completion");
                 runner.Expects.ExitedEvent()
@@ -1380,6 +1518,112 @@ namespace CppTests.Tests
                 runner.Expects.ExitedEvent()
                               .TerminatedEvent()
                               .AfterConfigurationDone();
+
+                runner.DisconnectAndVerify();
+            }
+        }
+
+        #endregion
+
+        #region HitCondition Edge Case Tests
+
+        [Theory]
+        [DependsOnTest(nameof(CompileKitchenSinkForBreakpointTests))]
+        [RequiresTestSettings]
+        public void HitConditionBreakpointEqualFiresOnce(ITestSettings settings)
+        {
+            this.TestPurpose("Tests that an EQUAL hitCondition fires exactly once and never again, even with re-arm");
+            this.WriteSettings(settings);
+
+            IDebuggee debuggee = SinkHelper.Open(this, settings.CompilerSettings, DebuggeeMonikers.KitchenSink.Breakpoint);
+
+            using (IDebuggerRunner runner = CreateDebugAdapterRunner(settings))
+            {
+                this.Comment("Configure launch");
+                runner.Launch(settings.DebuggerSettings, debuggee, "-fCalling");
+
+                this.Comment("Set EQUAL breakpoint at hit 3 on loop body, plus unconditional breakpoint after loop");
+                SourceBreakpoints callingBreakpoints = new SourceBreakpoints(debuggee, SinkHelper.Calling);
+                callingBreakpoints.Add(17, hitCondition: "3");
+                callingBreakpoints.Add(21);
+                runner.SetBreakpoints(callingBreakpoints);
+
+                this.Comment("Run - should stop at hit 3 (i == 2)");
+                runner.Expects.HitBreakpointEvent(SinkHelper.Calling, 17)
+                              .AfterConfigurationDone();
+
+                using (IThreadInspector inspector = runner.GetThreadInspector())
+                {
+                    IFrameInspector mainFrame = inspector.Stack.First();
+                    mainFrame.AssertVariables("i", "2");
+                }
+
+                this.Comment("Continue - EQUAL should not fire on hits 4-10; next stop is the post-loop breakpoint");
+                runner.Expects.HitBreakpointEvent(SinkHelper.Calling, 21)
+                              .AfterContinue();
+
+                this.Comment("Run to completion");
+                runner.Expects.ExitedEvent()
+                              .TerminatedEvent()
+                              .AfterContinue();
+
+                runner.DisconnectAndVerify();
+            }
+        }
+
+        [Theory]
+        [DependsOnTest(nameof(CompileKitchenSinkForBreakpointTests))]
+        [RequiresTestSettings]
+        public void HitConditionBreakpointEqualAfterGte(ITestSettings settings)
+        {
+            this.TestPurpose("Tests changing from >=N to EQUAL mid-run, verifying re-arm clears stale ignore count");
+            this.WriteSettings(settings);
+
+            IDebuggee debuggee = SinkHelper.Open(this, settings.CompilerSettings, DebuggeeMonikers.KitchenSink.Breakpoint);
+
+            using (IDebuggerRunner runner = CreateDebugAdapterRunner(settings))
+            {
+                this.Comment("Configure launch");
+                runner.Launch(settings.DebuggerSettings, debuggee, "-fCalling");
+
+                this.Comment("Set breakpoint with >=3 — fires on hits 3, 4, 5, ...");
+                SourceBreakpoints callingBreakpoints = new SourceBreakpoints(debuggee, SinkHelper.Calling);
+                callingBreakpoints.Add(17, hitCondition: ">=3");
+                runner.SetBreakpoints(callingBreakpoints);
+
+                this.Comment("Run to first fire at hit 3 (i == 2)");
+                runner.Expects.HitBreakpointEvent(SinkHelper.Calling, 17)
+                              .AfterConfigurationDone();
+
+                using (IThreadInspector inspector = runner.GetThreadInspector())
+                {
+                    IFrameInspector mainFrame = inspector.Stack.First();
+                    mainFrame.AssertVariables("i", "2");
+                }
+
+                this.Comment("Continue - >=3 fires on hit 4 (i == 3)");
+                runner.Expects.HitBreakpointEvent(SinkHelper.Calling, 17)
+                              .AfterContinue();
+
+                this.Comment("Switch to EQUAL 7 while stopped at hit 4");
+                callingBreakpoints.Remove(17);
+                callingBreakpoints.Add(17, hitCondition: "7");
+                runner.SetBreakpoints(callingBreakpoints);
+
+                this.Comment("Continue - should skip hits 5 and 6, fire at hit 7 (i == 6)");
+                runner.Expects.HitBreakpointEvent(SinkHelper.Calling, 17)
+                              .AfterContinue();
+
+                using (IThreadInspector inspector = runner.GetThreadInspector())
+                {
+                    IFrameInspector mainFrame = inspector.Stack.First();
+                    mainFrame.AssertVariables("i", "6");
+                }
+
+                this.Comment("Run to completion - EQUAL 7 already satisfied, should not fire again");
+                runner.Expects.ExitedEvent()
+                              .TerminatedEvent()
+                              .AfterContinue();
 
                 runner.DisconnectAndVerify();
             }

--- a/test/CppTests/Tests/BreakpointTests.cs
+++ b/test/CppTests/Tests/BreakpointTests.cs
@@ -516,6 +516,282 @@ namespace CppTests.Tests
                 Assert.True(runner.InitializeResponse.body.supportsFunctionBreakpoints.HasValue
                     && runner.InitializeResponse.body.supportsFunctionBreakpoints.Value == true, "Function breakpoints should be supported");
 
+                Assert.True(runner.InitializeResponse.body.supportsHitConditionalBreakpoints.HasValue
+                    && runner.InitializeResponse.body.supportsHitConditionalBreakpoints.Value == true, "Hit conditional breakpoints should be supported");
+
+                this.Comment("Run to completion");
+                runner.Expects.ExitedEvent()
+                              .TerminatedEvent()
+                              .AfterConfigurationDone();
+
+                runner.DisconnectAndVerify();
+            }
+        }
+
+        [Theory]
+        [DependsOnTest(nameof(CompileKitchenSinkForBreakpointTests))]
+        [RequiresTestSettings]
+        public void HitConditionBreakpointEqual(ITestSettings settings)
+        {
+            this.TestPurpose("Tests that a breakpoint with a hit count condition (equal) only breaks on the Nth hit");
+            this.WriteSettings(settings);
+
+            IDebuggee debuggee = SinkHelper.Open(this, settings.CompilerSettings, DebuggeeMonikers.KitchenSink.Breakpoint);
+
+            using (IDebuggerRunner runner = CreateDebugAdapterRunner(settings))
+            {
+                this.Comment("Configure launch");
+                runner.Launch(settings.DebuggerSettings, debuggee, "-fCalling");
+
+                this.Comment("Set a breakpoint with hit condition = 5 inside a loop that iterates 10 times");
+                SourceBreakpoints callingBreakpoints = new SourceBreakpoints(debuggee, SinkHelper.Calling);
+                callingBreakpoints.Add(17, hitCondition: "5");
+                runner.SetBreakpoints(callingBreakpoints);
+
+                this.Comment("Run to breakpoint - should only stop on 5th hit");
+                runner.Expects.HitBreakpointEvent(SinkHelper.Calling, 17)
+                              .AfterConfigurationDone();
+
+                this.Comment("Verify that the loop variable equals 4 (0-indexed, 5th iteration)");
+                using (IThreadInspector inspector = runner.GetThreadInspector())
+                {
+                    IFrameInspector mainFrame = inspector.Stack.First();
+                    mainFrame.AssertVariables("i", "4");
+                }
+
+                this.Comment("Run to completion - hit count 5 already reached, should not stop again");
+                runner.Expects.ExitedEvent()
+                              .TerminatedEvent()
+                              .AfterContinue();
+
+                runner.DisconnectAndVerify();
+            }
+        }
+
+        [Theory]
+        [DependsOnTest(nameof(CompileKitchenSinkForBreakpointTests))]
+        [RequiresTestSettings]
+        public void HitConditionBreakpointGreaterOrEqual(ITestSettings settings)
+        {
+            this.TestPurpose("Tests that a breakpoint with a hit count condition (>=) breaks on the Nth hit and every subsequent hit");
+            this.WriteSettings(settings);
+
+            IDebuggee debuggee = SinkHelper.Open(this, settings.CompilerSettings, DebuggeeMonikers.KitchenSink.Breakpoint);
+
+            using (IDebuggerRunner runner = CreateDebugAdapterRunner(settings))
+            {
+                this.Comment("Configure launch");
+                runner.Launch(settings.DebuggerSettings, debuggee, "-fCalling");
+
+                this.Comment("Set a breakpoint with hit condition >= 8 inside a loop that iterates 10 times");
+                SourceBreakpoints callingBreakpoints = new SourceBreakpoints(debuggee, SinkHelper.Calling);
+                callingBreakpoints.Add(17, hitCondition: ">=8");
+                runner.SetBreakpoints(callingBreakpoints);
+
+                this.Comment("Run to breakpoint - should stop on 8th hit");
+                runner.Expects.HitBreakpointEvent(SinkHelper.Calling, 17)
+                              .AfterConfigurationDone();
+
+                this.Comment("Verify that the loop variable equals 7 (0-indexed, 8th iteration)");
+                using (IThreadInspector inspector = runner.GetThreadInspector())
+                {
+                    IFrameInspector mainFrame = inspector.Stack.First();
+                    mainFrame.AssertVariables("i", "7");
+                }
+
+                this.Comment("Continue - should stop on 9th hit");
+                runner.Expects.HitBreakpointEvent(SinkHelper.Calling, 17)
+                              .AfterContinue();
+
+                this.Comment("Verify that the loop variable equals 8 (0-indexed, 9th iteration)");
+                using (IThreadInspector inspector = runner.GetThreadInspector())
+                {
+                    IFrameInspector mainFrame = inspector.Stack.First();
+                    mainFrame.AssertVariables("i", "8");
+                }
+
+                this.Comment("Continue - should stop on 10th hit");
+                runner.Expects.HitBreakpointEvent(SinkHelper.Calling, 17)
+                              .AfterContinue();
+
+                this.Comment("Verify that the loop variable equals 9 (0-indexed, 10th iteration)");
+                using (IThreadInspector inspector = runner.GetThreadInspector())
+                {
+                    IFrameInspector mainFrame = inspector.Stack.First();
+                    mainFrame.AssertVariables("i", "9");
+                }
+
+                this.Comment("Run to completion");
+                runner.Expects.ExitedEvent()
+                              .TerminatedEvent()
+                              .AfterContinue();
+
+                runner.DisconnectAndVerify();
+            }
+        }
+
+        [Theory]
+        [DependsOnTest(nameof(CompileKitchenSinkForBreakpointTests))]
+        [RequiresTestSettings]
+        public void HitConditionBreakpointModulo(ITestSettings settings)
+        {
+            this.TestPurpose("Tests that a breakpoint with a hit count condition (modulo) breaks on every Nth hit");
+            this.WriteSettings(settings);
+
+            IDebuggee debuggee = SinkHelper.Open(this, settings.CompilerSettings, DebuggeeMonikers.KitchenSink.Breakpoint);
+
+            using (IDebuggerRunner runner = CreateDebugAdapterRunner(settings))
+            {
+                this.Comment("Configure launch");
+                runner.Launch(settings.DebuggerSettings, debuggee, "-fCalling");
+
+                this.Comment("Set a breakpoint with hit condition %3 inside a loop that iterates 10 times");
+                SourceBreakpoints callingBreakpoints = new SourceBreakpoints(debuggee, SinkHelper.Calling);
+                callingBreakpoints.Add(17, hitCondition: "%3");
+                runner.SetBreakpoints(callingBreakpoints);
+
+                this.Comment("Run to breakpoint - should stop on 3rd hit");
+                runner.Expects.HitBreakpointEvent(SinkHelper.Calling, 17)
+                              .AfterConfigurationDone();
+
+                this.Comment("Verify that the loop variable equals 2 (0-indexed, 3rd iteration)");
+                using (IThreadInspector inspector = runner.GetThreadInspector())
+                {
+                    IFrameInspector mainFrame = inspector.Stack.First();
+                    mainFrame.AssertVariables("i", "2");
+                }
+
+                this.Comment("Continue - should stop on 6th hit");
+                runner.Expects.HitBreakpointEvent(SinkHelper.Calling, 17)
+                              .AfterContinue();
+
+                this.Comment("Verify that the loop variable equals 5 (0-indexed, 6th iteration)");
+                using (IThreadInspector inspector = runner.GetThreadInspector())
+                {
+                    IFrameInspector mainFrame = inspector.Stack.First();
+                    mainFrame.AssertVariables("i", "5");
+                }
+
+                this.Comment("Continue - should stop on 9th hit");
+                runner.Expects.HitBreakpointEvent(SinkHelper.Calling, 17)
+                              .AfterContinue();
+
+                this.Comment("Verify that the loop variable equals 8 (0-indexed, 9th iteration)");
+                using (IThreadInspector inspector = runner.GetThreadInspector())
+                {
+                    IFrameInspector mainFrame = inspector.Stack.First();
+                    mainFrame.AssertVariables("i", "8");
+                }
+
+                this.Comment("Run to completion - no more multiples of 3 within 10 iterations");
+                runner.Expects.ExitedEvent()
+                              .TerminatedEvent()
+                              .AfterContinue();
+
+                runner.DisconnectAndVerify();
+            }
+        }
+
+        [Theory]
+        [DependsOnTest(nameof(CompileKitchenSinkForBreakpointTests))]
+        [RequiresTestSettings]
+        [UnsupportedDebugger(SupportedDebugger.VsDbg, SupportedArchitecture.x86 | SupportedArchitecture.x64)]
+        public void InvalidHitConditionBreakpoint(ITestSettings settings)
+        {
+            this.TestPurpose("Tests that an invalid hit condition returns a non-verified breakpoint with an error message");
+            this.WriteSettings(settings);
+
+            IDebuggee debuggee = SinkHelper.Open(this, settings.CompilerSettings, DebuggeeMonikers.KitchenSink.Breakpoint);
+
+            using (IDebuggerRunner runner = CreateDebugAdapterRunner(settings))
+            {
+                this.Comment("Configure launch");
+                runner.Launch(settings.DebuggerSettings, debuggee, "-fCalling");
+
+                this.Comment("Set a breakpoint with an invalid hit condition");
+                SourceBreakpoints callingBreakpoints = new SourceBreakpoints(debuggee, SinkHelper.Calling);
+                callingBreakpoints.Add(17, hitCondition: "invalid");
+                var response = runner.SetBreakpoints(callingBreakpoints);
+
+                this.Comment("Verify breakpoint is not verified and has an error message about hit condition");
+                Assert.NotNull(response.body.breakpoints);
+                Assert.Single(response.body.breakpoints);
+                Assert.False(response.body.breakpoints[0].verified, "Breakpoint with invalid hit condition should not be verified");
+                Assert.Contains("hitCondition", response.body.breakpoints[0].message);
+
+                this.Comment("Run to completion");
+                runner.Expects.ExitedEvent()
+                              .TerminatedEvent()
+                              .AfterConfigurationDone();
+
+                runner.DisconnectAndVerify();
+            }
+        }
+
+        [Theory]
+        [DependsOnTest(nameof(CompileKitchenSinkForBreakpointTests))]
+        [RequiresTestSettings]
+        [UnsupportedDebugger(SupportedDebugger.VsDbg, SupportedArchitecture.x86 | SupportedArchitecture.x64)]
+        public void InvalidLogMessageBreakpoint(ITestSettings settings)
+        {
+            this.TestPurpose("Tests that an invalid log message returns a non-verified breakpoint with an error message");
+            this.WriteSettings(settings);
+
+            IDebuggee debuggee = SinkHelper.Open(this, settings.CompilerSettings, DebuggeeMonikers.KitchenSink.Breakpoint);
+
+            using (IDebuggerRunner runner = CreateDebugAdapterRunner(settings))
+            {
+                this.Comment("Configure launch");
+                runner.Launch(settings.DebuggerSettings, debuggee, "-fCalling");
+
+                this.Comment("Set a breakpoint with an invalid log message (unmatched brace)");
+                SourceBreakpoints callingBreakpoints = new SourceBreakpoints(debuggee, SinkHelper.Calling);
+                callingBreakpoints.Add(17, logMessage: "{unmatched");
+                var response = runner.SetBreakpoints(callingBreakpoints);
+
+                this.Comment("Verify breakpoint is not verified and has an error message about log message");
+                Assert.NotNull(response.body.breakpoints);
+                Assert.Single(response.body.breakpoints);
+                Assert.False(response.body.breakpoints[0].verified, "Breakpoint with invalid log message should not be verified");
+                Assert.Contains("logMessage", response.body.breakpoints[0].message);
+
+                this.Comment("Run to completion");
+                runner.Expects.ExitedEvent()
+                              .TerminatedEvent()
+                              .AfterConfigurationDone();
+
+                runner.DisconnectAndVerify();
+            }
+        }
+
+        [Theory]
+        [DependsOnTest(nameof(CompileKitchenSinkForBreakpointTests))]
+        [RequiresTestSettings]
+        [UnsupportedDebugger(SupportedDebugger.VsDbg, SupportedArchitecture.x86 | SupportedArchitecture.x64)]
+        public void InvalidLogMessageAndHitConditionBreakpoint(ITestSettings settings)
+        {
+            this.TestPurpose("Tests that both invalid log message and invalid hit condition errors are returned together");
+            this.WriteSettings(settings);
+
+            IDebuggee debuggee = SinkHelper.Open(this, settings.CompilerSettings, DebuggeeMonikers.KitchenSink.Breakpoint);
+
+            using (IDebuggerRunner runner = CreateDebugAdapterRunner(settings))
+            {
+                this.Comment("Configure launch");
+                runner.Launch(settings.DebuggerSettings, debuggee, "-fCalling");
+
+                this.Comment("Set a breakpoint with both an invalid log message and an invalid hit condition");
+                SourceBreakpoints callingBreakpoints = new SourceBreakpoints(debuggee, SinkHelper.Calling);
+                callingBreakpoints.Add(17, logMessage: "{unmatched", hitCondition: "invalid");
+                var response = runner.SetBreakpoints(callingBreakpoints);
+
+                this.Comment("Verify breakpoint is not verified and error message mentions both logMessage and hitCondition");
+                Assert.NotNull(response.body.breakpoints);
+                Assert.Single(response.body.breakpoints);
+                Assert.False(response.body.breakpoints[0].verified, "Breakpoint with invalid log message and hit condition should not be verified");
+                Assert.Contains("logMessage", response.body.breakpoints[0].message);
+                Assert.Contains("hitCondition", response.body.breakpoints[0].message);
+
                 this.Comment("Run to completion");
                 runner.Expects.ExitedEvent()
                               .TerminatedEvent()

--- a/test/DebuggerTesting/OpenDebug/Commands/InitializeCommand.cs
+++ b/test/DebuggerTesting/OpenDebug/Commands/InitializeCommand.cs
@@ -35,6 +35,9 @@ namespace DebuggerTesting.OpenDebug.Commands
 
             [JsonProperty(DefaultValueHandling = DefaultValueHandling.Ignore)]
             public bool? supportsSetVariable;
+
+            [JsonProperty(DefaultValueHandling = DefaultValueHandling.Ignore)]
+            public bool? supportsHitConditionalBreakpoints;
         }
 
         public Body body = new Body();

--- a/test/DebuggerTesting/OpenDebug/Commands/SetBreakpointsCommand.cs
+++ b/test/DebuggerTesting/OpenDebug/Commands/SetBreakpointsCommand.cs
@@ -18,12 +18,13 @@ namespace DebuggerTesting.OpenDebug.Commands
     {
         public sealed class SourceBreakpoint
         {
-            public SourceBreakpoint(int line, int? column, string condition, string logMessage)
+            public SourceBreakpoint(int line, int? column, string condition, string logMessage, string hitCondition)
             {
                 this.line = line;
                 this.column = column;
                 this.condition = condition;
                 this.logMessage = logMessage;
+                this.hitCondition = hitCondition;
             }
 
             public int line;
@@ -36,6 +37,9 @@ namespace DebuggerTesting.OpenDebug.Commands
 
             [JsonProperty(DefaultValueHandling = DefaultValueHandling.Ignore)]
             public string logMessage;
+
+            [JsonProperty(DefaultValueHandling = DefaultValueHandling.Ignore)]
+            public string hitCondition;
         }
 
         public Source source = new Source();
@@ -72,11 +76,11 @@ namespace DebuggerTesting.OpenDebug.Commands
 
         #region Add/Remove
 
-        public SourceBreakpoints Add(int lineNumber, string condition = null, string logMessage = null)
+        public SourceBreakpoints Add(int lineNumber, string condition = null, string logMessage = null, string hitCondition = null)
         {
             if (this.Breakpoints.ContainsKey(lineNumber))
                 throw new RunnerException("Breakpoint line {0} already added to file {1}.", lineNumber, this.RelativePath);
-            this.Breakpoints.Add(lineNumber, new SetBreakpointsCommandArgs.SourceBreakpoint(lineNumber, null, condition, logMessage));
+            this.Breakpoints.Add(lineNumber, new SetBreakpointsCommandArgs.SourceBreakpoint(lineNumber, null, condition, logMessage, hitCondition));
             return this;
         }
 


### PR DESCRIPTION
This PR adds in showing the Hit count for a breakpoint and for setting a HitCondition.

Enables m_supportsHitConditionalBreakpoints, OpenDebugAD7 now properly builds a AD7BreakpointRequest with a hitCondition, AD7BoundBreakpoint now properly tracks hits and will prevent a break event if theres a condition set.

Added CppTests and updated DebuggerTesting for associated commands.

Addresses: https://github.com/microsoft/MIEngine/issues/472