### PR TITLE
Fix UI-thread hang when resuming the target during launch

### DIFF
--- a/src/MIDebugEngine/AD7.Impl/AD7Engine.cs
+++ b/src/MIDebugEngine/AD7.Impl/AD7Engine.cs
@@ -319,28 +319,24 @@ namespace Microsoft.MIDebugEngine
             {
                 if (eventObject is AD7ProgramCreateEvent)
                 {
-                    Exception exception = null;
-
                     try
                     {
                         _engineCallback.OnLoadComplete();
-                        // At this point breakpoints and exception settings have been sent down, so we can resume the target
-                        _pollThread.RunOperation(() =>
-                        {
-                            return _debuggedProcess.ResumeFromLaunch();
-                        });
+
+                        // Resume the target on the worker thread without blocking the UI thread this runs on.
+                        // Resume faults are reported via onError, since the SDM drops errors returned from here.
+                        _pollThread.PostAsyncOperation(
+                            () => _debuggedProcess.ResumeFromLaunch(),
+                            (exception) =>
+                            {
+                                SendStartDebuggingError(exception);
+                                _debuggedProcess.Terminate();
+                            });
                     }
                     catch (Exception e)
                     {
-                        exception = e;
-                        // Return from the catch block so that we can let the exception unwind - the stack can get kind of big
-                    }
-
-                    if (exception != null)
-                    {
-                        // If something goes wrong, report the error and then stop debugging. The SDM will drop errors
-                        // from ContinueFromSynchronousEvent, so we want to deal with them ourself.
-                        SendStartDebuggingError(exception);
+                        // Report synchronous failures ourselves, since the SDM drops errors returned from here.
+                        SendStartDebuggingError(e);
                         _debuggedProcess.Terminate();
                     }
 

--- a/src/MIDebugEngine/Engine.Impl/OperationThread.cs
+++ b/src/MIDebugEngine/Engine.Impl/OperationThread.cs
@@ -37,6 +37,12 @@ namespace Microsoft.MIDebugEngine
             /// Delegate that was added via 'RunOperation'. Is of type 'Operation' or 'AsyncOperation'
             /// </summary>
             public readonly Delegate Target;
+
+            /// <summary>
+            /// Handler invoked on the worker thread if the operation faults. Only set for PostAsyncOperation.
+            /// </summary>
+            public Action<Exception> ErrorHandler;
+
             public ExceptionDispatchInfo ExceptionDispatchInfo;
             public Task Task;
             private bool _isStarted;
@@ -121,6 +127,20 @@ namespace Microsoft.MIDebugEngine
             SetOperationInternalWithProgress(op, text, canTokenSource);
         }
 
+        /// <summary>
+        /// Send an async operation to the worker thread, claiming the running-op slot but returning without
+        /// waiting for it to complete. Later operations still serialize behind it. Faults are reported to
+        /// <paramref name="onError"/>.
+        /// </summary>
+        public void PostAsyncOperation(AsyncOperation op, Action<Exception> onError)
+        {
+            if (op == null)
+                throw new ArgumentNullException(nameof(op));
+            if (onError == null)
+                throw new ArgumentNullException(nameof(onError));
+
+            PostAsyncOperationInternal(op, onError);
+        }
 
         public void Close()
         {
@@ -189,6 +209,27 @@ namespace Microsoft.MIDebugEngine
                 }
             }
         }
+
+        internal void PostAsyncOperationInternal(AsyncOperation op, Action<Exception> onError)
+        {
+            // If this is called on the Worker thread it will deadlock
+            Debug.Assert(!IsPollThread());
+
+            while (true)
+            {
+                if (_isClosed)
+                    throw new ObjectDisposedException("WorkerThread");
+
+                // Wait for the slot so this serializes behind any in-flight operation.
+                _runningOpCompleteEvent.WaitOne();
+
+                if (TryPostAsyncOperationInternal(op, onError))
+                {
+                    return;
+                }
+            }
+        }
+
         public void PostOperation(Operation op)
         {
             if (op == null)
@@ -276,7 +317,28 @@ namespace Microsoft.MIDebugEngine
             return false;
         }
 
+        private bool TryPostAsyncOperationInternal(AsyncOperation op, Action<Exception> onError)
+        {
+            lock (_eventLock)
+            {
+                if (_isClosed)
+                    throw new ObjectDisposedException("WorkerThread");
 
+                if (_runningOp == null)
+                {
+                    _runningOpCompleteEvent.Reset();
+
+                    _runningOp = new OperationDescriptor(op) { ErrorHandler = onError };
+
+                    _opSet.Set();
+
+                    // Unlike TrySetOperationInternal, do not wait for completion; faults are routed to onError.
+                    return true;
+                }
+            }
+
+            return false;
+        }
 
         // Thread routine for the poll loop. It handles calls coming in from the debug engine as well as polling for debug events.
         private void ThreadFunc()
@@ -333,11 +395,20 @@ namespace Microsoft.MIDebugEngine
 
                         if (!completeAsync)
                         {
+                            // Capture the fault before clearing the slot so a synchronous throw is still reported.
+                            Action<Exception> errorHandler = runningOp.ErrorHandler;
+                            ExceptionDispatchInfo exceptionDispatchInfo = runningOp.ExceptionDispatchInfo;
+
                             runningOp.MarkComplete();
 
                             Debug.Assert(_runningOp == runningOp, "How did m_runningOp change?");
                             _runningOp = null;
                             _runningOpCompleteEvent.Set();
+
+                            if (errorHandler != null && exceptionDispatchInfo != null)
+                            {
+                                InvokeErrorHandler(errorHandler, exceptionDispatchInfo.SourceException);
+                            }
                         }
                     }
 
@@ -389,8 +460,33 @@ namespace Microsoft.MIDebugEngine
                 }
             }
             _runningOp.MarkComplete();
+
+            // Capture the fault before clearing the slot so it is routed to the handler, not discarded.
+            Action<Exception> errorHandler = _runningOp.ErrorHandler;
+            ExceptionDispatchInfo exceptionDispatchInfo = _runningOp.ExceptionDispatchInfo;
+
             _runningOp = null;
             _runningOpCompleteEvent.Set();
+
+            if (errorHandler != null && exceptionDispatchInfo != null)
+            {
+                InvokeErrorHandler(errorHandler, exceptionDispatchInfo.SourceException);
+            }
+        }
+
+        private void InvokeErrorHandler(Action<Exception> errorHandler, Exception exception)
+        {
+            try
+            {
+                errorHandler(exception);
+            }
+            catch (Exception e) when (ExceptionHelper.BeforeCatch(e, Logger, reportOnlyCorrupting: false))
+            {
+                if (PostedOperationErrorEvent != null)
+                {
+                    PostedOperationErrorEvent(this, e);
+                }
+            }
         }
 
         internal bool IsPollThread()

--- a/src/MIDebugEngine/Engine.Impl/OperationThread.cs
+++ b/src/MIDebugEngine/Engine.Impl/OperationThread.cs
@@ -28,6 +28,7 @@ namespace Microsoft.MIDebugEngine
         private readonly ManualResetEvent _runningOpCompleteEvent; // fired when either m_syncOp finishes, or the kick off of m_async
         private readonly Object _eventLock = new object(); // Locking on an event directly can cause Mono to stop responding.
         private readonly Queue<Operation> _postedOperations; // queue of fire-and-forget operations
+        private readonly Queue<(AsyncOperation Operation, Action<Exception> OnError)> _postedAsyncOperations; // queue of fire-and-forget async operations
 
         public event EventHandler<Exception> PostedOperationErrorEvent;
 
@@ -88,6 +89,7 @@ namespace Microsoft.MIDebugEngine
             _opSet = new AutoResetEvent(false);
             _runningOpCompleteEvent = new ManualResetEvent(true);
             _postedOperations = new Queue<Operation>();
+            _postedAsyncOperations = new Queue<(AsyncOperation Operation, Action<Exception> OnError)>();
 
             _thread = new Thread(new ThreadStart(ThreadFunc));
             _thread.Name = "MIDebugger.PollThread";
@@ -129,9 +131,9 @@ namespace Microsoft.MIDebugEngine
         }
 
         /// <summary>
-        /// Send an async operation to the worker thread, claiming the running-op slot but returning without
-        /// waiting for it to complete. Later operations still serialize behind it. Faults are reported to
-        /// <paramref name="onError"/>.
+        /// Queue an async operation to run on the worker thread and return immediately, without waiting for the
+        /// operation to start or finish. Posted async operations run one at a time, in the order posted, and
+        /// serialize behind any in-flight operation. Faults are reported to <paramref name="onError"/>.
         /// </summary>
         public void PostAsyncOperation(AsyncOperation op, Action<Exception> onError)
         {
@@ -140,7 +142,17 @@ namespace Microsoft.MIDebugEngine
             if (onError == null)
                 throw new ArgumentNullException(nameof(onError));
 
-            PostAsyncOperationInternal(op, onError);
+            if (_isClosed)
+                throw new ObjectDisposedException("WorkerThread");
+
+            lock (_postedAsyncOperations)
+            {
+                if (_isClosed)
+                    throw new ObjectDisposedException("WorkerThread");
+
+                _postedAsyncOperations.Enqueue((op, onError));
+                _opSet.Set();
+            }
         }
 
         public void Close()
@@ -205,26 +217,6 @@ namespace Microsoft.MIDebugEngine
                 _runningOpCompleteEvent.WaitOne();
 
                 if (TrySetOperationInternalWithProgress(op, text, canTokenSource))
-                {
-                    return;
-                }
-            }
-        }
-
-        internal void PostAsyncOperationInternal(AsyncOperation op, Action<Exception> onError)
-        {
-            // If this is called on the Worker thread it will deadlock
-            Debug.Assert(!IsPollThread());
-
-            while (true)
-            {
-                if (_isClosed)
-                    throw new ObjectDisposedException("WorkerThread");
-
-                // Wait for the slot so this serializes behind any in-flight operation.
-                _runningOpCompleteEvent.WaitOne();
-
-                if (TryPostAsyncOperationInternal(op, onError))
                 {
                     return;
                 }
@@ -318,27 +310,33 @@ namespace Microsoft.MIDebugEngine
             return false;
         }
 
-        private bool TryPostAsyncOperationInternal(AsyncOperation op, Action<Exception> onError)
+        // Called on the poll thread to promote the next posted async operation into the running-op slot when it
+        // is free. Returns true if an operation was moved into the slot.
+        private bool TryStartPostedAsyncOperation()
         {
+            Debug.Assert(IsPollThread(), "TryStartPostedAsyncOperation must run on the poll thread.");
+
             lock (_eventLock)
             {
-                if (_isClosed)
-                    throw new ObjectDisposedException("WorkerThread");
+                if (_isClosed || _runningOp != null)
+                    return false;
 
-                if (_runningOp == null)
+                (AsyncOperation Operation, Action<Exception> OnError) posted;
+                lock (_postedAsyncOperations)
                 {
-                    _runningOpCompleteEvent.Reset();
+                    if (_postedAsyncOperations.Count == 0)
+                        return false;
 
-                    _runningOp = new OperationDescriptor(op) { ErrorHandler = onError };
-
-                    _opSet.Set();
-
-                    // Unlike TrySetOperationInternal, do not wait for completion; faults are routed to onError.
-                    return true;
+                    posted = _postedAsyncOperations.Dequeue();
                 }
-            }
 
-            return false;
+                _runningOpCompleteEvent.Reset();
+
+                // Unlike TrySetOperationInternal, no one waits for completion; faults are routed to the handler.
+                _runningOp = new OperationDescriptor(posted.Operation) { ErrorHandler = posted.OnError };
+
+                return true;
+            }
         }
 
         // Thread routine for the poll loop. It handles calls coming in from the debug engine as well as polling for debug events.
@@ -354,6 +352,11 @@ namespace Microsoft.MIDebugEngine
                 do
                 {
                     ranOperation = false;
+
+                    if (_runningOp == null)
+                    {
+                        TryStartPostedAsyncOperation();
+                    }
 
                     OperationDescriptor runningOp = _runningOp;
                     if (runningOp != null && !runningOp.IsStarted)
@@ -475,6 +478,14 @@ namespace Microsoft.MIDebugEngine
 
             _runningOp = null;
             _runningOpCompleteEvent.Set();
+
+            lock (_postedAsyncOperations)
+            {
+                if (_postedAsyncOperations.Count > 0)
+                {
+                    _opSet.Set();
+                }
+            }
         }
 
         private void InvokeErrorHandler(Action<Exception> errorHandler, Exception exception)

--- a/src/MIDebugEngine/Engine.Impl/OperationThread.cs
+++ b/src/MIDebugEngine/Engine.Impl/OperationThread.cs
@@ -39,7 +39,8 @@ namespace Microsoft.MIDebugEngine
             public readonly Delegate Target;
 
             /// <summary>
-            /// Handler invoked on the worker thread if the operation faults. Only set for PostAsyncOperation.
+            /// Handler invoked if the operation faults. For async operations, this may be invoked on a non-worker thread.
+            /// Only set for PostAsyncOperation.
             /// </summary>
             public Action<Exception> ErrorHandler;
 
@@ -465,13 +466,15 @@ namespace Microsoft.MIDebugEngine
             Action<Exception> errorHandler = _runningOp.ErrorHandler;
             ExceptionDispatchInfo exceptionDispatchInfo = _runningOp.ExceptionDispatchInfo;
 
-            _runningOp = null;
-            _runningOpCompleteEvent.Set();
-
+            // Invoke the handler while the running-op slot is still held so it does not run concurrently
+            // with the next queued operation. This may still run on the task's completion thread.
             if (errorHandler != null && exceptionDispatchInfo != null)
             {
                 InvokeErrorHandler(errorHandler, exceptionDispatchInfo.SourceException);
             }
+
+            _runningOp = null;
+            _runningOpCompleteEvent.Set();
         }
 
         private void InvokeErrorHandler(Action<Exception> errorHandler, Exception exception)

--- a/src/MIDebugEngine/Engine.Impl/OperationThread.cs
+++ b/src/MIDebugEngine/Engine.Impl/OperationThread.cs
@@ -183,6 +183,22 @@ namespace Microsoft.MIDebugEngine
                     }
                 }
             }
+
+            // Fail any queued async operations that will never run now that we are closed, instead of
+            // dropping them silently. The poll thread won't promote them once _isClosed is set.
+            while (true)
+            {
+                Action<Exception> onError;
+                lock (_postedAsyncOperations)
+                {
+                    if (_postedAsyncOperations.Count == 0)
+                        break;
+
+                    onError = _postedAsyncOperations.Dequeue().OnError;
+                }
+
+                InvokeErrorHandler(onError, new ObjectDisposedException("WorkerThread"));
+            }
         }
 
         internal void SetOperationInternal(Delegate op)
@@ -246,68 +262,98 @@ namespace Microsoft.MIDebugEngine
 
         private bool TrySetOperationInternal(Delegate op)
         {
-            lock (_eventLock)
+            bool claimed = false;
+            try
             {
-                if (_isClosed)
-                    throw new ObjectDisposedException("WorkerThread");
-
-                if (_runningOp == null)
+                lock (_eventLock)
                 {
-                    _runningOpCompleteEvent.Reset();
+                    if (_isClosed)
+                        throw new ObjectDisposedException("WorkerThread");
 
-                    OperationDescriptor runningOp = new OperationDescriptor(op);
-                    _runningOp = runningOp;
-
-                    _opSet.Set();
-
-                    _runningOpCompleteEvent.WaitOne();
-
-                    Debug.Assert(runningOp.IsComplete, "Why isn't the running op complete?");
-
-                    if (runningOp.ExceptionDispatchInfo != null)
+                    if (_runningOp == null)
                     {
-                        runningOp.ExceptionDispatchInfo.Throw();
-                    }
+                        _runningOpCompleteEvent.Reset();
 
-                    return true;
+                        OperationDescriptor runningOp = new OperationDescriptor(op);
+                        _runningOp = runningOp;
+
+                        _opSet.Set();
+
+                        _runningOpCompleteEvent.WaitOne();
+                        claimed = true;
+
+                        Debug.Assert(runningOp.IsComplete, "Why isn't the running op complete?");
+
+                        if (runningOp.ExceptionDispatchInfo != null)
+                        {
+                            runningOp.ExceptionDispatchInfo.Throw();
+                        }
+
+                        return true;
+                    }
+                }
+
+                return false;
+            }
+            finally
+            {
+                // The running-op slot was just freed and _eventLock is now released. If promotion on the poll
+                // thread lost the TryEnter race against this method, re-arm _opSet so a queued async operation
+                // is promoted immediately instead of stranded until the next unrelated wakeup.
+                if (claimed && HasPostedAsyncOperation())
+                {
+                    _opSet.Set();
                 }
             }
-
-            return false;
         }
 
         private bool TrySetOperationInternalWithProgress(AsyncProgressOperation op, string text, CancellationTokenSource canTokenSource)
         {
             var waitLoop = new HostWaitLoop(text);
 
-            lock (_eventLock)
+            bool claimed = false;
+            try
             {
-                if (_isClosed)
-                    throw new ObjectDisposedException("WorkerThread");
-
-                if (_runningOp == null)
+                lock (_eventLock)
                 {
-                    _runningOpCompleteEvent.Reset();
+                    if (_isClosed)
+                        throw new ObjectDisposedException("WorkerThread");
 
-                    OperationDescriptor runningOp = new OperationDescriptor(new AsyncOperation(() => { return op(waitLoop); }));
-                    _runningOp = runningOp;
-
-                    _opSet.Set();
-
-                    waitLoop.Wait(_runningOpCompleteEvent, canTokenSource);
-
-                    Debug.Assert(runningOp.IsComplete, "Why isn't the running op complete?");
-
-                    if (runningOp.ExceptionDispatchInfo != null)
+                    if (_runningOp == null)
                     {
-                        runningOp.ExceptionDispatchInfo.Throw();
-                    }
+                        _runningOpCompleteEvent.Reset();
 
-                    return true;
+                        OperationDescriptor runningOp = new OperationDescriptor(new AsyncOperation(() => { return op(waitLoop); }));
+                        _runningOp = runningOp;
+
+                        _opSet.Set();
+
+                        waitLoop.Wait(_runningOpCompleteEvent, canTokenSource);
+                        claimed = true;
+
+                        Debug.Assert(runningOp.IsComplete, "Why isn't the running op complete?");
+
+                        if (runningOp.ExceptionDispatchInfo != null)
+                        {
+                            runningOp.ExceptionDispatchInfo.Throw();
+                        }
+
+                        return true;
+                    }
+                }
+
+                return false;
+            }
+            finally
+            {
+                // The running-op slot was just freed and _eventLock is now released. If promotion on the poll
+                // thread lost the TryEnter race against this method, re-arm _opSet so a queued async operation
+                // is promoted immediately instead of stranded until the next unrelated wakeup.
+                if (claimed && HasPostedAsyncOperation())
+                {
+                    _opSet.Set();
                 }
             }
-
-            return false;
         }
 
         // Called on the poll thread to promote the next posted async operation into the running-op slot when it
@@ -316,7 +362,21 @@ namespace Microsoft.MIDebugEngine
         {
             Debug.Assert(IsPollThread(), "TryStartPostedAsyncOperation must run on the poll thread.");
 
-            lock (_eventLock)
+            // Cheap early-out so the poll loop does not contend on _eventLock when there is nothing to promote.
+            lock (_postedAsyncOperations)
+            {
+                if (_isClosed || _postedAsyncOperations.Count == 0)
+                    return false;
+            }
+
+            // Never block on _eventLock here: a client in TrySetOperationInternal holds it across
+            // _runningOpCompleteEvent.WaitOne() until its operation completes, and only the poll thread can
+            // complete that operation, so blocking here would deadlock. If a client is mid-set, skip promotion;
+            // it will be retried on a later poll-loop iteration or wakeup.
+            if (!Monitor.TryEnter(_eventLock))
+                return false;
+
+            try
             {
                 if (_isClosed || _runningOp != null)
                     return false;
@@ -336,6 +396,18 @@ namespace Microsoft.MIDebugEngine
                 _runningOp = new OperationDescriptor(posted.Operation) { ErrorHandler = posted.OnError };
 
                 return true;
+            }
+            finally
+            {
+                Monitor.Exit(_eventLock);
+            }
+        }
+
+        private bool HasPostedAsyncOperation()
+        {
+            lock (_postedAsyncOperations)
+            {
+                return _postedAsyncOperations.Count > 0;
             }
         }
 


### PR DESCRIPTION
AD7Engine.ContinueFromSynchronousEvent (the AD7ProgramCreateEvent path) dispatched ResumeFromLaunch through the blocking WorkerThread.RunOperation, coupling the VS UI/SDM thread to debugger I/O. Over a slow or remote (SSH) transport, AD7Engine.ContinueFromSynchronousEvent + ResumeFromLaunch could stall for a long time or indefinitely, producing a Watson hang.

- Add WorkerThread.PostAsyncOperation, a non-blocking dispatch that claims the running-op slot (so later AD7 operations still serialize behind it) but returns without waiting for completion. Faults from the operation are routed to an onError callback from both the synchronous and async completion paths.
- ContinueFromSynchronousEvent now posts ResumeFromLaunch via PostAsyncOperation and returns S_OK immediately, so the UI thread is no longer blocked. Resume faults report through SendStartDebuggingError + Terminate via onError, and synchronous failures (OnLoadComplete or the dispatch itself) are still handled locally, since the SDM drops errors returned from this method.

- [x] Built and tested locally
  - [x] Debugged through WSL Linux gdb and the async resume completed.