### PR TITLE
Support environment variables in config.xml

### DIFF
--- a/test/CppTests/OpenDebug/CrossPlatCpp/DebuggerRunner.cs
+++ b/test/CppTests/OpenDebug/CrossPlatCpp/DebuggerRunner.cs
@@ -62,7 +62,8 @@ namespace DebuggerTesting.OpenDebug.CrossPlatCpp
                 pauseForDebugger: false,
                 isVsDbg: this.DebuggerSettings.DebuggerType == SupportedDebugger.VsDbg,
                 isNative: true,
-                responseTimeout: 5000);
+                responseTimeout: 5000,
+                additionalEnvironmentVariables: this.DebuggerSettings.EnvironmentVariables);
 
             if (callbackHandlers != null)
             {

--- a/test/CppTests/TestConfigurations/config_msys_gdb.xml
+++ b/test/CppTests/TestConfigurations/config_msys_gdb.xml
@@ -17,7 +17,11 @@
       Name="GdbMingw64"
       Type="Gdb_MinGW"
       Path="D:\a\_temp\msys64\mingw64\bin\gdb.exe"
-      AdapterPath="OpenDebugAD7.exe"
-      />
+      AdapterPath="OpenDebugAD7.exe">
+      <Environment>
+        <!--If running tests outside of a cygwin shell, uncomment this and adjust paths-->
+        <!--<Path>C:\msys64\mingw64\bin;C:\msys64\usr\bin;%PATH%</Path>-->
+      </Environment>
+    </Debugger>
   </Debuggers>
 </TestMachineConfiguration>

--- a/test/DebuggerTesting/Attribution/DebuggerSettings.cs
+++ b/test/DebuggerTesting/Attribution/DebuggerSettings.cs
@@ -20,7 +20,8 @@ namespace DebuggerTesting
             string debuggerAdapterPath,
             string miMode,
             SupportedArchitecture debuggeeArchitecture,
-            IDictionary<string, string> debuggerProperties)
+            IDictionary<string, string> debuggerProperties,
+            IDictionary<string, string> environmentVariables = null)
         {
             this.DebuggeeArchitecture = debuggeeArchitecture;
             this.DebuggerName = debuggerName;
@@ -30,6 +31,7 @@ namespace DebuggerTesting
             if (!string.IsNullOrWhiteSpace(miMode))
                 this.MIMode = miMode;
             this.Properties = debuggerProperties ?? new Dictionary<string, string>(StringComparer.Ordinal);
+            this.EnvironmentVariables = environmentVariables ?? new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
         }
 
         #endregion
@@ -118,6 +120,8 @@ namespace DebuggerTesting
         public string MIMode { get; private set; }
 
         public IDictionary<string, string> Properties { get; private set; }
+
+        public IDictionary<string, string> EnvironmentVariables { get; private set; }
 
         #endregion
     }

--- a/test/DebuggerTesting/Attribution/TestSettings.cs
+++ b/test/DebuggerTesting/Attribution/TestSettings.cs
@@ -24,10 +24,11 @@ namespace DebuggerTesting
             string debuggerPath,
             string debuggerAdapterPath,
             string miMode,
-            IDictionary<string, string> debuggerProperties)
+            IDictionary<string, string> debuggerProperties,
+            IDictionary<string, string> environmentVariables = null)
         {
             this.CompilerSettings = new CompilerSettings(compilerName, compilerType, compilerPath, debuggeeArchitecture, compilerProperties);
-            this.DebuggerSettings = new DebuggerSettings(debuggerName, debuggerType, debuggerPath, debuggerAdapterPath, miMode, debuggeeArchitecture, debuggerProperties);
+            this.DebuggerSettings = new DebuggerSettings(debuggerName, debuggerType, debuggerPath, debuggerAdapterPath, miMode, debuggeeArchitecture, debuggerProperties, environmentVariables);
         }
 
         private TestSettings(ITestSettings original, string name)

--- a/test/DebuggerTesting/Attribution/TestSettingsHelper.cs
+++ b/test/DebuggerTesting/Attribution/TestSettingsHelper.cs
@@ -158,7 +158,8 @@ namespace DebuggerTesting
                             Path = x.GetAttributeValue("Path"),
                             AdapterPath = x.GetAttributeValue("AdapterPath"),
                             MIMode = x.GetAttributeValue("MIMode"),
-                            Properties = x.GetPropertiesDictionary()
+                            Properties = x.GetPropertiesDictionary(),
+                            EnvironmentVariables = x.GetEnvironmentDictionary()
                         });
                 Assert.True(null != debuggers && debuggers.Count != 0, "Object loaded from '{0}' is not a TestMachineConfiguration. Missing Debuggers.".FormatInvariantWithArgs(configPath));
 
@@ -197,7 +198,8 @@ namespace DebuggerTesting
                         SafeExpandEnvironmentVariables(config.Debugger.Path),
                         SafeExpandEnvironmentVariables(config.Debugger.AdapterPath),
                         config.Debugger.MIMode,
-                        config.Debugger.Properties);
+                        config.Debugger.Properties,
+                        config.Debugger.EnvironmentVariables);
 
                 // Force evaluation
                 return testSettings.ToArray();
@@ -213,6 +215,25 @@ namespace DebuggerTesting
                 .Element("Properties")
                 ?.Elements("Property")
                 ?.ToDictionary(p => p.GetAttributeValue("Name"), p => SafeExpandEnvironmentVariables(p.Value), StringComparer.Ordinal);
+        }
+
+        /// <summary>
+        /// Reads the Environment element and returns its child element names and values as a dictionary.
+        /// For example: <Environment><Path>value</Path></Environment> yields {"Path": "value"}
+        /// </summary>
+        private static IDictionary<string, string> GetEnvironmentDictionary(this XElement element)
+        {
+            var envElement = element.Element("Environment");
+            if (envElement == null)
+                return null;
+
+            var result = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+            foreach (var child in envElement.Elements())
+            {
+                result[child.Name.LocalName] = SafeExpandEnvironmentVariables(child.Value);
+            }
+
+            return result.Count > 0 ? result : null;
         }
 
         private static bool Matches(this IEnumerable<SupportedCompilerAttribute> compilers, ICompilerSettings settings)

--- a/test/DebuggerTesting/Attribution/TestSettingsHelper.cs
+++ b/test/DebuggerTesting/Attribution/TestSettingsHelper.cs
@@ -227,11 +227,9 @@ namespace DebuggerTesting
             if (envElement == null)
                 return null;
 
-            var result = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
-            foreach (var child in envElement.Elements())
-            {
-                result[child.Name.LocalName] = SafeExpandEnvironmentVariables(child.Value);
-            }
+            Dictionary<string, string> result = envElement
+                .Elements()
+                .ToDictionary(e => e.Name.LocalName, e => SafeExpandEnvironmentVariables(e.Value), StringComparer.OrdinalIgnoreCase);
 
             return result.Count > 0 ? result : null;
         }

--- a/test/DebuggerTesting/IDebuggerSettings.cs
+++ b/test/DebuggerTesting/IDebuggerSettings.cs
@@ -26,6 +26,8 @@ namespace DebuggerTesting
 
         IDictionary<string, string> Properties { get; }
 
+        IDictionary<string, string> EnvironmentVariables { get; }
+
         #endregion
     }
 }


### PR DESCRIPTION
This PR adds support for an `Environment` dictionary in config.xml to make it easy to configure cygwin tests on Windows.