### PR TITLE
Natvis: trim leading/trailing whitespace from DisplayString XML text

### DIFF
--- a/src/MIDebugEngine/Natvis.Impl/Natvis.cs
+++ b/src/MIDebugEngine/Natvis.Impl/Natvis.cs
@@ -1264,6 +1264,7 @@ namespace Microsoft.MIDebugEngine.Natvis
             {
                 return String.Empty;
             }
+            format = format.Trim();
             StringBuilder value = new StringBuilder();
             for (int i = 0; i < format.Length; ++i)
             {


### PR DESCRIPTION
Visual Studio trims whitespace from DisplayString inner XML text before processing. MIEngine did not, causing multi-line DisplayStrings to render as blank on GDB/LLDB — the leading newline and indentation made the display appear empty in the variables panel.

Fix: call format.Trim() at the top of FormatValue() before processing.