### PR TITLE
Fix hang in SSH attach when determining executable path

### DIFF
--- a/src/MIDebugEngine/Engine.Impl/DebuggedProcess.cs
+++ b/src/MIDebugEngine/Engine.Impl/DebuggedProcess.cs
@@ -944,52 +944,67 @@ namespace Microsoft.MIDebugEngine
             // Runs a shell command to get the full path of the exe.
             // /proc file system does not exist on OSX. And querying lsof on privilaged process fails with no output on Mac, while on Linux the command succeedes with 
             // embedded error text in lsof output like "(readlink error)". 
-            string absoluteExePath;
 
             // Must have a processId
             Debug.Assert(_launchOptions.ProcessId.HasValue, "ProcessId should have a value.");
 
+            string shellCommand;
             if (launchOptions.UnixPort.IsOSX())
             {
                 // Usually the first FD=txt in the output of lsof points to the executable.
-                absoluteExePath = string.Format(CultureInfo.InvariantCulture, "shell lsof -p {0} | awk '$4 == \"txt\" {{ print $9 }}'|awk 'NR==1 {{print $1}}'", _launchOptions.ProcessId.Value);
+                shellCommand = string.Format(CultureInfo.InvariantCulture, "lsof -p {0} | awk '$4 == \"txt\" {{ print $9 }}'|awk 'NR==1 {{print $1}}'", _launchOptions.ProcessId.Value);
             }
             else if (launchOptions.UnixPort.IsLinux())
             {
-                absoluteExePath = string.Format(CultureInfo.InvariantCulture, @"shell readlink -f /proc/{0}/exe", _launchOptions.ProcessId.Value);
+                shellCommand = string.Format(CultureInfo.InvariantCulture, "readlink -f /proc/{0}/exe", _launchOptions.ProcessId.Value);
             }
             else
             {
                 throw new LaunchErrorException(ResourceStrings.Error_UnsupportedPlatform);
             }
 
+            string commandOutput;
+            int exitCode;
+            try
+            {
+                launchOptions.UnixPort.ExecuteSyncCommand(
+                    string.Format(CultureInfo.CurrentCulture, ResourceStrings.DeterminingExecutablePath, _launchOptions.ProcessId.Value),
+                    shellCommand,
+                    out commandOutput,
+                    timeout: 30000,
+                    out exitCode);
+            }
+            catch (TimeoutException)
+            {
+                string message = string.Format(CultureInfo.CurrentCulture, ResourceStrings.Error_FailedToGetExePath,
+                    string.Format(CultureInfo.CurrentCulture, ResourceStrings.Error_GetExePathTimedOut, shellCommand));
+                throw new LaunchErrorException(message);
+            }
+
+            if (exitCode != 0 || string.IsNullOrWhiteSpace(commandOutput))
+            {
+                string errorDetail = !string.IsNullOrWhiteSpace(commandOutput)
+                    ? commandOutput.Trim()
+                    : string.Format(CultureInfo.CurrentCulture, ResourceStrings.Error_GetExePathFailed, shellCommand, exitCode);
+                string message = string.Format(CultureInfo.CurrentCulture, ResourceStrings.Error_FailedToGetExePath, errorDetail);
+                throw new LaunchErrorException(message);
+            }
+
+            string trimmedExePath = commandOutput.Trim();
+
+            // If the folder contains a space, we need to quote the path.
+            if (trimmedExePath.Contains(' '))
+            {
+                trimmedExePath = "\"" + trimmedExePath + "\"";
+            }
+
             Action<string> failureHandler = (string miError) =>
             {
-                string message = string.Format(CultureInfo.CurrentCulture, ResourceStrings.Error_FailedToGetExePath, miError);
+                string message = string.Format(CultureInfo.CurrentCulture, ResourceStrings.Error_ExePathInvalid, trimmedExePath, MICommandFactory.Name, miError);
                 throw new LaunchErrorException(message);
             };
 
-            Func<string, Task> successHandler = async (string exePath) =>
-            {
-                string trimmedExePath = exePath.Trim();
-                try
-                {
-                    // If the folder contains a space, we need to quote the path.
-                    if (trimmedExePath.Contains(' '))
-                    {
-                        trimmedExePath = "\"" + trimmedExePath + "\"";
-                    }
-
-                    await CmdAsync("-file-exec-and-symbols " + trimmedExePath, ResultClass.done);
-                }
-                catch (UnexpectedMIResultException miException)
-                {
-                    string message = string.Format(CultureInfo.CurrentCulture, ResourceStrings.Error_ExePathInvalid, trimmedExePath, MICommandFactory.Name, miException.MIError);
-                    throw new LaunchErrorException(message);
-                }
-            };
-
-            commands.Add(new LaunchCommand(absoluteExePath, ignoreFailures: false, failureHandler: failureHandler, successHandler: successHandler));
+            commands.Add(new LaunchCommand("-file-exec-and-symbols " + trimmedExePath, ignoreFailures: false, failureHandler: failureHandler));
         }
 
         private TargetArchitecture DefaultArch()

--- a/src/MIDebugEngine/ResourceStrings.Designer.cs
+++ b/src/MIDebugEngine/ResourceStrings.Designer.cs
@@ -119,6 +119,33 @@ namespace Microsoft.MIDebugEngine {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Determining executable path for process {0}.
+        /// </summary>
+        internal static string DeterminingExecutablePath {
+            get {
+                return ResourceManager.GetString("DeterminingExecutablePath", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to &apos;{0}&apos; timed out. The remote system may be unresponsive..
+        /// </summary>
+        internal static string Error_GetExePathTimedOut {
+            get {
+                return ResourceManager.GetString("Error_GetExePathTimedOut", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to &apos;{0}&apos; failed with exit code {1}. Verify the process is still running and accessible..
+        /// </summary>
+        internal static string Error_GetExePathFailed {
+            get {
+                return ResourceManager.GetString("Error_GetExePathFailed", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Failed to obtain target architecture..
         /// </summary>
         internal static string Error_FailedToGetTargetArchitecture {

--- a/src/MIDebugEngine/ResourceStrings.resx
+++ b/src/MIDebugEngine/ResourceStrings.resx
@@ -241,6 +241,18 @@ This may occur if the process's executable was changed after the process was sta
     <value>Failed to get executable path with error '{0}'.</value>
     <comment>0 = failure message</comment>
   </data>
+  <data name="DeterminingExecutablePath" xml:space="preserve">
+    <value>Determining executable path for process {0}</value>
+    <comment>{0} = process ID</comment>
+  </data>
+  <data name="Error_GetExePathTimedOut" xml:space="preserve">
+    <value>'{0}' timed out. The remote system may be unresponsive.</value>
+    <comment>{0} = shell command that was executed</comment>
+  </data>
+  <data name="Error_GetExePathFailed" xml:space="preserve">
+    <value>'{0}' failed with exit code {1}. Verify the process is still running and accessible.</value>
+    <comment>{0} = shell command that was executed, {1} = exit code</comment>
+  </data>
   <data name="Error_PTraceFailure" xml:space="preserve">
     <value>Attaching to process {0} with {1} failed because of insufficient privileges with error message '{2}'.
 

--- a/src/SSHDebugPS/AD7/AD7Port.cs
+++ b/src/SSHDebugPS/AD7/AD7Port.cs
@@ -11,6 +11,7 @@ using Microsoft.SSHDebugPS.Utilities;
 using Microsoft.VisualStudio.Debugger.Interop;
 using Microsoft.VisualStudio.Debugger.Interop.UnixPortSupplier;
 using Microsoft.VisualStudio.OLE.Interop;
+using Microsoft.VisualStudio.Shell;
 
 namespace Microsoft.SSHDebugPS
 {
@@ -153,11 +154,18 @@ namespace Microsoft.SSHDebugPS
             string output = null;
             string errorMessage;
 
-            string waitPrompt = StringResources.WaitingOp_ExecutingCommand.FormatCurrentCultureWithArgs(commandDescription);
-            VS.VSOperationWaiter.Wait(waitPrompt, throwOnCancel: true, action: (cancellationToken) =>
+            if (ThreadHelper.CheckAccess())
+            {
+                string waitPrompt = StringResources.WaitingOp_ExecutingCommand.FormatCurrentCultureWithArgs(commandDescription);
+                VS.VSOperationWaiter.Wait(waitPrompt, throwOnCancel: true, action: (cancellationToken) =>
+                {
+                    code = GetConnection().ExecuteCommand(commandText, timeout, out output, out errorMessage);
+                });
+            }
+            else
             {
                 code = GetConnection().ExecuteCommand(commandText, timeout, out output, out errorMessage);
-            });
+            }
 
             exitCode = code;
             commandOutput = output;


### PR DESCRIPTION
When attaching to a process via SSH, the debugger hung at 'Initializing debugger' because readlink was sent through GDB's MI interface which has no timeout. 

ExecuteSyncCommand on the SSH port did not exist when this code was written (PR #432), but was added two weeks later (PR #446).

Changes:
- DebuggedProcess.cs: Run readlink/lsof directly via the SSH port's ExecuteSyncCommand with a 30s timeout instead of GDB's MI interface. The -file-exec-and-symbols command still goes through GDB.
- AD7Port.cs: Skip VS wait dialog when ExecuteSyncCommand is called from a background thread (debugger worker thread hits an assert otherwise).
- ResourceStrings: Add localized strings for progress and error messages (timeout, non-zero exit code).