### PR TITLE
Use internal NuGet feed for release builds

### DIFF
--- a/eng/pipelines/NuGet.release.config
+++ b/eng/pipelines/NuGet.release.config
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- This NuGet config is used by release builds only (VS, VSCode, DebuggerTesting).
-     Release pipelines run under CFSClean network isolation policies which block direct
-     access to api.nuget.org. The MIEngine-Dependencies feed upstreams nuget.org through
-     the CFS-compliant internal path. CI and local builds use src/.nuget/NuGet.config
-     which restores directly from nuget.org. -->
+<!-- This NuGet config is used by Azure DevOps Pipelines (CI and release builds).
+     Azure DevOps pipelines run under CFSClean network isolation policies which block
+     direct access to api.nuget.org. The MIEngine-Dependencies feed upstreams nuget.org
+     through the CFS-compliant internal path. GitHub Actions and local builds
+     use src/.nuget/NuGet.config which restores directly from nuget.org. -->
 <configuration>
   <packageSources>
     <clear />

--- a/eng/pipelines/NuGet.release.config
+++ b/eng/pipelines/NuGet.release.config
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- This NuGet config is used by release builds only (VS, VSCode, DebuggerTesting).
+     Release pipelines run under CFSClean network isolation policies which block direct
+     access to api.nuget.org. The MIEngine-Dependencies feed upstreams nuget.org through
+     the CFS-compliant internal path. CI and local builds use src/.nuget/NuGet.config
+     which restores directly from nuget.org. -->
+<configuration>
+  <packageSources>
+    <clear />
+    <add key="MIEngine-Dependencies" value="https://pkgs.dev.azure.com/devdiv/DevDiv/_packaging/MIEngine-Dependencies/nuget/v3/index.json" />
+  </packageSources>
+</configuration>

--- a/eng/pipelines/steps/BuildSolution.yml
+++ b/eng/pipelines/steps/BuildSolution.yml
@@ -5,6 +5,7 @@ parameters:
   Configuration: 'Release'
   BuildArguments: ''
   OneESPT: false
+  NuGetConfigPath: '$(Build.SourcesDirectory)/src/.nuget/NuGet.config'
 
 steps:
 - template: ../tasks/NuGetCommand.yml
@@ -12,7 +13,7 @@ steps:
     Command: 'restore'
     solution: ${{ parameters.Solution }}
     selectOrConfig: 'config'
-    NugetConfigPath: '$(Build.SourcesDirectory)/src/.nuget/NuGet.config'
+    NugetConfigPath: '${{ parameters.NuGetConfigPath }}'
 
 # If running under System.Debug (Enable system diagnostics), enable binlogs
 - script: |

--- a/eng/pipelines/templates/Build.template.yml
+++ b/eng/pipelines/templates/Build.template.yml
@@ -19,6 +19,7 @@ steps:
   parameters:
     Configuration: ${{ parameters.Configuration }}
     OneESPT: false
+    NuGetConfigPath: '$(Build.SourcesDirectory)/eng/pipelines/NuGet.release.config'
 
 - template: ../tasks/CSharp.yml
 

--- a/eng/pipelines/templates/DebuggerTesting-release.template.yml
+++ b/eng/pipelines/templates/DebuggerTesting-release.template.yml
@@ -11,7 +11,7 @@ steps:
     Command: 'restore'
     solution: '$(Build.SourcesDirectory)\src\MIDebugEngine.sln'
     FeedsToUse: 'config'
-    NugetConfigPath: '$(Build.SourcesDirectory)\src\.nuget\NuGet.config'
+    NugetConfigPath: '$(Build.SourcesDirectory)\eng\pipelines\NuGet.release.config'
 
 - template: ../tasks/MSBuild.yml
   parameters:

--- a/eng/pipelines/templates/VS-release.template.yml
+++ b/eng/pipelines/templates/VS-release.template.yml
@@ -13,6 +13,7 @@ steps:
     Configuration: 'Lab.Release'
     BuildArguments: /p:NuGetPath=$(NuGetExeToolPath) /p:NuGetPrerelease=false
     OneESPT: true
+    NuGetConfigPath: '$(Build.SourcesDirectory)/eng/pipelines/NuGet.release.config'
 
 - template: ../steps/CollectAndPublishBinaries.yml
   parameters:

--- a/eng/pipelines/templates/VSCode-release.template.yml
+++ b/eng/pipelines/templates/VSCode-release.template.yml
@@ -14,6 +14,7 @@ steps:
   parameters:
     Configuration: 'Lab.Release'
     OneESPT: true
+    NuGetConfigPath: '$(Build.SourcesDirectory)/eng/pipelines/NuGet.release.config'
 
 - template: ../steps/CollectAndPublishBinaries.yml
   parameters:


### PR DESCRIPTION
Release pipelines (VS, VSCode, DebuggerTesting) now use the MIEngine-Dependencies Azure Artifacts feed which upstreams nuget.org. This resolves NuGet restore failures caused by CFSClean network isolation policies blocking direct access to api.nuget.org.

CI builds continue using the public nuget.org feed directly.