### PR TITLE
Copilot instructions + test filtering fix

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,25 @@
+# Conventions
+
+- Apply the code-formatting style defined in `.editorconfig`.
+- This repo builds a debugger. Any `debugger_*` tool call will generally be **debugging the debugger** — `debugger_launch` will likely start another instance of Visual Studio (or a different debugger host process) where the model can drive the code in this repo.
+
+# Documentation to read
+
+⚠️ **CRITICAL**: Before proceeding with any task listed below, you MUST read the linked files as your FIRST action. Do NOT attempt the task until you have read and understood the documentation.
+
+**Mandatory workflow for AI:**
+1. ✅ FIRST: read all required documentation files for the task
+2. ✅ SECOND: follow the workflow specified there
+3. ❌ NEVER: skip to code analysis, edits, or hypothesis formation before reading the docs
+
+| Task | Required documentation files |
+| --- | --- |
+| Understanding the project layout, how the layers fit together, or where new code belongs | [Architecture-for-AI.md](../docs/Architecture-for-AI.md) (and the project wiki: [Architecture-of-the-MIEngine](https://github.com/microsoft/MIEngine/wiki/Architecture-of-the-MIEngine), [Architecture-of-OpenDebugAD7](https://github.com/microsoft/MIEngine/wiki/Architecture-of-OpenDebugAD7), [Architecture-of-DebugAdapterRunner](https://github.com/microsoft/MIEngine/wiki/Architecture-of-DebugAdapterRunner)) |
+| Writing or reviewing C# in this repo | [CodingStandards-CSharp-for-AI.md](../docs/CodingStandards-CSharp-for-AI.md) |
+| Adding a new `DebugEngineHost` (host) API, or trying to understand what a `Host*` API actually does | [DebugEngineHost-for-AI.md](../docs/DebugEngineHost-for-AI.md) — `src/DebugEngineHost.Stub` is a **contract assembly only**; the real behavior lives in `src/DebugEngineHost` (VS) and `src/DebugEngineHost.VSCode` (VS Code), and a new API must be added to **all three** projects. |
+| Building MIEngine **outside of Visual Studio** (CLI / CI / VS Code scenarios) | [Building-outside-of-VS-for-AI.md](../docs/Building-outside-of-VS-for-AI.md) |
+| Running the in-process unit tests (`MICoreUnitTests`, `MIDebugEngineUnitTests`, `JDbgUnitTests`, `SSHDebugTests`) **outside of Visual Studio** | [RunningUnitTests-outside-of-VS-for-AI.md](../docs/RunningUnitTests-outside-of-VS-for-AI.md) |
+| Running the end-to-end DAP tests in `test/CppTests` (against real `gdb` / `lldb-mi`) **outside of Visual Studio** | [RunningCppTests-outside-of-VS-for-AI.md](../docs/RunningCppTests-outside-of-VS-for-AI.md) |
+| Capturing the MI traffic between MIEngine and `gdb`/`lldb` while reproducing a customer issue | wiki: [Logging](https://github.com/microsoft/MIEngine/wiki/Logging) (use the `Debug.MIDebugLog` Command Window verb in VS, or `src/MICore/SetMIDebugLogging.cmd on` for older flows) |
+
+⚠️ **When working inside Visual Studio**, do **not** follow the "outside of Visual Studio" docs above. VS already provides dedicated commands for these tasks. The `*-outside-of-VS-for-AI.md` docs are for command-line, CI, and VS Code scenarios where the IDE isn't hosting the conversation.

--- a/docs/Architecture-for-AI.md
+++ b/docs/Architecture-for-AI.md
@@ -1,0 +1,56 @@
+# MIEngine architecture for AI
+
+MIEngine is a Visual Studio **Debug Engine** that drives debuggers speaking the GDB **Machine Interface** ("MI") protocol — primarily GDB and LLDB-MI. The same code powers the `cppdbg` debug adapter for the VS Code C/C++ extension via `OpenDebugAD7`.
+
+## Layered design
+
+The engine is layered. New code almost always belongs in one of these projects; before adding a class, decide which layer owns the concern.
+
+| Layer | Project(s) | Responsibility |
+| --- | --- | --- |
+| Transport + MI parsing | `src/MICore` | Connections to the debuggee's debugger over local pty, SSH, pipe, serial. Owns the `MICommandFactory` family (`GdbMICommandFactory`, `LldbMICommandFactory`, `ClrdbgMICommandFactory`). All flavor-specific MI quirks live here as factory overrides. |
+| AD7 implementation | `src/MIDebugEngine` | Implements the VS Core Debug Interfaces (`IDebugEngine2`, `IDebug*2`). `DebuggedProcess` is the central object owning the `MICore.Debugger`, breakpoint/threads/modules managers, and the event pump. AD7 wrapper classes (`AD7Engine`, `AD7Thread`, `AD7StackFrame`, `AD7BoundBreakpoint`, …) translate VS SDK COM calls into engine operations. |
+| DAP shim | `src/OpenDebugAD7` | Hosts MIDebugEngine in-proc and exposes it as a Debug Adapter Protocol server. The entry point for the `cppdbg` adapter consumed by the VS Code C/C++ extension. |
+| Host abstraction | `src/DebugEngineHost`, `src/DebugEngineHost.Common`, `src/DebugEngineHost.Stub`, `src/DebugEngineHost.VSCode` | The shim that lets MIDebugEngine avoid calling VS APIs directly. Goes through `HostLogger`, `HostMarshal`, `HostOutputWindow`, etc. The `DebugEngineHost.VSCode` variant is used by OpenDebugAD7; the in-VS build uses the COM-based host (`src/DebugEngineHost`). |
+| Launchers | `src/AndroidDebugLauncher`, `src/IOSDebugLauncher`, `src/WindowsDebugLauncher` | Out-of-proc helpers spawned by the engine to start a debug session in a special environment (Android emulator, iOS device, Windows console). They communicate over stdio and implement `IPlatformAppLauncher`. |
+| SSH port supplier | `src/SSHDebugPS` | A standalone VS "Port Supplier" for picking processes over SSH or Linux Docker. Independent of the engine flow. |
+
+## Hard rules
+
+- **No raw MI strings outside `MICore.MICommandFactory` / `Debugger.CmdAsync`.** If MIDebugEngine needs a new MI command, add a method on the factory and override per debugger flavor when behavior diverges.
+- **MIDebugEngine does not depend on `Microsoft.VisualStudio.*` types directly.** Route everything through `DebugEngineHost`. This is what allows OpenDebugAD7 to host the engine on non-VS platforms.
+- **Don't add `MIDebugEngine.sln`-only projects to `MIDebugEngine-Unix.sln`** (and vice versa). The split is intentional — the Unix solution must remain SDK-buildable without `msbuild`, the Windows extension workload, or COM PIAs.
+- **AD7 surface goes on the `AD7*` partial class** for that interface. Keep VS-SDK COM concerns out of the core `Debugged*` classes (`DebuggedProcess`, `DebuggedThread`, `DebuggedModule`).
+
+## Inside MICore
+
+`MICore` itself decomposes into five concerns. When adding code there, place it in the right one rather than growing `Debugger` further:
+
+1. **`Debugger`** — central pump that processes text from GDB/LLDB and dispatches it to consumers.
+2. **`MICommandFactory`** + flavor overrides (`Gdb`, `Lldb`, `Clrdbg`) — the abstraction for "send command X". *All* MI string construction goes through here.
+3. **Result parser** (`ResultValue`, etc.) — parses MI result records into typed objects.
+4. **Transports** — local pty, SSH, named-pipe, serial; set up the stdin/stdout connection to the debugger.
+5. **Launch options** — XML deserialization driven by `LaunchOptions.xsd` (codegenned by `tools/LaunchOptionsGen` into `LaunchOptions.cs`); also loads custom launchers.
+
+The only enforced layering rule between MICore and MIDebugEngine is that **launchers depend on `MICore` only**. Any type a launcher needs must therefore live in MICore, not in MIDebugEngine.
+
+## Async / threading
+
+MIDebugEngine uses TPL `Task`s but AD7 callbacks must not block the dispatcher thread. The pattern is `Task.Run` for the work + post results back via the engine's `WorkerThread` / `EngineCallback`. Mirror existing call sites rather than inventing new threading; introducing a new pattern almost always causes deadlocks against `DebuggedProcess.WorkerThread`.
+
+## LaunchOptions
+
+The XML payload that `launch.json` (VS Code) or `vsdbg`/the IDE (VS) sends to the engine is described by `src/MICore/LaunchOptions.xsd`. The C# binding classes are **generated** by `tools/LaunchOptionsGen` — regenerate (`LaunchOptionsGen <xsd>`) rather than hand-editing the generated `LaunchOptions.cs`.
+
+## Entry points worth knowing
+
+- VS extension entry: `MIDebugPackage` registers MIDebugEngine and pulls in `MIDebugEngine.dll`.
+- VS Code adapter entry: `src/OpenDebugAD7/Program.cs` — main loop reads DAP messages from stdin and dispatches to `AD7DebugSession`.
+- Engine creation: `AD7Engine.LaunchSuspended` / `AD7Engine.Attach` — both end at constructing a `DebuggedProcess`.
+
+## Tests at a glance
+
+- Pure managed unit tests live in `MICoreUnitTests`, `MIDebugEngineUnitTests`, `JDbgUnitTests`, `SSHDebugTests`.
+- End-to-end DAP tests against a real debugger live in `test/CppTests` and use the `DebugAdapterRunner` framework.
+
+See [RunningUnitTests-outside-of-VS-for-AI.md](RunningUnitTests-outside-of-VS-for-AI.md) and [RunningCppTests-outside-of-VS-for-AI.md](RunningCppTests-outside-of-VS-for-AI.md).

--- a/docs/Building-outside-of-VS-for-AI.md
+++ b/docs/Building-outside-of-VS-for-AI.md
@@ -1,0 +1,56 @@
+# Building MIEngine outside of Visual Studio
+
+⚠️ **Do not use these instructions when working inside Visual Studio.** When VS is hosting the conversation (e.g. via the in-IDE Copilot chat / `debugger_*` tools), prefer the IDE's built-in build functions, or functions like `debugger_launch` which have an implicit build. Those commands set up the VS environment correctly and update the Error List for you. The scripts below are for command-line / CI / VS Code scenarios where no IDE is available.
+
+## Solutions
+
+There are two solutions, picked by what you are targeting:
+
+| Solution | Use when… | How to build |
+| --- | --- | --- |
+| `src/MIDebugEngine.sln` | Building the **Visual Studio extension** (full set of projects, including the VSIX, COM/PIA references, IOSDebugLauncher, MIDebugPackage, SSHDebugPS, …). | `msbuild` from a **VS Developer Command Prompt** (Dev 17+ with the *Visual Studio extension development* workload), via `eng/Scripts/CI-Build.ps1`. **Windows only.** |
+| `src/MIDebugEngine-Unix.sln` | Building the subset that the **VS Code `cppdbg` adapter** uses (MICore, MIDebugEngine, OpenDebugAD7, DebugEngineHost.VSCode, the launchers, and the test projects). | `dotnet build` — works on Windows, Linux, and macOS. |
+
+Don't add an `.sln`-only project to the other solution; the split is intentional so the Unix/VS Code flavor remains buildable with just the .NET SDK.
+
+## Command-line build
+
+### Windows (full VS extension build)
+
+From a VS Developer Command Prompt or after putting `MSBuild.exe` on `PATH`:
+
+```powershell
+# Debug, VS extension flavor (default)
+eng\Scripts\CI-Build.ps1 -Configuration Debug -TargetPlatform vs
+
+# Debug, VS Code adapter flavor (also publishes OpenDebugAD7 + native deps to
+# bin\DebugAdapterProtocolTests\Debug\extension\debugAdapters)
+eng\Scripts\CI-Build.ps1 -Configuration Debug -TargetPlatform vscode
+```
+
+The script restores NuGet, builds `MIDebugEngine.sln` with `msbuild`, and (for `-TargetPlatform vscode`) `dotnet publish`es OpenDebugAD7 and stages the adapter under `bin\DebugAdapterProtocolTests\<Configuration>\extension\debugAdapters`.
+
+If `msbuild.exe` isn't on `PATH`, locate it with vswhere:
+
+```powershell
+$msbuild = & "${env:ProgramFiles(x86)}\Microsoft Visual Studio\Installer\vswhere.exe" -latest -prerelease -requires Microsoft.Component.MSBuild -find "MSBuild\**\Bin\MSBuild.exe"
+$env:Path = (Split-Path $msbuild) + ';' + $env:Path
+```
+
+### Linux / macOS
+
+```bash
+eng/Scripts/CI-Build.sh
+```
+
+This runs `dotnet build src/MIDebugEngine-Unix.sln` and then `PublishOpenDebugAD7.sh -c Debug -o bin/DebugAdapterProtocolTests/Debug/extension/debugAdapters`.
+
+## Outputs
+
+- `bin/<Configuration>/...` — primary binaries from `msbuild`.
+- `bin/<Configuration>/vscode/...` — the VS Code-flavor host (`Microsoft.DebugEngineHost.dll` for VSCode, `WindowsDebugLauncher.exe`, etc.).
+- `bin/DebugAdapterProtocolTests/<Configuration>/extension/debugAdapters/` — the staged VS Code debug adapter used by the CppTests.
+
+## Targeting
+
+The .NET SDK target is `net8.0` (CI installs `dotnet-version: 8.0.x`). Some projects multi-target .NET Framework for the in-VS host. Don't change target frameworks without checking both solutions still build.

--- a/docs/Building-outside-of-VS-for-AI.md
+++ b/docs/Building-outside-of-VS-for-AI.md
@@ -53,4 +53,4 @@ This runs `dotnet build src/MIDebugEngine-Unix.sln` and then `PublishOpenDebugAD
 
 ## Targeting
 
-The .NET SDK target is `net8.0` (CI installs `dotnet-version: 8.0.x`). Some projects multi-target .NET Framework for the in-VS host. Don't change target frameworks without checking both solutions still build.
+The projects in this repo run on both .NET and .NET Framework, with most of the core projects targeting `netstandard2.0`. .NET is used for VS Code support while .NET Framework is used for VS. See `TargetFramework` in [OpenDebugAD7.csproj](../src/OpenDebugAD7/OpenDebugAD7.csproj) for the specific target framework moniker used for VS Code.

--- a/docs/CodingStandards-CSharp-for-AI.md
+++ b/docs/CodingStandards-CSharp-for-AI.md
@@ -1,0 +1,42 @@
+# C# coding conventions for MIEngine
+
+The `.editorconfig` at the repo root is authoritative — these are the conventions an AI assistant is most likely to get wrong if it isn't reminded.
+
+## File header
+
+Every `.cs` file starts with the MIT header (enforced by `dotnet_diagnostic` via `file_header_template` in `.editorconfig`):
+
+```csharp
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+```
+
+## Naming
+
+Enforced as **warnings** by `.editorconfig`:
+
+| Symbol | Convention | Example |
+| --- | --- | --- |
+| `static` private/internal/private_protected fields | `s_camelCase` | `private static readonly object s_lock` |
+| Other private/internal fields | `_camelCase` | `private readonly Debugger _debugger` |
+
+`readonly` is preferred where possible (`dotnet_style_readonly_field = true:warning`).
+
+## Usings
+
+`dotnet_sort_system_directives_first = false` — `using` directives are **not** auto-sorted. Leave the existing order alone; do not run an "organize usings" pass on otherwise unrelated files.
+
+## Indentation
+
+- 4 spaces for `.cs` (`indent_size = 4`).
+- CRLF line endings (`end_of_line = crlf`) on Windows-tracked files.
+- 2 spaces for XML formats (`.csproj`, `.props`, `.targets`, `.resx`, `.natvis`, `.vsct`, `.xsd`).
+
+## Engine-specific patterns
+
+These aren't in `.editorconfig` but show up everywhere — follow the existing call sites:
+
+- **MI commands go through `MICommandFactory`.** Don't build raw MI strings in MIDebugEngine. Add a method to the factory and override per debugger flavor when behavior diverges (`GdbMICommandFactory`, `LldbMICommandFactory`, …).
+- **Host calls go through `DebugEngineHost`.** MIDebugEngine never references `Microsoft.VisualStudio.*` directly; use `HostLogger`, `HostMarshal`, `HostOutputWindow`, etc.
+- **AD7 surface lives on `AD7*` partial classes.** Keep VS-SDK COM concerns out of the core `Debugged*` classes.
+- **Worker thread discipline.** AD7 callbacks must not block. Use `Task.Run` for work and post results back via the engine's `WorkerThread` / `EngineCallback`. Mirror existing call sites; do not invent new threading patterns.

--- a/docs/DebugEngineHost-for-AI.md
+++ b/docs/DebugEngineHost-for-AI.md
@@ -1,0 +1,76 @@
+# `Microsoft.DebugEngineHost` — contract assembly + two implementations
+
+`Microsoft.DebugEngineHost` is the shim that lets `MIDebugEngine` (and the
+launchers) avoid calling `Microsoft.VisualStudio.*` directly. It is what
+allows the same engine to run inside Visual Studio *and* inside the VS Code
+`cppdbg` debug adapter (OpenDebugAD7).
+
+⚠️ The host is split across **four** projects on disk. Knowing which is
+which is critical before you read or change anything host-related.
+
+| Project | What it is | When you build it |
+| --- | --- | --- |
+| `src/DebugEngineHost.Stub` | **Contract / reference assembly.** Defines the public shape of `Microsoft.DebugEngineHost` (types, method signatures, XML docs). Method bodies are stubs (`throw new NotImplementedException()`, `return null`, etc.) — **this assembly is never loaded at runtime by the engine.** Built only as a reference assembly so consumers can compile against the surface. | Always (part of `MIDebugEngine.sln`). |
+| `src/DebugEngineHost` | **Visual Studio implementation.** The real `Microsoft.DebugEngineHost.dll` used when MIDebugEngine runs inside VS. Backed by `Microsoft.VisualStudio.*` (settings store, output window, COM marshaling, telemetry, wait dialog, …). | `MIDebugEngine.sln` only (Windows, VS Dev Cmd Prompt). |
+| `src/DebugEngineHost.VSCode` | **VS Code / OpenDebugAD7 implementation.** The real `Microsoft.DebugEngineHost.dll` used when MIDebugEngine is hosted by `OpenDebugAD7` (the `cppdbg` DAP adapter). No VS / COM dependencies — pure .NET. | Both solutions (`MIDebugEngine.sln` and `MIDebugEngine-Unix.sln`). Output lands in `bin/<Configuration>/vscode/`. |
+| `src/DebugEngineHost.Common` | Shared source files (e.g. `HostLogChannel.cs`) that are linked into the two real implementations so they don't drift. Not an assembly the engine references on its own. | Linked into both implementations. |
+
+All three of `DebugEngineHost.Stub`, `DebugEngineHost`, and `DebugEngineHost.VSCode` emit an assembly
+named **`Microsoft.DebugEngineHost.dll`** with the same `AssemblyVersion`
+(`1.0.0`). That is intentional — the engine binds to one name and the
+build wires up whichever real implementation matches the host.
+
+## Rules for AI working on host APIs
+
+1. **`DebugEngineHost.Stub` is a contract, not behavior.** If you want to
+   know what a host API actually *does*, do **not** read `.Stub`. Open the
+   matching file in `src/DebugEngineHost` (VS behavior) and/or
+   `src/DebugEngineHost.VSCode` (VS Code behavior). The `.Stub` body is
+   meaningless — it exists only so other projects can compile.
+
+2. **Adding a new host API means editing all three projects.** A new
+   method or type on a `Host*` class must be added to:
+   - `src/DebugEngineHost.Stub/DebugEngineHost.ref.cs` (or the right `Shared` file) — declare the signature with XML docs, stub the body.
+   - `src/DebugEngineHost/<HostXxx>.cs` — implement it against the VS APIs.
+   - `src/DebugEngineHost.VSCode/<HostXxx>.cs` — implement it against the VS Code / OpenDebugAD7 environment.
+   The three surfaces must stay **identical** (same namespace, type, name,
+   parameters, return type, generic arity, accessibility). If they drift,
+   one of the two hosts will fail to bind at runtime with a
+   `MissingMethodException` / `TypeLoadException`.
+
+3. **Shared helpers go in `DebugEngineHost.Common`.** If the two real
+   implementations would copy/paste the same code, put it in `.Common` and
+   link it into both — do **not** add it to `.Stub` (`.Stub` has no real
+   code).
+
+4. **No `Microsoft.VisualStudio.*` references from `.VSCode` or
+   `.Stub`'s public surface.** The whole point of the split is that
+   OpenDebugAD7 / VS Code can load the engine without any VS assemblies.
+   `.Stub` may reference `Microsoft.VisualStudio.Debugger.Interop` because
+   that is part of the contract (e.g. `HostMarshal` deals in `IDebug*`
+   interfaces), but the `.VSCode` implementation must provide its own
+   substitute behavior, not pull in VS.
+
+5. **MIDebugEngine itself only references the contract.** It compiles
+   against `.Stub`, then at runtime loads whichever real
+   `Microsoft.DebugEngineHost.dll` is next to it. This is why you can't
+   "just call a VS API" from MIDebugEngine — there is no VS API on the
+   `.Stub` surface to call.
+
+## Quick map of the `Host*` types
+
+Every `Host*` file has three copies (one in each project). Common ones:
+
+- `Host` — top-level host identity (`GetHostUIIdentifier()`).
+- `HostConfigurationStore` — engine/launcher configuration lookup. VS reads from the settings store; VS Code reads from launch.json / registered options.
+- `HostLogger` / `HostLogChannel` — logging plumbing (`Debug.MIDebugLog` in VS; file-based in VS Code).
+- `HostMarshal` — marshals AD7 COM interface pointers (`IDebugDocumentPosition2`, etc.) across boundaries. Real COM in VS; an in-proc table in VS Code.
+- `HostOutputWindow` — writes to the VS Debug Output pane vs. the DAP `output` event.
+- `HostRunInTerminal` — launches a child process in an interactive terminal (VS terminal vs. DAP `runInTerminal` request).
+- `HostWaitDialog` / `HostWaitLoop` — modal progress UI (VS dialog vs. DAP progress events / no-op).
+- `HostTelemetry` — VS telemetry sink vs. a VS Code no-op.
+- `HostNatvisProject` — natvis discovery from the loaded VS project vs. from launch.json.
+- `HostDebugger` — only present in the VS implementation (it drives the VS debugger itself for nested scenarios); no `.VSCode` counterpart is needed.
+
+When in doubt, grep for the type name across all three project folders
+and read **both** real implementations — they're the source of truth.

--- a/docs/RunningCppTests-outside-of-VS-for-AI.md
+++ b/docs/RunningCppTests-outside-of-VS-for-AI.md
@@ -1,0 +1,91 @@
+# Running CppTests (end-to-end DAP tests) outside of Visual Studio
+
+⚠️ **Do not use these instructions when working inside Visual Studio.** Use VS **Test Explorer** (or the `debugger_run_tests` tool if available) — it sets up the working directory and lets you attach the debugger to both the test and the spawned `OpenDebugAD7`. The command-line flow below is for CI / VS Code / headless scenarios.
+
+`test/CppTests` drives the built `OpenDebugAD7` adapter against a real `gdb` (or `lldb-mi`) using the `DebugAdapterRunner` framework. Every test has an `[xunit.Theory]` parameterized by an `ITestSettings` discovered at runtime from `config.xml` — see [Filtering CppTests](#filtering-cpptests) below for an important quirk.
+
+## Prerequisites
+
+1. A VSCode-flavor build (see [Building-outside-of-VS-for-AI.md](Building-outside-of-VS-for-AI.md)):
+
+   ```powershell
+   eng\Scripts\CI-Build.ps1 -Configuration Debug -TargetPlatform vscode    # Windows
+   ```
+
+   ```bash
+   eng/Scripts/CI-Build.sh                                                  # Linux / macOS
+   ```
+
+2. A native toolchain for the test debuggees:
+   - **Windows:** **MSYS2 + MinGW64** (`mingw-w64-x86_64-toolchain`, providing `g++` and `gdb`). **Cygwin is not supported.** Install with `winget install --id MSYS2.MSYS2 --silent` and then, in `C:\msys64\usr\bin\bash.exe -lc "..."`:
+
+     ```bash
+     pacman -Syu --noconfirm
+     pacman -S --needed --noconfirm mingw-w64-x86_64-toolchain
+     ```
+
+     Put `C:\msys64\mingw64\bin;C:\msys64\usr\bin` on `PATH`, or run `dotnet test` from `msys2_shell.cmd -mingw64`.
+   - **Linux:** `gdb`, `g++`, plus `ptrace_scope=0` and a writable `core_pattern` if any test exercises core dumps:
+
+     ```bash
+     sudo apt-get install -y gdb g++
+     echo 0    | sudo tee /proc/sys/kernel/yama/ptrace_scope
+     echo core | sudo tee /proc/sys/kernel/core_pattern
+     ```
+
+   - **macOS:** `lldb-mi` is downloaded by `tools/DownloadLldbMI.sh`; CI does this automatically inside `eng/Scripts/CI-Test.sh`.
+
+3. A `config.xml` next to `CppTests.dll`. Pick the right template from `bin/DebugAdapterProtocolTests/<Configuration>/CppTests/TestConfigurations/` and copy it as `config.xml`:
+
+   | Platform / debugger | Template |
+   | --- | --- |
+   | Windows + MSYS2 GDB | `config_msys_gdb.xml` |
+   | Linux + GDB | `config_gdb.xml` |
+   | macOS + LLDB-MI | `config_lldb.xml` |
+   | Windows + VsDbg | `config_vsdbg.xml` |
+
+   ⚠️ The shipped `config_msys_gdb.xml` has hardcoded GitHub Actions paths (`D:\a\_temp\msys64\mingw64\bin\…`). Edit it to match your local install (e.g. `C:\msys64\mingw64\bin\g++.exe`, `C:\msys64\mingw64\bin\gdb.exe`) before running.
+
+`eng/Scripts/CI-Test.sh` performs steps 2-3 automatically on Linux/macOS.
+
+## Running
+
+```powershell
+cd bin\DebugAdapterProtocolTests\Debug\CppTests
+dotnet test CppTests.dll --logger "trx;LogFileName=results.trx"
+```
+
+```bash
+cd bin/DebugAdapterProtocolTests/Debug/CppTests
+dotnet test CppTests.dll --logger "trx;LogFileName=results.trx"
+```
+
+## Filtering CppTests
+
+Standard VSTest filters work:
+
+```powershell
+dotnet test CppTests.dll --filter "FullyQualifiedName~SampleTests.TestArguments"
+```
+
+**Quirk to know about — dependency ordering vs. filtering.** Many CppTests use `[DependsOnTest("OtherTest")]` (e.g. a debuggee-compile step), and the type is decorated with `[TestCaseOrderer(DependencyTestOrderer.TypeName, DependencyTestOrderer.AssemblyName)]`. The orderer (`test/DebuggerTesting/Ordering/DependencyOrderer.cs`) runs **after** VSTest's `--filter`. Historically it removed any test whose dependency wasn't in the filtered set, so a single-test filter would silently produce *"No test matches the given testcase filter"*. The orderer was updated to instead ignore missing dependencies and run the test anyway, logging a warning through xUnit's diagnostic message sink (`IMessageSink` / `DiagnosticMessage`). The warning is only surfaced when xUnit diagnostic messages are enabled — see [Seeing xUnit diagnostic messages](#seeing-xunit-diagnostic-messages) below. When adding new dependency-ordered tests:
+
+- Don't rely on the orderer to *skip* a test when its dependency is filtered out — it will run, and may fail at runtime if the predecessor was genuinely required.
+- If a predecessor produces a build artifact (e.g. a compiled debuggee), ensure the dependent test can find or rebuild that artifact when run in isolation.
+
+## Seeing xUnit diagnostic messages
+
+Diagnostics emitted via xUnit's `IMessageSink` (used by `DependencyTestOrderer` and other test infrastructure) are **suppressed by default**. To see them in `dotnet test` console output, in VS Test Explorer's Test output pane, or in TRX logs, drop an `xunit.runner.json` next to the test DLL with diagnostics enabled:
+
+```json
+{
+  "$schema": "https://xunit.net/schema/current/xunit.runner.schema.json",
+  "diagnosticMessages": true
+}
+```
+
+For `CppTests`, place it next to `bin\DebugAdapterProtocolTests\<Configuration>\CppTests\CppTests.dll`. With `--logger "console;verbosity=detailed"`, diagnostic lines appear prefixed with `[xUnit.net …]` (e.g. `WARNING: Missing dependency for 'CppTests.Tests.SampleTests.TestArguments'; running anyway.`).
+
+## Test-data XML
+
+`config.xml` defines `<TestConfiguration>` entries (compiler + debugger + architecture). Every `[RequiresTestSettings]` theory is invoked once per matching configuration. To run against multiple debuggers in one pass, add multiple `<TestConfiguration>` entries.

--- a/docs/RunningUnitTests-outside-of-VS-for-AI.md
+++ b/docs/RunningUnitTests-outside-of-VS-for-AI.md
@@ -1,0 +1,47 @@
+# Running the in-process unit tests outside of Visual Studio
+
+⚠️ **Do not use these instructions when working inside Visual Studio.** Use VS **Test Explorer** (or the `debugger_run_tests` tool if available) to discover, run, and debug these tests — that path attaches the VS debugger and updates the Test Explorer UI. The commands below are for command-line / CI scenarios.
+
+This page covers the four pure .NET unit-test assemblies. For end-to-end DAP tests against a real `gdb`/`lldb-mi`, see [RunningCppTests-outside-of-VS-for-AI.md](RunningCppTests-outside-of-VS-for-AI.md).
+
+## The unit-test assemblies
+
+| Project | What it tests |
+| --- | --- |
+| `MICoreUnitTests` | MI parser, transports, command factories. |
+| `MIDebugEngineUnitTests` | AD7 wrappers, expression evaluation helpers, and other in-engine logic. |
+| `JDbgUnitTests` | JDWP client used by `AndroidDebugLauncher`. |
+| `SSHDebugTests` | SSHDebugPS port supplier and related SSH helpers. |
+
+All four are built by `MIDebugEngine.sln` (Windows) and most are also built by `MIDebugEngine-Unix.sln`.
+
+## Prerequisites
+
+- A successful build (see [Building-outside-of-VS-for-AI.md](Building-outside-of-VS-for-AI.md)).
+- No native toolchain is required — these are managed-only tests.
+
+## Running the full suite (Windows / VSTest)
+
+This matches what GitHub Actions does. From a VS Developer Command Prompt:
+
+```powershell
+vstest.console.exe `
+  bin\Debug\MICoreUnitTests.dll `
+  bin\Debug\JDbgUnitTests.dll `
+  bin\Debug\SSHDebugTests.dll `
+  bin\Debug\MIDebugEngineUnitTests.dll
+```
+
+## Running a single test
+
+```powershell
+vstest.console.exe bin\Debug\MICoreUnitTests.dll /Tests:Namespace.ClassName.MethodName
+```
+
+`/Tests:` does substring matching, so you can pass just the method name if it is unique.
+
+For the projects that are also in the Unix solution, `dotnet test` works too:
+
+```powershell
+dotnet test src\MICoreUnitTests\MICoreUnitTests.csproj --filter "FullyQualifiedName~Namespace.ClassName.MethodName"
+```

--- a/src/DebugEngineHost.Stub/README.md
+++ b/src/DebugEngineHost.Stub/README.md
@@ -1,0 +1,17 @@
+# DebugEngineHost.Stub
+
+⚠️ **This project is a contract / reference assembly. It is never loaded
+at runtime.** The method bodies here are stubs — they do not describe
+what the host actually does.
+
+If you want to know what a `Host*` API actually does, read the **real**
+implementations instead:
+
+- `src/DebugEngineHost` — Visual Studio implementation.
+- `src/DebugEngineHost.VSCode` — VS Code / OpenDebugAD7 implementation.
+
+If you are adding or changing a host API, you must update all three
+projects (`DebugEngineHost.Stub`, `DebugEngineHost`,
+`DebugEngineHost.VSCode`) so their public surfaces stay identical. See
+[`docs/DebugEngineHost-for-AI.md`](../../docs/DebugEngineHost-for-AI.md)
+for the full rules and rationale.

--- a/src/DebugEngineHost.VSCode/README.md
+++ b/src/DebugEngineHost.VSCode/README.md
@@ -1,0 +1,18 @@
+# DebugEngineHost.VSCode (VS Code / OpenDebugAD7 implementation)
+
+This project is the **VS Code** implementation of
+`Microsoft.DebugEngineHost.dll`. It is one of two real implementations
+of the host contract defined in
+[`src/DebugEngineHost.Stub`](../DebugEngineHost.Stub/README.md); the
+other is [`src/DebugEngineHost`](../DebugEngineHost/README.md) (the
+Visual Studio implementation).
+
+Behavior here has **no `Microsoft.VisualStudio.*` dependencies** — it is
+pure .NET so the engine can be hosted by `OpenDebugAD7` (the `cppdbg`
+debug adapter) on Windows, Linux, and macOS.
+
+If you are adding or changing a host API, you must update all three
+projects (`DebugEngineHost.Stub`, `DebugEngineHost`,
+`DebugEngineHost.VSCode`) so their public surfaces stay identical. See
+[`docs/DebugEngineHost-for-AI.md`](../../docs/DebugEngineHost-for-AI.md)
+for the full rules and rationale.

--- a/src/DebugEngineHost/README.md
+++ b/src/DebugEngineHost/README.md
@@ -1,0 +1,17 @@
+# DebugEngineHost (Visual Studio implementation)
+
+This project is the **Visual Studio** implementation of
+`Microsoft.DebugEngineHost.dll`. It is one of two real implementations
+of the host contract defined in
+[`src/DebugEngineHost.Stub`](../DebugEngineHost.Stub/README.md); the
+other is [`src/DebugEngineHost.VSCode`](../DebugEngineHost.VSCode/README.md).
+
+Behavior here is backed by `Microsoft.VisualStudio.*` APIs (settings
+store, output window, COM marshaling, telemetry, wait dialog, …) and is
+loaded when MIDebugEngine runs inside Visual Studio.
+
+If you are adding or changing a host API, you must update all three
+projects (`DebugEngineHost.Stub`, `DebugEngineHost`,
+`DebugEngineHost.VSCode`) so their public surfaces stay identical. See
+[`docs/DebugEngineHost-for-AI.md`](../../docs/DebugEngineHost-for-AI.md)
+for the full rules and rationale.

--- a/src/MIDebugEngine-Unix.sln
+++ b/src/MIDebugEngine-Unix.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio Version 17
-VisualStudioVersion = 17.65535.65535.65535
+# Visual Studio Version 18
+VisualStudioVersion = 18.65535.65535.65535
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{CF02407C-BF37-4D51-83F4-845A7F36C101}"
 	ProjectSection(SolutionItems) = preProject

--- a/src/MIDebugEngine.sln
+++ b/src/MIDebugEngine.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio Version 17
-VisualStudioVersion = 17.65535.65535.65535
+# Visual Studio Version 18
+VisualStudioVersion = 18.65535.65535.65535
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Platform Launchers", "Platform Launchers", "{B864C337-1AA8-42B3-BF01-90901F55DE70}"
 EndProject
@@ -102,6 +102,21 @@ EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "MakePIAPortableTool", "tools\MakePIAPortableTool\MakePIAPortableTool.csproj", "{CC5BDD33-7EB1-4FB9-BC67-806773018989}"
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "MIDebugEngineUnitTests", "MIDebugEngineUnitTests\MIDebugEngineUnitTests.csproj", "{7F98435A-526E-41DC-9F9A-BFD55CC991DE}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = ".github", ".github", "{617F1819-7755-445A-8F8E-7C96137BA449}"
+	ProjectSection(SolutionItems) = preProject
+		..\.github\copilot-instructions.md = ..\.github\copilot-instructions.md
+	EndProjectSection
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "docs", "docs", "{03A604B5-0964-4B2B-A7F1-CD89764B8BB1}"
+	ProjectSection(SolutionItems) = preProject
+		..\docs\Architecture-for-AI.md = ..\docs\Architecture-for-AI.md
+		..\docs\Building-outside-of-VS-for-AI.md = ..\docs\Building-outside-of-VS-for-AI.md
+		..\docs\CodingStandards-CSharp-for-AI.md = ..\docs\CodingStandards-CSharp-for-AI.md
+		..\docs\DebugEngineHost-for-AI.md = ..\docs\DebugEngineHost-for-AI.md
+		..\docs\RunningCppTests-outside-of-VS-for-AI.md = ..\docs\RunningCppTests-outside-of-VS-for-AI.md
+		..\docs\RunningUnitTests-outside-of-VS-for-AI.md = ..\docs\RunningUnitTests-outside-of-VS-for-AI.md
+	EndProjectSection
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -294,6 +309,8 @@ Global
 		{6B26CBAE-38A1-47E6-BFF1-F4A626C9A5B5} = {9D97EF1A-BCD5-4932-BBCC-98194CF8A841}
 		{4F96DA84-CCBA-4ADE-8D7D-BC15D566A329} = {CF02407C-BF37-4D51-83F4-845A7F36C101}
 		{CC5BDD33-7EB1-4FB9-BC67-806773018989} = {20B91EF1-0CE0-4E6D-A122-319BF9B68E94}
+		{617F1819-7755-445A-8F8E-7C96137BA449} = {CF02407C-BF37-4D51-83F4-845A7F36C101}
+		{03A604B5-0964-4B2B-A7F1-CD89764B8BB1} = {CF02407C-BF37-4D51-83F4-845A7F36C101}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {6099AC71-DA1D-4578-A8A3-376EB3C602E6}

--- a/test/DebuggerTesting/Ordering/DependencyOrderer.cs
+++ b/test/DebuggerTesting/Ordering/DependencyOrderer.cs
@@ -1,9 +1,9 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using System;
 using System.Collections;
 using System.Collections.Generic;
-using System.Diagnostics;
 using System.Linq;
 
 namespace DebuggerTesting.Ordering
@@ -15,6 +15,16 @@ namespace DebuggerTesting.Ordering
     /// </summary>
     public abstract class DependencyOrderer<T, TKey>
     {
+        /// <summary>
+        /// Reports a diagnostic message produced while ordering items. The default
+        /// implementation discards the message; derived classes should override to
+        /// route the message to whatever logging facility is available in their
+        /// hosting environment (e.g. xUnit's <c>IMessageSink</c>).
+        /// </summary>
+        protected virtual void LogDiagnostic(string message)
+        {
+        }
+
         protected IEnumerable<T> OrderBasedOnDependencies(IEnumerable<T> itemsEnumerable)
         {
             List<T> items = new List<T>(itemsEnumerable);
@@ -26,32 +36,35 @@ namespace DebuggerTesting.Ordering
             while (i < items.Count)
             {
                 T currentItem = items[i];
-                IEnumerable<int> dependencyIndexes = GetDependencyIndexes(items, currentItem);
-                if (dependencyIndexes == null)
-                    continue;
+                // Materialize once: GetDependencyIndexes returns a lazy Select(...),
+                // and we both filter it and count it below. Treat null (no dependency
+                // metadata) the same as an empty list so the loop always advances —
+                // otherwise `continue` would leave `i` unchanged and loop forever.
+                IList<int> dependencyIndexes = (IList<int>)GetDependencyIndexes(items, currentItem)?.ToList() ?? Array.Empty<int>();
 
-                if (dependencyIndexes.Any(x => x < 0))
+                // Ignore dependencies that aren't present in the current item set
+                // (for example, when the user filtered the run with `dotnet test --filter`
+                // or via VS Test Explorer). The orderer's job is to order items, not to
+                // drop them — silently removing the dependent test makes filtered runs
+                // appear to match nothing. If the dependency is genuinely required at
+                // runtime, the test will fail with an actionable error rather than
+                // vanishing from the run.
+                IList<int> presentDependencyIndexes = dependencyIndexes.Where(x => x >= 0).ToList();
+                if (presentDependencyIndexes.Count < dependencyIndexes.Count)
                 {
-                    // Remove item if dependency cannot be resolved in this set of items
-                    Debug.WriteLine("ERROR: Cannot find dependency for '{0}'.".FormatWithArgs(GetItemName(currentItem)));
-
-                    // Remove the item and start over
-                    items.RemoveAt(i);
-                    stallCount = 0;
-                    i = 0;
-                    continue;
+                    LogDiagnostic("WARNING: Missing dependency for '{0}'; running anyway.".FormatWithArgs(GetItemName(currentItem)));
                 }
 
                 // Move the current test after any required dependencies.
                 // Verify we aren't stuck in an infinite loop
-                int lastDependencyIndex = dependencyIndexes.Any() ? dependencyIndexes.Max() : -1;
+                int lastDependencyIndex = presentDependencyIndexes.Count > 0 ? presentDependencyIndexes.Max() : -1;
                 if (lastDependencyIndex > i)
                 {
                     MoveAfter(items, i, lastDependencyIndex);
                     stallCount++;
                     if (stallCount > (items.Count - i))
                     {
-                        Debug.WriteLine("ERROR: Circular test dependency found.");
+                        LogDiagnostic("ERROR: Circular test dependency found.");
                         // Based on the stall count, the items at the end of the list
                         // have a circular reference. Remove them all.
                         items.RemoveRange(i, items.Count - i);

--- a/test/DebuggerTesting/Ordering/DependencyTestOrderer.cs
+++ b/test/DebuggerTesting/Ordering/DependencyTestOrderer.cs
@@ -15,10 +15,42 @@ namespace DebuggerTesting.Ordering
         public const string TypeName = nameof(DebuggerTesting) + "." + nameof(Ordering) + "." + nameof(DependencyTestOrderer);
         public const string AssemblyName = nameof(DebuggerTesting);
 
+        private readonly IMessageSink _diagnosticMessageSink;
+
+        // xUnit will pick the constructor with the most parameters it can satisfy
+        // and inject the diagnostic message sink when available. The parameterless
+        // constructor is retained so the orderer still works in hosts that don't
+        // supply a sink.
+        public DependencyTestOrderer()
+        {
+        }
+
+        public DependencyTestOrderer(IMessageSink diagnosticMessageSink)
+        {
+            _diagnosticMessageSink = diagnosticMessageSink;
+        }
+
         public IEnumerable<TTestCase> OrderTestCases<TTestCase>(IEnumerable<TTestCase> testCases)
             where TTestCase : ITestCase
         {
             return OrderBasedOnDependencies(testCases.Cast<ITestCase>()).Cast<TTestCase>();
+        }
+
+        protected override void LogDiagnostic(string message)
+        {
+            // Route through xUnit's diagnostic message sink so the message shows up
+            // in `dotnet test` output (with `<DiagnosticMessages>true</DiagnosticMessages>`
+            // in xunit.runner.json or `-diagnostics` on the runner) and in the VS
+            // test output pane. Fall back to Console.Error so the message isn't lost
+            // when no sink is available (e.g. unit-testing the orderer directly).
+            if (_diagnosticMessageSink != null)
+            {
+                _diagnosticMessageSink.OnMessage(new DiagnosticMessage(message));
+            }
+            else
+            {
+                Console.Error.WriteLine(message);
+            }
         }
 
         #region Dependency Helpers


### PR DESCRIPTION
This PR:
- Adds copilot-instructions.md with links to documentation
- Adds a READMD.md to the various DebugEngineHost implementations to make that more clear
- Fixes a bug with how `DependsOnTest` works which made it so that any test with that attribute couldn't be run with a test filter