### PR TITLE
Fix inverted condition check for LinkedListItems in NatVis

### DIFF
--- a/src/MIDebugEngine/Natvis.Impl/Natvis.cs
+++ b/src/MIDebugEngine/Natvis.Impl/Natvis.cs
@@ -789,7 +789,7 @@ namespace Microsoft.MIDebugEngine.Natvis
                     //      <ValueNode>m_element</ValueNode>
                     //    </LinkedListItems>
                     LinkedListItemsType item = (LinkedListItemsType)i;
-                    if (String.IsNullOrWhiteSpace(item.Condition))
+                    if (!String.IsNullOrWhiteSpace(item.Condition))
                     {
                         if (!EvalCondition(item.Condition, variable, visualizer.ScopedNames, visualizer.Intrinsics))
                             continue;

--- a/test/CppTests/Tests/NatvisTests.cs
+++ b/test/CppTests/Tests/NatvisTests.cs
@@ -38,8 +38,8 @@ namespace CppTests.Tests
         private const string NatvisSourceName = "main.cpp";
 
         // These line numbers will need to change if src/natvis/main.cpp changes
-        private const int SimpleClassAssignmentLine = 65;
-        private const int ReturnSourceLine = 80;
+        private const int SimpleClassAssignmentLine = 66;
+        private const int ReturnSourceLine = 90;
 
         [Theory]
         [RequiresTestSettings]
@@ -667,6 +667,52 @@ namespace CppTests.Tests
                     Assert.Equal("30", showRawObj.GetVariable("A").Value);
                     Assert.Equal("40", showRawObj.GetVariable("B").Value);
                     Assert.True(showRawObj.Variables.ContainsKey("[Raw View]"), "[Raw View] should be visible by default");
+                }
+
+                runner.Expects.ExitedEvent(exitCode: 0).TerminatedEvent().AfterContinue();
+                runner.DisconnectAndVerify();
+            }
+        }
+
+        [Theory]
+        [DependsOnTest(nameof(CompileNatvisDebuggee))]
+        [RequiresTestSettings]
+        public void TestLinkedListItemsCondition(ITestSettings settings)
+        {
+            this.TestPurpose("This test checks that a Condition attribute on LinkedListItems is evaluated correctly.");
+            this.WriteSettings(settings);
+
+            IDebuggee debuggee = Debuggee.Open(this, settings.CompilerSettings, NatvisName, DebuggeeMonikers.Natvis.Default);
+
+            using (IDebuggerRunner runner = CreateDebugAdapterRunner(settings))
+            {
+                this.Comment("Configure launch");
+                string visFile = Path.Join(debuggee.SourceRoot, "visualizer_files", "Simple.natvis");
+
+                LaunchCommand launch = new LaunchCommand(settings.DebuggerSettings, debuggee.OutputPath, visFile, false);
+                runner.RunCommand(launch);
+
+                this.Comment("Set Breakpoint");
+                SourceBreakpoints writerBreakpoints = debuggee.Breakpoints(NatvisSourceName, ReturnSourceLine);
+                runner.SetBreakpoints(writerBreakpoints);
+
+                runner.Expects.StoppedEvent(StoppedReason.Breakpoint).AfterConfigurationDone();
+
+                using (IThreadInspector threadInspector = runner.GetThreadInspector())
+                {
+                    IFrameInspector currentFrame = threadInspector.Stack.First();
+
+                    this.Comment("Verifying LinkedListItems with Condition='isActive' when isActive is true");
+                    var activeList = currentFrame.GetVariable("activeList");
+                    Assert.Contains("active=true", activeList.Value);
+                    Assert.Equal("3", activeList.GetVariable("Count").Value);
+                    Assert.True(activeList.Variables.ContainsKey("[0]"), "activeList should show indexed children when condition is true");
+
+                    this.Comment("Verifying LinkedListItems with Condition='isActive' when isActive is false");
+                    var inactiveList = currentFrame.GetVariable("inactiveList");
+                    Assert.Contains("active=false", inactiveList.Value);
+                    Assert.Equal("2", inactiveList.GetVariable("Count").Value);
+                    Assert.False(inactiveList.Variables.ContainsKey("[0]"), "inactiveList should not show indexed children when condition is false");
                 }
 
                 runner.Expects.ExitedEvent(exitCode: 0).TerminatedEvent().AfterContinue();

--- a/test/CppTests/debuggees/natvis/src/ConditionalLinkedList.h
+++ b/test/CppTests/debuggees/natvis/src/ConditionalLinkedList.h
@@ -1,0 +1,25 @@
+#include <cstddef>
+
+class ConditionalLinkedList
+{
+private:
+    struct Node {
+        int data;
+        Node* next;
+        Node(int value) : data(value), next(NULL) {}
+    };
+
+    Node* head;
+    int numElements;
+    bool isActive;
+
+public:
+    ConditionalLinkedList(bool active) : head(NULL), numElements(0), isActive(active) {}
+
+    void Add(int val) {
+        Node* n = new Node(val);
+        n->next = head;
+        head = n;
+        numElements++;
+    }
+};

--- a/test/CppTests/debuggees/natvis/src/main.cpp
+++ b/test/CppTests/debuggees/natvis/src/main.cpp
@@ -6,6 +6,7 @@
 #include "SimpleMatrix.h"
 #include "SimpleTemplated.h"
 #include "DataPoint.h"
+#include "ConditionalLinkedList.h"
 
 class SimpleDisplayObject
 {
@@ -76,6 +77,15 @@ int main(int argc, char** argv)
 
     DataPoint dp(42);
     DataPoint *dpPtr = &dp;
+
+    ConditionalLinkedList activeList(true);
+    activeList.Add(10);
+    activeList.Add(20);
+    activeList.Add(30);
+
+    ConditionalLinkedList inactiveList(false);
+    inactiveList.Add(100);
+    inactiveList.Add(200);
 
     return 0;
 }

--- a/test/CppTests/debuggees/natvis/src/visualizer_files/Simple.natvis
+++ b/test/CppTests/debuggees/natvis/src/visualizer_files/Simple.natvis
@@ -121,4 +121,18 @@
     <DisplayString>{{ {this}={*this} }}</DisplayString>
   </Type>
 
+  <Type Name="ConditionalLinkedList">
+    <DisplayString>{{ active={isActive}, count={numElements} }}</DisplayString>
+    <Expand>
+      <Item Name="IsActive">isActive</Item>
+      <Item Name="Count">numElements</Item>
+      <LinkedListItems Condition="isActive">
+        <Size>numElements</Size>
+        <HeadPointer>head</HeadPointer>
+        <NextPointer>next</NextPointer>
+        <ValueNode>data</ValueNode>
+      </LinkedListItems>
+    </Expand>
+  </Type>
+
 </AutoVisualizer>


### PR DESCRIPTION
The condition guard was using `IsNullOrWhiteSpace` instead of `!IsNullOrWhiteSpace`, which meant `LinkedListItems` with a `Condition` attribute were never filtered, items were always shown regardless of the condition value.

Added an integration test (`TestLinkedListItemsCondition`) that creates two `ConditionalLinkedList` objects, one with `isActive=true` and one with `isActive=false`, and verifies that the NatVis `LinkedListItems` `Condition` attribute is respected.