### PR TITLE
handle synthetic frames produced by GDB FrameFilter without a level

### DIFF
--- a/src/MIDebugEngine/AD7.Impl/AD7StackFrame.cs
+++ b/src/MIDebugEngine/AD7.Impl/AD7StackFrame.cs
@@ -345,6 +345,13 @@ namespace Microsoft.MIDebugEngine
 
         private void CreateRegisterContent(enum_DEBUGPROP_INFO_FLAGS dwFields, out uint elementsReturned, out IEnumDebugPropertyInfo2 enumObject)
         {
+            if (ThreadContext.Level == null)
+            {
+                elementsReturned = 0;
+                enumObject = new AD7PropertyInfoEnum(Array.Empty<DEBUG_PROPERTY_INFO>());
+                return;
+            }
+
             IReadOnlyCollection<RegisterGroup> registerGroups = Engine.DebuggedProcess.GetRegisterGroups();
 
             elementsReturned = (uint)registerGroups.Count;
@@ -352,7 +359,7 @@ namespace Microsoft.MIDebugEngine
             Tuple<int, string>[] values = null;
             Engine.DebuggedProcess.WorkerThread.RunOperation(async () =>
             {
-                values = await Engine.DebuggedProcess.GetRegisters(Thread.GetDebuggedThread().Id, ThreadContext.Level);
+                values = await Engine.DebuggedProcess.GetRegisters(Thread.GetDebuggedThread().Id, ThreadContext.Level.Value);
             });
             int i = 0;
             foreach (var grp in registerGroups)
@@ -366,10 +373,16 @@ namespace Microsoft.MIDebugEngine
 
         public string EvaluateExpression(string expr)
         {
+            if (ThreadContext.Level == null)
+            {
+                return null;
+            }
+            uint level = ThreadContext.Level.Value;
+
             string val = null;
             Engine.DebuggedProcess.WorkerThread.RunOperation(async () =>
             {
-                val = await Engine.DebuggedProcess.MICommandFactory.DataEvaluateExpression(expr, Thread.Id, ThreadContext.Level);
+                val = await Engine.DebuggedProcess.MICommandFactory.DataEvaluateExpression(expr, Thread.Id, level);
             });
             return val;
         }

--- a/src/MIDebugEngine/AD7.Impl/AD7Thread.cs
+++ b/src/MIDebugEngine/AD7.Impl/AD7Thread.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Text;
 using Microsoft.VisualStudio.Debugger.Interop;
 using System.Diagnostics;
@@ -127,21 +128,23 @@ namespace Microsoft.MIDebugEngine
                 int numStackFrames = stackFrames != null ? stackFrames.Count : 0;
                 FRAMEINFO[] frameInfoArray;
 
-                if (numStackFrames == 0)
+                // -stack-list-arguments is a frame-relative command. If we walked no frames, or
+                // none of them carries a level (e.g. every frame is a GDB synthetic frame-filter
+                // frame), there is nothing addressable to query.
+                if (numStackFrames == 0 || !stackFrames.Any(f => f.Level != null))
                 {
-                    // failed to walk any frames. Return an empty stack.
+                    // failed to walk any real frames. Return an empty stack.
                     frameInfoArray = new FRAMEINFO[0];
                 }
                 else
                 {
-                    // -stack-list-arguments takes a low/high *frame number* range. When a Python
-                    // frame filter is active, those numbers index the decorated stack (synthetic
-                    // frames are counted but carry no level), which is the same order as
-                    // stackFrames here. So request the whole [0, count-1] range rather than a
-                    // range of levels: a level-based range would stop at the first synthetic
-                    // frame and miss every real frame below it. Synthetic frames in the range
-                    // have no arguments and are skipped in GetParameterInfoOnly, and results are
-                    // matched back to frames by level below, so ordering within the range is moot.
+                    // -stack-list-arguments takes a low/high *frame index* range. When a GDB Python
+                    // frame filter is active, those numbers index the decorated stack, not the GDB frame
+                    // level. Thus, synthetic frames are indexed even though they carry no level, and we
+                    // must request the whole [0, count-1] decorated range.
+                    // Synthetic frames in the range have no arguments and are skipped in
+                    // GetParameterInfoOnly, and results are matched back to frames by level below,
+                    // so ordering within the range is moot.
                     uint low = 0;
                     uint high = (uint)(stackFrames.Count - 1);
                     FilterUnknownFrames(stackFrames);

--- a/src/MIDebugEngine/AD7.Impl/AD7Thread.cs
+++ b/src/MIDebugEngine/AD7.Impl/AD7Thread.cs
@@ -128,12 +128,9 @@ namespace Microsoft.MIDebugEngine
                 int numStackFrames = stackFrames != null ? stackFrames.Count : 0;
                 FRAMEINFO[] frameInfoArray;
 
-                // -stack-list-arguments is a frame-relative command. If we walked no frames, or
-                // none of them carries a level (e.g. every frame is a GDB synthetic frame-filter
-                // frame), there is nothing addressable to query.
-                if (numStackFrames == 0 || !stackFrames.Any(f => f.Level != null))
+                if (numStackFrames == 0)
                 {
-                    // failed to walk any real frames. Return an empty stack.
+                    // failed to walk any frames. Return an empty stack.
                     frameInfoArray = new FRAMEINFO[0];
                 }
                 else
@@ -152,7 +149,8 @@ namespace Microsoft.MIDebugEngine
                     frameInfoArray = new FRAMEINFO[numStackFrames];
                     List<ArgumentList> parameters = null;
 
-                    if ((dwFieldSpec & enum_FRAMEINFO_FLAGS.FIF_FUNCNAME_ARGS) != 0 && !_engine.DebuggedProcess.MICommandFactory.SupportsFrameFormatting)
+                    if ((dwFieldSpec & enum_FRAMEINFO_FLAGS.FIF_FUNCNAME_ARGS) != 0 && !_engine.DebuggedProcess.MICommandFactory.SupportsFrameFormatting
+                        && stackFrames.Any(f => f.Level != null))
                     {
                         _engine.DebuggedProcess.WorkerThread.RunOperation(async () => parameters = await _engine.DebuggedProcess.GetParameterInfoOnly(this, (dwFieldSpec & enum_FRAMEINFO_FLAGS.FIF_FUNCNAME_ARGS_VALUES) != 0,
                             (dwFieldSpec & enum_FRAMEINFO_FLAGS.FIF_FUNCNAME_ARGS_TYPES) != 0, low, high));

--- a/src/MIDebugEngine/AD7.Impl/AD7Thread.cs
+++ b/src/MIDebugEngine/AD7.Impl/AD7Thread.cs
@@ -134,8 +134,16 @@ namespace Microsoft.MIDebugEngine
                 }
                 else
                 {
-                    uint low = stackFrames[0].Level;
-                    uint high = stackFrames[stackFrames.Count - 1].Level;
+                    // -stack-list-arguments takes a low/high *frame number* range. When a Python
+                    // frame filter is active, those numbers index the decorated stack (synthetic
+                    // frames are counted but carry no level), which is the same order as
+                    // stackFrames here. So request the whole [0, count-1] range rather than a
+                    // range of levels: a level-based range would stop at the first synthetic
+                    // frame and miss every real frame below it. Synthetic frames in the range
+                    // have no arguments and are skipped in GetParameterInfoOnly, and results are
+                    // matched back to frames by level below, so ordering within the range is moot.
+                    uint low = 0;
+                    uint high = (uint)(stackFrames.Count - 1);
                     FilterUnknownFrames(stackFrames);
                     numStackFrames = stackFrames.Count;
                     frameInfoArray = new FRAMEINFO[numStackFrames];

--- a/src/MIDebugEngine/Engine.Impl/DebuggedProcess.cs
+++ b/src/MIDebugEngine/Engine.Impl/DebuggedProcess.cs
@@ -1989,7 +1989,13 @@ namespace Microsoft.MIDebugEngine
         {
             List<VariableInformation> variables = new List<VariableInformation>();
 
-            ValueListValue localsAndParameters = await MICommandFactory.StackListVariables(PrintValue.NoValues, thread.Id, ctx.Level);
+            if (ctx.Level == null)
+            {
+                return variables;
+            }
+            uint level = ctx.Level.Value;
+
+            ValueListValue localsAndParameters = await MICommandFactory.StackListVariables(PrintValue.NoValues, thread.Id, level);
 
             foreach (var localOrParamResult in localsAndParameters.Content)
             {
@@ -2000,7 +2006,7 @@ namespace Microsoft.MIDebugEngine
                 variables.Add(vi);
             }
 
-            if (ReturnValue != null && ctx.Level == 0 && ReturnValue.Client.Id == thread.Id)
+            if (ReturnValue != null && level == 0 && ReturnValue.Client.Id == thread.Id)
                 variables.Add(ReturnValue);
 
             return variables;
@@ -2012,7 +2018,12 @@ namespace Microsoft.MIDebugEngine
         {
             List<SimpleVariableInformation> parameters = new List<SimpleVariableInformation>();
 
-            ValueListValue localAndParameters = await MICommandFactory.StackListVariables(PrintValue.SimpleValues, thread.Id, ctx.Level);
+            if (ctx.Level == null)
+            {
+                return parameters;
+            }
+
+            ValueListValue localAndParameters = await MICommandFactory.StackListVariables(PrintValue.SimpleValues, thread.Id, ctx.Level.Value);
 
             foreach (var results in localAndParameters.Content.Where(r => r.TryFindString("arg") == "1"))
             {

--- a/src/MIDebugEngine/Engine.Impl/DebuggedProcess.cs
+++ b/src/MIDebugEngine/Engine.Impl/DebuggedProcess.cs
@@ -2050,7 +2050,15 @@ namespace Microsoft.MIDebugEngine
 
             foreach (var f in frames)
             {
-                int level = f.FindInt("level");
+                // Synthetic frames injected by a GDB Python frame filter have no "level" field.
+                // GDB doesn't support querying them by level either, so their argument lists
+                // can't be retrieved. Just skip them instead of failing the whole stack walk.
+                uint? levelOpt = f.TryFindUint("level");
+                if (levelOpt == null)
+                {
+                    continue;
+                }
+                int level = (int)levelOpt.Value;
                 ListValue argList = null;
                 f.TryFind<ListValue>("args", out argList);
                 List<SimpleVariableInformation> args = new List<SimpleVariableInformation>();

--- a/src/MIDebugEngine/Engine.Impl/DebuggedThread.cs
+++ b/src/MIDebugEngine/Engine.Impl/DebuggedThread.cs
@@ -300,15 +300,15 @@ namespace Microsoft.MIDebugEngine
             else
             {
                 stack = new List<ThreadContext>();
-                for (uint i = 0; i < frameinfo.Length; i++)
+                foreach (var frame in frameinfo)
                 {
-                    stack.Add(CreateContext(frameinfo[i], i));
+                    stack.Add(CreateContext(frame));
                 }
             }
             return stack;
         }
 
-        private ThreadContext CreateContext(TupleValue frame, uint index)
+        private ThreadContext CreateContext(TupleValue frame)
         {
             ulong? pc = frame.TryFindAddr("addr");
 
@@ -325,13 +325,12 @@ namespace Microsoft.MIDebugEngine
             MITextPosition textPosition = !ignoreSource ? MITextPosition.TryParse(this._debugger, frame) : null;
 
             string func = frame.TryFindString("func");
-            // Synthetic frames injected by a GDB Python frame filter do not carry a "level" field.
-            // Fall back to the frame's position in the stack so the whole stack walk doesn't fail.
-            // Real frames keep their true level (GDB's own -stack-list-* numbering ignores the synthetic frames).
-            // This can produce duplicate levels (async collides with the real frame below it), but
-            // the level is only used to get locals of the frame, and synthetic frame locals can't be displayed
-            // anyway, so it behaves as a graceful fallback, displaying the locals of the real frame below.
-            uint level = frame.TryFindUint("level") ?? index;
+            // Synthetic frames injected by a GDB Python frame filter (e.g. an async-stack
+            // decorator) do not carry a "level" field, since they have no underlying debugger
+            // frame. Leave the level null in that case; frame-relative operations (locals,
+            // args, registers, evaluation) early-out on a null level rather than failing the
+            // whole stack walk. Real frames keep their true level.
+            uint? level = frame.TryFindUint("level");
             string from = frame.TryFindString("from");
 
             return new ThreadContext(pc, textPosition, func, level, from);
@@ -450,7 +449,7 @@ namespace Microsoft.MIDebugEngine
                         if (frames.Any())
                         {
                             List<ThreadContext> stack = new List<ThreadContext>();
-                            stack.AddRange(frames.Select((frame, i) => CreateContext(frame, (uint)i)));
+                            stack.AddRange(frames.Select(frame => CreateContext(frame)));
 
                             _topContext[threadId] = stack[0];
                             if (threadId == cxtThreadId)

--- a/src/MIDebugEngine/Engine.Impl/DebuggedThread.cs
+++ b/src/MIDebugEngine/Engine.Impl/DebuggedThread.cs
@@ -300,15 +300,15 @@ namespace Microsoft.MIDebugEngine
             else
             {
                 stack = new List<ThreadContext>();
-                foreach (var frame in frameinfo)
+                for (uint i = 0; i < frameinfo.Length; i++)
                 {
-                    stack.Add(CreateContext(frame));
+                    stack.Add(CreateContext(frameinfo[i], i));
                 }
             }
             return stack;
         }
 
-        private ThreadContext CreateContext(TupleValue frame)
+        private ThreadContext CreateContext(TupleValue frame, uint index)
         {
             ulong? pc = frame.TryFindAddr("addr");
 
@@ -325,7 +325,13 @@ namespace Microsoft.MIDebugEngine
             MITextPosition textPosition = !ignoreSource ? MITextPosition.TryParse(this._debugger, frame) : null;
 
             string func = frame.TryFindString("func");
-            uint level = frame.FindUint("level");
+            // Synthetic frames injected by a GDB Python frame filter do not carry a "level" field.
+            // Fall back to the frame's position in the stack so the whole stack walk doesn't fail.
+            // Real frames keep their true level (GDB's own -stack-list-* numbering ignores the synthetic frames).
+            // This can produce duplicate levels (async collides with the real frame below it), but
+            // the level is only used to get locals of the frame, and synthetic frame locals can't be displayed
+            // anyway, so it behaves as a graceful fallback, displaying the locals of the real frame below.
+            uint level = frame.TryFindUint("level") ?? index;
             string from = frame.TryFindString("from");
 
             return new ThreadContext(pc, textPosition, func, level, from);
@@ -444,7 +450,7 @@ namespace Microsoft.MIDebugEngine
                         if (frames.Any())
                         {
                             List<ThreadContext> stack = new List<ThreadContext>();
-                            stack.AddRange(frames.Select(frame => CreateContext(frame)));
+                            stack.AddRange(frames.Select((frame, i) => CreateContext(frame, (uint)i)));
 
                             _topContext[threadId] = stack[0];
                             if (threadId == cxtThreadId)

--- a/src/MIDebugEngine/Engine.Impl/Structures.cs
+++ b/src/MIDebugEngine/Engine.Impl/Structures.cs
@@ -12,7 +12,7 @@ namespace Microsoft.MIDebugEngine
 {
     internal class ThreadContext
     {
-        public ThreadContext(ulong? addr, MITextPosition textPosition, string function, uint level, string from)
+        public ThreadContext(ulong? addr, MITextPosition textPosition, string function, uint? level, string from)
         {
             pc = addr;
             sp = 0;
@@ -32,7 +32,14 @@ namespace Microsoft.MIDebugEngine
 
         public string From { get; private set; }
 
-        public uint Level { get; private set; }
+        /// <summary>
+        /// [Optional] The GDB/LLDB frame level. This is null for synthetic frames
+        /// injected by a Python frame filter (e.g. an async-stack decorator): those
+        /// frames have no underlying debugger frame, so they carry no level and cannot
+        /// be targeted by frame-relative MI commands (locals, args, registers, eval).
+        /// Callers that pass the level to the debugger must early-out when it is null.
+        /// </summary>
+        public uint? Level { get; private set; }
 
         /// <summary>
         /// Finds the module for this context

--- a/src/MIDebugEngine/Engine.Impl/Variables.cs
+++ b/src/MIDebugEngine/Engine.Impl/Variables.cs
@@ -587,7 +587,7 @@ namespace Microsoft.MIDebugEngine
 
             if (_ctx.Level == null)
             {
-                throw GetEvalUnsupportedInFrameException();
+                throw GetEvalUnsupportedInFrameException("-data-evaluate-expression");
             }
             uint frameLevel = _ctx.Level.Value;
 
@@ -925,7 +925,7 @@ namespace Microsoft.MIDebugEngine
             Error = true;
         }
 
-        private Exception GetEvalUnsupportedInFrameException() => new UnexpectedMIResultException(_debuggedProcess.MICommandFactory.Name, "-data-evaluate-expression", ResourceStrings.ExpressionEvalUnsupportedInFrame);
+        private Exception GetEvalUnsupportedInFrameException(string command) => new UnexpectedMIResultException(_debuggedProcess.MICommandFactory.Name, command, ResourceStrings.ExpressionEvalUnsupportedInFrame);
 
         private bool IsArrayType()
         {
@@ -976,7 +976,7 @@ namespace Microsoft.MIDebugEngine
 
             if (_ctx.Level == null)
             {
-                throw GetEvalUnsupportedInFrameException();
+                throw GetEvalUnsupportedInFrameException("-var-assign");
             }
 
             _engine.DebuggedProcess.WorkerThread.RunOperation(async () =>

--- a/src/MIDebugEngine/Engine.Impl/Variables.cs
+++ b/src/MIDebugEngine/Engine.Impl/Variables.cs
@@ -585,10 +585,16 @@ namespace Microsoft.MIDebugEngine
         {
             this.VerifyNotDisposed();
 
+            if (_ctx.Level == null)
+            {
+                return null;
+            }
+            uint frameLevel = _ctx.Level.Value;
+
             string val = null;
             Task eval = Task.Run(async () =>
             {
-                val = await _engine.DebuggedProcess.MICommandFactory.DataEvaluateExpression(expr, Client.GetDebuggedThread().Id, _ctx.Level);
+                val = await _engine.DebuggedProcess.MICommandFactory.DataEvaluateExpression(expr, Client.GetDebuggedThread().Id, frameLevel);
             });
             eval.Wait();
             return val;
@@ -633,7 +639,15 @@ namespace Microsoft.MIDebugEngine
                     }
 
                     int threadId = Client.GetDebuggedThread().Id;
-                    uint frameLevel = _ctx.Level;
+
+                    // Synthetic frames injected by a Python frame filter have no level and provide
+                    // no evaluation context. This is normally unreachable (annotated frames expose
+                    // no expression context), but guard defensively rather than crash on a null level.
+                    if (_ctx.Level == null)
+                    {
+                        return;
+                    }
+                    uint frameLevel = _ctx.Level.Value;
 
                     string expression = _strippedName;
 
@@ -957,10 +971,15 @@ namespace Microsoft.MIDebugEngine
         {
             this.VerifyNotDisposed();
 
+            if (_ctx.Level == null)
+            {
+                return;
+            }
+
             _engine.DebuggedProcess.WorkerThread.RunOperation(async () =>
             {
                 int threadId = Client.GetDebuggedThread().Id;
-                uint frameLevel = _ctx.Level;
+                uint frameLevel = _ctx.Level.Value;
 
                 _engine.DebuggedProcess.FlushBreakStateData();
                 Value = await _engine.DebuggedProcess.MICommandFactory.VarAssign(_internalName, expression, threadId, frameLevel);

--- a/src/MIDebugEngine/Engine.Impl/Variables.cs
+++ b/src/MIDebugEngine/Engine.Impl/Variables.cs
@@ -587,7 +587,7 @@ namespace Microsoft.MIDebugEngine
 
             if (_ctx.Level == null)
             {
-                return null;
+                throw GetEvalUnsupportedInFrameException();
             }
             uint frameLevel = _ctx.Level.Value;
 
@@ -645,6 +645,7 @@ namespace Microsoft.MIDebugEngine
                     // no expression context), but guard defensively rather than crash on a null level.
                     if (_ctx.Level == null)
                     {
+                        SetAsError(ResourceStrings.ExpressionEvalUnsupportedInFrame);
                         return;
                     }
                     uint frameLevel = _ctx.Level.Value;
@@ -924,6 +925,8 @@ namespace Microsoft.MIDebugEngine
             Error = true;
         }
 
+        private Exception GetEvalUnsupportedInFrameException() => new UnexpectedMIResultException(_debuggedProcess.MICommandFactory.Name, "-data-evaluate-expression", ResourceStrings.ExpressionEvalUnsupportedInFrame);
+
         private bool IsArrayType()
         {
             if (DisplayHint == "array")
@@ -973,7 +976,7 @@ namespace Microsoft.MIDebugEngine
 
             if (_ctx.Level == null)
             {
-                return;
+                throw GetEvalUnsupportedInFrameException();
             }
 
             _engine.DebuggedProcess.WorkerThread.RunOperation(async () =>

--- a/src/MIDebugEngine/Natvis.Impl/VisualizationCache.cs
+++ b/src/MIDebugEngine/Natvis.Impl/VisualizationCache.cs
@@ -21,7 +21,10 @@ namespace Microsoft.MIDebugEngine.Natvis
             {
                 _name = variable.FullName();
                 _threadId = variable.Client.Id;
-                _level = (int)variable.ThreadContext.Level;
+                // Variables only ever come from real (level-bearing) frames; synthetic frames
+                // from a Python frame filter expose no locals to visualize. Fall back to 0 to
+                // keep the key total in the null case rather than throwing.
+                _level = (int)(variable.ThreadContext.Level ?? 0);
             }
 
             public VisualizerKey(string name, int threadId, int level)

--- a/src/MIDebugEngine/Natvis.Impl/VisualizationCache.cs
+++ b/src/MIDebugEngine/Natvis.Impl/VisualizationCache.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
@@ -24,6 +25,7 @@ namespace Microsoft.MIDebugEngine.Natvis
                 // Variables only ever come from real (level-bearing) frames; synthetic frames
                 // from a Python frame filter expose no locals to visualize. Fall back to 0 to
                 // keep the key total in the null case rather than throwing.
+                Debug.Assert(variable.ThreadContext.Level.HasValue, "How are we getting a variable from a synthetic thread context?");
                 _level = (int)(variable.ThreadContext.Level ?? 0);
             }
 

--- a/src/MIDebugEngine/ResourceStrings.Designer.cs
+++ b/src/MIDebugEngine/ResourceStrings.Designer.cs
@@ -210,7 +210,16 @@ namespace Microsoft.MIDebugEngine {
                 return ResourceManager.GetString("ExceptionSettingsError", resourceCulture);
             }
         }
-        
+
+        /// <summary>
+        ///   Looks up a localized string similar to Expression evaluation is unavailable in the current frame.
+        /// </summary>
+        internal static string ExpressionEvalUnsupportedInFrame {
+            get {
+                return ResourceManager.GetString("ExpressionEvalUnsupportedInFrame", resourceCulture);
+            }
+        }
+
         /// <summary>
         ///   Looks up a localized string similar to Error: {0}.
         /// </summary>

--- a/src/MIDebugEngine/ResourceStrings.resx
+++ b/src/MIDebugEngine/ResourceStrings.resx
@@ -132,6 +132,9 @@
   <data name="ExceptionSettingsError" xml:space="preserve">
     <value>Error while updating exception settings. {0}</value>
   </data>
+  <data name="ExpressionEvalUnsupportedInFrame" xml:space="preserve">
+    <value>Expression evaluation is unavailable in the current frame</value>
+  </data>
   <data name="FileNotFound" xml:space="preserve">
     <value>File not found: {0}</value>
   </data>


### PR DESCRIPTION
Synthetic frames produced by GDB's FrameFilter, e.g. async stack backtraces for C++20 coroutines produced by a [GDB script](https://github.com/tzcnt/tmc-examples/blob/backtrace/coro_backtrace_gdb.py) do not have a Level, and cannot be assigned a Level with the current version of GDB. Attempting to set a breakpoint inside of an async stack then causes an error when walking the synthetic backtrace:

```
ERROR: Error while trying to enter break state. Debugging will now stop. Unrecognized format of field "level" in result: {addr=0x000055555555fef0,func=[async] main::$_0::operator()(unsigned long) const [clone .destroy],file=<file>,line=80,arch=i386:x86-64}
```

This PR updates MIEngine’s callstack and expression-evaluation paths to tolerate GDB FrameFilter “synthetic” frames that omit the `level` field, avoiding stack-walk failures and guarding frame-relative MI commands (locals/args/registers/eval) when the frame is not addressable by level.

**Changes:**
- Make `ThreadContext.Level` nullable and update stack walking/parsing to allow frames without `level`.
- Add defensive guards across locals/args/registers/expression evaluation paths when `Level == null`.
- Introduce a user-facing resource string for unsupported evaluation scenarios in non-level-bearing frames.
