### PR TITLE
Auto-deploy debug adapter when building CppTests

### DIFF
--- a/.github/workflows/Build-And-Test.yml
+++ b/.github/workflows/Build-And-Test.yml
@@ -39,7 +39,7 @@ jobs:
 
     - name: Build MIDebugEngine
       run: |
-        ${{ github.workspace }}/eng/Scripts/CI-Build.cmd -c $env:Configuration -t vs
+        ${{ github.workspace }}/eng/Scripts/CI-Build.cmd -c $env:Configuration
       env:
         Configuration: ${{ matrix.configuration }}
 
@@ -71,7 +71,7 @@ jobs:
 
     - name: Build MIDebugEngine
       run: |
-        ${{ github.workspace }}/eng/Scripts/CI-Build.cmd -t vscode
+        ${{ github.workspace }}/eng/Scripts/CI-Build.cmd
 
     - name: Copy Test Configuration
       run: |

--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,4 @@ project.lock.json
 src/*/*.nuget.props
 src/*/*.nuget.targets
 .DS_Store
+test/CppTests/config.xml

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+    "dotnet.defaultSolution": "src/MIDebugEngine-Unix.sln"
+}

--- a/build/Debugger.PIAs.Portable.Packages.settings.targets
+++ b/build/Debugger.PIAs.Portable.Packages.settings.targets
@@ -1,4 +1,6 @@
-<!-- If you add this file to a project, make sure you add a dependency to MakePIAPortable -->
+<!-- Adding a build dependency to MakePIAPortable so that the PIA assemblies are generated
+     before any project that references them is compiled. This enables building individual 
+     projects (e.g. via 'dotnet build') without relying on solution-level build ordering. -->
 
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
     <!--  'package_versions.settings.targets' must have been imported before importing this file. -->
@@ -14,5 +16,9 @@
         <Reference Include="$(MIDefaultOutputPath)PIA\drop\Microsoft.VisualStudio.Debugger.Interop.12.0.dll" />
         <Reference Include="$(MIDefaultOutputPath)PIA\drop\Microsoft.VisualStudio.Debugger.InteropA.dll" />
         <Reference Include="$(MIDefaultOutputPath)PIA\drop\Microsoft.VisualStudio.Interop.dll" />
+    </ItemGroup>
+
+    <ItemGroup Label="PIA Build Dependency">
+        <ProjectReference Include="$(MIEngineRoot)src\MakePIAPortable\MakePIAPortable.csproj" ReferenceOutputAssembly="false" Private="false" SkipGetTargetFrameworkProperties="true" />
     </ItemGroup>
 </Project>

--- a/docs/Building-outside-of-VS-for-AI.md
+++ b/docs/Building-outside-of-VS-for-AI.md
@@ -21,16 +21,10 @@ From a VS Developer Command Prompt or after putting `MSBuild.exe` on `PATH`:
 
 ```powershell
 # Debug, VS extension flavor (default)
-eng\Scripts\CI-Build.ps1 -Configuration Debug -TargetPlatform vs
-
-# Debug, VS Code adapter flavor (also publishes OpenDebugAD7 + native deps to
-# bin\DebugAdapterProtocolTests\Debug\extension\debugAdapters)
-eng\Scripts\CI-Build.ps1 -Configuration Debug -TargetPlatform vscode
+eng\Scripts\CI-Build.ps1 -Configuration Debug
 ```
 
-The script restores NuGet, builds `MIDebugEngine.sln` with `msbuild`, and (for `-TargetPlatform vscode`) `dotnet publish`es OpenDebugAD7 and stages the adapter under `bin\DebugAdapterProtocolTests\<Configuration>\extension\debugAdapters`.
-
-If `msbuild.exe` isn't on `PATH`, locate it with vswhere:
+The script restores NuGet, builds `MIDebugEngine.sln` with `msbuild`. If `msbuild.exe` isn't on `PATH`, locate it with vswhere:
 
 ```powershell
 $msbuild = & "${env:ProgramFiles(x86)}\Microsoft Visual Studio\Installer\vswhere.exe" -latest -prerelease -requires Microsoft.Component.MSBuild -find "MSBuild\**\Bin\MSBuild.exe"
@@ -43,7 +37,7 @@ $env:Path = (Split-Path $msbuild) + ';' + $env:Path
 eng/Scripts/CI-Build.sh
 ```
 
-This runs `dotnet build src/MIDebugEngine-Unix.sln` and then `PublishOpenDebugAD7.sh -c Debug -o bin/DebugAdapterProtocolTests/Debug/extension/debugAdapters`.
+This runs `dotnet build src/MIDebugEngine-Unix.sln`
 
 ## Outputs
 

--- a/docs/RunningCppTests-outside-of-VS-for-AI.md
+++ b/docs/RunningCppTests-outside-of-VS-for-AI.md
@@ -35,7 +35,7 @@
 
    - **macOS:** `lldb-mi` is downloaded by `tools/DownloadLldbMI.sh`; CI does this automatically inside `eng/Scripts/CI-Test.sh`.
 
-3. A `config.xml` next to `CppTests.csproj`. Pick the right template from `bin/DebugAdapterProtocolTests/<Configuration>/CppTests/TestConfigurations/` and copy it as `config.xml`:
+3. A `config.xml` next to `CppTests.csproj`. Pick the right template from `test\CppTests\TestConfigurations` and copy it as `config.xml`:
 
    | Platform / debugger | Template |
    | --- | --- |

--- a/docs/RunningCppTests-outside-of-VS-for-AI.md
+++ b/docs/RunningCppTests-outside-of-VS-for-AI.md
@@ -9,11 +9,11 @@
 1. A VSCode-flavor build (see [Building-outside-of-VS-for-AI.md](Building-outside-of-VS-for-AI.md)):
 
    ```powershell
-   eng\Scripts\CI-Build.ps1 -Configuration Debug -TargetPlatform vscode    # Windows
+   eng\Scripts\CI-Build.ps1   # Windows
    ```
 
    ```bash
-   eng/Scripts/CI-Build.sh                                                  # Linux / macOS
+   eng/Scripts/CI-Build.sh    # Linux / macOS
    ```
 
 2. A native toolchain for the test debuggees:
@@ -35,7 +35,7 @@
 
    - **macOS:** `lldb-mi` is downloaded by `tools/DownloadLldbMI.sh`; CI does this automatically inside `eng/Scripts/CI-Test.sh`.
 
-3. A `config.xml` next to `CppTests.dll`. Pick the right template from `bin/DebugAdapterProtocolTests/<Configuration>/CppTests/TestConfigurations/` and copy it as `config.xml`:
+3. A `config.xml` next to `CppTests.csproj`. Pick the right template from `bin/DebugAdapterProtocolTests/<Configuration>/CppTests/TestConfigurations/` and copy it as `config.xml`:
 
    | Platform / debugger | Template |
    | --- | --- |

--- a/eng/Scripts/CI-Build.ps1
+++ b/eng/Scripts/CI-Build.ps1
@@ -1,15 +1,7 @@
 param(
 [ValidateSet("Debug", "Release")]
 [Alias("c")]
-[string]$Configuration="Debug",
-
-[ValidateSet("win-x86", "win-arm64")]
-[Alias("r")]
-[string]$RID="win-x86",
-
-[ValidateSet("vs", "vscode")]
-[Alias("t")]
-[string]$TargetPlatform="vs"
+[string]$Configuration="Debug"
 )
 
 $ErrorActionPreference="Stop"
@@ -31,24 +23,4 @@ msbuild $RootPath\src\MIDebugEngine.sln /p:Configuration=$Configuration
 if ($lastexitcode -ne 0)
 {
     throw "Failed to build MIDebugEngine.sln"
-}
-
-
-if ($TargetPlatform -eq "vscode")
-{
-    $dotnetPath = (Get-Command dotnet.exe -ErrorAction Ignore).Path;
-
-    if (!$dotnetPath) {
-        throw "Missing .NET SDK. Please install the SDK at https://dotnet.microsoft.com/download"
-    }
-
-    dotnet publish $RootPath\src\OpenDebugAD7\OpenDebugAD7.csproj -c $Configuration -r $RID --self-contained -o $RootPath\bin\DebugAdapterProtocolTests\$Configuration\extension\debugAdapters
-    if ($lastexitcode -ne 0)
-    {
-        throw "Failed to publish OpenDebugAD7"
-    }
-
-    Copy-Item $RootPath\bin\$Configuration\Microsoft.MIDebugEngine.dll $RootPath\bin\DebugAdapterProtocolTests\$Configuration\extension\debugAdapters/.
-    Copy-Item $RootPath\bin\$Configuration\Microsoft.MICore.dll $RootPath\bin\DebugAdapterProtocolTests\$Configuration\extension\debugAdapters\.
-    Copy-Item $RootPath\bin\$Configuration\vscode\WindowsDebugLauncher.exe $RootPath\bin\DebugAdapterProtocolTests\$Configuration\extension\debugAdapters\.
 }

--- a/eng/Scripts/CI-Build.sh
+++ b/eng/Scripts/CI-Build.sh
@@ -13,9 +13,4 @@ if ! dotnet build "$RootDir"/src/MIDebugEngine-Unix.sln; then
     exit 1
 fi 
 
-if ! "$RootDir"/PublishOpenDebugAD7.sh -c Debug -o "$RootDir"/bin/DebugAdapterProtocolTests/Debug/extension/debugAdapters; then
-    echo "ERROR: Failed to build MIDebugEngine-Unix.sln"
-    exit 1
-fi 
-
 exit 0

--- a/src/MIDebugEngine-Unix.sln
+++ b/src/MIDebugEngine-Unix.sln
@@ -36,9 +36,6 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "DebugEngineHost.VSCode", "D
 	EndProjectSection
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "MakePIAPortable", "MakePIAPortable\MakePIAPortable.csproj", "{114039A0-87B5-425B-90C9-6AFC1960A247}"
-	ProjectSection(ProjectDependencies) = postProject
-		{CC5BDD33-7EB1-4FB9-BC67-806773018989} = {CC5BDD33-7EB1-4FB9-BC67-806773018989}
-	EndProjectSection
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "DebugAdapterProtocolTests", "DebugAdapterProtocolTests", "{9D97EF1A-BCD5-4932-BBCC-98194CF8A841}"
 EndProject

--- a/src/MIDebugEngine.sln
+++ b/src/MIDebugEngine.sln
@@ -64,9 +64,6 @@ EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "WindowsDebugLauncher", "WindowsDebugLauncher\WindowsDebugLauncher.csproj", "{AE7F97CA-DFD2-41BC-B581-98C91C83065C}"
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "MakePIAPortable", "MakePIAPortable\MakePIAPortable.csproj", "{114039A0-87B5-425B-90C9-6AFC1960A247}"
-	ProjectSection(ProjectDependencies) = postProject
-		{CC5BDD33-7EB1-4FB9-BC67-806773018989} = {CC5BDD33-7EB1-4FB9-BC67-806773018989}
-	EndProjectSection
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "MIDebugPackage", "MIDebugPackage\MIDebugPackage.csproj", "{A8D8E02F-4258-4F2E-88B6-A50FEBD5AD8C}"
 	ProjectSection(ProjectDependencies) = postProject

--- a/src/MakePIAPortable/MakePIAPortable.csproj
+++ b/src/MakePIAPortable/MakePIAPortable.csproj
@@ -40,6 +40,11 @@
     <PackageReference Include="Microsoft.VisualStudioEng.MicroBuild.Core" Version="$(Microsoft_VisualStudioEng_MicroBuild_Core_Version)" GeneratePathProperty="true" />
   </ItemGroup>
 
+  <!-- Ensure MakePIAPortableTool builds before this project -->
+  <ItemGroup Label="Project References">
+    <ProjectReference Include="..\tools\MakePIAPortableTool\MakePIAPortableTool.csproj" ReferenceOutputAssembly="false" Private="false" SkipGetTargetFrameworkProperties="true" />
+  </ItemGroup>
+
   <ItemGroup> 
     <MakePIAPortableFiles Include="$(PkgMicrosoft_VisualStudio_Debugger_InteropA)\lib\net472\Microsoft.VisualStudio.Debugger.InteropA.dll" />
     <MakePIAPortableFiles Include="$(PkgMicrosoft_VisualStudio_Debugger_Interop_10_0)\lib\net472\Microsoft.VisualStudio.Debugger.Interop.10.0.dll" />

--- a/test/CppTests/CppTests.csproj
+++ b/test/CppTests/CppTests.csproj
@@ -1,4 +1,5 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project>
+  <Import Project="Sdk.props" Sdk="Microsoft.NET.Sdk" />
   <Import Project="..\..\build\debuggertesting.settings.targets" />
 
   <PropertyGroup>
@@ -8,7 +9,16 @@
 
     <OutputPath>$(OutputPath)\CppTests</OutputPath>
   </PropertyGroup>
-  
+
+  <!-- Deploy debug adapter configuration -->
+  <PropertyGroup>
+    <DebugAdaptersDeployPath>$(MIEngineRoot)bin\DebugAdapterProtocolTests\$(Configuration)\extension\debugAdapters\</DebugAdaptersDeployPath>
+    <OpenDebugAD7OutputPath>$(MIDefaultOutputPath)vscode\</OpenDebugAD7OutputPath>
+    <!-- Only deploy the debug adapter for Debug configurations (Debug, Lab.Debug) -->
+    <_ShouldDeployDebugAdapter>false</_ShouldDeployDebugAdapter>
+    <_ShouldDeployDebugAdapter Condition="$(Configuration.Contains('Debug'))">true</_ShouldDeployDebugAdapter>
+  </PropertyGroup>
+
   <!-- 
     This ItemGroup is to override the packages that being depended on for the PackageReferences above. 
     The issue is that Microsoft.NET.Test.Sdk ->
@@ -34,6 +44,8 @@
   <ItemGroup Label="Additional Files">
     <None Include="debuggees\**" CopyToOutputDirectory="PreserveNewest" />
     <None Include="TestConfigurations\**" CopyToOutputDirectory="PreserveNewest" />
+    <!-- Deploy config.xml to test output if it exists in the project directory -->
+    <None Include="config.xml" CopyToOutputDirectory="PreserveNewest" Condition="Exists('$(MSBuildProjectDirectory)\config.xml')" />
 
     <ContentFiles Include="debuggees\**" />
     <ContentFiles Include="TestConfigurations\**" />
@@ -42,7 +54,48 @@
   <ItemGroup Label="Project References">
     <ProjectReference Include="..\DebugAdapterRunner\DebugAdapterRunner.csproj" />
     <ProjectReference Include="..\DebuggerTesting\DebuggerTesting.csproj" />
+    <!-- Build the debug adapter and engine (not compile-time references, but needed at runtime for tests) -->
+    <ProjectReference Include="..\..\src\OpenDebugAD7\OpenDebugAD7.csproj" ReferenceOutputAssembly="false" Private="false" />
+    <ProjectReference Include="..\..\src\MIDebugEngine\MIDebugEngine.csproj" ReferenceOutputAssembly="false" Private="false" />
+    <ProjectReference Condition="$([MSBuild]::IsOSPlatform('windows'))" Include="..\..\src\WindowsDebugLauncher\WindowsDebugLauncher.csproj" ReferenceOutputAssembly="false" Private="false" SkipGetTargetFrameworkProperties="true" />
   </ItemGroup>
+
+  <!--
+    =============================================================================
+    Deploy Debug Adapter Target
+    =============================================================================
+    Copies the built debug adapter files to the test output structure expected by
+    the test framework (extension/debugAdapters/ relative to the test output root).
+    
+    Only runs for Debug configurations (Debug, Lab.Debug) since those are the
+    configurations used for running tests locally and in CI.
+  -->
+  <Target Name="ResolveDebugAdapterFiles"
+          Condition="'$(_ShouldDeployDebugAdapter)' == 'true'">
+    <ItemGroup>
+      <!-- All files from OpenDebugAD7's output (includes OpenDebugAD7.exe, deps, DebugEngineHost,
+           Newtonsoft.Json, MIDebugEngine.dll (via its copy target), WindowsDebugLauncher.exe, etc.) -->
+      <_DebugAdapterSourceFiles Include="$(OpenDebugAD7OutputPath)*.*" />
+      <!-- MICore.dll is not in the vscode output folder (no project reference from OpenDebugAD7) -->
+      <_DebugAdapterSourceFiles Include="$(MIDefaultOutputPath)Microsoft.MICore.dll" />
+    </ItemGroup>
+    <ItemGroup>
+      <_DebugAdapterDestFiles Include="@(_DebugAdapterSourceFiles->'$(DebugAdaptersDeployPath)%(Filename)%(Extension)')" />
+    </ItemGroup>
+  </Target>
+
+  <Target Name="DeployDebugAdapter"
+          DependsOnTargets="ResolveDebugAdapterFiles"
+          AfterTargets="Build"
+          Inputs="@(_DebugAdapterSourceFiles)"
+          Outputs="@(_DebugAdapterDestFiles)"
+          Condition="'$(_ShouldDeployDebugAdapter)' == 'true' AND '$(DesignTimeBuild)' != 'true'">
+    <MakeDir Directories="$(DebugAdaptersDeployPath)" />
+    <Copy SourceFiles="@(_DebugAdapterSourceFiles)"
+          DestinationFolder="$(DebugAdaptersDeployPath)"
+          SkipUnchangedFiles="true" />
+    <Touch Files="@(_DebugAdapterDestFiles)" />
+  </Target>
 
   <Target Name="Copy Config and Debuggees" BeforeTargets="DropFiles">
     <Copy SourceFiles="@(ContentFiles)" DestinationFolder="$(DropDir)\contentFiles\%(RecursiveDir)" />
@@ -61,5 +114,44 @@
   </ItemGroup>
 
   <Import Project="..\..\build\DropFiles.targets" />
+
+  <!--IMPORTANT: The fast up-to-date check targets must be defined AFTER this -->
+  <Import Project="Sdk.targets" Sdk="Microsoft.NET.Sdk" />
+
+  <!--
+    =============================================================================
+    VS Fast Up-to-Date Check Support
+    =============================================================================
+    These targets tell Visual Studio's fast up-to-date check which files are inputs
+    and outputs of the DeployDebugAdapter target, enabling incremental builds in VS.
+    See: https://github.com/dotnet/project-system/blob/main/docs/up-to-date-check.md
+  -->
+  <Target Name="CollectUpToDateCheckInputDesignTime"
+          DependsOnTargets="ResolveDebugAdapterFiles"
+          Returns="@(UpToDateCheckInput)"
+          Condition="'$(_ShouldDeployDebugAdapter)' == 'true'">
+    <ItemGroup>
+      <UpToDateCheckInput Remove="@(UpToDateCheckInput)" />
+      <UpToDateCheckInput Include="@(_DebugAdapterSourceFiles)" Set="DebugAdapter" />
+    </ItemGroup>
+  </Target>
+
+  <Target Name="CollectUpToDateCheckOutputDesignTime"
+          DependsOnTargets="ResolveDebugAdapterFiles"
+          Returns="@(UpToDateCheckOutput)"
+          Condition="'$(_ShouldDeployDebugAdapter)' == 'true'">
+    <ItemGroup>
+      <UpToDateCheckOutput Remove="@(UpToDateCheckOutput)" />
+      <UpToDateCheckOutput Include="@(_DebugAdapterDestFiles)" Set="DebugAdapter" />
+    </ItemGroup>
+  </Target>
+
+  <Target Name="CollectUpToDateCheckBuiltDesignTime"
+          Returns="@(UpToDateCheckBuilt)"
+          Condition="'$(_ShouldDeployDebugAdapter)' == 'true'">
+    <ItemGroup>
+      <UpToDateCheckBuilt Remove="@(UpToDateCheckBuilt)" />
+    </ItemGroup>
+  </Target>
 
 </Project>

--- a/test/CppTests/CppTests.csproj
+++ b/test/CppTests/CppTests.csproj
@@ -75,9 +75,7 @@
     <ItemGroup>
       <!-- All files from OpenDebugAD7's output (includes OpenDebugAD7.exe, deps, DebugEngineHost,
            Newtonsoft.Json, MIDebugEngine.dll (via its copy target), WindowsDebugLauncher.exe, etc.) -->
-      <_DebugAdapterSourceFiles Include="$(OpenDebugAD7OutputPath)*.*" />
-      <!-- MICore.dll is not in the vscode output folder (no project reference from OpenDebugAD7) -->
-      <_DebugAdapterSourceFiles Include="$(MIDefaultOutputPath)Microsoft.MICore.dll" />
+      <_DebugAdapterSourceFiles Include="$(OpenDebugAD7OutputPath)*" />
     </ItemGroup>
     <ItemGroup>
       <_DebugAdapterDestFiles Include="@(_DebugAdapterSourceFiles->'$(DebugAdaptersDeployPath)%(Filename)%(Extension)')" />


### PR DESCRIPTION
## Why is this change being made

This PR fixes the way we deploy the debug adapter for CppTests so that you don't need to rerun CI-Build.ps1/.sh between test iterations. This way you can make a code change, then run a test from the command line, from Test Explorer in Visual Studio, or the Testing panel in VS Code.

## Summary of changes

- Removed steps from CI-Build.ps1/.sh to publish OpenDebugAD7
- Added targets to CppTests.csproj to deploy the debug adapter
- Added project references so that building CppTests.csproj will ensure all the other projects are built
- Removed solution build dependencies from the .sln files since they are now in the .csproj files
- Added code to copy config.xml in test/CppTests project directory
- Updated documentation from the changes

Unrelated, but I also added src/MIDebugEngine-Unix.sln as the default solution in VS Code

## Testing

* [X] **.NET CLI**: ran `git clean`, copied in the correct config.xml, and verified I could run a test using `dotnet test`
* [X] **Visual Studio**: ran `git clean`, copied in the correct config.xml, and verified I could run a test
* [X] **Visual Studio**: made a change to DebuggedProcess.cs, then rerun a test and verified my new code was running
* [X] **Visual Studio Code**: cloned the repo into WSL, copied in the correct config.xml, opened the workspace and verified I could run tests from the Testing pannel.