### PR TITLE
Fix DebuggerTesting Release Pipeline

### DIFF
--- a/eng/pipelines/templates/DebuggerTesting-release.template.yml
+++ b/eng/pipelines/templates/DebuggerTesting-release.template.yml
@@ -10,7 +10,7 @@ steps:
   parameters:
     Command: 'restore'
     solution: '$(Build.SourcesDirectory)\src\MIDebugEngine.sln'
-    FeedsToUse: 'config'
+    selectOrConfig: 'config'
     NugetConfigPath: '$(Build.SourcesDirectory)\eng\pipelines\NuGet.release.config'
 
 - template: ../tasks/MSBuild.yml


### PR DESCRIPTION
Accidently used `FeedsToUse` instead of `selectOrConfig`. This will now force it to use the NuGet.release.config instead of nuget.org as a source. 

See https://github.com/microsoft/MIEngine/blob/97dd65384343577330cc5ee135054dce3ba9ac71/eng/pipelines/tasks/NuGetCommand.yml#L32