### PR TITLE
Prepare for nullable reference types in MICore

### DIFF
--- a/src/DebugEngineHost.Common/HostLogChannel.cs
+++ b/src/DebugEngineHost.Common/HostLogChannel.cs
@@ -50,15 +50,15 @@ namespace Microsoft.DebugEngineHost
 
     public class HostLogChannel : ILogChannel
     {
-        private readonly Action<string> _log;
+        private readonly Action<string>? _log;
         private StreamWriter? _logFile;
         private LogLevel _minLevelToBeLogged;
 
         private readonly object _lock = new object();
 
-        private HostLogChannel() { _log = null!; }
+        private HostLogChannel() { }
 
-        public HostLogChannel(Action<string> logAction, string? file, LogLevel logLevel)
+        public HostLogChannel(Action<string>? logAction, string? file, LogLevel logLevel)
         {
             _log = logAction;
 

--- a/src/DebugEngineHost.Stub/DebugEngineHost.ref.cs
+++ b/src/DebugEngineHost.Stub/DebugEngineHost.ref.cs
@@ -259,7 +259,7 @@ namespace Microsoft.DebugEngineHost
         /// </summary>
         /// <param name="callback">The callback to use to send the engine log.</param>
         /// <param name="level">The level of the log to filter the channel on.</param>
-        public static void EnableHostLogging(Action<string> callback, LogLevel level = LogLevel.Verbose)
+        public static void EnableHostLogging(Action<string>? callback, LogLevel level = LogLevel.Verbose)
         {
             throw new NotImplementedException();
         }
@@ -527,7 +527,7 @@ namespace Microsoft.DebugEngineHost
         /// <returns>true if the message is sent, false if not.</returns>
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Naming", "CA1704:IdentifiersShouldBeSpelledCorrectly", MessageId = "cwd")]
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Design", "CA1006:DoNotNestGenericTypesInMemberSignatures")]
-        public static void RunInTerminal(string title, string workingDirectory, bool useExternalConsole, IReadOnlyList<string> commandArgs, IReadOnlyDictionary<string, string> environmentVariables, Action<int?> success, Action<string> failure)
+        public static void RunInTerminal(string title, string workingDirectory, bool useExternalConsole, IReadOnlyList<string> commandArgs, IReadOnlyDictionary<string, string?> environmentVariables, Action<int?> success, Action<string> failure)
         {
             throw new NotImplementedException();
         }

--- a/src/DebugEngineHost.VSCode/HostLogger.cs
+++ b/src/DebugEngineHost.VSCode/HostLogger.cs
@@ -21,7 +21,7 @@ namespace Microsoft.DebugEngineHost
             }
         }
 
-        public static void EnableHostLogging(Action<string> callback, LogLevel level = LogLevel.Verbose)
+        public static void EnableHostLogging(Action<string>? callback, LogLevel level = LogLevel.Verbose)
         {
             if (s_engineLogChannel is null)
             {

--- a/src/DebugEngineHost.VSCode/HostRunInTerminal.cs
+++ b/src/DebugEngineHost.VSCode/HostRunInTerminal.cs
@@ -9,7 +9,7 @@ namespace Microsoft.DebugEngineHost
 {
     public static class HostRunInTerminal
     {
-        private static Action<string, string, bool, List<string>, Dictionary<string, object>, Action<int?>, Action<string>>? s_runInTerminalCallback;
+        private static Action<string, string, bool, List<string>, Dictionary<string, object?>, Action<int?>, Action<string>>? s_runInTerminalCallback;
 
         /// <summary>
         /// Checks to see if RunInTerminal is available
@@ -23,11 +23,11 @@ namespace Microsoft.DebugEngineHost
         /// <summary>
         /// Passes the call to the UI to attempt to RunInTerminal if possible.
         /// </summary>
-        public static void RunInTerminal(string title, string cwd, bool useExternalConsole, IReadOnlyList<string> commandArgs, IReadOnlyDictionary<string, string> environmentVars, Action<int?> success, Action<string> failure)
+        public static void RunInTerminal(string title, string cwd, bool useExternalConsole, IReadOnlyList<string> commandArgs, IReadOnlyDictionary<string, string?> environmentVars, Action<int?> success, Action<string> failure)
         {
             if (s_runInTerminalCallback is not null)
             {
-                Dictionary<string, object> env = new Dictionary<string, object>();
+                Dictionary<string, object?> env = new Dictionary<string, object?>();
                 foreach (var item in environmentVars)
                 {
                     env.Add(item.Key, item.Value);
@@ -41,7 +41,7 @@ namespace Microsoft.DebugEngineHost
         /// Registers callback to call when RunInTerminal is called
         /// </summary>
         /// <param name="runInTerminalCallback">Callback for RunInTerminal</param>
-        public static void RegisterRunInTerminalCallback(Action<string, string, bool, List<string>, Dictionary<string, object>, Action<int?>, Action<string>> runInTerminalCallback)
+        public static void RegisterRunInTerminalCallback(Action<string, string, bool, List<string>, Dictionary<string, object?>, Action<int?>, Action<string>> runInTerminalCallback)
         {
             Debug.Assert(runInTerminalCallback != null, "Callback should not be null.");
             s_runInTerminalCallback = runInTerminalCallback;

--- a/src/DebugEngineHost/HostLogger.cs
+++ b/src/DebugEngineHost/HostLogger.cs
@@ -19,7 +19,7 @@ namespace Microsoft.DebugEngineHost
         private static FeedbackLogBuffer? s_circularBuffer;
         private static VSFeedbackLogger? s_feedbackLogger;
 
-        public static void EnableHostLogging(Action<string> callback, LogLevel level = LogLevel.Verbose)
+        public static void EnableHostLogging(Action<string>? callback, LogLevel level = LogLevel.Verbose)
         {
             if (s_engineLogChannel is null)
             {

--- a/src/DebugEngineHost/HostRunInTerminal.cs
+++ b/src/DebugEngineHost/HostRunInTerminal.cs
@@ -22,7 +22,7 @@ namespace Microsoft.DebugEngineHost
 
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Naming", "CA1704:IdentifiersShouldBeSpelledCorrectly", MessageId = "cwd")]
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Design", "CA1006:DoNotNestGenericTypesInMemberSignatures")]
-        public static void RunInTerminal(string title, string workingDirectory, bool useExternalConsole, IReadOnlyList<string> commandArgs, IReadOnlyDictionary<string, string> environmentVariables, Action<int?> success, Action<string> failure)
+        public static void RunInTerminal(string title, string workingDirectory, bool useExternalConsole, IReadOnlyList<string> commandArgs, IReadOnlyDictionary<string, string?> environmentVariables, Action<int?> success, Action<string> failure)
         {
             throw new NotImplementedException();
         }

--- a/src/MICore/CommandFactories/MICommandFactory.cs
+++ b/src/MICore/CommandFactories/MICommandFactory.cs
@@ -48,13 +48,18 @@ namespace MICore
 
     public abstract class MICommandFactory
     {
-        protected Debugger _debugger;
+        protected readonly Debugger _debugger;
 
         public MIMode Mode { get; private set; }
 
         public abstract string Name { get; }
 
         internal int MajorVersion { get; set; }
+
+        protected MICommandFactory(Debugger debugger)
+        {
+            _debugger = debugger;
+        }
 
         public static MICommandFactory GetInstance(MIMode mode, Debugger debugger)
         {
@@ -63,15 +68,14 @@ namespace MICore
             switch (mode)
             {
                 case MIMode.Gdb:
-                    commandFactory = new GdbMICommandFactory();
+                    commandFactory = new GdbMICommandFactory(debugger);
                     break;
                 case MIMode.Lldb:
-                    commandFactory = new LlldbMICommandFactory();
+                    commandFactory = new LlldbMICommandFactory(debugger);
                     break;
                 default:
                     throw new ArgumentException(null, nameof(mode));
             }
-            commandFactory._debugger = debugger;
             commandFactory.Mode = mode;
             commandFactory.Radix = 10;
             return commandFactory;

--- a/src/MICore/CommandFactories/gdb.cs
+++ b/src/MICore/CommandFactories/gdb.cs
@@ -19,6 +19,11 @@ namespace MICore
         private int _currentThreadId = 0;
         private uint _currentFrameLevel = 0;
 
+        public GdbMICommandFactory(Debugger debugger)
+            : base(debugger)
+        {
+        }
+
         public override string Name
         {
             get { return "GDB"; }

--- a/src/MICore/CommandFactories/lldb.cs
+++ b/src/MICore/CommandFactories/lldb.cs
@@ -16,6 +16,11 @@ namespace MICore
 {
     internal class LlldbMICommandFactory : MICommandFactory
     {
+        public LlldbMICommandFactory(Debugger debugger)
+            : base(debugger)
+        {
+        }
+
         public override string Name
         {
             get { return "LLDB"; }

--- a/src/MICore/Debugger.cs
+++ b/src/MICore/Debugger.cs
@@ -1619,7 +1619,13 @@ namespace MICore
 
         private void SendToTransport(string cmd)
         {
-            ITransport transport = _transport ?? throw new InvalidOperationException();
+            ITransport transport = _transport;
+            if (transport is null)
+            {
+                Debug.Fail("Invalid: `SendToTransport` called before `Init`");
+                throw new InvalidOperationException();
+            }
+
             transport.Send(cmd);
 
             // https://github.com/Microsoft/MIEngine/issues/616 :

--- a/src/MICore/Debugger.cs
+++ b/src/MICore/Debugger.cs
@@ -72,7 +72,7 @@ namespace MICore
         public uint MaxInstructionSize { get; private set; }
         public bool Is64BitArch { get; private set; }
         public CommandLock CommandLock { get { return _commandLock; } }
-        public MICommandFactory MICommandFactory { get; protected set; }
+        public MICommandFactory MICommandFactory { get; }
         public Logger Logger { private set; get; }
 
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Security", "CA2104:DoNotDeclareReadOnlyMutableReferenceTypes")]
@@ -124,12 +124,12 @@ namespace MICore
         }
 
         private ITransport _transport;
-        private CommandLock _commandLock = new CommandLock();
+        private readonly CommandLock _commandLock = new CommandLock();
 
         /// <summary>
         /// The last command we sent over the transport. This includes both the command name and arguments.
         /// </summary>
-        private string _lastCommandText;
+        private string _lastCommandText = string.Empty;
         private uint _lastCommandId;
 
         /// <summary>
@@ -169,6 +169,7 @@ namespace MICore
             _debuggeePids = new Dictionary<string, int>();
             Logger = logger;
             _miResults = new MIResults(logger);
+            MICommandFactory = MICommandFactory.GetInstance(launchOptions.DebuggerMIMode, this);
         }
 
         protected void SetDebuggerPid(int debuggerPid)
@@ -392,7 +393,7 @@ namespace MICore
                 }
                 catch (Exception e) when (ExceptionHelper.BeforeCatch(e, Logger, reportOnlyCorrupting: true))
                 {
-                    if (firstException != null)
+                    if (firstException is null)
                     {
                         firstException = e;
                     }
@@ -404,7 +405,7 @@ namespace MICore
             {
                 if (this.IsClosed)
                 {
-                    source.TrySetException(new DebuggerDisposedException(_closeMessage));
+                    source.TrySetException(new DebuggerDisposedException(GetTargetProcessExitedReason()));
                 }
                 else
                 {
@@ -524,7 +525,7 @@ namespace MICore
             Debug.Assert(_closeMessage == null, "Why was Close called more than once? Should be impossible.");
 
             _closeMessage = closeMessage;
-            _transport.Close();
+            _transport?.Close();
             lock (_waitingOperations)
             {
                 foreach (var value in _waitingOperations.Values)
@@ -905,7 +906,7 @@ namespace MICore
             {
                 if (this.IsClosed)
                 {
-                    throw new DebuggerDisposedException(_closeMessage);
+                    throw new DebuggerDisposedException(GetTargetProcessExitedReason());
                 }
 
                 id = ++_lastCommandId;
@@ -992,13 +993,13 @@ namespace MICore
                             if (isMinGWOrCygwin && IsUnsupportedWindowsGdbVersion(_gdbVersion))
                             {
                                 exception = new MIDebuggerInitializeFailedUnsupportedGdbException(
-                                    this.MICommandFactory.Name, _initialErrors.ToList().AsReadOnly(), _initializationLog.ToList().AsReadOnly(), _gdbVersion);
+                                    this.MICommandFactory.Name, (_initialErrors?.ToList() ?? new List<string>()).AsReadOnly(), (_initializationLog?.ToList() ?? new List<string>()).AsReadOnly(), _gdbVersion);
                                 SendUnsupportedWindowsGdbEvent(_gdbVersion);
                             }
                             else
                             {
                                 exception = new MIDebuggerInitializeFailedException(
-                                    this.MICommandFactory.Name, _initialErrors.ToList().AsReadOnly(), _initializationLog.ToList().AsReadOnly());
+                                    this.MICommandFactory.Name, (_initialErrors?.ToList() ?? new List<string>()).AsReadOnly(), (_initializationLog?.ToList() ?? new List<string>()).AsReadOnly());
                             }
 
                             _initialErrors = null;
@@ -1029,7 +1030,7 @@ namespace MICore
                 {
                     if (DebuggerExitEvent != null)
                     {
-                        DebuggerExitEvent(this, null);
+                        DebuggerExitEvent(this, EventArgs.Empty);
                     }
                 }
             }
@@ -1419,8 +1420,7 @@ namespace MICore
 
         private void OnNotificationOutput(string cmd)
         {
-            Results results = null;
-            if ((results = MICommandFactory.IsModuleLoad(cmd)) != null)
+            if (MICommandFactory.IsModuleLoad(cmd) is Results results)
             {
                 if (LibraryLoadEvent != null)
                 {
@@ -1460,12 +1460,12 @@ namespace MICore
             else if (cmd.StartsWith("thread-created,", StringComparison.Ordinal))
             {
                 results = _miResults.ParseResultList(cmd.Substring("thread-created,".Length));
-                ThreadCreatedEvent(this, new ResultEventArgs(results, 0));
+                ThreadCreatedEvent?.Invoke(this, new ResultEventArgs(results, 0));
             }
             else if (cmd.StartsWith("thread-exited,", StringComparison.Ordinal))
             {
                 results = _miResults.ParseResultList(cmd.Substring("thread-exited,".Length));
-                ThreadExitedEvent(this, new ResultEventArgs(results, 0));
+                ThreadExitedEvent?.Invoke(this, new ResultEventArgs(results, 0));
             }
             else if (cmd.StartsWith("telemetry,", StringComparison.Ordinal))
             {
@@ -1619,14 +1619,15 @@ namespace MICore
 
         private void SendToTransport(string cmd)
         {
-            _transport.Send(cmd);
+            ITransport transport = _transport ?? throw new InvalidOperationException();
+            transport.Send(cmd);
 
             // https://github.com/Microsoft/MIEngine/issues/616 :
             // If it is local gdb (MinGW/Cygwin) on Windows, we need to send an extra line after commands 
             // so that if it errors, the error will come through. 
             if (this.SendNewLineAfterCmd)
             {
-                _transport.Send(String.Empty);
+                transport.Send(String.Empty);
             }
         }
 

--- a/src/MIDebugEngine/Engine.Impl/DebuggedProcess.cs
+++ b/src/MIDebugEngine/Engine.Impl/DebuggedProcess.cs
@@ -64,7 +64,6 @@ namespace Microsoft.MIDebugEngine
             _libraryLoaded = new List<string>();
             _loadOrder = 0;
             _deleteEntryPointBreakpoint = false;
-            MICommandFactory = MICommandFactory.GetInstance(launchOptions.DebuggerMIMode, this);
             _waitDialog = (MICommandFactory.SupportsStopOnDynamicLibLoad() && launchOptions.WaitDynamicLibLoad) ? new HostWaitDialog(ResourceStrings.LoadingSymbolMessage, ResourceStrings.LoadingSymbolCaption) : null;
             Natvis = new Natvis.Natvis(this, launchOptions.ShowDisplayString, configStore);
 


### PR DESCRIPTION
This PR contains work to prepare for enabling nullable reference types in MICore. Changes:

- Correct two incorrect annotations in DebugEngineHost
- Refactor MICommandFactory to use constructor injection (readonly _debugger field)
- Move MICommandFactory.GetInstance() from DebuggedProcess to Debugger constructor
- Fix bug: firstException should only be set when null (was checking != null)
- Add null safety: _transport?.Close(), ThreadCreatedEvent?.Invoke, ThreadExitedEvent?.Invoke
- Add null throw in SendToTransport for null transport
- Use GetTargetProcessExitedReason() instead of raw _closeMessage
- Null-safe access to _initialErrors/_initializationLog in OnDebuggerProcessExit
- Pass EventArgs.Empty instead of null for DebuggerExitEvent
- Use pattern matching for IsModuleLoad check
- Make _commandLock readonly, initialize _lastCommandText
