### PR TITLE
Disable debuginfod by default

### DIFF
--- a/loc/lci/OpenFolderSchema.json.lci
+++ b/loc/lci/OpenFolderSchema.json.lci
@@ -408,7 +408,7 @@
       </Item>
       <Item ItemId=";debugExtensions.cppdbg.schema.definitions.cpp_schema.properties.debuginfod.properties.enabled.description" ItemType="0" PsrId="306" InstFlg="true" Leaf="true">
         <Str Cat="Text">
-          <Val><![CDATA[If true (default), GDB's debuginfod support is enabled. Set to false to disable debuginfod, which can prevent GDB from hanging when debuginfod servers are unavailable.]]></Val>
+          <Val><![CDATA[If true, GDB's debuginfod support is enabled. Set to true to enable debuginfod. Default is false.]]></Val>
         </Str>
         <Disp Icon="Str" />
         <Cmts>

--- a/src/MICore/JsonLaunchOptions.cs
+++ b/src/MICore/JsonLaunchOptions.cs
@@ -324,7 +324,7 @@ namespace MICore.Json.LaunchOptions
     public partial class DebuginfodSettings
     {
         /// <summary>
-        /// If true (default), GDB's debuginfod support is enabled.
+        /// If true, GDB's debuginfod support is enabled. Default is false.
         /// </summary>
         [JsonProperty("enabled")]
         public bool? Enabled { get; set; }

--- a/src/MICore/LaunchOptions.cs
+++ b/src/MICore/LaunchOptions.cs
@@ -1224,10 +1224,10 @@ namespace MICore
             }
         }
 
-        private bool _enableDebuginfod = true;
+        private bool _enableDebuginfod = false;
 
         /// <summary>
-        /// If true (default), GDB's debuginfod support is enabled.
+        /// If true, GDB's debuginfod support is enabled. Default is false.
         /// </summary>
         public bool EnableDebuginfod
         {
@@ -1912,7 +1912,7 @@ namespace MICore
             }
 
             this.UnknownBreakpointHandling = options.UnknownBreakpointHandling ?? UnknownBreakpointHandling.Throw;
-            this.EnableDebuginfod = options.Debuginfod?.Enabled ?? true;
+            this.EnableDebuginfod = options.Debuginfod?.Enabled ?? false;
             int debuginfodTimeout = options.Debuginfod?.Timeout ?? 30;
             this.DebuginfodTimeout = debuginfodTimeout >= 0 ? debuginfodTimeout : 30;
         }

--- a/src/MICore/LaunchOptions.xsd
+++ b/src/MICore/LaunchOptions.xsd
@@ -207,11 +207,11 @@
         </xs:documentation>
       </xs:annotation>
     </xs:attribute>
-    <xs:attribute name="EnableDebuginfod" type="xs:boolean" use="optional" default="true">
+    <xs:attribute name="EnableDebuginfod" type="xs:boolean" use="optional" default="false">
       <xs:annotation>
         <xs:documentation>
-          If true (default), GDB's debuginfod support is enabled, allowing automatic downloading of debug symbols.
-          Set to false to disable debuginfod, which can prevent GDB from hanging when debuginfod servers are unavailable.
+          If true, GDB's debuginfod support is enabled, allowing automatic downloading of debug symbols.
+          Set to true to enable debuginfod. Default is false.
         </xs:documentation>
       </xs:annotation>
     </xs:attribute>

--- a/src/MICore/LaunchOptions.xsd.types.designer.cs
+++ b/src/MICore/LaunchOptions.xsd.types.designer.cs
@@ -101,7 +101,7 @@ namespace MICore.Xml.LaunchOptions {
         
         /// <remarks/>
         [System.Xml.Serialization.XmlAttributeAttribute()]
-        [System.ComponentModel.DefaultValueAttribute(true)]
+        [System.ComponentModel.DefaultValueAttribute(false)]
         public bool EnableDebuginfod;
 
         /// <remarks/>
@@ -115,7 +115,7 @@ namespace MICore.Xml.LaunchOptions {
             this.JVMPort = 65534;
             this.JVMHost = "localhost";
             this.WaitDynamicLibLoad = true;
-            this.EnableDebuginfod = true;
+            this.EnableDebuginfod = false;
             this.DebuginfodTimeout = 30;
         }
     }
@@ -468,7 +468,7 @@ namespace MICore.Xml.LaunchOptions {
         
         /// <remarks/>
         [System.Xml.Serialization.XmlAttributeAttribute()]
-        [System.ComponentModel.DefaultValueAttribute(true)]
+        [System.ComponentModel.DefaultValueAttribute(false)]
         public bool EnableDebuginfod;
 
         /// <remarks/>
@@ -478,7 +478,7 @@ namespace MICore.Xml.LaunchOptions {
         
         public BaseLaunchOptions() {
             this.WaitDynamicLibLoad = true;
-            this.EnableDebuginfod = true;
+            this.EnableDebuginfod = false;
             this.DebuginfodTimeout = 30;
         }
     }
@@ -562,7 +562,7 @@ namespace MICore.Xml.LaunchOptions {
         
         /// <remarks/>
         [System.Xml.Serialization.XmlAttributeAttribute()]
-        [System.ComponentModel.DefaultValueAttribute(true)]
+        [System.ComponentModel.DefaultValueAttribute(false)]
         public bool EnableDebuginfod;
 
         /// <remarks/>
@@ -572,7 +572,7 @@ namespace MICore.Xml.LaunchOptions {
         
         public IOSLaunchOptions() {
             this.WaitDynamicLibLoad = true;
-            this.EnableDebuginfod = true;
+            this.EnableDebuginfod = false;
             this.DebuginfodTimeout = 30;
         }
     }

--- a/src/MIDebugEngine/Engine.Impl/DebuggedProcess.cs
+++ b/src/MIDebugEngine/Engine.Impl/DebuggedProcess.cs
@@ -628,6 +628,10 @@ namespace Microsoft.MIDebugEngine
                 {
                     commands.Add(new LaunchCommand("set debuginfod enabled on", ignoreFailures: true));
                 }
+                else
+                {
+                    commands.Add(new LaunchCommand("set debuginfod enabled off", ignoreFailures: true));
+                }
             }
 
             // When user specifies loading directives then the debugger cannot auto load symbols, the MIEngine must intervene at each solib-load event and make a determination

--- a/src/MIDebugPackage/OpenFolderSchema.json
+++ b/src/MIDebugPackage/OpenFolderSchema.json
@@ -197,12 +197,12 @@
               "debuginfod": {
                 "type": "object",
                 "description": "Controls GDB's debuginfod behavior for automatic downloading of debug symbols.",
-                "default": { "enabled": true, "timeout": 30 },
+                "default": { "enabled": false, "timeout": 30 },
                 "properties": {
                   "enabled": {
                     "type": "boolean",
-                    "description": "If true (default), GDB's debuginfod support is enabled. Set to false to disable debuginfod, which can prevent GDB from hanging when debuginfod servers are unavailable.",
-                    "default": true
+                    "description": "If true, GDB's debuginfod support is enabled. Set to true to enable debuginfod. Default is false.",
+                    "default": false
                   },
                   "timeout": {
                     "type": "integer",

--- a/test/CppTests/Tests/DebuginfodTests.cs
+++ b/test/CppTests/Tests/DebuginfodTests.cs
@@ -108,7 +108,8 @@ namespace CppTests.Tests
                 {
                     string logContent = File.ReadAllText(engineLogPath);
                     this.Comment("Verifying debuginfod was NOT enabled in GDB");
-                    Assert.DoesNotContain("debuginfod enabled", logContent);
+                    Assert.DoesNotContain("set debuginfod enabled on", logContent);
+                    Assert.Contains("set debuginfod enabled off", logContent);
                 }
             }
             finally


### PR DESCRIPTION
Change the default for debuginfod from enabled to disabled based on feedback from partner teams. Users can still opt-in by explicitly setting `"debuginfod": { "enabled": true }` in their launch configuration.

Additionally, send an explicit "set debuginfod enabled off" command to GDB when disabled, ensuring debuginfod is fully turned off regardless of GDB config files or system defaults.