### PR TITLE
Implement natvis 'na' modifier and $T substitution

### DIFF
--- a/src/MIDebugEngine/Engine.Impl/Variables.cs
+++ b/src/MIDebugEngine/Engine.Impl/Variables.cs
@@ -5,6 +5,7 @@ using MICore;
 using Microsoft.VisualStudio.Debugger.Interop;
 using Microsoft.VisualStudio.Debugger.Interop.DAP;
 using System;
+using Microsoft.DebugEngineHost;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Globalization;
@@ -272,6 +273,17 @@ namespace Microsoft.MIDebugEngine
         {
             TypeName = results.TryFindString("type");
             Value = results.TryFindString("value");
+            // Diagnostic: log raw tuple child value before any cleanup
+            _debuggedProcess.Logger?.WriteLine(LogLevel.Verbose, FormattableString.Invariant($"TupleCtor: name={Name}, exp={results.TryFindString("exp")}, type={TypeName}, format={_format}, formatHasNa={_formatHasNa}, rawValue={results.TryFindString("value")}"));
+            // Only strip the leading MI address prefix ("0x... \"\"") when the natvis
+            // format included the 'na' modifier. 
+            if (_formatHasNa && !string.IsNullOrEmpty(Value) && Regex.IsMatch(Value, "^0x[0-9a-fA-F]+\\s+"))
+            {
+                // Recognize typical GDB prefix: 0x<hex> <string>
+                string before = Value;
+                Value = Regex.Replace(Value, "^0x[0-9a-fA-F]+\\s+", "");
+                _debuggedProcess.Logger?.WriteLine(LogLevel.Verbose, FormattableString.Invariant($"TupleCtor: stripped address prefix: before={before}, after={Value}"));
+            }
             Name = name ?? results.FindString("exp");
             if (results.Contains("dynamic"))
             {
@@ -332,6 +344,8 @@ namespace Microsoft.MIDebugEngine
             _internalName = results.FindString("name");
             IsChild = true;
             _format = parent._format; // inherit formatting
+            // inherit whether the parent's format included the 'na' modifier
+            _formatHasNa = parent._formatHasNa;
             _parent = parent.VariableNodeType == NodeType.AccessQualifier ? parent._parent : parent;
             this.PropertyInfoFlags = parent.PropertyInfoFlags;
         }
@@ -375,6 +389,9 @@ namespace Microsoft.MIDebugEngine
         private DeferedFormatExpression _deferedFormatExpression;
         private IVariableInformation _parent;
         private string _format;
+        // Indicates the original format specifier included the natvis "na" modifier
+        // (used to decide whether to strip MI's leading address prefix from string values)
+        private bool _formatHasNa = false;
         private string _strippedName;  // "Name" stripped of format specifiers
         private string _fullname;
 
@@ -416,6 +433,9 @@ namespace Microsoft.MIDebugEngine
 
             // Find the format specifier expression
             string expFS = exp.Substring(lastComma + 1).Trim();
+            // Detect whether the natvis 'na' modifier is present in the original format specifier.
+            // We must detect this before we strip modifiers below.
+            _formatHasNa = expFS.IndexOf("na", StringComparison.Ordinal) >= 0;
 
             // Strip off modifiers that may be included together with another format specifier, e.g. 'nvoXb' is a valid format specifier, but we only care about the 'Xb' part
             // This is not quite the right fix -- really the below switch statement should be a series of if statements. But since none of the supported format specifiers
@@ -698,6 +718,11 @@ namespace Microsoft.MIDebugEngine
                             _attribsFetched = true;
                         }
                         Value = results.TryFindString("value");
+                        // If natvis requested 'na', strip MI's leading address prefix
+                        if (_formatHasNa && !string.IsNullOrEmpty(Value) && Regex.IsMatch(Value, "^0x[0-9a-fA-F]+\\s+"))
+                        {
+                            Value = Regex.Replace(Value, "^0x[0-9a-fA-F]+\\s+", "");
+                        }
                         if ((string.IsNullOrEmpty(Value) || _format != null) && !string.IsNullOrEmpty(_internalName))
                         {
                             if (_format != null)
@@ -711,6 +736,11 @@ namespace Microsoft.MIDebugEngine
                                 if (results.ResultClass == ResultClass.done)
                                 {
                                     Value = results.FindString("value");
+                                    // If natvis requested 'na', strip MI's leading address prefix
+                                    if (_formatHasNa && !string.IsNullOrEmpty(Value) && Regex.IsMatch(Value, "^0x[0-9a-fA-F]+\\s+"))
+                                    {
+                                        Value = Regex.Replace(Value, "^0x[0-9a-fA-F]+\\s+", "");
+                                    }
                                 }
                                 else if (results.ResultClass == ResultClass.error)
                                 {

--- a/src/MIDebugEngine/Engine.Impl/Variables.cs
+++ b/src/MIDebugEngine/Engine.Impl/Variables.cs
@@ -93,6 +93,18 @@ namespace Microsoft.MIDebugEngine
 
         static readonly Lazy<Regex> s_addressPattern = new Lazy<Regex>(() => new Regex(@"^(0x[0-9a-fA-F]+)\b"));
 
+        static readonly Regex s_naPattern = new Regex(@"^0x[0-9a-fA-F]+\s+(.)");
+
+        private static string StripLeadingAddress(string value, bool formatNa)
+        {
+            if(!formatNa || string.IsNullOrEmpty(value))
+            {
+                return value;
+            }
+
+            return s_naPattern.Replace(value, "$1");
+        }
+
         public string Address()
         {
             // ask GDB to evaluate "&expression"
@@ -239,7 +251,7 @@ namespace Microsoft.MIDebugEngine
             : this(ctx, engine, thread)
         {
             // strip off formatting string
-            _strippedName = ProcessFormatSpecifiers(expr, out _format);
+            _strippedName = ProcessFormatSpecifiers(expr, out _format, out _formatHasNa);
             Name = displayName;
             IsParameter = isParameter;
             _parent = null;
@@ -251,7 +263,7 @@ namespace Microsoft.MIDebugEngine
             : this(parent.ThreadContext, engine, parent.Client)
         {
             // strip off formatting string
-            _strippedName = ProcessFormatSpecifiers(expr, out _format);
+            _strippedName = ProcessFormatSpecifiers(expr, out _format, out _formatHasNa);
             Name = displayName ?? expr;
             _parent = parent;
             VariableNodeType = NodeType.Synthetic;
@@ -262,7 +274,7 @@ namespace Microsoft.MIDebugEngine
             : this(parent._ctx, parent._engine, parent.Client)
         {
             // strip off formatting string
-            _strippedName = ProcessFormatSpecifiers(expr, out _format);
+            _strippedName = ProcessFormatSpecifiers(expr, out _format, out _formatHasNa);
             Name = expr;
             VariableNodeType = NodeType.Root;
         }
@@ -273,17 +285,10 @@ namespace Microsoft.MIDebugEngine
         {
             TypeName = results.TryFindString("type");
             Value = results.TryFindString("value");
-            // Diagnostic: log raw tuple child value before any cleanup
-            _debuggedProcess.Logger?.WriteLine(LogLevel.Verbose, FormattableString.Invariant($"TupleCtor: name={Name}, exp={results.TryFindString("exp")}, type={TypeName}, format={_format}, formatHasNa={_formatHasNa}, rawValue={results.TryFindString("value")}"));
-            // Only strip the leading MI address prefix ("0x... \"\"") when the natvis
-            // format included the 'na' modifier. 
-            if (_formatHasNa && !string.IsNullOrEmpty(Value) && Regex.IsMatch(Value, "^0x[0-9a-fA-F]+\\s+"))
-            {
-                // Recognize typical GDB prefix: 0x<hex> <string>
-                string before = Value;
-                Value = Regex.Replace(Value, "^0x[0-9a-fA-F]+\\s+", "");
-                _debuggedProcess.Logger?.WriteLine(LogLevel.Verbose, FormattableString.Invariant($"TupleCtor: stripped address prefix: before={before}, after={Value}"));
-            }
+            // Only strip the leading MI address prefix ("0x... ") when the natvis format included the 'na' modifier.
+            Value = StripLeadingAddress(Value, _formatHasNa);
+
+
             Name = name ?? results.FindString("exp");
             if (results.Contains("dynamic"))
             {
@@ -418,8 +423,9 @@ namespace Microsoft.MIDebugEngine
 
         private static Regex s_isFunction = new Regex(@".+\(.*\).*");
 
-        private string ProcessFormatSpecifiers(string exp, out string formatSpecifier)
+        private string ProcessFormatSpecifiers(string exp, out string formatSpecifier, out bool formatNa)
         {
+            formatNa = false;
             formatSpecifier = null; // will be used with -var-set-format
 
             if (EngineUtils.IsConsoleExecCmd(exp, out string _, out string _))
@@ -436,6 +442,7 @@ namespace Microsoft.MIDebugEngine
             // Detect whether the natvis 'na' modifier is present in the original format specifier.
             // We must detect this before we strip modifiers below.
             _formatHasNa = expFS.IndexOf("na", StringComparison.Ordinal) >= 0;
+            formatNa = _formatHasNa;
 
             // Strip off modifiers that may be included together with another format specifier, e.g. 'nvoXb' is a valid format specifier, but we only care about the 'Xb' part
             // This is not quite the right fix -- really the below switch statement should be a series of if statements. But since none of the supported format specifiers
@@ -719,10 +726,7 @@ namespace Microsoft.MIDebugEngine
                         }
                         Value = results.TryFindString("value");
                         // If natvis requested 'na', strip MI's leading address prefix
-                        if (_formatHasNa && !string.IsNullOrEmpty(Value) && Regex.IsMatch(Value, "^0x[0-9a-fA-F]+\\s+"))
-                        {
-                            Value = Regex.Replace(Value, "^0x[0-9a-fA-F]+\\s+", "");
-                        }
+                        Value = StripLeadingAddress(Value, _formatHasNa);
                         if ((string.IsNullOrEmpty(Value) || _format != null) && !string.IsNullOrEmpty(_internalName))
                         {
                             if (_format != null)
@@ -737,10 +741,7 @@ namespace Microsoft.MIDebugEngine
                                 {
                                     Value = results.FindString("value");
                                     // If natvis requested 'na', strip MI's leading address prefix
-                                    if (_formatHasNa && !string.IsNullOrEmpty(Value) && Regex.IsMatch(Value, "^0x[0-9a-fA-F]+\\s+"))
-                                    {
-                                        Value = Regex.Replace(Value, "^0x[0-9a-fA-F]+\\s+", "");
-                                    }
+                                    Value = StripLeadingAddress(Value, _formatHasNa);
                                 }
                                 else if (results.ResultClass == ResultClass.error)
                                 {

--- a/src/MIDebugEngine/Engine.Impl/Variables.cs
+++ b/src/MIDebugEngine/Engine.Impl/Variables.cs
@@ -441,8 +441,7 @@ namespace Microsoft.MIDebugEngine
             string expFS = exp.Substring(lastComma + 1).Trim();
             // Detect whether the natvis 'na' modifier is present in the original format specifier.
             // We must detect this before we strip modifiers below.
-            _formatHasNa = expFS.IndexOf("na", StringComparison.Ordinal) >= 0;
-            formatNa = _formatHasNa;
+            formatNa = expFS.IndexOf("na", StringComparison.Ordinal) >= 0;
 
             // Strip off modifiers that may be included together with another format specifier, e.g. 'nvoXb' is a valid format specifier, but we only care about the 'Xb' part
             // This is not quite the right fix -- really the below switch statement should be a series of if statements. But since none of the supported format specifiers

--- a/src/MIDebugEngine/Engine.Impl/Variables.cs
+++ b/src/MIDebugEngine/Engine.Impl/Variables.cs
@@ -95,9 +95,9 @@ namespace Microsoft.MIDebugEngine
 
         static readonly Regex s_naPattern = new Regex(@"^0x[0-9a-fA-F]+\s+(.)");
 
-        private static string StripLeadingAddress(string value, bool formatNa)
+        internal static string StripLeadingAddress(string value)
         {
-            if(!formatNa || string.IsNullOrEmpty(value))
+            if (string.IsNullOrEmpty(value))
             {
                 return value;
             }
@@ -285,9 +285,11 @@ namespace Microsoft.MIDebugEngine
         {
             TypeName = results.TryFindString("type");
             Value = results.TryFindString("value");
-            // Only strip the leading MI address prefix ("0x... ") when the natvis format included the 'na' modifier.
-            Value = StripLeadingAddress(Value, _formatHasNa);
-
+            _formatHasNa = parent._formatHasNa;
+            if (_formatHasNa)
+            {
+                Value = StripLeadingAddress(Value);
+            }
 
             Name = name ?? results.FindString("exp");
             if (results.Contains("dynamic"))
@@ -349,8 +351,6 @@ namespace Microsoft.MIDebugEngine
             _internalName = results.FindString("name");
             IsChild = true;
             _format = parent._format; // inherit formatting
-            // inherit whether the parent's format included the 'na' modifier
-            _formatHasNa = parent._formatHasNa;
             _parent = parent.VariableNodeType == NodeType.AccessQualifier ? parent._parent : parent;
             this.PropertyInfoFlags = parent.PropertyInfoFlags;
         }
@@ -725,8 +725,10 @@ namespace Microsoft.MIDebugEngine
                             _attribsFetched = true;
                         }
                         Value = results.TryFindString("value");
-                        // If natvis requested 'na', strip MI's leading address prefix
-                        Value = StripLeadingAddress(Value, _formatHasNa);
+                        if (_formatHasNa)
+                        {
+                            Value = StripLeadingAddress(Value);
+                        }
                         if ((string.IsNullOrEmpty(Value) || _format != null) && !string.IsNullOrEmpty(_internalName))
                         {
                             if (_format != null)
@@ -740,8 +742,10 @@ namespace Microsoft.MIDebugEngine
                                 if (results.ResultClass == ResultClass.done)
                                 {
                                     Value = results.FindString("value");
-                                    // If natvis requested 'na', strip MI's leading address prefix
-                                    Value = StripLeadingAddress(Value, _formatHasNa);
+                                    if (_formatHasNa)
+                                    {
+                                        Value = StripLeadingAddress(Value);
+                                    }
                                 }
                                 else if (results.ResultClass == ResultClass.error)
                                 {

--- a/src/MIDebugEngine/Natvis.Impl/Natvis.cs
+++ b/src/MIDebugEngine/Natvis.Impl/Natvis.cs
@@ -1283,12 +1283,24 @@ namespace Microsoft.MIDebugEngine.Natvis
                     if (m.Success)
                     {
                         string rawExpr = format.Substring(i + 1, m.Length - 2);
+                        // Substitute template parameter macros ($T1, $T2, ...) inside the whole brace
+                        // expression (this covers both the expression and any trailing format specifier)
+                        if (scopedNames != null)
+                        {
+                            rawExpr = Regex.Replace(rawExpr, "\\$T\\d+", (Match mt) =>
+                            {
+                                if (scopedNames.TryGetValue(mt.Value, out string replacement))
+                                    return replacement;
+                                return mt.Value;
+                            });
+                        }
+                        bool hasNa = HasNaModifier(rawExpr);
                         string spec = ExtractFormatSpecifier(rawExpr);
                         string exprValue = GetExpressionValue(rawExpr, variable, scopedNames, intrinsics);
-                        if (spec == "sub" || spec == "su")
-                            exprValue = CleanUtf16StringValue(exprValue);
-                        else if (spec == "sb")
-                            exprValue = CleanAsciiStringValue(exprValue);
+                        if (hasNa && !string.IsNullOrEmpty(exprValue))
+                        {
+                            exprValue = s_addressPrefix.Replace(exprValue, "");
+                        }
                         value.Append(exprValue);
                         i += m.Length - 1;
                     }
@@ -1503,26 +1515,32 @@ namespace Microsoft.MIDebugEngine.Natvis
         }
 
         /// <summary>
+        /// Returns true if the NatVis expression's trailing format specifier (the part after the
+        /// last top-level comma) contains the "na" modifier. This intentionally inspects the
+        /// raw specifier text and does not normalize/remove modifiers so callers can detect
+        /// whether the original expression asked for the "na" behavior.
+        /// </summary>
+        private static bool HasNaModifier(string expression)
+        {
+            int commaPos = FindLastTopLevelComma(expression);
+            if (commaPos < 0) return false;
+            string tail = expression.Substring(commaPos + 1);
+            return tail.IndexOf("na", StringComparison.Ordinal) >= 0;
+        }
+
+        /// <summary>
         /// Cleans up the raw value that GDB/LLDB returns for a <c>const char16_t*</c>
         /// expression (i.e. one evaluated with the <c>,sub</c> / <c>,su</c> format specifier).
         /// GDB and LLDB both prefix the string with the pointer address, e.g.
         ///   <c>0x00007fff5fbff6c0 u"Hello"</c>
-        /// This method strips the address and the surrounding <c>u"…"</c> quotes so that
-        /// the NatVis DisplayString shows just the string content.
+        /// This method strips the leading address prefix that GDB/LLDB emits ("0x... ").
+        /// It does NOT remove surrounding quotes or the leading character-width prefix (u/U).
         /// </summary>
         internal static string CleanUtf16StringValue(string value)
         {
             if (string.IsNullOrEmpty(value)) return value;
             // Strip leading "0x<hex> " address prefix emitted by GDB/LLDB.
             value = s_addressPrefix.Replace(value, "");
-            // Strip surrounding u"..." or U"..." quotes.
-            if (value.Length >= 3 &&
-                (value.StartsWith("u\"", StringComparison.Ordinal) || value.StartsWith("U\"", StringComparison.Ordinal)))
-            {
-                value = value.EndsWith("\"", StringComparison.Ordinal)
-                    ? value.Substring(2, value.Length - 3)
-                    : value.Substring(2);
-            }
             return value;
         }
 
@@ -1531,9 +1549,9 @@ namespace Microsoft.MIDebugEngine.Natvis
         /// (i.e. one evaluated with the <c>,sb</c> format specifier).
         /// GDB and LLDB prefix the string with the pointer address, e.g.
         ///   <c>0x00007fff5fbff6c0 "Hello"</c>
-        /// This method strips the address and the surrounding <c>"…"</c> quotes so that
-        /// the NatVis DisplayString shows just the string content (matching VS behaviour,
-        /// where <c>{ptr,sb}</c> evaluates to bare text without quotes).
+        /// This method strips the leading address prefix that GDB/LLDB emits ("0x... ").
+        /// It does NOT remove surrounding quotes; callers should decide whether quotes
+        /// should be removed based on the caller's context.
         /// </summary>
         internal static string CleanAsciiStringValue(string value)
         {

--- a/src/MIDebugEngine/Natvis.Impl/Natvis.cs
+++ b/src/MIDebugEngine/Natvis.Impl/Natvis.cs
@@ -1296,9 +1296,9 @@ namespace Microsoft.MIDebugEngine.Natvis
                         }
                         bool hasNa = HasNaModifier(rawExpr);
                         string exprValue = GetExpressionValue(rawExpr, variable, scopedNames, intrinsics);
-                        if (hasNa && !string.IsNullOrEmpty(exprValue))
+                        if (hasNa)
                         {
-                            exprValue = s_addressPrefix.Replace(exprValue, "");
+                            exprValue = VariableInformation.StripLeadingAddress(exprValue);
                         }
                         value.Append(exprValue);
                         i += m.Length - 1;

--- a/src/MIDebugEngine/Natvis.Impl/Natvis.cs
+++ b/src/MIDebugEngine/Natvis.Impl/Natvis.cs
@@ -1544,7 +1544,14 @@ namespace Microsoft.MIDebugEngine.Natvis
         {
             if (string.IsNullOrEmpty(value)) return value;
             // Strip leading "0x<hex> " address prefix emitted by GDB/LLDB.
-            value = s_addressPrefix.Replace(value, "");
+            value = VariableInformation.StripLeadingAddress(value);
+            // Strip surrounding u"..." or U"..." quotes.
+            if (value.Length >= 3 && (value.StartsWith("u\"", StringComparison.Ordinal) || value.StartsWith("U\"", StringComparison.Ordinal)))
+            {
+                value = value.EndsWith("\"", StringComparison.Ordinal)
+                    ? value.Substring(2, value.Length - 3)
+                    : value.Substring(2);
+            }
             return value;
         }
 
@@ -1559,7 +1566,7 @@ namespace Microsoft.MIDebugEngine.Natvis
         {
             if (string.IsNullOrEmpty(value)) return value;
             // Strip leading "0x<hex> " address prefix emitted by GDB/LLDB.
-            value = s_addressPrefix.Replace(value, "");
+            value = VariableInformation.StripLeadingAddress(value);
             // Strip surrounding "..." quotes.
             if (value.Length >= 2 && value.StartsWith("\"", StringComparison.Ordinal))
             {

--- a/src/MIDebugEngine/Natvis.Impl/Natvis.cs
+++ b/src/MIDebugEngine/Natvis.Impl/Natvis.cs
@@ -1294,7 +1294,7 @@ namespace Microsoft.MIDebugEngine.Natvis
                                 return mt.Value;
                             });
                         }
-                        bool hasNa = HasNaModifier(rawExpr);
+                        ExtractFormatSpecifier(rawExpr, out bool hasNa);
                         string exprValue = GetExpressionValue(rawExpr, variable, scopedNames, intrinsics);
                         if (hasNa)
                         {
@@ -1524,12 +1524,6 @@ namespace Microsoft.MIDebugEngine.Natvis
         /// raw specifier text and does not normalize/remove modifiers so callers can detect
         /// whether the original expression asked for the "na" behavior.
         /// </summary>
-        private static bool HasNaModifier(string expression)
-        {
-            ExtractFormatSpecifier(expression, out bool hasNa);
-            return hasNa;
-        }
-
         /// <summary>
         /// Cleans up the raw value that GDB/LLDB returns for a <c>const char16_t*</c>
         /// expression (i.e. one evaluated with the <c>,sub</c> / <c>,su</c> format specifier).

--- a/src/MIDebugEngine/Natvis.Impl/Natvis.cs
+++ b/src/MIDebugEngine/Natvis.Impl/Natvis.cs
@@ -1526,10 +1526,8 @@ namespace Microsoft.MIDebugEngine.Natvis
         /// </summary>
         private static bool HasNaModifier(string expression)
         {
-            int commaPos = FindLastTopLevelComma(expression);
-            if (commaPos < 0) return false;
-            string tail = expression.Substring(commaPos + 1);
-            return tail.IndexOf("na", StringComparison.Ordinal) >= 0;
+            ExtractFormatSpecifier(expression, out bool hasNa);
+            return hasNa;
         }
 
         /// <summary>

--- a/src/MIDebugEngine/Natvis.Impl/Natvis.cs
+++ b/src/MIDebugEngine/Natvis.Impl/Natvis.cs
@@ -1287,7 +1287,7 @@ namespace Microsoft.MIDebugEngine.Natvis
                         // expression (this covers both the expression and any trailing format specifier)
                         if (scopedNames != null)
                         {
-                            rawExpr = Regex.Replace(rawExpr, "\\$T\\d+", (Match mt) =>
+                            rawExpr = Regex.Replace(rawExpr, @"\$T\d+", (Match mt) =>
                             {
                                 if (scopedNames.TryGetValue(mt.Value, out string replacement))
                                     return replacement;
@@ -1295,7 +1295,6 @@ namespace Microsoft.MIDebugEngine.Natvis
                             });
                         }
                         bool hasNa = HasNaModifier(rawExpr);
-                        string spec = ExtractFormatSpecifier(rawExpr);
                         string exprValue = GetExpressionValue(rawExpr, variable, scopedNames, intrinsics);
                         if (hasNa && !string.IsNullOrEmpty(exprValue))
                         {
@@ -1506,10 +1505,15 @@ namespace Microsoft.MIDebugEngine.Natvis
         /// <see cref="VariableInformation.ProcessFormatSpecifiers"/>: modifiers "nvo", "na",
         /// "nr", "nd" are stripped before returning.  Returns null when no specifier is present.
         /// </summary>
-        internal static string ExtractFormatSpecifier(string expression)
+        internal static string ExtractFormatSpecifier(string expression, out bool hasNa)
         {
+            hasNa = false;
             int commaPos = FindLastTopLevelComma(expression);
             if (commaPos < 0) return null;
+
+            string tail = expression.Substring(commaPos + 1).Trim();
+            hasNa = tail.IndexOf("na", StringComparison.Ordinal) >= 0;
+
             return expression.Substring(commaPos + 1).Trim()
                 .Replace("nvo", "").Replace("na", "").Replace("nr", "").Replace("nd", "");
         }
@@ -1550,8 +1554,6 @@ namespace Microsoft.MIDebugEngine.Natvis
         /// GDB and LLDB prefix the string with the pointer address, e.g.
         ///   <c>0x00007fff5fbff6c0 "Hello"</c>
         /// This method strips the leading address prefix that GDB/LLDB emits ("0x... ").
-        /// It does NOT remove surrounding quotes; callers should decide whether quotes
-        /// should be removed based on the caller's context.
         /// </summary>
         internal static string CleanAsciiStringValue(string value)
         {

--- a/src/MIDebugEngine/Natvis.Impl/Natvis.cs
+++ b/src/MIDebugEngine/Natvis.Impl/Natvis.cs
@@ -1283,16 +1283,12 @@ namespace Microsoft.MIDebugEngine.Natvis
                     if (m.Success)
                     {
                         string rawExpr = format.Substring(i + 1, m.Length - 2);
-                        string spec = ExtractFormatSpecifier(rawExpr, out bool hasNa);
+                        string spec = ExtractFormatSpecifier(rawExpr);
                         string exprValue = GetExpressionValue(rawExpr, variable, scopedNames, intrinsics);
-                        if (spec == "sub")
+                        if (spec == "sub" || spec == "su")
                             exprValue = CleanUtf16StringValue(exprValue);
                         else if (spec == "sb")
                             exprValue = CleanAsciiStringValue(exprValue);
-                        if (hasNa)
-                        {
-                            exprValue = VariableInformation.StripLeadingAddress(exprValue);
-                        }
                         value.Append(exprValue);
                         i += m.Length - 1;
                     }
@@ -1498,6 +1494,21 @@ namespace Microsoft.MIDebugEngine.Natvis
         /// <see cref="VariableInformation.ProcessFormatSpecifiers"/>: modifiers "nvo", "na",
         /// "nr", "nd" are stripped before returning.  Returns null when no specifier is present.
         /// </summary>
+        internal static string ExtractFormatSpecifier(string expression)
+        {
+            int commaPos = FindLastTopLevelComma(expression);
+            if (commaPos < 0) return null;
+            return expression.Substring(commaPos + 1).Trim()
+                .Replace("nvo", "").Replace("na", "").Replace("nr", "").Replace("nd", "");
+        }
+
+        /// <summary>
+        /// Returns the format specifier from a NatVis expression (the part after the last
+        /// top-level comma), normalized the same way as
+        /// <see cref="VariableInformation.ProcessFormatSpecifiers"/>: modifiers "nvo", "na",
+        /// "nr", "nd" are stripped before returning.  Returns null when no specifier is present.
+        /// also returns whether modifier 'na' was there via the out parameter
+        /// </summary>
         internal static string ExtractFormatSpecifier(string expression, out bool hasNa)
         {
             hasNa = false;
@@ -1507,31 +1518,24 @@ namespace Microsoft.MIDebugEngine.Natvis
             string tail = expression.Substring(commaPos + 1).Trim();
             hasNa = tail.IndexOf("na", StringComparison.Ordinal) >= 0;
 
-            return expression.Substring(commaPos + 1).Trim()
+            return tail
                 .Replace("nvo", "").Replace("na", "").Replace("nr", "").Replace("nd", "");
         }
 
-        /// <summary>
-        /// Returns true if the NatVis expression's trailing format specifier (the part after the
-        /// last top-level comma) contains the "na" modifier. This intentionally inspects the
-        /// raw specifier text and does not normalize/remove modifiers so callers can detect
-        /// whether the original expression asked for the "na" behavior.
-        /// </summary>
         /// <summary>
         /// Cleans up the raw value that GDB/LLDB returns for a <c>const char16_t*</c>
         /// expression (i.e. one evaluated with the <c>,sub</c> / <c>,su</c> format specifier).
         /// GDB and LLDB both prefix the string with the pointer address, e.g.
         ///   <c>0x00007fff5fbff6c0 u"Hello"</c>
-        /// This method strips the leading address prefix that GDB/LLDB emits ("0x... ").
-        /// It does NOT remove surrounding quotes or the leading character-width prefix (u/U).
         /// </summary>
         internal static string CleanUtf16StringValue(string value)
         {
             if (string.IsNullOrEmpty(value)) return value;
             // Strip leading "0x<hex> " address prefix emitted by GDB/LLDB.
-            value = VariableInformation.StripLeadingAddress(value);
+            value = s_addressPrefix.Replace(value, "");
             // Strip surrounding u"..." or U"..." quotes.
-            if (value.Length >= 3 && (value.StartsWith("u\"", StringComparison.Ordinal) || value.StartsWith("U\"", StringComparison.Ordinal)))
+            if (value.Length >= 3 &&
+                (value.StartsWith("u\"", StringComparison.Ordinal) || value.StartsWith("U\"", StringComparison.Ordinal)))
             {
                 value = value.EndsWith("\"", StringComparison.Ordinal)
                     ? value.Substring(2, value.Length - 3)
@@ -1545,13 +1549,12 @@ namespace Microsoft.MIDebugEngine.Natvis
         /// (i.e. one evaluated with the <c>,sb</c> format specifier).
         /// GDB and LLDB prefix the string with the pointer address, e.g.
         ///   <c>0x00007fff5fbff6c0 "Hello"</c>
-        /// This method strips the leading address prefix that GDB/LLDB emits ("0x... ").
         /// </summary>
         internal static string CleanAsciiStringValue(string value)
         {
             if (string.IsNullOrEmpty(value)) return value;
             // Strip leading "0x<hex> " address prefix emitted by GDB/LLDB.
-            value = VariableInformation.StripLeadingAddress(value);
+            value = s_addressPrefix.Replace(value, "");
             // Strip surrounding "..." quotes.
             if (value.Length >= 2 && value.StartsWith("\"", StringComparison.Ordinal))
             {

--- a/src/MIDebugEngine/Natvis.Impl/Natvis.cs
+++ b/src/MIDebugEngine/Natvis.Impl/Natvis.cs
@@ -1283,19 +1283,12 @@ namespace Microsoft.MIDebugEngine.Natvis
                     if (m.Success)
                     {
                         string rawExpr = format.Substring(i + 1, m.Length - 2);
-                        // Substitute template parameter macros ($T1, $T2, ...) inside the whole brace
-                        // expression (this covers both the expression and any trailing format specifier)
-                        if (scopedNames != null)
-                        {
-                            rawExpr = Regex.Replace(rawExpr, @"\$T\d+", (Match mt) =>
-                            {
-                                if (scopedNames.TryGetValue(mt.Value, out string replacement))
-                                    return replacement;
-                                return mt.Value;
-                            });
-                        }
-                        ExtractFormatSpecifier(rawExpr, out bool hasNa);
+                        string spec = ExtractFormatSpecifier(rawExpr, out bool hasNa);
                         string exprValue = GetExpressionValue(rawExpr, variable, scopedNames, intrinsics);
+                        if (spec == "sub")
+                            exprValue = CleanUtf16StringValue(exprValue);
+                        else if (spec == "sb")
+                            exprValue = CleanAsciiStringValue(exprValue);
                         if (hasNa)
                         {
                             exprValue = VariableInformation.StripLeadingAddress(exprValue);

--- a/src/MIDebugEngineUnitTests/NatvisFormatSpecifierTest.cs
+++ b/src/MIDebugEngineUnitTests/NatvisFormatSpecifierTest.cs
@@ -15,33 +15,34 @@ namespace MIDebugEngineUnitTests
         [Fact]
         public void ExtractFormatSpecifier_Sub_Extracted()
         {
-            Assert.Equal("sub", Natvis.ExtractFormatSpecifier("schemeStr(),sub"));
+            Assert.Equal("sub", Natvis.ExtractFormatSpecifier("schemeStr(),sub", out _));
         }
 
         [Fact]
         public void ExtractFormatSpecifier_Decimal_Extracted()
         {
-            Assert.Equal("d", Natvis.ExtractFormatSpecifier("year(),d"));
+            Assert.Equal("d", Natvis.ExtractFormatSpecifier("year(),d", out _));
         }
 
         [Fact]
         public void ExtractFormatSpecifier_NoSpecifier_ReturnsNull()
         {
-            Assert.Null(Natvis.ExtractFormatSpecifier("cspec == 1"));
+            Assert.Null(Natvis.ExtractFormatSpecifier("cspec == 1", out _));
         }
 
         [Fact]
         public void ExtractFormatSpecifier_NvoModifierStripped()
         {
             // "nvoXb": strip "nvo" modifier, result is "Xb"
-            Assert.Equal("Xb", Natvis.ExtractFormatSpecifier("data1,nvoXb"));
+            Assert.Equal("Xb", Natvis.ExtractFormatSpecifier("data1,nvoXb", out _));
         }
 
         [Fact]
         public void ExtractFormatSpecifier_NaModifierStripped()
         {
             // "view(RecZone)na": strip "na", result is "view(RecZone)"
-            Assert.Equal("view(RecZone)", Natvis.ExtractFormatSpecifier("this,view(RecZone)na"));
+            Assert.Equal("view(RecZone)", Natvis.ExtractFormatSpecifier("this,view(RecZone)na", out bool hasNa));
+            Assert.True(hasNa);
         }
 
         // -- CleanUtf16StringValue --------------------------------------------

--- a/src/MIDebugEngineUnitTests/NatvisFormatStringTest.cs
+++ b/src/MIDebugEngineUnitTests/NatvisFormatStringTest.cs
@@ -1,0 +1,85 @@
+using Xunit;
+using Microsoft.MIDebugEngine.Natvis;
+using Microsoft.MIDebugEngine;
+
+namespace MIDebugEngineUnitTests
+{
+    /// <summary>
+    /// unit tests for natvis format string processing with format specifiers
+    /// tests the handling of format specifiers like, 'na', sub (UTF-16), sb (ASCII).
+    /// </summary>
+    public class NatvisFormatStringTest
+    {
+        // -- format specifier with template parameters ($T1, $T2,) --
+        [Fact]
+        public void ExtractFormatSpecifier_HasTemplateParameter_TemplateSubstituted()
+        {
+            string spec = Natvis.ExtractFormatSpecifier("myVector,sub");
+            Assert.Equal("sub", spec);
+        }
+
+        // -- Format specifier na --
+
+        [Fact]
+        public void ExtractFormatSpecifier_WithNaModifier_HasNaIsTrue()
+        {
+            string spec = Natvis.ExtractFormatSpecifier("someExpr,na", out bool hasNa);
+            Assert.Equal("", spec);
+            Assert.True(hasNa);
+        }
+
+        [Fact]
+        public void ExtractFormatSpecifier_WithNaAndFormat_HasNaIsTrueAndSpecReturned()
+        {
+            string spec = Natvis.ExtractFormatSpecifier("myString,subna", out bool hasNa);
+            Assert.Equal("sub", spec);
+            Assert.True(hasNa);
+        }
+
+        [Fact]
+        public void ExtractFormatSpecifier_WithoutNaModifier_HasNaIsFalse()
+        {
+            string spec = Natvis.ExtractFormatSpecifier("myString,sub", out bool hasNa);
+            Assert.Equal("sub", spec);
+            Assert.False(hasNa);
+        }
+
+        // -- UTF-16 and ASCII string cleanup --
+
+        [Fact]
+        public void CleanUtf16StringValue_WithAddressAndQuotes_AddressAndQuotesStripped()
+        {
+            string result = Natvis.CleanUtf16StringValue("0x00007fff5fbff6c0 u\"Hello\"");
+            Assert.Equal("Hello", result);
+        }
+
+        [Fact]
+        public void CleanUtf16StringValue_WithCapitalU_QuotesStripped()
+        {
+            string result = Natvis.CleanUtf16StringValue("U\"Hello\"");
+            Assert.Equal("Hello", result);
+        }
+
+        [Fact]
+        public void CleanUtf16StringValue_JustAddress_AddressStripped()
+        {
+            string result = Natvis.CleanUtf16StringValue("0x00007fff u");
+            Assert.Equal("u", result);
+        }
+
+        [Fact]
+        public void CleanAsciiStringValue_WithAddressAndQuotes_AddressAndQuotesStripped()
+        {
+            string result = Natvis.CleanAsciiStringValue("0x00007fff5fbff6c0 \"Hello\"");
+            Assert.Equal("Hello", result);
+        }
+
+        [Fact]
+        public void CleanAsciiStringValue_TruncatedNoClosingQuote_OpeningQuoteStripped()
+        {
+            string result = Natvis.CleanAsciiStringValue("0x00007fff \"Hello...");
+            Assert.Equal("Hello...", result);
+        }
+    }
+}
+


### PR DESCRIPTION
Add support for the natvis 'na' (no-address) modifier to strip MI's leading address prefix from string values. This requires tracking the format specifier through variable initialization and applying cleanup at value retrieval points.

Also implement template parameter substitution ($T1, $T2, etc.) within natvis brace expressions before format specifier extraction.