### PR TITLE
Add VS feedback tool integration for MIEngine diagnostic logs

### DIFF
--- a/IL/Microsoft.Internal.VisualStudio.Shell.Embeddable.il
+++ b/IL/Microsoft.Internal.VisualStudio.Shell.Embeddable.il
@@ -1,0 +1,23 @@
+.assembly extern mscorlib
+{
+	.publickeytoken = (B7 7A 5C 56 19 34 E0 89)
+	.ver 4:0:0:0
+}
+.assembly Microsoft.Internal.VisualStudio.Shell.Embeddable
+{
+	.publickey = (00 24 00 00 04 80 00 00 94 00 00 00 06 02 00 00 00 24 00 00 52 53 41 31 00 04 00 00 01 00 01 00 07 D1 FA 57 C4 AE D9 F0 A3 2E 84 AA 0F AE FD 0D E9 E8 FD 6A EC 8F 87 FB 03 76 6C 83 4C 99 92 1E B2 3B E7 9A D9 D5 DC C1 DD 9A D2 36 13 21 02 90 0B 72 3C F9 80 95 7F C4 E1 77 10 8F C6 07 77 4F 29 E8 32 0E 92 EA 05 EC E4 E8 21 C0 A5 EF E8 F1 64 5C 4C 0C 93 C1 AB 99 28 5D 62 2C AA 65 2C 1D FA D6 3D 74 5D 6F 2D E5 F1 7E 5E AF 0F C4 96 3D 26 1C 8A 12 43 65 18 20 6D C0 93 34 4D 5A D2 93)
+	.hash algorithm 0x00008004
+	.ver 16:0:0:0
+}
+.namespace Microsoft.Internal.VisualStudio.Shell.Embeddable.Feedback
+{
+	.class interface public abstract auto ansi import IFeedbackDiagnosticFileProvider
+	{
+		.custom instance void [mscorlib]System.Runtime.InteropServices.GuidAttribute::.ctor(string) = { string('5F67C426-4C63-4CDB-917B-45B400B96C31') }
+		.method public hidebysig newslot abstract virtual
+			instance class [mscorlib]System.Collections.Generic.IReadOnlyCollection`1<string>
+			GetFiles() cil managed
+		{
+		}
+	}
+}

--- a/IL/Microsoft.Internal.VisualStudio.Shell.Embeddable.il
+++ b/IL/Microsoft.Internal.VisualStudio.Shell.Embeddable.il
@@ -5,6 +5,8 @@
 }
 .assembly Microsoft.Internal.VisualStudio.Shell.Embeddable
 {
+	.custom instance void [mscorlib]System.Runtime.InteropServices.ImportedFromTypeLibAttribute::.ctor(string) = { string('Microsoft.Internal.VisualStudio.Shell.Embeddable') }
+	.custom instance void [mscorlib]System.Runtime.InteropServices.GuidAttribute::.ctor(string) = { string('190F8999-290E-4111-AE15-1509B895B58C') }
 	.publickey = (00 24 00 00 04 80 00 00 94 00 00 00 06 02 00 00 00 24 00 00 52 53 41 31 00 04 00 00 01 00 01 00 07 D1 FA 57 C4 AE D9 F0 A3 2E 84 AA 0F AE FD 0D E9 E8 FD 6A EC 8F 87 FB 03 76 6C 83 4C 99 92 1E B2 3B E7 9A D9 D5 DC C1 DD 9A D2 36 13 21 02 90 0B 72 3C F9 80 95 7F C4 E1 77 10 8F C6 07 77 4F 29 E8 32 0E 92 EA 05 EC E4 E8 21 C0 A5 EF E8 F1 64 5C 4C 0C 93 C1 AB 99 28 5D 62 2C AA 65 2C 1D FA D6 3D 74 5D 6F 2D E5 F1 7E 5E AF 0F C4 96 3D 26 1C 8A 12 43 65 18 20 6D C0 93 34 4D 5A D2 93)
 	.hash algorithm 0x00008004
 	.ver 16:0:0:0

--- a/src/DebugEngineHost.Stub/DebugEngineHost.ref.cs
+++ b/src/DebugEngineHost.Stub/DebugEngineHost.ref.cs
@@ -308,6 +308,11 @@ namespace Microsoft.DebugEngineHost
         {
             throw new NotImplementedException();
         }
+
+        public static void WriteFeedbackLog(string message)
+        {
+            throw new NotImplementedException();
+        }
     }
 
     /// <summary>

--- a/src/DebugEngineHost.Stub/DebugEngineHost.ref.cs
+++ b/src/DebugEngineHost.Stub/DebugEngineHost.ref.cs
@@ -309,6 +309,18 @@ namespace Microsoft.DebugEngineHost
             throw new NotImplementedException();
         }
 
+        /// <summary>
+        /// Returns true if the feedback log is currently active
+        /// </summary>
+        public static bool IsFeedbackLogEnabled
+        {
+            get { throw new NotImplementedException(); }
+        }
+
+        /// <summary>
+        /// Writes a message to the feedback circular buffer and, if active, to the feedback log file.
+        /// </summary>
+        /// <param name="message">The message to write to the feedback log.</param>
         public static void WriteFeedbackLog(string message)
         {
             throw new NotImplementedException();

--- a/src/DebugEngineHost.VSCode/HostLogger.cs
+++ b/src/DebugEngineHost.VSCode/HostLogger.cs
@@ -51,5 +51,9 @@ namespace Microsoft.DebugEngineHost
             s_engineLogChannel?.Close();
             s_engineLogChannel = null;
         }
+
+        public static void WriteFeedbackLog(string message)
+        {
+        }
     }
 }

--- a/src/DebugEngineHost.VSCode/HostLogger.cs
+++ b/src/DebugEngineHost.VSCode/HostLogger.cs
@@ -52,6 +52,11 @@ namespace Microsoft.DebugEngineHost
             s_engineLogChannel = null;
         }
 
+        public static bool IsFeedbackLogEnabled
+        {
+            get { return false; }
+        }
+
         public static void WriteFeedbackLog(string message)
         {
         }

--- a/src/DebugEngineHost/DebugEngineHost.csproj
+++ b/src/DebugEngineHost/DebugEngineHost.csproj
@@ -99,12 +99,17 @@
 
   <ItemGroup Label="Assembly to Generate">
     <GenerateAssembly Include="$(ILDir)Microsoft.Internal.VisualStudio.Interop.il" />
+    <GenerateAssembly Include="$(ILDir)Microsoft.Internal.VisualStudio.Shell.Embeddable.il" />
   </ItemGroup>
   
   <ItemGroup Label="References">
     <Reference Include="System.ComponentModel.Composition" />
     <Reference Include="Microsoft.Internal.VisualStudio.Interop">
       <HintPath>$(GeneratedAssembliesDir)Microsoft.Internal.VisualStudio.Interop.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.Internal.VisualStudio.Shell.Embeddable">
+      <HintPath>$(GeneratedAssembliesDir)Microsoft.Internal.VisualStudio.Shell.Embeddable.dll</HintPath>
+      <Private>false</Private>
     </Reference>
   </ItemGroup>
   

--- a/src/DebugEngineHost/DebugEngineHost.csproj
+++ b/src/DebugEngineHost/DebugEngineHost.csproj
@@ -109,6 +109,7 @@
     </Reference>
     <Reference Include="Microsoft.Internal.VisualStudio.Shell.Embeddable">
       <HintPath>$(GeneratedAssembliesDir)Microsoft.Internal.VisualStudio.Shell.Embeddable.dll</HintPath>
+      <EmbedInteropTypes>true</EmbedInteropTypes>
       <Private>false</Private>
     </Reference>
   </ItemGroup>

--- a/src/DebugEngineHost/FeedbackDiagnosticFileProvider.cs
+++ b/src/DebugEngineHost/FeedbackDiagnosticFileProvider.cs
@@ -1,11 +1,12 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using System;
 using System.Collections.Generic;
 using System.ComponentModel.Composition;
 using System.Diagnostics;
 using System.IO;
-using System.Text;
+using System.Threading.Tasks;
 using Microsoft.Internal.VisualStudio.Shell.Embeddable.Feedback;
 
 namespace Microsoft.DebugEngineHost
@@ -15,35 +16,34 @@ namespace Microsoft.DebugEngineHost
     {
         public IReadOnlyCollection<string> GetFiles()
         {
+            if (!HostLogger.HasFeedbackEntries)
+            {
+                return Array.Empty<string>();
+            }
+
             string logFileName = HostLogger.GetFeedbackLogFilePath(Process.GetCurrentProcess().Id);
 
+            IReadOnlyCollection<string> entries = HostLogger.GetNewFeedbackEntries();
+            if (entries.Count > 0)
+            {
+                _ = Task.Run(() => WriteFeedbackEntries(logFileName, entries));
+            }
+
+            return new[] { logFileName };
+        }
+
+        private static void WriteFeedbackEntries(string logFileName, IReadOnlyCollection<string> entries)
+        {
             try
             {
-                IReadOnlyCollection<string> entries = HostLogger.GetNewFeedbackEntries();
-                if (entries.Count > 0)
+                using (StreamWriter logWriter = FeedbackLogBuffer.OpenLogFile(logFileName))
                 {
-                    using (var fs = new FileStream(logFileName, FileMode.Append, FileAccess.Write, FileShare.ReadWrite))
-                    using (var logWriter = new StreamWriter(fs, Encoding.UTF8))
-                    {
-                        foreach (string logLine in entries)
-                        {
-                            logWriter.WriteLine(logLine);
-                        }
-
-                        logWriter.Flush();
-                    }
+                    FeedbackLogBuffer.WriteEntries(logWriter, entries);
                 }
             }
             catch
             {
             }
-
-            if (File.Exists(logFileName))
-            {
-                return new[] { logFileName };
-            }
-
-            return new string[0];
         }
     }
 }

--- a/src/DebugEngineHost/FeedbackDiagnosticFileProvider.cs
+++ b/src/DebugEngineHost/FeedbackDiagnosticFileProvider.cs
@@ -1,0 +1,49 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Collections.Generic;
+using System.ComponentModel.Composition;
+using System.Diagnostics;
+using System.IO;
+using System.Text;
+using Microsoft.Internal.VisualStudio.Shell.Embeddable.Feedback;
+
+namespace Microsoft.DebugEngineHost
+{
+    [Export(typeof(IFeedbackDiagnosticFileProvider))]
+    public class FeedbackDiagnosticFileProvider : IFeedbackDiagnosticFileProvider
+    {
+        public IReadOnlyCollection<string> GetFiles()
+        {
+            string logFileName = HostLogger.GetFeedbackLogFilePath(Process.GetCurrentProcess().Id);
+
+            try
+            {
+                IReadOnlyCollection<string> entries = HostLogger.GetNewFeedbackEntries();
+                if (entries.Count > 0)
+                {
+                    using (var fs = new FileStream(logFileName, FileMode.Append, FileAccess.Write, FileShare.ReadWrite))
+                    using (var logWriter = new StreamWriter(fs, Encoding.UTF8))
+                    {
+                        foreach (string logLine in entries)
+                        {
+                            logWriter.WriteLine(logLine);
+                        }
+
+                        logWriter.Flush();
+                    }
+                }
+            }
+            catch
+            {
+            }
+
+            if (File.Exists(logFileName))
+            {
+                return new[] { logFileName };
+            }
+
+            return new string[0];
+        }
+    }
+}

--- a/src/DebugEngineHost/FeedbackLogBuffer.cs
+++ b/src/DebugEngineHost/FeedbackLogBuffer.cs
@@ -1,0 +1,61 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Collections.Generic;
+using System.Linq;
+
+namespace Microsoft.DebugEngineHost
+{
+    /// <summary>
+    /// In-memory circular buffer that caches recent log messages for feedback reports.
+    /// </summary>
+    internal class FeedbackLogBuffer
+    {
+        private const int s_maxLogBufferSize = 256 * 1024;
+
+        private readonly LinkedList<string> _logBuffer = new LinkedList<string>();
+        private int _logLength;
+        private long _writeSequence;
+        private long _lastFlushSequence;
+        private readonly object _syncObj = new object();
+
+        internal void Write(string logLine)
+        {
+            lock (_syncObj)
+            {
+                if (logLine.Length > s_maxLogBufferSize)
+                {
+                    logLine = logLine.Substring(0, s_maxLogBufferSize);
+                }
+
+                _logBuffer.AddLast(logLine);
+                _logLength += logLine.Length;
+                _writeSequence++;
+
+                while (_logLength > s_maxLogBufferSize)
+                {
+                    string entry = _logBuffer.First();
+                    _logLength -= entry.Length;
+                    _logBuffer.RemoveFirst();
+                }
+            }
+        }
+
+        internal IReadOnlyCollection<string> FlushNewEntries()
+        {
+            lock (_syncObj)
+            {
+                long newEntryCount = System.Math.Min(_writeSequence - _lastFlushSequence, _logBuffer.Count);
+                _lastFlushSequence = _writeSequence;
+
+                if (newEntryCount <= 0)
+                {
+                    return new string[0];
+                }
+
+                int skipCount = _logBuffer.Count - (int)newEntryCount;
+                return _logBuffer.Skip(skipCount).ToList().AsReadOnly();
+            }
+        }
+    }
+}

--- a/src/DebugEngineHost/FeedbackLogBuffer.cs
+++ b/src/DebugEngineHost/FeedbackLogBuffer.cs
@@ -23,15 +23,15 @@ namespace Microsoft.DebugEngineHost
         private readonly object _syncObj = new object();
 
         /// <summary>
-        /// Returns true if no entries have been written since the last flush.
+        /// Returns true if any entries have ever been written to the buffer.
         /// </summary>
-        internal bool IsEmpty
+        internal bool HasEntries
         {
             get
             {
                 lock (_syncObj)
                 {
-                    return _writeSequence == _lastFlushSequence;
+                    return _writeSequence > 0;
                 }
             }
         }

--- a/src/DebugEngineHost/FeedbackLogBuffer.cs
+++ b/src/DebugEngineHost/FeedbackLogBuffer.cs
@@ -1,8 +1,11 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Linq;
+using System.Text;
 
 namespace Microsoft.DebugEngineHost
 {
@@ -18,6 +21,20 @@ namespace Microsoft.DebugEngineHost
         private long _writeSequence;
         private long _lastFlushSequence;
         private readonly object _syncObj = new object();
+
+        /// <summary>
+        /// Returns true if no entries have been written since the last flush.
+        /// </summary>
+        internal bool IsEmpty
+        {
+            get
+            {
+                lock (_syncObj)
+                {
+                    return _writeSequence == _lastFlushSequence;
+                }
+            }
+        }
 
         internal void Write(string logLine)
         {
@@ -50,12 +67,42 @@ namespace Microsoft.DebugEngineHost
 
                 if (newEntryCount <= 0)
                 {
-                    return new string[0];
+                    return Array.Empty<string>();
                 }
 
                 int skipCount = _logBuffer.Count - (int)newEntryCount;
                 return _logBuffer.Skip(skipCount).ToList().AsReadOnly();
             }
+        }
+
+        /// <summary>
+        /// Opens the feedback log file for appending with shared read/write access.
+        /// </summary>
+        internal static StreamWriter OpenLogFile(string logFileName)
+        {
+            var fs = new FileStream(logFileName, FileMode.Append, FileAccess.Write, FileShare.ReadWrite);
+            try
+            {
+                return new StreamWriter(fs, Encoding.UTF8);
+            }
+            catch
+            {
+                fs.Dispose();
+                throw;
+            }
+        }
+
+        /// <summary>
+        /// Writes a collection of log entries to the given writer.
+        /// </summary>
+        internal static void WriteEntries(StreamWriter writer, IEnumerable<string> entries)
+        {
+            foreach (string logLine in entries)
+            {
+                writer.WriteLine(logLine);
+            }
+
+            writer.Flush();
         }
     }
 }

--- a/src/DebugEngineHost/HostLogger.cs
+++ b/src/DebugEngineHost/HostLogger.cs
@@ -3,9 +3,8 @@
 
 using System;
 using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+using System.Globalization;
+using System.IO;
 
 namespace Microsoft.DebugEngineHost
 {
@@ -16,11 +15,19 @@ namespace Microsoft.DebugEngineHost
 
         private static string s_engineLogFile;
 
+        private static readonly FeedbackLogBuffer s_circularBuffer = new FeedbackLogBuffer();
+        private static VSFeedbackLogger s_feedbackLogger;
+
         public static void EnableHostLogging(Action<string> callback, LogLevel level = LogLevel.Verbose)
         {
             if (s_engineLogChannel == null)
             {
                 s_engineLogChannel = new HostLogChannel(callback, s_engineLogFile, level);
+            }
+
+            if (s_feedbackLogger == null)
+            {
+                s_feedbackLogger = new VSFeedbackLogger(s_circularBuffer);
             }
         }
 
@@ -50,6 +57,39 @@ namespace Microsoft.DebugEngineHost
         public static ILogChannel GetNatvisLogChannel()
         {
             return s_natvisLogChannel;
+        }
+
+        /// <summary>
+        /// Writes a message to the feedback circular buffer and, if active, to the feedback log file.
+        /// </summary>
+        public static void WriteFeedbackLog(string message)
+        {
+            if (string.IsNullOrEmpty(message))
+            {
+                return;
+            }
+
+            string timestamp = DateTime.Now.ToString("MM/dd/yyyy HH:mm:ss.fff", CultureInfo.InvariantCulture);
+            string logLine = string.Format(CultureInfo.InvariantCulture, "{0}: {1}", timestamp, message);
+
+            s_circularBuffer.Write(logLine);
+            s_feedbackLogger?.Write(logLine);
+        }
+
+        /// <summary>
+        /// Returns log entries added since the last flush, then advances the flush marker.
+        /// </summary>
+        internal static IReadOnlyCollection<string> GetNewFeedbackEntries()
+        {
+            return s_circularBuffer.FlushNewEntries();
+        }
+
+        /// <summary>
+        /// Gets the path for the feedback log file for a given VS process ID.
+        /// </summary>
+        internal static string GetFeedbackLogFilePath(int vsPid)
+        {
+            return Path.Combine(Path.GetTempPath(), string.Format(CultureInfo.InvariantCulture, "MIEngine-{0}.log", vsPid));
         }
 
         public static void Reset()

--- a/src/DebugEngineHost/HostLogger.cs
+++ b/src/DebugEngineHost/HostLogger.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections.Generic;
 using System.Globalization;
 using System.IO;
+using System.Threading;
 
 namespace Microsoft.DebugEngineHost
 {
@@ -15,7 +16,7 @@ namespace Microsoft.DebugEngineHost
 
         private static string s_engineLogFile;
 
-        private static readonly FeedbackLogBuffer s_circularBuffer = new FeedbackLogBuffer();
+        private static FeedbackLogBuffer s_circularBuffer;
         private static VSFeedbackLogger s_feedbackLogger;
 
         public static void EnableHostLogging(Action<string> callback, LogLevel level = LogLevel.Verbose)
@@ -27,7 +28,7 @@ namespace Microsoft.DebugEngineHost
 
             if (s_feedbackLogger == null)
             {
-                s_feedbackLogger = new VSFeedbackLogger(s_circularBuffer);
+                s_feedbackLogger = new VSFeedbackLogger(EnsureFeedbackBuffer());
             }
         }
 
@@ -60,6 +61,14 @@ namespace Microsoft.DebugEngineHost
         }
 
         /// <summary>
+        /// Returns true if the feedback log is currently active (buffer has been created).
+        /// </summary>
+        public static bool IsFeedbackLogEnabled
+        {
+            get { return s_circularBuffer != null; }
+        }
+
+        /// <summary>
         /// Writes a message to the feedback circular buffer and, if active, to the feedback log file.
         /// </summary>
         public static void WriteFeedbackLog(string message)
@@ -72,8 +81,31 @@ namespace Microsoft.DebugEngineHost
             string timestamp = DateTime.Now.ToString("MM/dd/yyyy HH:mm:ss.fff", CultureInfo.InvariantCulture);
             string logLine = string.Format(CultureInfo.InvariantCulture, "{0}: {1}", timestamp, message);
 
-            s_circularBuffer.Write(logLine);
+            EnsureFeedbackBuffer().Write(logLine);
             s_feedbackLogger?.Write(logLine);
+        }
+
+        private static FeedbackLogBuffer EnsureFeedbackBuffer()
+        {
+            if (s_circularBuffer == null)
+            {
+                Interlocked.CompareExchange(ref s_circularBuffer, new FeedbackLogBuffer(), null);
+            }
+
+            return s_circularBuffer;
+        }
+
+        /// <summary>
+        /// Returns true if the feedback buffer has been created and has entries.
+        /// This is a cheap check to avoid unnecessary work in non-MIEngine scenarios.
+        /// </summary>
+        internal static bool HasFeedbackEntries
+        {
+            get
+            {
+                FeedbackLogBuffer buffer = s_circularBuffer;
+                return buffer != null && !buffer.IsEmpty;
+            }
         }
 
         /// <summary>
@@ -81,7 +113,7 @@ namespace Microsoft.DebugEngineHost
         /// </summary>
         internal static IReadOnlyCollection<string> GetNewFeedbackEntries()
         {
-            return s_circularBuffer.FlushNewEntries();
+            return s_circularBuffer?.FlushNewEntries() ?? Array.Empty<string>();
         }
 
         /// <summary>

--- a/src/DebugEngineHost/HostLogger.cs
+++ b/src/DebugEngineHost/HostLogger.cs
@@ -89,7 +89,7 @@ namespace Microsoft.DebugEngineHost
         /// </summary>
         internal static string GetFeedbackLogFilePath(int vsPid)
         {
-            return Path.Combine(Path.GetTempPath(), string.Format(CultureInfo.InvariantCulture, "MIEngine-{0}.log", vsPid));
+            return Path.Combine(Path.GetTempPath(), string.Format(CultureInfo.InvariantCulture, "Microsoft.VisualStudio.MIDebugEngine-{0}.log", vsPid));
         }
 
         public static void Reset()

--- a/src/DebugEngineHost/HostLogger.cs
+++ b/src/DebugEngineHost/HostLogger.cs
@@ -96,15 +96,14 @@ namespace Microsoft.DebugEngineHost
         }
 
         /// <summary>
-        /// Returns true if the feedback buffer has been created and has entries.
-        /// This is a cheap check to avoid unnecessary work in non-MIEngine scenarios.
+        /// Returns true if feedback entries have ever been written during this session.
         /// </summary>
         internal static bool HasFeedbackEntries
         {
             get
             {
                 FeedbackLogBuffer buffer = s_circularBuffer;
-                return buffer != null && !buffer.IsEmpty;
+                return buffer != null && buffer.HasEntries;
             }
         }
 

--- a/src/DebugEngineHost/VSFeedbackLogger.cs
+++ b/src/DebugEngineHost/VSFeedbackLogger.cs
@@ -72,14 +72,10 @@ namespace Microsoft.DebugEngineHost
                         if (!_enabled)
                         {
                             string logFileName = HostLogger.GetFeedbackLogFilePath(_vsPid);
-                            StreamWriter writer = new StreamWriter(logFileName, append: true, encoding: Encoding.UTF8);
+                            StreamWriter writer = FeedbackLogBuffer.OpenLogFile(logFileName);
                             try
                             {
-                                foreach (string logLine in _circularBuffer.FlushNewEntries())
-                                {
-                                    writer.WriteLine(logLine);
-                                }
-                                writer.Flush();
+                                FeedbackLogBuffer.WriteEntries(writer, _circularBuffer.FlushNewEntries());
                             }
                             catch
                             {

--- a/src/DebugEngineHost/VSFeedbackLogger.cs
+++ b/src/DebugEngineHost/VSFeedbackLogger.cs
@@ -1,0 +1,163 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Diagnostics;
+using System.IO;
+using System.Linq;
+using System.Text;
+using Newtonsoft.Json.Linq;
+
+namespace Microsoft.DebugEngineHost
+{
+    /// <summary>
+    /// Watches for the VS feedback tool's semaphore file and writes to a log file when recording is active.
+    /// </summary>
+    internal class VSFeedbackLogger
+    {
+        private const string s_vsFeedbackSemaphoreDir = @"Microsoft\VSFeedbackCollector";
+        private const string s_vsFeedbackSemaphoreFile = "feedback.recording.json";
+
+        private readonly int _vsPid;
+        private readonly System.DateTime _vsStartTime;
+        private bool _enabled;
+
+        private readonly FileSystemWatcher _vsFeedbackFileWatcher;
+        private readonly FeedbackLogBuffer _circularBuffer;
+
+        private StreamWriter _logWriter;
+        private readonly object _syncObj = new object();
+
+        internal VSFeedbackLogger(FeedbackLogBuffer circularBuffer)
+        {
+            _circularBuffer = circularBuffer;
+
+            try
+            {
+                Process vsProcess = Process.GetCurrentProcess();
+                _vsPid = vsProcess.Id;
+                _vsStartTime = vsProcess.StartTime;
+                _enabled = false;
+
+                string vsFeedbackTempDir = Path.Combine(Path.GetTempPath(), s_vsFeedbackSemaphoreDir);
+
+                Directory.CreateDirectory(vsFeedbackTempDir);
+
+                _vsFeedbackFileWatcher = new FileSystemWatcher(vsFeedbackTempDir, s_vsFeedbackSemaphoreFile);
+                _vsFeedbackFileWatcher.Created += OnFeedbackSemaphoreCreated;
+                _vsFeedbackFileWatcher.Deleted += OnFeedbackSemaphoreDeleted;
+                _vsFeedbackFileWatcher.Changed += OnFeedbackSemaphoreChanged;
+
+                if (File.Exists(Path.Combine(vsFeedbackTempDir, s_vsFeedbackSemaphoreFile)))
+                {
+                    OnFeedbackSemaphoreCreated(_vsFeedbackFileWatcher, new FileSystemEventArgs(WatcherChangeTypes.Created, vsFeedbackTempDir, s_vsFeedbackSemaphoreFile));
+                }
+
+                _vsFeedbackFileWatcher.EnableRaisingEvents = true;
+            }
+            catch
+            {
+                _vsFeedbackFileWatcher?.Dispose();
+                _vsFeedbackFileWatcher = null;
+            }
+        }
+
+        private void OnFeedbackSemaphoreCreated(object sender, FileSystemEventArgs e)
+        {
+            try
+            {
+                if (!_enabled && IsLoggingEnabledForThisVSInstance(e.FullPath))
+                {
+                    lock (_syncObj)
+                    {
+                        if (!_enabled)
+                        {
+                            string logFileName = HostLogger.GetFeedbackLogFilePath(_vsPid);
+                            StreamWriter writer = new StreamWriter(logFileName, append: true, encoding: Encoding.UTF8);
+                            try
+                            {
+                                foreach (string logLine in _circularBuffer.FlushNewEntries())
+                                {
+                                    writer.WriteLine(logLine);
+                                }
+                                writer.Flush();
+                            }
+                            catch
+                            {
+                                writer.Dispose();
+                                throw;
+                            }
+
+                            _logWriter = writer;
+                            _enabled = true;
+                        }
+                    }
+                }
+            }
+            catch
+            {
+            }
+        }
+
+        private void OnFeedbackSemaphoreDeleted(object sender, FileSystemEventArgs e)
+        {
+            lock (_syncObj)
+            {
+                if (_enabled)
+                {
+                    _enabled = false;
+                    _circularBuffer.FlushNewEntries();
+
+                    if (_logWriter != null)
+                    {
+                        _logWriter.Dispose();
+                        _logWriter = null;
+                    }
+                }
+            }
+        }
+
+        private void OnFeedbackSemaphoreChanged(object sender, FileSystemEventArgs e)
+        {
+            OnFeedbackSemaphoreCreated(sender, e);
+        }
+
+        private bool IsLoggingEnabledForThisVSInstance(string semaphoreFilePath)
+        {
+            try
+            {
+                if (_vsStartTime > File.GetCreationTime(semaphoreFilePath))
+                {
+                    return false;
+                }
+
+                string content = File.ReadAllText(semaphoreFilePath);
+                JObject root = JObject.Parse(content);
+                JContainer pidCollection = root["processIds"] as JContainer;
+                if (pidCollection != null)
+                {
+                    return pidCollection.Values<int>().Contains(_vsPid);
+                }
+            }
+            catch
+            {
+            }
+
+            return false;
+        }
+
+        internal void Write(string logLine)
+        {
+            if (_enabled)
+            {
+                lock (_syncObj)
+                {
+                    if (_logWriter != null)
+                    {
+                        _logWriter.WriteLine(logLine);
+                        _logWriter.Flush();
+                    }
+                }
+            }
+        }
+    }
+}

--- a/src/MICore/Logger.cs
+++ b/src/MICore/Logger.cs
@@ -108,6 +108,8 @@ namespace MICore
         /// <param name="line">[Required] line to write</param>
         public void WriteLine(LogLevel level, string line)
         {
+            HostLogger.WriteFeedbackLog(line);
+
             if (s_isEnabled)
             {
                 WriteLineImpl(level, line);
@@ -122,9 +124,12 @@ namespace MICore
         /// <param name="args">arguments to use in the format string</param>
         public void WriteLine(LogLevel level, string format, params object[] args)
         {
+            string message = string.Format(CultureInfo.CurrentCulture, format, args);
+            HostLogger.WriteFeedbackLog(message);
+
             if (s_isEnabled)
             {
-                WriteLineImpl(level, format, args);
+                WriteLineImpl(level, message);
             }
         }
 
@@ -136,6 +141,8 @@ namespace MICore
         /// <param name="textBlock">Block of text to write</param>
         public void WriteTextBlock(LogLevel level, string prefix, string textBlock)
         {
+            HostLogger.WriteFeedbackLog((!string.IsNullOrEmpty(prefix) ? prefix : string.Empty) + textBlock);
+
             if (s_isEnabled)
             {
                 WriteTextBlockImpl(level, prefix, textBlock);

--- a/src/MICore/Logger.cs
+++ b/src/MICore/Logger.cs
@@ -108,11 +108,14 @@ namespace MICore
         /// <param name="line">[Required] line to write</param>
         public void WriteLine(LogLevel level, string line)
         {
-            HostLogger.WriteFeedbackLog(line);
-
             if (s_isEnabled)
             {
                 WriteLineImpl(level, line);
+            }
+
+            if (HostLogger.IsFeedbackLogEnabled)
+            {
+                HostLogger.WriteFeedbackLog(line);
             }
         }
 
@@ -124,12 +127,10 @@ namespace MICore
         /// <param name="args">arguments to use in the format string</param>
         public void WriteLine(LogLevel level, string format, params object[] args)
         {
-            string message = string.Format(CultureInfo.CurrentCulture, format, args);
-            HostLogger.WriteFeedbackLog(message);
-
-            if (s_isEnabled)
+            if (s_isEnabled || HostLogger.IsFeedbackLogEnabled)
             {
-                WriteLineImpl(level, message);
+                string message = string.Format(CultureInfo.CurrentCulture, format, args);
+                WriteLine(level, message);
             }
         }
 
@@ -141,11 +142,14 @@ namespace MICore
         /// <param name="textBlock">Block of text to write</param>
         public void WriteTextBlock(LogLevel level, string prefix, string textBlock)
         {
-            HostLogger.WriteFeedbackLog((!string.IsNullOrEmpty(prefix) ? prefix : string.Empty) + textBlock);
-
             if (s_isEnabled)
             {
                 WriteTextBlockImpl(level, prefix, textBlock);
+            }
+
+            if (HostLogger.IsFeedbackLogEnabled)
+            {
+                HostLogger.WriteFeedbackLog((!string.IsNullOrEmpty(prefix) ? prefix : string.Empty) + textBlock);
             }
         }
 

--- a/src/MIDebugPackage/source.extension.vsixmanifest
+++ b/src/MIDebugPackage/source.extension.vsixmanifest
@@ -21,5 +21,6 @@
     <Asset Type="Microsoft.VisualStudio.VsPackage" Path="Microsoft.MIDebugEngine.pkgdef" />
     <Asset Type="Microsoft.VisualStudio.VsPackage" Path="Microsoft.AndroidDebugLauncher.pkgdef" />
     <Asset Type="Microsoft.VisualStudio.VsPackage" Path="Microsoft.SSHDebugPS.pkgdef" />
+    <Asset Type="Microsoft.VisualStudio.MefComponent" Path="Microsoft.DebugEngineHost.dll" />
   </Assets>
 </PackageManifest>


### PR DESCRIPTION
Attach MIEngine diagnostic logs to VS "Report a Problem" feedback reports via IFeedbackDiagnosticFileProvider (MEF export).

- FeedbackLogBuffer: always-on 256KB circular buffer with sequence-tracked FlushNewEntries() to prevent duplicate entries across consumers
- VSFeedbackLogger: FileSystemWatcher monitors feedback semaphore file; when VS starts "Record Steps", opens a StreamWriter and dumps buffered entries plus live-streams new ones
- FeedbackDiagnosticFileProvider: MEF export discovered by VS feedback tool; flushes new buffer entries to temp file (MIEngine-{pid}.log) and returns the path
- IL reference assembly for IFeedbackDiagnosticFileProvider interface (package is on Azure-Public but we cant have multifeeds)