### PR TITLE
Don't expose a memory reference for non-pointer evaluation results

### DIFF
--- a/src/MIDebugEngine/AD7.Impl/AD7Property.cs
+++ b/src/MIDebugEngine/AD7.Impl/AD7Property.cs
@@ -230,6 +230,18 @@ namespace Microsoft.MIDebugEngine
                 return AD7_HRESULT.S_GETMEMORYCONTEXT_NO_MEMORY_CONTEXT;
             }
 
+            // Only a pointer's value is itself an address; an array re-evaluates to its
+            // address below. For any other type (e.g. a plain int) the value is not an
+            // address, so expose no memory reference - otherwise a scalar value like "1"
+            // is misinterpreted as the address 0x1.
+            bool isArrayValue = v[0] == '[' && v[v.Length - 1] == ']';
+            string typeName = _variableInformation.TypeName;
+            bool isPointer = !string.IsNullOrEmpty(typeName) && typeName.TrimEnd().EndsWith("*", StringComparison.Ordinal);
+            if (!isArrayValue && !isPointer)
+            {
+                return AD7_HRESULT.S_GETMEMORYCONTEXT_NO_MEMORY_CONTEXT;
+            }
+
             if ((v[0] == '[') && (v[v.Length-1] == ']'))
             {
                 // this is an array evaluation result from GDB, which does not contain an address


### PR DESCRIPTION
## Problem

In a debug data-tip (or the Variables view), hovering a **non-pointer** scalar shows the value correctly but attaches a `memoryReference`, so VS Code renders the "view binary data" hex icon and clicking it navigates to an address equal to the value. For example, hovering a `uint32_t stsdig` whose value is `1` offers a memory view that opens at address `0x1`.

## Cause

`AD7Property.GetMemoryContext` (`src/MIDebugEngine/AD7.Impl/AD7Property.cs`) tries to interpret the result's **display value** as a memory address, for every type:

```csharp
// try to interpret the result as an address
string v = _variableInformation.Value;
...
UInt64.TryParse(v, NumberStyles.Any, ...)   // "1" -> addr = 1
ppMemory = new AD7MemoryAddress(_engine, addr, null);
```

For a pointer this is correct — the value *is* an address (`0x...`). For a plain scalar (e.g. `int`/`uint32_t`) the value is a number, not an address, so `UInt64.TryParse("1")` succeeds and the memory reference becomes `0x1`. OpenDebugAD7 then reports that as `memoryReference` on the `evaluate`/`variables` response, and VS Code's memory navigation goes to address `1`.

## Fix

Only treat the value as an address when the result is a pointer (or an array, which already re-evaluates to its address with `&(...)` further down). For any other type, return `S_GETMEMORYCONTEXT_NO_MEMORY_CONTEXT` so no `memoryReference` is reported and no spurious memory icon/navigation appears.

```csharp
bool isArrayValue = v[0] == '[' && v[v.Length - 1] == ']';
string typeName = _variableInformation.TypeName;
bool isPointer = !string.IsNullOrEmpty(typeName) && typeName.TrimEnd().EndsWith("*", StringComparison.Ordinal);
if (!isArrayValue && !isPointer)
{
    return AD7_HRESULT.S_GETMEMORYCONTEXT_NO_MEMORY_CONTEXT;
}
```

`TypeName` is already on `IVariableInformation`, and the same `EndsWith("*")` pointer test is used elsewhere in `Variables.cs` (`IsPointer`).

## Testing

Built the patched engine and ran it against a live `cppdbg`/gdb session:
- Pointer (`int32_t *`, `const uint32_t *`) — still shows its address and the memory icon, unchanged.
- Scalar (`uint32_t`) — now shows just the value, with no memory icon and no navigation to `0x<value>`.
- Array — unchanged (still resolves to its base address via the existing `&(...)` path).

Note: the change was written with the help of an LLM and verified manually in VS Code against a real gdb target.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
